### PR TITLE
medium: cibconfig: Warn if constraint applies to container child (bsc#927423) (#101)

### DIFF
--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -1635,8 +1635,9 @@ def _check_if_constraint_ref_is_child(obj):
             common_warn("%s: resource %s does not exist" % (obj.obj_id, rscid))
             rc = 1
         elif tgt.parent and tgt.parent.obj_type == "group":
-            common_warn("%s: resource %s is grouped, constraints should apply to the group" % (obj.obj_id, rscid))
-            rc = 1
+            if obj.obj_type != "order":
+                common_warn("%s: resource %s is grouped, constraints should apply to the group" % (obj.obj_id, rscid))
+                rc = 1
         elif tgt.parent and tgt.parent.obj_type in constants.container_tags:
             common_warn("%s: resource %s ambiguous, apply constraints to container" % (obj.obj_id, rscid))
             rc = 1

--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -1622,6 +1622,27 @@ class CibContainer(CibObject):
             child_rsc.repr_gv(sg_obj, from_grp=True)
 
 
+def _check_if_constraint_ref_is_child(obj):
+    """
+    Used by check_sanity for constraints to verify
+    that referenced resources are not children in
+    a container.
+    """
+    rc = 0
+    for rscid in obj._referenced_resources():
+        tgt = cib_factory.find_object(rscid)
+        if not tgt:
+            common_warn("%s: resource %s does not exist" % (obj.obj_id, rscid))
+            rc = 1
+        elif tgt.parent and tgt.parent.obj_type == "group":
+            common_warn("%s: resource %s is grouped, constraints should apply to the group" % (obj.obj_id, rscid))
+            rc = 1
+        elif tgt.parent and tgt.parent.obj_type in constants.container_tags:
+            common_warn("%s: resource %s ambiguous, apply constraints to container" % (obj.obj_id, rscid))
+            rc = 1
+    return rc
+
+
 class CibLocation(CibObject):
     '''
     Location constraint.
@@ -1692,7 +1713,14 @@ class CibLocation(CibObject):
                 if uname and uname.lower() not in ids:
                     common_warn("%s: referenced node %s does not exist" % (self.obj_id, uname))
                     rc = 1
+        rc2 = _check_if_constraint_ref_is_child(self)
+        if rc2 > rc:
+            rc = rc2
         return rc
+
+    def _referenced_resources(self):
+        ret = self.node.xpath('.//resource_set/resource_ref/@id')
+        return ret or [self.node.get("rsc")]
 
     def repr_gv(self, gv_obj, from_grp=False):
         '''
@@ -1829,6 +1857,23 @@ class CibSimpleConstraint(CibObject):
             self._mk_one_edge(gv_obj, [
                 self.node.get("first"),
                 self.node.get("then")])
+
+    def _referenced_resources(self):
+        ret = self.node.xpath('.//resource_set/resource_ref/@id')
+        if ret:
+            return ret
+        if self.obj_type == "order":
+            return [self.node.get("first"), self.node.get("then")]
+        elif self.obj_type == "colocation":
+            return [self.node.get("rsc"), self.node.get("with-rsc")]
+        elif self.node.get("rsc"):
+            return [self.node.get("rsc")]
+
+    def check_sanity(self):
+        if self.node is None:
+            common_err("%s: no xml (strange)" % self.obj_id)
+            return utils.get_check_rc()
+        return _check_if_constraint_ref_is_child(self)
 
 
 class CibRscTicket(CibSimpleConstraint):

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -60,7 +60,6 @@ WARNING: 51: c2: resource d1 is grouped, constraints should apply to the group
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata
-WARNING: 51: o2: resource d1 is grouped, constraints should apply to the group
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -135,4 +134,3 @@ op_defaults opsdef2: \
 	record-pending=true
 .INP: commit
 WARNING: 53: c2: resource d1 is grouped, constraints should apply to the group
-WARNING: 53: o2: resource d1 is grouped, constraints should apply to the group

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -56,9 +56,11 @@
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
+WARNING: 51: c2: resource d1 is grouped, constraints should apply to the group
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata
+WARNING: 51: o2: resource d1 is grouped, constraints should apply to the group
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -132,3 +134,5 @@ op_defaults opsdef2: \
 	rule 100: #uname eq node1 \
 	record-pending=true
 .INP: commit
+WARNING: 53: c2: resource d1 is grouped, constraints should apply to the group
+WARNING: 53: o2: resource d1 is grouped, constraints should apply to the group

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -85,6 +85,7 @@ order o-d456 d4 d5 d6
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata
+WARNING: 61: loc-d1: resource d1 is grouped, constraints should apply to the group
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -121,3 +122,4 @@ property cib-bootstrap-options: \
 rsc_defaults rsc_options: \
 	failure-timeout=10m
 .INP: commit
+WARNING: 63: loc-d1: resource d1 is grouped, constraints should apply to the group

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -280,9 +280,9 @@ def test_bnc878112():
     crm configure group can hijack a cloned primitive (and then crash)
     """
     obj1 = factory.create_object('primitive', 'p1', 'Dummy')
-    assert obj1 is not None
+    assert obj1 is True
     obj2 = factory.create_object('group', 'g1', 'p1')
-    assert obj2 is not None
+    assert obj2 is True
     obj3 = factory.create_object('group', 'g2', 'p1')
     print obj3
     assert obj3 is False
@@ -476,3 +476,58 @@ def test_nodeattrs():
     exp = 'node 1: dell71 attributes staging-0-0-placement=true meta-0-0-placement=true attributes standby=off'
     assert data == exp
     assert obj.cli_use_validate()
+
+
+@with_setup(setup_func, teardown_func)
+def test_group_constraint_location():
+    """
+    configuring a constraint on a grouped resource is bad
+    """
+    factory.create_object('node', 'node1')
+    factory.create_object('primitive', 'p1', 'Dummy')
+    factory.create_object('primitive', 'p2', 'Dummy')
+    factory.create_object('group', 'g1', 'p1', 'p2')
+    factory.create_object('location', 'loc-p1', 'p1', 'inf:', 'node1')
+    c = factory.find_object('loc-p1')
+    assert c and c.check_sanity() > 0
+
+
+@with_setup(setup_func, teardown_func)
+def test_group_constraint_colocation():
+    """
+    configuring a constraint on a grouped resource is bad
+    """
+    factory.create_object('primitive', 'p1', 'Dummy')
+    factory.create_object('primitive', 'p2', 'Dummy')
+    factory.create_object('group', 'g1', 'p1', 'p2')
+    factory.create_object('colocation', 'coloc-p1-p2', 'inf:', 'p1', 'p2')
+    c = factory.find_object('coloc-p1-p2')
+    assert c and c.check_sanity() > 0
+
+
+@with_setup(setup_func, teardown_func)
+def test_group_constraint_colocation_rscset():
+    """
+    configuring a constraint on a grouped resource is bad
+    """
+    factory.create_object('primitive', 'p1', 'Dummy')
+    factory.create_object('primitive', 'p2', 'Dummy')
+    factory.create_object('primitive', 'p3', 'Dummy')
+    factory.create_object('group', 'g1', 'p1', 'p2')
+    factory.create_object('colocation', 'coloc-p1-p2-p3', 'inf:', 'p1', 'p2', 'p3')
+    c = factory.find_object('coloc-p1-p2-p3')
+    assert c and c.check_sanity() > 0
+
+
+@with_setup(setup_func, teardown_func)
+def test_clone_constraint_colocation_rscset():
+    """
+    configuring a constraint on a cloned resource is bad
+    """
+    factory.create_object('primitive', 'p1', 'Dummy')
+    factory.create_object('primitive', 'p2', 'Dummy')
+    factory.create_object('primitive', 'p3', 'Dummy')
+    factory.create_object('clone', 'c1', 'p1')
+    factory.create_object('colocation', 'coloc-p1-p2-p3', 'inf:', 'p1', 'p2', 'p3')
+    c = factory.find_object('coloc-p1-p2-p3')
+    assert c and c.check_sanity() > 0


### PR DESCRIPTION
In general, constraints should apply to the outer-most container of a resource, not resources that appear in a group, clone or m/s.

Resolves: #101 
