### PR TITLE
high: parse: Support for event-driven alerts (fate#320855)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -47,7 +47,7 @@ from .xmlutil import cibtext2elem, is_related, check_id_ref
 from .cliformat import get_score, nvpairs2list, abs_pos_score, cli_acl_roleref, nvpair_format
 from .cliformat import cli_nvpair, cli_acl_rule, rsc_set_constraint, get_kind, head_id_format
 from .cliformat import cli_operations, simple_rsc_constraint, cli_rule, cli_format
-from .cliformat import cli_acl_role, cli_acl_permission
+from .cliformat import cli_acl_role, cli_acl_permission, cli_path
 
 
 def show_unrecognized_elems(cib_elem):
@@ -657,6 +657,7 @@ def fix_node_ids(node, oldnode):
         'rsc_location': 'location',
         'fencing-topology': 'fencing',
         'tags': 'tag',
+        'alerts': 'alert',
         }
 
     idless = set(['operations', 'fencing-topology'])
@@ -2018,6 +2019,53 @@ class CibTag(CibObject):
                          for c in self.node.iterchildren() if not is_comment(c)])
 
 
+class CibAlert(CibObject):
+    '''
+    Alert objects
+
+    TODO: check_sanity, repr_gv
+
+    FIXME: display instance / meta attributes, description
+
+    '''
+    set_names = {
+        "instance_attributes": "attributes",
+        "meta_attributes": "meta",
+    }
+
+    def _repr_cli_head(self, fmt):
+        ret = [clidisplay.keyword(self.obj_type),
+               clidisplay.ident(self.obj_id),
+               cli_path(self.node.get('path'))]
+        return ' '.join(ret)
+
+    def _repr_cli_child(self, c, format_mode):
+        if c.tag in self.set_names:
+            return self._attr_set_str(c)
+        elif c.tag == "recipient":
+            r = ["to"]
+            complex = self._is_complex()
+            if complex:
+                r.append('{')
+            r.append(cli_path(c.get('value')))
+            for subset in c.xpath('instance_attributes|meta_attributes'):
+                r.append(self._attr_set_str(subset))
+            if complex:
+                r.append('}')
+            return ' '.join(r)
+
+    def _is_complex(self):
+        '''
+        True if this alert is ambiguous wrt meta attributes in recipient tags
+        '''
+        children = [c.tag for c in self.node.xpath('recipient|instance_attributes|meta_attributes')]
+        ri = children.index('recipient')
+        if ri < 0:
+            return False
+        children = children[ri+1:]
+        return 'instance_attributes' in children or 'meta_attributes' in children
+
+
 #
 ################################################################
 
@@ -2062,6 +2110,7 @@ cib_object_map = {
     "acl_target": ("acl_target", CibAcl, "acls"),
     "acl_group": ("acl_group", CibAcl, "acls"),
     "tag": ("tag", CibTag, "tags"),
+    "alert": ("alert", CibAlert, "alerts"),
 }
 
 

--- a/crmsh/cliformat.py
+++ b/crmsh/cliformat.py
@@ -250,6 +250,10 @@ def mkrscaction(node, n):
         return rsc
 
 
+def cli_path(p):
+    return clidisplay.attr_value(quote_wrap(p))
+
+
 def boolean_maybe(v):
     "returns True/False or None"
     if v is None:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -218,6 +218,9 @@ clone_meta_attributes = (
 ms_meta_attributes = (
     "master-max", "master-node-max", "description",
 )
+alert_meta_attributes = (
+    "timeout", "timestamp-format"
+)
 trace_ra_attr = "trace_ra"
 score_types = {'advisory': '0', 'mandatory': 'INFINITY'}
 boolean_ops = ('or', 'and')

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -847,6 +847,10 @@ class CibConfig(command.UI):
     def do_tag(self, context, *args):
         return self.__conf_object(context.get_command_name(), *args)
 
+    @command.skill_level('administrator')
+    def do_alert(self, context, *args):
+        return self.__conf_object(context.get_command_name(), *args)
+
     @command.skill_level('expert')
     @command.completers_repeating(_rsc_id_list)
     def do_rsctest(self, context, *args):

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -687,7 +687,9 @@ match_list = defaultdict(tuple,
                           "op": ("name", "interval"),
                           "rule": ("score", "score-attribute", "role"),
                           "expression": ("attribute", "operation", "value"),
-                          "fencing-level": ("target", "devices")})
+                          "fencing-level": ("target", "devices"),
+                          "alert": ("path",),
+                          "recipient": ("value",)})
 
 
 def add_comment(e, s):
@@ -833,7 +835,8 @@ _sort_xml_order = make_sort_map('node',
                                 ['rsc_location', 'rsc_colocation', 'rsc_order'],
                                 ['rsc_ticket', 'fencing-topology'],
                                 'cluster_property_set', 'rsc_defaults', 'op_defaults',
-                                'acl_role', ['acl_target', 'acl_group', 'acl_user'])
+                                'acl_role', ['acl_target', 'acl_group', 'acl_user'],
+                                'alert')
 
 _sort_cli_order = make_sort_map('node',
                                 'rsc_template', 'primitive', 'group',
@@ -842,7 +845,8 @@ _sort_cli_order = make_sort_map('node',
                                 ['location', 'colocation', 'collocation', 'order'],
                                 ['rsc_ticket', 'fencing_topology'],
                                 'property', 'rsc_defaults', 'op_defaults',
-                                'role', ['acl_target', 'acl_group', 'user'])
+                                'role', ['acl_target', 'acl_group', 'user'],
+                                'alert')
 
 _SORT_LAST = 1000
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2639,6 +2639,59 @@ Example:
 acl_target joe resource_admin constraint_editor
 ................
 
+[[cmdhelp_configure_alert,Event-driven alerts]]
+==== `alert`
+
+.Version note
+****************************
+This feature is only available
+in Pacemaker 1.1.15+.
+****************************
+
+Event-driven alerts enables calling scripts whenever interesting
+events occur in the cluster (nodes joining or leaving, resources
+starting or stopping, etc.).
+
+The +path+ is an arbitrary file path to an alert script.  Existing
+external scripts used with ClusterMon resources can be used as alert
+scripts, since the interface is compatible.
+
+Each alert may have a number of receipients configured.  These will be
+passed to the script as arguments. The first recipient will also be
+passed as the +CRM_alert_recipient+ environment variable, for
+compatibility with existing scripts that only support one recipient.
+
+The available meta attributes are +timeout+ (default 30s) and
++timestamp-format+ (default `"%H:%M:%S.%06N"`).
+
+Some configurations may require each recipient to be delimited by
+brackets, to avoid ambiguity. In the example +alert-2+ below, the meta
+attribute for `timeout` is defined after the recipient, so the
+brackets are used to ensure that the meta attribute is set for the
+alert and not just the recipient. This can be avoided by setting any
+alert attributes before defining the recipients.
+
+Usage:
+...............
+alert <id> <path> \
+  [attributes <nvpair> ...] \
+  [meta <nvpair> ...] \
+  [to [{] <recipient>
+    [attributes <nvpair> ...] \
+    [meta <nvpair> ...] [}] \
+    ...]
+...............
+
+Example:
+...............
+alert alert-1 /srv/pacemaker/pcmk_alert_sample.sh \
+    to /var/log/cluster-alerts.log
+
+alert alert-2 /srv/pacemaker/example_alert.sh \
+    to { /var/log/cluster-alerts.log } \
+    meta timeout=60s
+...............
+
 [[cmdhelp_configure_cib,CIB shadow management]]
 ==== `cib`
 
@@ -3793,51 +3846,6 @@ Example:
 ...............
 tag web: p-webserver p-vip
 tag ips server-vip admin-vip
-...............
-
-[[cmdhelp_configure_alert,Event-driven alerts]]
-==== `alert`
-
-.Version note
-****************************
-This feature is only available
-in Pacemaker 1.1.15+.
-****************************
-
-Event-driven alerts enables calling scripts whenever
-interesting events occur in the cluster (nodes
-joining or leaving, resources starting or stopping,
-etc.).
-
-The +path+ is an arbitrary file path to an alert script.
-Existing external scripts used with ClusterMon resources
-can be used as alert scripts, since the interface is
-compatible.
-
-Each alert may have a number of receipients configured.
-These will be passed to the script as arguments. The
-first recipient will also be passed as the
-+CRM_alert_recipient+ environment variable, for compatibility
-with existing scripts that only support one recipient.
-
-The available meta attributes are +timeout+ (default 30s) and
-+timestamp-format+ (default `"%H:%M:%S.%06N"`).
-
-Usage:
-...............
-alert <id> <path> \
-  [attributes <nvpair> ...] \
-  [meta <nvpair> ...] \
-  [to <recipient>
-    [attributes <nvpair> ...] \
-    [meta <nvpair> ...] \
-    ...]
-...............
-
-Example:
-...............
-alert alert-1 /srv/pacemaker/pcmk_alert_sample.sh \
-    to /var/log/cluster-alerts.log
 ...............
 
 [[cmdhelp_configure_template,edit and import a configuration from a template]]

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3795,6 +3795,50 @@ tag web: p-webserver p-vip
 tag ips server-vip admin-vip
 ...............
 
+[[cmdhelp_configure_alert,Event-driven alerts]]
+==== `alert`
+
+.Version note
+****************************
+This feature is only available
+in Pacemaker 1.1.15+.
+****************************
+
+Event-driven alerts enables calling scripts whenever
+interesting events occur in the cluster (nodes
+joining or leaving, resources starting or stopping,
+etc.).
+
+The +path+ is an arbitrary file path to an alert script.
+Existing external scripts used with ClusterMon resources
+can be used as alert scripts, since the interface is
+compatible.
+
+Each alert may have a number of receipients configured.
+These will be passed to the script as arguments. The
+first recipient will also be passed as the
++CRM_alert_recipient+ environment variable, for compatibility
+with existing scripts that only support one recipient.
+
+The available meta attributes are +timeout+ (default 30s) and
++timestamp-format+ (default `"%H:%M:%S.%06N"`).
+
+Usage:
+...............
+alert <id> <path> \
+  [attributes <nvpair> ...] \
+  [meta <nvpair> ...] \
+  [to <recipient>
+    [attributes <nvpair> ...] \
+    [meta <nvpair> ...] \
+    ...]
+...............
+
+Example:
+...............
+alert alert-1 /srv/pacemaker/pcmk_alert_sample.sh \
+    to /var/log/cluster-alerts.log
+...............
 
 [[cmdhelp_configure_template,edit and import a configuration from a template]]
 ==== `template`

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -266,3 +266,24 @@ def test_is_value_sane():
 @with_setup(setup_func, teardown_func)
 def test_is_value_sane_2():
     roundtrip('primitive p1 dummy params state="bo\\"o"')
+
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_1():
+    roundtrip('alert alert1 "/tmp/foo.sh" to "/tmp/bar.log"')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_2():
+    roundtrip('alert alert2 "/tmp/foo.sh" attributes foo=bar to "/tmp/bar.log"')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_3():
+    roundtrip('alert alert3 "a path here" meta baby to "/tmp/bar.log"')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_4():
+    roundtrip('alert alert4 "/also/a/path"')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_5():
+    roundtrip('alert alert5 "/a/path" to { "/another/path" } meta timeout=30s')

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -474,6 +474,26 @@ class TestCliParser(unittest.TestCase):
         self.assertEqual(out.get('id'), 'tag1')
         self.assertEqual(['foo', 'bar'], out.xpath('/tag/obj_ref/@id'))
 
+    def test_alerts(self):
+        "Test alerts (1.1.15+)"
+        out = self._parse('alert alert1 /tmp/foo.sh to /tmp/bar.log')
+        self.assertEqual(out.get('id'), 'alert1')
+        self.assertEqual(['/tmp/foo.sh'],
+                         out.xpath('/alert/@path'))
+        self.assertEqual(['/tmp/bar.log'],
+                         out.xpath('/alert/recipient/@value'))
+
+    def test_alerts_brackets(self):
+        "Test alerts w/ brackets (1.1.15+)"
+        out = self._parse('alert alert2 /tmp/foo.sh to { /tmp/bar.log meta timeout=10s }')
+        self.assertEqual(out.get('id'), 'alert2')
+        self.assertEqual(['/tmp/foo.sh'],
+                         out.xpath('/alert/@path'))
+        self.assertEqual(['/tmp/bar.log'],
+                         out.xpath('/alert/recipient/@value'))
+        self.assertEqual(['10s'],
+                         out.xpath('/alert/recipient/meta_attributes/nvpair[@name="timeout"]/@value'))
+
     def _parse_lines(self, lines):
         out = []
         for line in lines2cli(lines):


### PR DESCRIPTION
For a description of the alerts feature, see http://clusterlabs.org/pipermail/users/2016-April/002762.html

Bugs non-withstanding, the feature should now be fully supported by this PR.
