### PR TITLE
Makefile.am: do not remove generated docs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,7 +78,6 @@ install-exec-local:
 		--record $(DESTDIR)$(pkgpythondir)/install_files.txt \
 		--verbose
 	$(INSTALL) -d -m 770 $(DESTDIR)/$(CRM_CACHE_DIR)
-	-rm -rf $(generated_docs) $(generated_mans)
 
 uninstall-local:
 	cat $(DESTDIR)$(pkgpythondir)/install_files.txt | xargs rm -rf


### PR DESCRIPTION
Do not remove generated docs and manuals which may cause parallel make
issue:

| rm -rf  doc/crm.8.html doc/crmsh_hb_report.8.html doc/crm.8 doc/crmsh_hb_report.8
| .../usr/bin/install: cannot stat 'doc/crm.8.html': No such file or directory

Signed-off-by: Kai Kang <kai.kang@windriver.com>