### PR TITLE
Patch queue/remove fix for debian

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,12 +68,7 @@ all-local:
 		--build-base $(shell readlink -f $(builddir))/build \
 		--verbose)
 
-# Fix for GNU/Linux
-if UNAME_IS_DEBIAN
-python_prefix = 
-else
 python_prefix = --prefix=$(prefix)
-endif
 
 install-exec-local:
 	-mkdir -p $(DESTDIR)$(pkgpythondir)

--- a/configure.ac
+++ b/configure.ac
@@ -41,8 +41,6 @@ dnl command line
 dnl Wrap in m4_ifdef to avoid breaking on older platforms
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES])
 
-AM_CONDITIONAL([UNAME_IS_DEBIAN], [test x`uname -v | grep -oh Debian` = x"Debian"])
-
 AC_SUBST(OCF_ROOT_DIR)
 AC_SUBST(CRM_DAEMON_USER)
 


### PR DESCRIPTION
The fix for Debian which was added to resolve packaging issues is not necessary,  so this pull request offers the commits to remove the respective logic.

 - The `AM_CONDITIONAL` added to `configure.ac` is removed
 - The extra logic found in `Makefile.am` for setting `--prefix` is removed