### PR TITLE
high: parse: Allow role in rule-based location constraints (bnc#878128)

### DIFF
--- a/doc/crm.8.txt
+++ b/doc/crm.8.txt
@@ -2406,9 +2406,9 @@ which specify a score to be awarded if the rule matches.
 
 Usage:
 ...............
-location <id> <rsc> {node_pref|rules}
+location <id> <rsc> [role=<role>] {node_pref|rules}
 
-node_pref :: <score>: <node> [role=<role>]
+node_pref :: <score>: <node>
 
 rules ::
   rule [id_spec] [$role=<role>] <score>: <expression>

--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -1621,16 +1621,16 @@ class CibLocation(CibObject):
         s = clidisplay.keyword(self.obj_type)
         id = clidisplay.id(self.obj_id)
         s = "%s %s %s" % (s, id, rsc)
+
+        role = self.node.get("role")
+        if role is not None:
+            s += " role=%s" % (role)
+
         pref_node = self.node.get("node")
         score = clidisplay.score(get_score(self.node))
         if pref_node is not None:
-            ret = "%s %s: %s" % (s, score, pref_node)
-            role = self.node.get("role")
-            if role is not None:
-                ret += " role=%s" % (role)
-            return ret
-        else:
-            return s
+            s = "%s %s: %s" % (s, score, pref_node)
+        return s
 
     def _repr_cli_child(self, c, format):
         if c.tag == "rule":

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -234,3 +234,23 @@ def test_pcs_interop_1():
     print "AFTER:", etree.tostring(elem)
 
     assert len(elem.xpath(".//meta_attributes/nvpair[@name='target-role']")) == 1
+
+
+def test_bnc878128():
+    xml = """<rsc_location id="cli-prefer-dummy-resource" rsc="dummy-resource"
+role="Started">
+  <rule id="cli-prefer-rule-dummy-resource" score="INFINITY">
+    <expression id="cli-prefer-expr-dummy-resource" attribute="#uname"
+operation="eq" value="x64-4"/>
+    <date_expression id="cli-prefer-lifetime-end-dummy-resource" operation="lt"
+end="2014-05-17 17:56:11Z"/>
+  </rule>
+</rsc_location>"""
+    data = etree.fromstring(xml)
+    obj = factory.create_from_node(data)
+    assert obj is not None
+    data = obj.repr_cli(format=-1)
+    print "OUTPUT:", data
+    exp = 'location cli-prefer-dummy-resource dummy-resource role=Started rule #uname eq x64-4 and date lt "2014-05-17 17:56:11Z"'
+    assert data == exp
+    assert obj.cli_use_validate()


### PR DESCRIPTION
A quirk in the structure of location constraints prevented constraints
with both role assignment and location rules from parsing correctly.

This changes the parse structure of the constraints to allow this. It
also allows the previous structure when parsing the CLI syntax, for
backwards compatibility.
