### PR TITLE
low: hb_report: Suggest user checks timeframe on empty logs (bsc#970823)

### DIFF
--- a/hb_report/hb_report.in
+++ b/hb_report/hb_report.in
@@ -1161,7 +1161,9 @@ finalword() {
 }
 
 check_if_log_is_empty() {
-	find "$1" -iname $HALOG_F | grep '.*' >/dev/null 2>&1 || warning "Report contains no logs"
+	if ! find "$1" -iname $HALOG_F | grep -q .; then
+		warning "Report contains no logs; did you get the right timeframe?"
+	fi
 }
 
 [ $# -eq 0 ] && usage


### PR DESCRIPTION
(N.B. I didn't test this yet.)

If the logs are empty, it could be because the user accidentally chose
the wrong timeframe, e.g. with `"Fri 11 16:41"`, the `11` is parsed as
the year not the date.  So suggest the user checks the timeframe
when they get an empty report.

Also use `grep`'s `-q` option which doesn't hide real errors, and use
`if` rather than `||` in the unlikely case the script is ever invoked with
the `-e` option enabled.

https://bugzilla.suse.com/show_bug.cgi?id=970823