### PR TITLE
[UNTESTED] low: don't use deprecated crm_attribute -U option

### DIFF
--- a/modules/ui_node.py
+++ b/modules/ui_node.py
@@ -88,22 +88,22 @@ class NodeMgmt(command.UI):
     node_clear_state_118 = "stonith_admin --confirm %s"
     hb_delnode = config.path.hb_delnode + " '%s'"
     crm_node = "crm_node"
-    node_fence = "crm_attribute -t status -U '%s' -n terminate -v true"
+    node_fence = "crm_attribute -t status -N '%s' -n terminate -v true"
     dc = "crmadmin -D"
     node_attr = {
-        'set': "crm_attribute -t nodes -U '%s' -n '%s' -v '%s'",
-        'delete': "crm_attribute -D -t nodes -U '%s' -n '%s'",
-        'show': "crm_attribute -G -t nodes -U '%s' -n '%s'",
+        'set': "crm_attribute -t nodes -N '%s' -n '%s' -v '%s'",
+        'delete': "crm_attribute -D -t nodes -N '%s' -n '%s'",
+        'show': "crm_attribute -G -t nodes -N '%s' -n '%s'",
     }
     node_status = {
-        'set': "crm_attribute -t status -U '%s' -n '%s' -v '%s'",
-        'delete': "crm_attribute -D -t status -U '%s' -n '%s'",
-        'show': "crm_attribute -G -t status -U '%s' -n '%s'",
+        'set': "crm_attribute -t status -N '%s' -n '%s' -v '%s'",
+        'delete': "crm_attribute -D -t status -N '%s' -n '%s'",
+        'show': "crm_attribute -G -t status -N '%s' -n '%s'",
     }
     node_utilization = {
-        'set': "crm_attribute -z -t nodes -U '%s' -n '%s' -v '%s'",
-        'delete': "crm_attribute -z -D -t nodes -U '%s' -n '%s'",
-        'show': "crm_attribute -z -G -t nodes -U '%s' -n '%s'",
+        'set': "crm_attribute -z -t nodes -N '%s' -n '%s' -v '%s'",
+        'delete': "crm_attribute -z -D -t nodes -N '%s' -n '%s'",
+        'show': "crm_attribute -z -G -t nodes -N '%s' -n '%s'",
     }
 
     def requires(self):

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -90,7 +90,7 @@ node1: normal
 </cib>
 
 .TRY node attribute node1 set a1 "1 2 3"
-.EXT crm_attribute -t nodes -U 'node1' -n 'a1' -v '1 2 3'
+.EXT crm_attribute -t nodes -N 'node1' -n 'a1' -v '1 2 3'
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -113,7 +113,7 @@ node1: normal
 </cib>
 
 .TRY node attribute node1 show a1
-.EXT crm_attribute -G -t nodes -U 'node1' -n 'a1'
+.EXT crm_attribute -G -t nodes -N 'node1' -n 'a1'
 scope=nodes  name=a1 value=1 2 3
 .INP: configure
 .INP: _regtest on
@@ -137,7 +137,7 @@ scope=nodes  name=a1 value=1 2 3
 </cib>
 
 .TRY node attribute node1 delete a1
-.EXT crm_attribute -D -t nodes -U 'node1' -n 'a1'
+.EXT crm_attribute -D -t nodes -N 'node1' -n 'a1'
 Deleted nodes attribute: id=nodes-node1-a1 name=a1
 
 .INP: configure


### PR DESCRIPTION
crm_attribute -U was deprecated in favour of -N (--node)

N.B. I haven't tested this at all; just going on what @gao-yan told me on IRC.  So please test before merging :-)