### PR TITLE
Add the "push" Method to the "configure load" Command

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2936,8 +2936,11 @@ group vm-and-services vm vm-sshd meta container="vm"
 
 Load a part of configuration (or all of it) from a local file or
 a network URL. The +replace+ method replaces the current
-configuration with the one from the source. The +update+ tries to
-import the contents into the current configuration.
+configuration with the one from the source. The +update+ method
+tries to import the contents into the current configuration. The
++push+ method imports the contents into the current configuration
+and removes any lines that are not present in the given
+configuration.
 The file may be a CLI file or an XML file.
 
 If the URL is `-`, the configuration is read from standard input.
@@ -2946,12 +2949,13 @@ Usage:
 ...............
 load [xml] <method> URL
 
-method :: replace | update
+method :: replace | update | push
 ...............
 Example:
 ...............
 load xml update myfirstcib.xml
 load xml replace http://storage.big.com/cibs/bigcib.xml
+load xml push smallcib.xml
 ...............
 
 [[cmdhelp_configure_location,a location preference]]

--- a/modules/cibconfig.py
+++ b/modules/cibconfig.py
@@ -403,7 +403,7 @@ class CibObjectSet(object):
 
     def import_file(self, method, fname):
         '''
-        method: update or replace
+        method: update or replace or push
         '''
         if not cib_factory.is_cib_sane():
             return False
@@ -413,7 +413,10 @@ class CibObjectSet(object):
         s = f.read()
         if f != sys.stdin:
             f.close()
-        return self.save(s, no_remove=True, method=method)
+        if method == 'push':
+            return self.save(s, no_remove=False, method='update')
+        else:
+            return self.save(s, no_remove=True, method=method)
 
     def repr(self, format=format):
         '''

--- a/modules/ui_configure.py
+++ b/modules/ui_configure.py
@@ -87,7 +87,7 @@ def stonith_resource_list(args):
 
 def _load_2nd_completer(args):
     if args[1] == 'xml':
-        return ['replace', 'update']
+        return ['replace', 'update', 'push']
     return []
 
 
@@ -491,9 +491,9 @@ class CibConfig(command.UI):
         return set_obj.save_to_file(filename)
 
     @command.skill_level('administrator')
-    @command.completers(compl.choice(['xml', 'replace', 'update']), _load_2nd_completer)
+    @command.completers(compl.choice(['xml', 'replace', 'update', 'push']), _load_2nd_completer)
     def do_load(self, context, *args):
-        "usage: load [xml] {replace|update} {<url>|<path>}"
+        "usage: load [xml] {replace|update|push} {<url>|<path>}"
         if len(args) < 2:
             context.fatal_error("Expected 2 arguments (0 given)")
         if args[0] == "xml":
@@ -508,7 +508,7 @@ class CibConfig(command.UI):
             url = args[1]
             method = args[0]
             xml = False
-        if method not in ("replace", "update"):
+        if method not in ("replace", "update", "push"):
             context.fatal_error("Unknown method %s" % method)
         if method == "replace":
             if options.interactive and cib_factory.has_cib_changed():


### PR DESCRIPTION
This adds a new method called "push" to the "configure load" command of crmsh. This new method differs from replace and update in that it removes configuration lines from the running configuration that are not present in the imported content (file/URL). Similar to the behavior of "configure edit" except that you can specify an import file instead of using an interactive editor.

I've tested this new feature with Pacemaker 1.1.12 + Corosync 2.3.4 and it works as expected, and the current two methods (update and replace) still appear to work as well. Tested the auto-complete function too.

I also fixed the grammar of a line in the help text for "configure load" and provided an example line using "push" for completeness.

--Marc