### PR TITLE
low: history: update the syslog format matching

### DIFF
--- a/crmsh/logtime.py
+++ b/crmsh/logtime.py
@@ -57,7 +57,7 @@ def make_time(t):
 # fmt2: group 2 is node
 # fmt3: group 2 is node
 # fmt4: node not available?
-_syslog2node_formats = (re.compile(r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d+)([+-])(\d{2}):(\d{2})\s+(?:\[\d+\])?\s*([\S]+)'),
+_syslog2node_formats = (re.compile(r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:.(\d+))?([+-])(\d{2}):?(\d{2})\s+(?:\[\d+\])?\s*([\S]+)'),
                         re.compile(r'^(\d{4}-\d{2}-\d{2}T\S+)\s+(?:\[\d+\])?\s*([\S]+)'),
                         re.compile(r'^([a-zA-Z]{2,4}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?:\[\d+\])?\s*([\S]+)'),
                         re.compile(r'^(\d{4}\/\d{2}\/\d{2}_\d{2}:\d{2}:\d{2})'))


### PR DESCRIPTION
Found the following time formats:

2016-03-23T12:46:59+0100 and
2016-03-23T12:42:00.671293+01:00

The first one wasn't matched by fmt1 in _syslog2node_formats.