### PR TITLE
medium: ui_node: Fix handling of default arguments (bnc#889673)

### DIFF
--- a/doc/crm.8.txt
+++ b/doc/crm.8.txt
@@ -1790,11 +1790,9 @@ Make CRM fence a node. This functionality depends on stonith
 resources capable of fencing the specified node. No such stonith
 resources, no fencing will happen.
 
-The node parameter defaults to the node where the command is run.
-
 Usage:
 ...............
-fence [<node>]
+fence <node>
 ...............
 
 [[cmdhelp_node_clearstate,Clear node state]]
@@ -1808,11 +1806,9 @@ Be careful! This can cause data corruption if you confirm that a node is
 down that is, in fact, not cleanly down - the cluster will proceed as if
 the fence had succeeded, possibly starting resources multiple times.
 
-The node parameter defaults to the node where the command is run.
-
 Usage:
 ...............
-clearstate [<node>]
+clearstate <node>
 ...............
 
 [[cmdhelp_node_delete,delete node]]

--- a/modules/ui_node.py
+++ b/modules/ui_node.py
@@ -214,10 +214,8 @@ class NodeMgmt(command.UI):
 
     @command.wait
     @command.completers(compl.nodes)
-    def do_fence(self, context, node=None):
+    def do_fence(self, context, node):
         'usage: fence <node>'
-        if not node:
-            node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
         if not config.core.force and \


### PR DESCRIPTION
Syncronize the code for some node commands with the documentation,
and allow the node name to be omitted where it makes sense.
