### PR TITLE
high: parse: Implicit initial parameter list

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3054,7 +3054,7 @@ Usage:
 ...............
 primitive <rsc> {[<class>:[<provider>:]]<type>|@<template>}
   [description=<description>]
-  [params attr_list]
+  [[params] attr_list]
   [meta attr_list]
   [utilization attr_list]
   [operations id_spec]
@@ -3073,7 +3073,7 @@ primitive apcfence stonith:apcsmart \
   op monitor interval=30m timeout=60s
 
 primitive www8 apache \
-  params configfile=/etc/apache/www8.conf \
+  configfile=/etc/apache/www8.conf \
   operations $id-ref=apache_ops
 
 primitive db0 mysql \
@@ -3086,8 +3086,7 @@ primitive r0 ocf:linbit:drbd \
   op monitor role=Master interval=60s \
   op monitor role=Slave interval=300s
 
-primitive xen0 @vm_scheme1 \
-  params xmfile=/etc/xen/vm/xen0
+primitive xen0 @vm_scheme1 xmfile=/etc/xen/vm/xen0
 
 primitive mySpecialRsc Special \
   params 3: rule #uname eq node1 interface=eth1 \

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -157,6 +157,11 @@ class TestCliParser(unittest.TestCase):
         out = self.parser.parse('primitive st stonith:ssh params hostlist=node1 meta target-role=Started op start requires=nothing timeout=60s op monitor interval=60m timeout=60s')
         self.assertEqual(out.get('id'), 'st')
 
+        out2 = self.parser.parse('primitive st stonith:ssh hostlist=node1 meta target-role=Started op start requires=nothing timeout=60s op monitor interval=60m timeout=60s')
+        self.assertEqual(out2.get('id'), 'st')
+
+        self.assertEqual(etree.tostring(out), etree.tostring(out2))
+
         out = self.parser.parse('primitive st stonith:ssh params hostlist= meta')
         self.assertEqual(out.get('id'), 'st')
 
@@ -168,6 +173,10 @@ class TestCliParser(unittest.TestCase):
         print etree.tostring(out)
         self.assertEqual(['resource'], out.xpath('./crmsh-ref/@id'))
         self.assertEqual(['b'], out.xpath('instance_attributes/nvpair[@name="a"]/@value'))
+
+        out2 = self.parser.parse('ms m0 resource a=b')
+        self.assertEqual(out.get('id'), 'm0')
+        self.assertEqual(etree.tostring(out), etree.tostring(out2))
 
         out = self.parser.parse('master ma resource meta a=b')
         self.assertEqual(out.get('id'), 'ma')


### PR DESCRIPTION
Proposed new syntax: Implicit initial parameter list.

This adds support for a shorthand syntax when creating
primitives and nodes: Instead of explicitly writing

primitive foo Foo params foo-param=1

this is now accepted as equivalent:

primitive foo Foo foo-param=1

Same thing for nodes, this

node my-node kernel=3.17.2

is parsed as

node my-node attributes kernel=3.17.2

The XML->CIB parser is still the same, so when inspecting
the created CLI syntax, params will have been injected.

However, this should make the creation of new primitives
a bit cleaner.
