### PR TITLE
Fix splitrsc TypeError Problem

### DIFF
--- a/modules/parse.py
+++ b/modules/parse.py
@@ -1041,7 +1041,8 @@ class ResourceSet(object):
                     l[1],
                     self.parent.validation.resource_roles())
             if not l[1]:
-                self.err('Invalid %s for %s' % (self.q_attr, p))
+                self.err(token=None,
+                         errmsg='Invalid %s for %s' % (self.q_attr, p))
         elif len(l) == 1:
             l = [p, '']
         return l


### PR DESCRIPTION
I encounted below error when I execute `crm configure load update xx.cib`.  This patch fix this TypeError.

```
ERROR: 3: syntax in primitive: Unknown arguments: nodename= op monitor interval=5s t
imeout=20s op start interval=0 timeout=600 op stop interval=0 timeout=120 near <node
name=> parsing 'primitive res_rabbitmq ocf:rabbitmq:rabbitmq-server params mnesia_ba
se=/var/lib/rabbitmq/mnesia nodename= op monitor interval=5s timeout=20s op start in
terval=0 timeout=600 op stop interval=0 timeout=120'
ESC[?1034hTraceback (most recent call last):
  File "/usr/sbin/crm", line 56, in <module>
    rc = main.run()
  File "/usr/lib64/python2.6/site-packages/crmsh/main.py", line 432, in run
    return do_work(context, user_args)
  File "/usr/lib64/python2.6/site-packages/crmsh/main.py", line 271, in do_work
    if context.run(' '.join(l)):
  File "/usr/lib64/python2.6/site-packages/crmsh/ui_context.py", line 87, in run
    rv = self.execute_command() is not False
  File "/usr/lib64/python2.6/site-packages/crmsh/ui_context.py", line 244, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib64/python2.6/site-packages/crmsh/ui_configure.py", line 438, in do_load
    return set_obj.import_file(method, url)
  File "/usr/lib64/python2.6/site-packages/crmsh/cibconfig.py", line 315, in import_file
    return self.save(s, no_remove=True, method=method)
  File "/usr/lib64/python2.6/site-packages/crmsh/cibconfig.py", line 509, in save
    cli_list = cp.parse2(cli_text)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 1241, in parse2
    p = self.parse(s)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 1230, in parse
    ret = parser.do_parse(s)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 90, in do_parse
    out = self.parse(cmd)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 486, in parse
    return self.begin_dispatch(cmd, min_args=2)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 83, in begin_dispatch
    return self.match_dispatch(errmsg="Unknown command")
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 275, in match_dispatch
    return getattr(self, t)()
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 677, in parse_order
    out.simple, out.resources = self.match_resource_set('action')
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 719, in match_resource_set
    return simple, parser.parse()
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 1077, in parse
    rsc, q = self.splitrsc(p)
  File "/usr/lib64/python2.6/site-packages/crmsh/parse.py", line 1022, in splitrsc
    self.err('Invalid %s for %s' % (self.q_attr, p))
TypeError: err() takes exactly 3 arguments (2 given)
```
