### PR TITLE
medium: parse: pacemaker allows order without score or kind

### DIFF
--- a/doc/crm.8.txt
+++ b/doc/crm.8.txt
@@ -2682,9 +2682,9 @@ For more details on how to configure resource sets, see
 
 Usage:
 ...............
-order <id> {kind|<score>}: first then [symmetrical=<bool>]
+order <id> [{kind|<score>}:] first then [symmetrical=<bool>]
 
-order <id> {kind|<score>}: resource_sets [symmetrical=<bool>]
+order <id> [{kind|<score>}:] resource_sets [symmetrical=<bool>]
 
 kind :: Mandatory | Optional | Serialize
 
@@ -2702,9 +2702,10 @@ attributes :: [require-all=(true|false)] [sequential=(true|false)]
 ...............
 Example:
 ...............
-order c_apache_1 Mandatory: apache:start ip_1
-order o1 Serialize: A ( B C )
-order order_2 Mandatory: [ A B ] C
+order o-1 Mandatory: apache:start ip_1
+order o-2 Serialize: A ( B C )
+order o-3 inf: [ A B ] C
+order o-4 first-resource then-resource
 ...............
 
 [[cmdhelp_configure_rsc_ticket,resources ticket dependency]]

--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -1793,7 +1793,7 @@ class CibSimpleConstraint(CibObject):
     def _repr_cli_head(self, format):
         s = clidisplay.keyword(self.obj_type)
         id = clidisplay.id(self.obj_id)
-        score = clidisplay.score(get_score(self.node) or get_kind(self.node))
+        score = get_score(self.node) or get_kind(self.node)
         if self.node.find("resource_set") is not None:
             col = rsc_set_constraint(self.node, self.obj_type)
         else:
@@ -1808,7 +1808,10 @@ class CibSimpleConstraint(CibObject):
             node_attr = self.node.get("node-attribute")
             if node_attr:
                 col.append("node-attribute=%s" % node_attr)
-        return "%s %s %s: %s" % (s, id, score, ' '.join(col))
+        s = "%s %s " % (s, id)
+        if score != '':
+            s += "%s: " % (clidisplay.score(score))
+        return s + ' '.join(col)
 
     def _mk_optional_set(self, gv_obj, n):
         '''

--- a/modules/parse.py
+++ b/modules/parse.py
@@ -762,7 +762,7 @@ class ConstraintParser(RuleParser):
 
     def parse_order(self):
         '''
-        order <id> {kind|<score>}: <rsc>[:<action>] <rsc>[:<action>] ...
+        order <id> [{kind|<score>}:] <rsc>[:<action>] <rsc>[:<action>] ...
           [symmetrical=<bool>]
 
         kind :: Mandatory | Optional | Serialize
@@ -771,8 +771,7 @@ class ConstraintParser(RuleParser):
         if self.try_match('(%s):$' % ('|'.join(self.validation.rsc_order_kinds()))):
             out.set('kind', self.validation.canonize(
                 self.matched(1), self.validation.rsc_order_kinds()))
-        else:
-            self.match(self._SCORE_RE, errmsg="Expected kind|<score>:")
+        elif self.try_match(self._SCORE_RE):
             out.set(*self.validate_score(self.matched(1), noattr=True))
         if self.try_match_tail('symmetrical=(true|false|yes|no|on|off)$'):
             out.set('symmetrical', canonical_boolean(self.matched(1)))

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -259,6 +259,22 @@ end="2014-05-17 17:56:11Z"/>
     assert obj.cli_use_validate()
 
 
+def test_order_without_score_kind():
+    """
+    Spec says order doesn't require score or kind to be set
+    """
+    xml = '<rsc_order first="a" first-action="promote" id="order-a-b" then="b" then-action="start"/>'
+    data = etree.fromstring(xml)
+    obj = factory.create_from_node(data)
+    assert obj is not None
+    data = obj.repr_cli(format=-1)
+    print "OUTPUT:", data
+    exp = 'order order-a-b a:promote b:start'
+    assert data == exp
+    assert obj.cli_use_validate()
+
+
+
 def test_bnc878112():
     """
     crm configure group can hijack a cloned primitive (and then crash)


### PR DESCRIPTION
A legal CIB can have order constraints that don't have score
or kind set. Make sure crmsh can parse these correctly.
