### PR TITLE
medium: config: add multiarch support for libdir

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -19,7 +19,9 @@ _PERUSER = os.getenv("CRM_CONFIG_FILE") or os.path.join(userdir.CONFIG_HOME, 'cr
 _PATHLIST = {
     'datadir': ('/usr/share', '/usr/local/share', '/opt'),
     'cachedir': ('/var/cache', '/opt/cache'),
-    'libdir': ('/usr/lib64', '/usr/libexec', '/usr/lib',
+    'libdir': ('/usr/lib64', '/usr/lib/x86_64-linux-gnu', '/usr/lib/i386-linux-gnu',
+               '/usr/libexec', '/usr/lib', '/usr/local/lib64',
+               '/usr/local/lib/x86_64-linux-gnu', '/usr/local/lib/i386-linux-gnu',
                '/usr/local/lib64', '/usr/local/libexec', '/usr/local/lib'),
     'varlib': ('/var/lib', '/opt/var/lib'),
     'wwwdir': ('/srv/www', '/var/www')


### PR DESCRIPTION
Debian and Ubuntu doesn't use the directory /usr/lib64. They switched to
a different directory structure for better multiarch support.

This also fixes a problem where crmsh can't find crmd on recent
Debian/Ubuntu 64bit installations (same as in #67) because the
autodetection doesn't find the correct crm_daemon_dir path

References:
* https://wiki.debian.org/Multiarch/
* https://wiki.ubuntu.com/MultiarchSpec