### PR TITLE
low: report: Detect errors in hb_report live creation

### DIFF
--- a/modules/report.py
+++ b/modules/report.py
@@ -967,6 +967,9 @@ class Report(object):
                 self.error("hb_report failed")
                 return None
         self.last_live_update = time.time()
+        if not os.path.isfile(tarball):
+            self.error("Report file not found: %s" % (tarball))
+            return None
         return self.unpack_report(tarball)
 
     def set_source(self, src):


### PR DESCRIPTION
If hb_report exits with a 0 code but doesn't generate a
tarball, crmsh would try to unpack the non-existing file
and crash. This patch makes crmsh exit with a clearer
error message.
