### PR TITLE
Fix garbage characters in prompt (issue#7)

### DIFF
--- a/modules/clidisplay.py
+++ b/modules/clidisplay.py
@@ -65,6 +65,11 @@ class CliDisplay(Singleton):
             return s + "${RLIGNOREBEGIN}${NORMAL}${RLIGNOREEND}"
         return s
 
+    def prompt_noreadline(self, s):
+        if self.colors_enabled():
+            return "${GREEN}${BOLD}" + s + "${NORMAL}"
+        return s
+
     def help_header(self, s):
         return self._colorize(s, config.color.help_header)
 

--- a/modules/main.py
+++ b/modules/main.py
@@ -297,11 +297,12 @@ def do_work(context, user_args):
                 termctrl = TerminalController.getInstance()
                 cli_display = CliDisplay.getInstance()
                 promptstr = "crm(%s)%s# " % (cib_prompt(), context.prompt())
+                vars.prompt = promptstr
                 if cli_display.colors_enabled():
-                    vars.prompt = termctrl.render(cli_display.prompt(promptstr))
+                    rendered_prompt = termctrl.render(cli_display.prompt(promptstr))
                 else:
-                    vars.prompt = promptstr
-            inp = utils.multi_input(vars.prompt)
+                    rendered_prompt = promptstr
+            inp = utils.multi_input(rendered_prompt)
             if inp is None:
                 if options.interactive:
                     rc = 0

--- a/modules/ui_configure.py
+++ b/modules/ui_configure.py
@@ -26,6 +26,8 @@ import userdir
 import xmlutil
 import ra
 from cibconfig import mkset_obj, CibFactory
+from clidisplay import CliDisplay
+from term import TerminalController
 import options
 from msg import ErrorBuffer
 from msg import common_err, common_info, common_warn
@@ -143,7 +145,13 @@ class CompletionHelp(object):
             import readline
             cmdline = readline.get_line_buffer()
             print "\n%s" % helptxt
-            print "%s%s" % (vars.prompt, cmdline),
+            cli_display = CliDisplay.getInstance()
+            if cli_display.colors_enabled():
+                termctrl = TerminalController.getInstance()
+                print "%s%s" % (termctrl.render(cli_display.prompt_noreadline(vars.prompt)),
+                                cmdline),
+            else:
+                print "%s%s" % (vars.prompt, cmdline),
             cls.laststamp = time.time()
             cls.lasttopic = topic
 


### PR DESCRIPTION
When tab completion returns help text instead of completion,
the resulting re-printing of the prompt leaks readline escape codes
to the prompt. To avoid this, store prompt without color information
and handle the colorization separately for the help completion.
