### PR TITLE
Low: term: get rid of annying ^O in piped-to-less-R output

### DIFF
--- a/modules/term.py
+++ b/modules/term.py
@@ -97,12 +97,30 @@ def _init():
     assumed to be a dumb terminal (i.e., have no capabilities).
     """
     def _tigetstr(cap_name):
+        import curses
+        cap = curses.tigetstr(cap_name) or ''
+
         # String capabilities can include "delays" of the form "$<2>".
         # For any modern terminal, we should be able to just ignore
         # these, so strip them out.
-        import curses
-        cap = curses.tigetstr(cap_name) or ''
-        return re.sub(r'\$<\d+>[/*]?', '', cap)
+        # terminof(5) states that:
+        #   A "/" suffix indicates that the padding is mandatory and forces a
+        #   delay of the given number of milliseconds even on devices for which
+        #   xon is present to indicate flow control.
+        # So let's respect that. But not the optional ones.
+        cap = re.sub(r'\$<\d+>[*]?', '', cap)
+
+        # To switch back to "NORMAL", we use sgr0, which resets "everything" to defaults.
+        # That on some terminals includes ending "alternate character set mode".
+        # Which is usually done by appending '\017'.  Unfortunately, less -R
+        # does not eat that, but shows it as an annoying inverse '^O'
+        # Instead of falling back to less -r, which would have other implications as well,
+        # strip off that '\017': we don't use the alternative character set,
+        # so we won't need to reset it either.
+        if cap_name == 'sgr0':
+            cap = re.sub(r'\017$', '', cap)
+
+        return cap
 
     _term_stream = sys.stdout
     # Curses isn't available on all platforms


### PR DESCRIPTION
Ever been annoyed by that stupid "^O" in the colored output?
Not sure how you dealt with it so far, but I usually just hit "-r" in less.
Which would potentially let other control characters through as well, which I did not like.
This fixes it at the source: don't even output that byte.
