### PR TITLE
high: report: Preserve path when checking timestamp of tarball (bnc#889328)

### DIFF
--- a/modules/report.py
+++ b/modules/report.py
@@ -687,7 +687,7 @@ class Report(object):
             return None
         self.set_change_origin(CH_SRC)
         if os.path.isdir(loc):
-            if (os.stat(bfname).st_mtime - os.stat(loc).st_mtime) < 60:
+            if (os.stat(tarball).st_mtime - os.stat(loc).st_mtime) < 60:
                 return loc
             rmdir_r(loc)
         cwd = os.getcwd()


### PR DESCRIPTION
stat is called on the filename part of the file path only, ignoring the
path.
