### PR TITLE
Support for pacemaker-1.3 RNG schema

### DIFF
--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -2212,7 +2212,7 @@ class CibFactory(Singleton):
         self.last_commit_time = 0
         # internal (just not to produce silly messages)
         self._no_constraint_rm_msg = False
-        self.supported_cib_re = "^pacemaker-1[.][012]$"
+        self.supported_cib_re = "^pacemaker-1[.][0123]$"
 
     def is_cib_sane(self):
         # try to initialize

--- a/modules/pacemaker.py
+++ b/modules/pacemaker.py
@@ -30,6 +30,7 @@ known_schemas = {
     "pacemaker-1.0": ("rng", "pacemaker-1.0.rng"),
     "pacemaker-1.1": ("rng", "pacemaker-1.1.rng"),
     "pacemaker-1.2": ("rng", "pacemaker-1.2.rng"),
+    "pacemaker-1.3": ("rng", "pacemaker-1.3.rng"),
 }
 
 


### PR DESCRIPTION
pacemaker supported pacemaker-1.3.rng, so follow it.

FYI:
https://github.com/ClusterLabs/pacemaker/commit/041ba953e284fea1752dec1c9544bb270515c227

```
$ cibadmin -Q
<cib epoch="2" num_updates="10" admin_epoch="0" validate-with="pacemaker-1.3" crm_feature_set="3.0.9"  ...snip...

# crm configure show
crm configure show
ERROR: CIB not supported: validator 'pacemaker-1.3', release '3.0.9'
ERROR: You may try the upgrade command
ERROR: No CIB!
ERROR: configure.show: CIB is not valid
```
