### PR TITLE
make history example consistent with timeframe deprecation

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -4359,7 +4359,7 @@ command.
 
 Example:
 ...............
-crm(live)history# timeframe "Jul 18 12:00" "Jul 18 12:30"
+crm(live)history# limit "Jul 18 12:00" "Jul 18 12:30"
 crm(live)history# session save strange_restart
 crm(live)history# session pack
 Report saved in .../strange_restart.tar.bz2

--- a/doc/website-v1/man-1.2.adoc
+++ b/doc/website-v1/man-1.2.adoc
@@ -2982,7 +2982,7 @@ If you think you may have found a bug or just need clarification
 from developers or your support, the `session pack` command can
 help create a report. This is an example:
 ...............
-    crm(live)history# timeframe "Jul 18 12:00" "Jul 18 12:30"
+    crm(live)history# limit "Jul 18 12:00" "Jul 18 12:30"
     crm(live)history# session save strange_restart
     crm(live)history# session pack
     Report saved in .../strange_restart.tar.bz2

--- a/doc/website-v1/man-2.0.adoc
+++ b/doc/website-v1/man-2.0.adoc
@@ -4335,7 +4335,7 @@ command.
 
 Example:
 ...............
-crm(live)history# timeframe "Jul 18 12:00" "Jul 18 12:30"
+crm(live)history# limit "Jul 18 12:00" "Jul 18 12:30"
 crm(live)history# session save strange_restart
 crm(live)history# session pack
 Report saved in .../strange_restart.tar.bz2


### PR DESCRIPTION
It seems "timeframe" is deprecated in favour of "limit", so the examples should reflect that.