### PR TITLE
Fix CFLAGS for supporting triplet paths with pacemaker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,7 @@ eval datadir="`eval echo ${datadir}`"
 eval sysconfdir="`eval echo ${sysconfdir}`"
 eval sharedstatedir="`eval echo ${sharedstatedir}`"
 eval localstatedir="`eval echo ${localstatedir}`"
+eval includedir="`eval echo ${includedir}`"
 eval libdir="`eval echo ${libdir}`"
 eval infodir="`eval echo ${infodir}`"
 eval mandir="`eval echo ${mandir}`"
@@ -123,7 +124,7 @@ if test x"${docdir}" = x""; then
 fi
 AC_SUBST(docdir)
 
-CFLAGS="$CFLAGS -I${prefix}/include/heartbeat -I${prefix}/include/pacemaker"
+CFLAGS="$CFLAGS -I${prefix}/include/heartbeat -I${includedir}/heartbeat -I${prefix}/include/pacemaker -I${includedir}/pacemaker"
 
 for j in prefix exec_prefix bindir sbindir libexecdir datadir sysconfdir \
     sharedstatedir localstatedir libdir infodir \


### PR DESCRIPTION
 - On debian we enabled multiarch support for pacemaker, and
   so the includes install to /usr/include/<triplet_path>/
   pacemaker; requiring configure.ac to be updated to include
   said path for its search when AC_CHECK_HEADERS is run for 
   crm_conf.h.

Change-Id: I8a18dda2229caaf4a398561a0f4e239c9964e239
Signed-off-by: Richard B Winters <rik@mmogp.com>