### PR TITLE
When generating CIB syntax, elide initial in some cases

### DIFF
--- a/modules/constants.py
+++ b/modules/constants.py
@@ -39,6 +39,15 @@ cib_cli_map = {
     "fencing-topology": "fencing_topology",
     "tag": "tag"
 }
+# xml name => implicit initial
+implicit_initial = {
+    "node": "attributes",
+    "primitive": "params",
+    "template": "params",
+    "master": "params",
+    "clone": "params",
+    "group": "params"
+}
 container_tags = ("group", "clone", "ms", "master")
 clonems_tags = ("clone", "ms", "master")
 resource_tags = ("primitive", "group", "clone", "ms", "master", "template")

--- a/test/testcases/acl
+++ b/test/testcases/acl
@@ -2,7 +2,7 @@ show ACL
 node node1
 property enable-acl=true
 primitive st stonith:ssh \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta target-role="Started" \
 	op start requires=nothing timeout=60s \
 	op monitor interval=60m timeout=60s

--- a/test/testcases/acl.exp
+++ b/test/testcases/acl.exp
@@ -5,7 +5,7 @@
 .INP: erase nodes
 .INP: node node1
 .INP: property enable-acl=true
-.INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
+.INP: primitive st stonith:ssh 	hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
 .INP: primitive d0 ocf:pacemaker:Dummy
 .INP: primitive d1 ocf:pacemaker:Dummy
 .INP: role basic-read        read status        read type:node attribute:uname        read type:node attribute:type        read property
@@ -30,7 +30,7 @@ node node1
 primitive d0 ocf:pacemaker:Dummy
 primitive d1 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s

--- a/test/testcases/bugs
+++ b/test/testcases/bugs
@@ -5,7 +5,7 @@ up
 configure
 erase
 primitive st stonith:null \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta description="some description here" \
 	op start requires=nothing \
 	op monitor interval=60m

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -4,7 +4,7 @@
 .INP: up
 .INP: configure
 .INP: erase
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" 	op start requires=nothing 	op monitor interval=60m
+.INP: primitive st stonith:null 	hostlist='node1' 	meta description="some description here" 	op start requires=nothing 	op monitor interval=60m
 .INP: primitive p4 Dummy
 .INP: primitive p3 Dummy
 .INP: primitive p2 Dummy
@@ -24,7 +24,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: show
 node node1
 primitive st stonith:null \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta description="some description here" \
 	op start requires=nothing interval=0 \
 	op monitor interval=60m
@@ -46,7 +46,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: show
 node node1
 primitive st stonith:null \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta description="some description here" \
 	op start requires=nothing interval=0 \
 	op monitor interval=60m
@@ -67,7 +67,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: show
 node node1
 primitive st stonith:null \
-	params hostlist=node1
+	hostlist=node1
 primitive p4 Dummy
 primitive p3 Dummy
 primitive p2 Dummy

--- a/test/testcases/commit
+++ b/test/testcases/commit
@@ -1,13 +1,13 @@
 show Commits of all kinds
 property default-action-timeout=2m
 primitive st stonith:null \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta yoyo-meta="yoyo 2" \
 	op start requires=nothing \
 	op monitor interval=60m
 commit
 node node1 \
-	attributes mem=16G
+	mem=16G
 primitive p1 ocf:heartbeat:Dummy \
 	op monitor interval=60m \
 	op monitor interval=120m OCF_CHECK_LEVEL=10

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -4,7 +4,7 @@
 .INP: erase
 .INP: erase nodes
 .INP: property default-action-timeout=2m
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta yoyo-meta="yoyo 2" 	op start requires=nothing 	op monitor interval=60m
+.INP: primitive st stonith:null 	hostlist='node1' 	meta yoyo-meta="yoyo 2" 	op start requires=nothing 	op monitor interval=60m
 .INP: commit
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
@@ -12,7 +12,7 @@
 .EXT pengine metadata
 .EXT cib metadata
 ERROR: 7: st: attribute yoyo-meta does not exist
-.INP: node node1 	attributes mem=16G
+.INP: node node1 	mem=16G
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
 .INP: primitive p2 ocf:heartbeat:Dummy
 .INP: primitive p3 ocf:heartbeat:Dummy
@@ -52,7 +52,7 @@ INFO: 24: resource references in order:o1 updated
 ERROR: 35: st: attribute yoyo-meta does not exist
 .INP: show
 node node1 \
-	attributes mem=16G
+	mem=16G
 primitive d1 Dummy
 primitive d3 Dummy
 primitive p1 Dummy \
@@ -61,7 +61,7 @@ primitive p1 Dummy \
 primitive p2 Dummy
 primitive p3 Dummy
 primitive st stonith:null \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta yoyo-meta="yoyo 2" \
 	op start requires=nothing interval=0 \
 	op monitor interval=60m

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -2,22 +2,22 @@ show Basic configure
 node node1
 delete node1
 node node1 \
-	attributes mem=16G
+	mem=16G
 node node2 utilization cpu=4
 primitive st stonith:ssh \
-	params hostlist='node1 node2' \
+	hostlist='node1 node2' \
 	meta target-role="Started" \
 	op start requires=nothing timeout=60s \
 	op monitor interval=60m timeout=60s
 primitive st2 stonith:ssh \
-	params hostlist='node1 node2'
+	hostlist='node1 node2'
 primitive d1 ocf:pacemaker:Dummy \
 	operations $id=d1-ops \
 	op monitor interval=60m \
 	op monitor interval=120m OCF_CHECK_LEVEL=10
 monitor d1 60s:30s
 primitive d2 ocf:heartbeat:Delay \
-	params mondelay=60 \
+	mondelay=60 \
 	op start timeout=60s \
 	op stop timeout=60s
 monitor d2:Started 60s:30s

--- a/test/testcases/confbasic-xml
+++ b/test/testcases/confbasic-xml
@@ -2,22 +2,22 @@ showxml Basic configure (xml dump)
 node node1
 delete node1
 node node1 \
-	attributes mem=16G
+	mem=16G
 node node2 utilization cpu=4
 primitive st stonith:ssh \
-	params hostlist='node1 node2' \
+	hostlist='node1 node2' \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s \
 	op monitor interval=60m timeout=60s
 primitive st2 stonith:ssh \
-	params hostlist='node1 node2'
+	hostlist='node1 node2'
 primitive d1 ocf:pacemaker:Dummy \
 	operations $id=d1-ops \
 	op monitor interval=60m \
 	op monitor interval=120m OCF_CHECK_LEVEL=10
 monitor d1 60s:30s
 primitive d2 ocf:heartbeat:Delay \
-	params mondelay=60 \
+	mondelay=60 \
 	op start timeout=60s \
 	op stop timeout=60s
 monitor d2:Started 60s:30s

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -5,13 +5,13 @@
 .INP: erase nodes
 .INP: node node1
 .INP: delete node1
-.INP: node node1 	attributes mem=16G
+.INP: node node1 	mem=16G
 .INP: node node2 utilization cpu=4
-.INP: primitive st stonith:ssh 	params hostlist='node1 node2' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
-.INP: primitive st2 stonith:ssh 	params hostlist='node1 node2'
+.INP: primitive st stonith:ssh 	hostlist='node1 node2' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
+.INP: primitive st2 stonith:ssh 	hostlist='node1 node2'
 .INP: primitive d1 ocf:pacemaker:Dummy 	operations $id=d1-ops 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
 .INP: monitor d1 60s:30s
-.INP: primitive d2 ocf:heartbeat:Delay 	params mondelay=60 	op start timeout=60s 	op stop timeout=60s
+.INP: primitive d2 ocf:heartbeat:Delay 	mondelay=60 	op start timeout=60s 	op stop timeout=60s
 .INP: monitor d2:Started 60s:30s
 .INP: group g1 d1 d2
 .INP: primitive d3 ocf:pacemaker:Dummy
@@ -61,7 +61,7 @@
 .EXT cib metadata
 .INP: show
 node node1 \
-	attributes mem=16G
+	mem=16G
 node node2 \
 	utilization cpu=4
 primitive d1 ocf:pacemaker:Dummy \
@@ -70,7 +70,7 @@ primitive d1 ocf:pacemaker:Dummy \
 	op monitor interval=120m OCF_CHECK_LEVEL=10 \
 	op monitor interval=60s timeout=30s
 primitive d2 Delay \
-	params mondelay=45 \
+	mondelay=45 \
 	op start timeout=60s interval=0 \
 	op stop timeout=60s interval=0 \
 	op monitor role=Started interval=60s timeout=30s
@@ -84,12 +84,12 @@ primitive s5 ocf:pacemaker:Stateful \
 primitive s6 ocf:pacemaker:Stateful \
 	operations  $id-ref=d1-ops
 primitive st stonith:ssh \
-	params hostlist="node1 node2" \
+	hostlist="node1 node2" \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
 primitive st2 stonith:ssh \
-	params hostlist="node1 node2"
+	hostlist="node1 node2"
 group g1 d1 d2
 ms m d4
 ms m5 s5

--- a/test/testcases/delete
+++ b/test/testcases/delete
@@ -6,7 +6,7 @@ erase nodes
 node node1
 # create one stonith so that verify does not complain
 primitive st stonith:ssh \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta target-role="Started" \
 	op start requires=nothing timeout=60s \
 	op monitor interval=60m timeout=60s

--- a/test/testcases/delete.exp
+++ b/test/testcases/delete.exp
@@ -5,7 +5,7 @@
 .INP: erase nodes
 .INP: node node1
 .INP: # create one stonith so that verify does not complain
-.INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
+.INP: primitive st stonith:ssh 	hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
 .INP: primitive d1 ocf:pacemaker:Dummy
 .INP: primitive d2 ocf:pacemaker:Dummy
 .INP: location d1-pref d1 100: node1
@@ -14,7 +14,7 @@ node node1
 primitive d1 ocf:pacemaker:Dummy
 primitive d2 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -27,7 +27,7 @@ node node1
 primitive d2 ocf:pacemaker:Dummy
 primitive p1 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -39,7 +39,7 @@ location d1-pref p1 100: node1
 node node1
 primitive p1 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -51,7 +51,7 @@ INFO: 20: hanging location:d1-pref deleted
 .INP: show
 node node1
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -68,7 +68,7 @@ INFO: 29: resource references in location:d1-pref updated
 node node1
 primitive d1 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -81,7 +81,7 @@ INFO: 33: resource references in location:d1-pref updated
 node node1
 primitive d1 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -105,7 +105,7 @@ node node1
 primitive d1 ocf:pacemaker:Dummy
 primitive d2 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -125,7 +125,7 @@ node node1
 primitive d1 ocf:pacemaker:Dummy
 primitive d2 ocf:pacemaker:Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s
@@ -143,7 +143,7 @@ INFO: 53: hanging location:d1-pref deleted
 .INP: show
 node node1
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -1,9 +1,9 @@
 show Configuration editing
 property default-action-timeout=2m
 node node1 \
-	attributes mem=16G
+	mem=16G
 primitive st stonith:null \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta description="some description here" \
 	op start requires=nothing \
 	op monitor interval=60m

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -4,8 +4,8 @@
 .INP: erase
 .INP: erase nodes
 .INP: property default-action-timeout=2m
-.INP: node node1 	attributes mem=16G
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" 	op start requires=nothing 	op monitor interval=60m
+.INP: node node1 	mem=16G
+.INP: primitive st stonith:null 	hostlist='node1' 	meta description="some description here" 	op start requires=nothing 	op monitor interval=60m
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
 .INP: filter "sed '$aprimitive p2 ocf:heartbeat:Dummy'"
 .INP: filter "sed '$agroup g1 p1 p2'"
@@ -87,7 +87,7 @@ order o-d456 d4 d5 d6
 .EXT cib metadata
 .INP: show
 node node1 \
-	attributes mem=16G
+	mem=16G
 primitive d1 Dummy
 primitive d2 Dummy
 primitive d3 Dummy
@@ -100,7 +100,7 @@ primitive p1 Dummy \
 primitive p2 Dummy
 primitive p3 Dummy
 primitive st stonith:null \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta description="some description here" \
 	op start requires=nothing interval=0 \
 	op monitor interval=60m

--- a/test/testcases/file.exp
+++ b/test/testcases/file.exp
@@ -4,10 +4,10 @@ node node1
 primitive p0 ocf:pacemaker:Dummy
 primitive p1 ocf:pacemaker:Dummy
 primitive p2 Delay \
-	params startdelay=2 mondelay=2 stopdelay=2
+	startdelay=2 mondelay=2 stopdelay=2
 primitive p3 ocf:pacemaker:Dummy
 primitive st stonith:null \
-	params hostlist=node1
+	hostlist=node1
 ms m1 p2
 clone c1 p1
 property cib-bootstrap-options: \
@@ -40,10 +40,10 @@ node node1
 primitive p0 ocf:pacemaker:Dummy
 primitive p1 ocf:pacemaker:Dummy
 primitive p2 Delay \
-	params startdelay=2 mondelay=2 stopdelay=2
+	startdelay=2 mondelay=2 stopdelay=2
 primitive p3 ocf:pacemaker:Dummy
 primitive st stonith:null \
-	params hostlist=node1
+	hostlist=node1
 # comment
 ms m1 p2
 clone c1 p1

--- a/test/testcases/newfeatures
+++ b/test/testcases/newfeatures
@@ -6,15 +6,15 @@ erase nodes
 node node1
 # create one stonith so that verify does not complain
 primitive st stonith:ssh \
-	params hostlist='node1' \
+	hostlist='node1' \
 	meta target-role="Started" \
 	op start requires=nothing timeout=60s \
 	op monitor interval=60m timeout=60s
-primitive p0 Dummy params $p0-state:state=1
-primitive p1 Dummy params \
+primitive p0 Dummy $p0-state:state=1
+primitive p1 Dummy \
     rule role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01 \
     state=2
-primitive p2 Dummy params @p0-state
+primitive p2 Dummy @p0-state
 property rule #uname eq node1 stonith-enabled=no
 tag tag1: p0 p1 p2
 tag tag2 p0 p1 p2

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -5,10 +5,10 @@
 .INP: erase nodes
 .INP: node node1
 .INP: # create one stonith so that verify does not complain
-.INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
-.INP: primitive p0 Dummy params $p0-state:state=1
-.INP: primitive p1 Dummy params     rule role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01     state=2
-.INP: primitive p2 Dummy params @p0-state
+.INP: primitive st stonith:ssh 	hostlist='node1' 	meta target-role="Started" 	op start requires=nothing timeout=60s 	op monitor interval=60m timeout=60s
+.INP: primitive p0 Dummy $p0-state:state=1
+.INP: primitive p1 Dummy     rule role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01     state=2
+.INP: primitive p2 Dummy @p0-state
 nvpair_ref: 'p0-state' None
 nvpair_ref: 'p0-state' None
 .INP: property rule #uname eq node1 stonith-enabled=no
@@ -18,13 +18,13 @@ nvpair_ref: 'p0-state' None
 .INP: show
 node node1
 primitive p0 Dummy \
-	params state=1
+	state=1
 primitive p1 Dummy \
-	params rule $role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01 state=2
+	rule $role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01 state=2
 primitive p2 Dummy \
-	params @p0-state
+	@p0-state
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	meta target-role=Started \
 	op start requires=nothing timeout=60s interval=0 \
 	op monitor interval=60m timeout=60s

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -61,9 +61,6 @@ livedangerously (enum): Live Dangerously!!
     setting this parameter to yes makes it an even worse idea.
     Viva la Vida Loca!
 
-stonith-timeout (time, [60s]): How long to wait for the STONITH action to complete per a stonith device.
-    Overrides the stonith-timeout cluster property
-
 priority (integer, [0]): The priority of the stonith resource. Devices are tried in order of highest priority to lowest.
 pcmk_host_argument (string, [port]): Advanced use only: An alternate parameter to supply instead of 'port'
     Some devices do not support the standard 'port' parameter or may provide additional ones.

--- a/test/testcases/rset
+++ b/test/testcases/rset
@@ -1,7 +1,7 @@
 show Resource sets
 node node1
 primitive st stonith:ssh \
-	params hostlist='node1' \
+	hostlist='node1' \
 	op start timeout=60s
 primitive d1 ocf:pacemaker:Dummy
 primitive d2 ocf:heartbeat:Dummy

--- a/test/testcases/rset-xml
+++ b/test/testcases/rset-xml
@@ -1,7 +1,7 @@
 showxml Resource sets
 node node1
 primitive st stonith:ssh \
-	params hostlist='node1' \
+	hostlist='node1' \
 	op start timeout=60s
 primitive d1 ocf:pacemaker:Dummy
 primitive d2 ocf:heartbeat:Dummy

--- a/test/testcases/rset.exp
+++ b/test/testcases/rset.exp
@@ -4,7 +4,7 @@
 .INP: erase
 .INP: erase nodes
 .INP: node node1
-.INP: primitive st stonith:ssh 	params hostlist='node1' 	op start timeout=60s
+.INP: primitive st stonith:ssh 	hostlist='node1' 	op start timeout=60s
 .INP: primitive d1 ocf:pacemaker:Dummy
 .INP: primitive d2 ocf:heartbeat:Dummy
 .INP: primitive d3 ocf:heartbeat:Dummy
@@ -47,7 +47,7 @@ primitive d1 ocf:pacemaker:Dummy
 primitive d3 Dummy
 primitive d5 Dummy
 primitive st stonith:ssh \
-	params hostlist=node1 \
+	hostlist=node1 \
 	op start timeout=60s interval=0
 colocation c1 inf: ( d1 d3 )
 colocation c2 inf: d3 d1

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -338,7 +338,10 @@ def test_pengine_test():
     assert obj is not None
     data = obj.repr_cli(format=-1)
     print "OUTPUT:", data
-    exp = 'primitive rsc1 ocf:pacemaker:Dummy rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" op monitor interval=10'
+    exp = ('primitive rsc1 ocf:pacemaker:Dummy ' +
+           'params rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" ' +
+           'params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" ' +
+           'op monitor interval=10')
     assert data == exp
     assert obj.cli_use_validate()
 

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -338,7 +338,7 @@ def test_pengine_test():
     assert obj is not None
     data = obj.repr_cli(format=-1)
     print "OUTPUT:", data
-    exp = 'primitive rsc1 ocf:pacemaker:Dummy params rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" op monitor interval=10'
+    exp = 'primitive rsc1 ocf:pacemaker:Dummy rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" op monitor interval=10'
     assert data == exp
     assert obj.cli_use_validate()
 
@@ -401,7 +401,7 @@ def test_nvpair_no_value():
     assert obj is not None
     data = obj.repr_cli(format=-1)
     print "OUTPUT:", data
-    exp = 'primitive rsc3 Dummy params verbose verbase="" verbese=" "'
+    exp = 'primitive rsc3 Dummy verbose verbase="" verbese=" "'
     assert data == exp
     assert obj.cli_use_validate()
 
@@ -441,6 +441,6 @@ def test_quotes():
     assert obj is not None
     data = obj.repr_cli(format=-1)
     print "OUTPUT:", data
-    exp = 'primitive q1 ocf:pacemaker:Dummy params state="foo\\"foo\\""'
+    exp = 'primitive q1 ocf:pacemaker:Dummy state="foo\\"foo\\""'
     assert data == exp
     assert obj.cli_use_validate()

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -67,7 +67,7 @@ def test_rscset():
 
 def test_group():
     factory.create_from_cli('primitive p1 Dummy')
-    roundtrip('group g1 p1 params target-role=Stopped')
+    roundtrip('group g1 p1 target-role=Stopped')
 
 
 def test_bnc863736():
@@ -104,13 +104,13 @@ def test_comment2():
 
 
 def test_nvpair_ref1():
-    factory.create_from_cli("primitive dummy-0 Dummy params $fiz:buz=bin")
-    roundtrip('primitive dummy-1 Dummy params @fiz:boz')
+    factory.create_from_cli("primitive dummy-0 Dummy $fiz:buz=bin")
+    roundtrip('primitive dummy-1 Dummy @fiz:boz')
 
 
 def test_idresolve():
-    factory.create_from_cli("primitive dummy-5 Dummy params buz=bin")
-    roundtrip('primitive dummy-1 Dummy params @dummy-5-instance_attributes-buz')
+    factory.create_from_cli("primitive dummy-5 Dummy buz=bin")
+    roundtrip('primitive dummy-1 Dummy @dummy-5-instance_attributes-buz')
 
 
 def test_ordering():
@@ -193,11 +193,11 @@ def test_master():
 
 def test_param_rules():
     roundtrip('primitive foo Dummy ' +
-              'params rule #uname eq wizbang laser=yes ' +
+              'rule #uname eq wizbang laser=yes ' +
               'params rule #uname eq gandalf staff=yes')
 
     roundtrip('primitive mySpecialRsc me:Special ' +
-              'params 3: rule #uname eq node1 interface=eth1 ' +
+              '3: rule #uname eq node1 interface=eth1 ' +
               'params 2: rule #uname eq node2 interface=eth2 port=8888 ' +
               'params 1: interface=eth0 port=9999')
 
@@ -216,7 +216,7 @@ def test_acls_oldsyntax():
               expected='role boo deny ref:d0 deny type:nvpair')
 
 def test_rules():
-    roundtrip('primitive p1 Dummy params ' +
+    roundtrip('primitive p1 Dummy ' +
               'rule $role=Started date in start=2009-05-26 end=2010-05-26 ' +
               'or date gt 2014-01-01 state=2')
 

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -193,11 +193,11 @@ def test_master():
 
 def test_param_rules():
     roundtrip('primitive foo Dummy ' +
-              'rule #uname eq wizbang laser=yes ' +
+              'params rule #uname eq wizbang laser=yes ' +
               'params rule #uname eq gandalf staff=yes')
 
     roundtrip('primitive mySpecialRsc me:Special ' +
-              '3: rule #uname eq node1 interface=eth1 ' +
+              'params 3: rule #uname eq node1 interface=eth1 ' +
               'params 2: rule #uname eq node2 interface=eth2 port=8888 ' +
               'params 1: interface=eth0 port=9999')
 


### PR DESCRIPTION
This is something I worked on this weekend, but now that I have it working, I don't know if I really think it is a good idea. This would make eliding the "params" or "attributes" the default even when displaying the configuration, except when there are multiple params or attributes tags.

Dejan, how do you feel about this? I'm apprehensive, because although I think it improves the readability of examples like

```
primitive vip IPaddr2 ip=192.168.0.200
```

...there are other cases that aren't as clear cut, and it makes the generated syntax context-sensitive, not just the accepted input (where I don't think there are any downsides to allowing it).

So right now I am inclined to throw this away :P
