### PR TITLE
high: cibconfig: Allow node/rsc id collision in _set_update (bsc#948547)

### DIFF
--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -12,7 +12,9 @@ primitive p1 ocf:heartbeat:Dummy \
 	op monitor interval=120m OCF_CHECK_LEVEL=10
 filter "sed '$aprimitive p2 ocf:heartbeat:Dummy'"
 filter "sed '$agroup g1 p1 p2'"
+show
 filter "sed 's/p2/p3/;$aprimitive p3 ocf:heartbeat:Dummy'" g1
+show
 filter "sed '$aclone c1 p2'"
 filter "sed 's/p2/g1/'" c1
 filter "sed '/clone/s/g1/p2/'" c1 g1

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -9,7 +9,38 @@
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
 .INP: filter "sed '$aprimitive p2 ocf:heartbeat:Dummy'"
 .INP: filter "sed '$agroup g1 p1 p2'"
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" \
+	op start requires=nothing interval=0 \
+	op monitor interval=60m
+group g1 p1 p2
+property cib-bootstrap-options: \
+	default-action-timeout=2m
 .INP: filter "sed 's/p2/p3/;$aprimitive p3 ocf:heartbeat:Dummy'" g1
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive p3 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" \
+	op start requires=nothing interval=0 \
+	op monitor interval=60m
+group g1 p1 p3
+property cib-bootstrap-options: \
+	default-action-timeout=2m
 .INP: filter "sed '$aclone c1 p2'"
 .INP: filter "sed 's/p2/g1/'" c1
 .INP: filter "sed '/clone/s/g1/p2/'" c1 g1
@@ -26,7 +57,7 @@
 .INP: primitive d3 ocf:heartbeat:Dummy
 .INP: group g2 d1 d2
 .INP: filter "sed '/g2/s/d1/p1/;/g1/s/p1/d1/'"
-ERROR: 27: Cannot create group:g1: Child primitive:d1 already in group:g2
+ERROR: 29: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: filter "sed '/g1/s/d1/p1/;/g2/s/p1/d1/'"
 .INP: filter "sed '$alocation loc-d1 d1 rule $id=r1 -inf: not_defined webserver rule $id=r2 webserver: defined webserver'"
 .INP: filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
@@ -41,15 +72,15 @@ ERROR: 27: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: modgroup g1 add p1
 ERROR: 1: syntax in group: child p1 listed more than once in group g1 parsing 'group g1 p1 p2 d3 p1'
 .INP: modgroup g1 remove st
-ERROR: 40: configure.modgroup: st is not member of g1
+ERROR: 42: configure.modgroup: st is not member of g1
 .INP: modgroup g1 remove c1
-ERROR: 41: configure.modgroup: c1 is not member of g1
+ERROR: 43: configure.modgroup: c1 is not member of g1
 .INP: modgroup g1 remove nosuch
-ERROR: 42: configure.modgroup: nosuch is not member of g1
+ERROR: 44: configure.modgroup: nosuch is not member of g1
 .INP: modgroup g1 add c1
-ERROR: 43: a group may contain only primitives; c1 is clone
+ERROR: 45: a group may contain only primitives; c1 is clone
 .INP: modgroup g1 add nosuch
-ERROR: 44: g1 refers to missing object nosuch
+ERROR: 46: g1 refers to missing object nosuch
 .INP: filter "sed 's/^/# this is a comment\n/'" loc-d1
 .INP: rsc_defaults $id="rsc_options" failure-timeout=10m
 .INP: filter "sed 's/2m/60s/'" cib-bootstrap-options

--- a/test/unittests/__init__.py
+++ b/test/unittests/__init__.py
@@ -17,6 +17,8 @@ _here = os.path.dirname(__file__)
 config.path.sharedir = os.path.join(_here, "../../doc")
 config.path.crm_dtd_dir = os.path.join(_here, "schemas")
 
+os.environ["CIB_file"] = "test"
+
 
 # install a basic CIB
 from crmsh import cibconfig

--- a/test/unittests/__init__.py
+++ b/test/unittests/__init__.py
@@ -35,9 +35,9 @@ _CIB = """
       </cluster_property_set>
     </crm_config>
     <nodes>
-      <node id="1" uname="ha-one"/>
-      <node id="2" uname="ha-two"/>
-      <node id="3" uname="ha-three"/>
+      <node id="ha-one" uname="ha-one"/>
+      <node id="ha-two" uname="ha-two"/>
+      <node id="ha-three" uname="ha-three"/>
     </nodes>
     <resources>
     </resources>

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -570,3 +570,85 @@ def test_existing_node_resource_2():
         text2 = obj.repr()
 
     assert sorted(text.split('\n')) == sorted(text2.split('\n'))
+
+
+@with_setup(setup_func, teardown_func)
+def test_id_collision_breakage_1():
+    from crmsh import clidisplay
+
+    obj = cibconfig.mkset_obj()
+    assert obj is not None
+    with clidisplay.nopretty():
+        original_cib = obj.repr()
+    print original_cib
+
+    obj = cibconfig.mkset_obj()
+    assert obj is not None
+
+    ok = obj.save("""node node1
+primitive p0 ocf:pacemaker:Dummy
+primitive p1 ocf:pacemaker:Dummy
+primitive p2 ocf:heartbeat:Delay \
+    params startdelay=2 mondelay=2 stopdelay=2
+primitive p3 ocf:pacemaker:Dummy
+primitive st stonith:null params hostlist=node1
+clone c1 p1
+ms m1 p2
+property default-action-timeout=60s
+""")
+    assert ok
+
+    obj = cibconfig.mkset_obj()
+    assert obj is not None
+    ok = obj.save("""property default-action-timeout=2m
+node node1 \
+    attributes mem=16G
+primitive st stonith:null \
+    params hostlist='node1' \
+    meta description="some description here" \
+    op start requires=nothing \
+    op monitor interval=60m
+primitive p1 ocf:heartbeat:Dummy \
+    op monitor interval=60m \
+    op monitor interval=120m OCF_CHECK_LEVEL=10
+""")
+    assert ok
+
+    obj = cibconfig.mkset_obj()
+    with clidisplay.nopretty():
+        text = obj.repr()
+    text = text + "\nprimitive p2 ocf:heartbeat:Dummy"
+    ok = obj.save(text)
+    assert ok
+
+    obj = cibconfig.mkset_obj()
+    with clidisplay.nopretty():
+        text = obj.repr()
+    text = text + "\ngroup g1 p1 p2"
+    ok = obj.save(text)
+    assert ok
+
+    obj = cibconfig.mkset_obj("g1")
+    with clidisplay.nopretty():
+        text = obj.repr()
+    text = text.replace("group g1 p1 p2", "group g1 p1 p3")
+    text = text + "\nprimitive p3 ocf:heartbeat:Dummy"
+    ok = obj.save(text)
+    assert ok
+
+    obj = cibconfig.mkset_obj("g1")
+    with clidisplay.nopretty():
+        print obj.repr().strip()
+        assert obj.repr().strip() == "group g1 p1 p3"
+
+    obj = cibconfig.mkset_obj()
+    assert obj is not None
+    ok = obj.save(original_cib)
+    assert ok
+    obj = cibconfig.mkset_obj()
+    with clidisplay.nopretty():
+        print "*** ORIGINAL"
+        print original_cib
+        print "*** NOW"
+        print obj.repr()
+        assert original_cib == obj.repr()

--- a/test/unittests/test_objset.py
+++ b/test/unittests/test_objset.py
@@ -39,4 +39,4 @@ def test_show():
     setobj = cibconfig.mkset_obj()
     s = setobj.repr_nopretty()
     sp = s.splitlines()
-    assert_in("node 1: ha-one", sp[0:3])
+    assert_in("node ha-one", sp[0:3])

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -434,7 +434,8 @@ class TestCliParser(unittest.TestCase):
         # num test nodes are 3
 
         out = self.parser.parse('fencing_topology poison-pill power')
-        self.assertEqual("""<fencing-topology><fencing-level devices="poison-pill" index="1" target="ha-one"/><fencing-level devices="power" index="2" target="ha-one"/><fencing-level devices="poison-pill" index="1" target="ha-two"/><fencing-level devices="power" index="2" target="ha-two"/><fencing-level devices="poison-pill" index="1" target="ha-three"/><fencing-level devices="power" index="2" target="ha-three"/></fencing-topology>""", etree.tostring(out))
+        expect = '<fencing-topology><fencing-level devices="poison-pill" index="1" target="ha-one"/><fencing-level devices="power" index="2" target="ha-one"/><fencing-level devices="poison-pill" index="1" target="ha-three"/><fencing-level devices="power" index="2" target="ha-three"/><fencing-level devices="poison-pill" index="1" target="ha-two"/><fencing-level devices="power" index="2" target="ha-two"/></fencing-topology>'
+        self.assertEqual(expect, etree.tostring(out))
 
         out = self.parser.parse('fencing_topology node-a: poison-pill power node-b: ipmi serial')
         self.assertEqual(4, len(out))
@@ -661,7 +662,7 @@ class TestCliParser(unittest.TestCase):
             '<rsc_ticket id="ticket-A_m6" ticket="ticket-A" rsc="m6"/>',
             '<rsc_ticket id="ticket-B_m6_m5" ticket="ticket-B" loss-policy="fence"><resource_set><resource_ref id="m6"/><resource_ref id="m5"/></resource_set></rsc_ticket>',
             '<rsc_ticket id="ticket-C_master" ticket="ticket-C" loss-policy="fence"><resource_set><resource_ref id="m6"/></resource_set><resource_set role="Master"><resource_ref id="m5"/></resource_set></rsc_ticket>',
-            '<fencing-topology><fencing-level devices="st" index="1" target="ha-one"/><fencing-level devices="st2" index="2" target="ha-one"/><fencing-level devices="st" index="1" target="ha-two"/><fencing-level devices="st2" index="2" target="ha-two"/><fencing-level devices="st" index="1" target="ha-three"/><fencing-level devices="st2" index="2" target="ha-three"/></fencing-topology>',
+            '<fencing-topology><fencing-level devices="st" index="1" target="ha-one"/><fencing-level devices="st2" index="2" target="ha-one"/><fencing-level devices="st" index="1" target="ha-three"/><fencing-level devices="st2" index="2" target="ha-three"/><fencing-level devices="st" index="1" target="ha-two"/><fencing-level devices="st2" index="2" target="ha-two"/></fencing-topology>',
             '<cluster_property_set><nvpair name="stonith-enabled" value="true"/></cluster_property_set>',
             '<cluster_property_set id="cpset2"><nvpair name="maintenance-mode" value="true"/></cluster_property_set>',
             '<rsc_defaults><meta_attributes><nvpair name="failure-timeout" value="10m"/></meta_attributes></rsc_defaults>',


### PR DESCRIPTION
I'm a bit nervous about this change, so in order to make it stand out a bit I am making it a pull request.

The core problem is this: Pacemaker no longer enforces unique ids for nodes, and remote nodes may have associated resources with the same name as the node.

crmsh, on the other hand, has no notion of scope and has always assumed that ids are globally unique. The bugs resulting from this change may be subtle. All tests are passing, but who knows.