### PR TITLE
ability to install crmsh using pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(name='crmsh',
       author='Kristoffer Gronlund',
       author_email='kgronlund@suse.com',
       url='http://crmsh.github.io/',
-      packages=['crmsh'])
+      packages=['crmsh'],
+      scripts=['crm'])


### PR DESCRIPTION
Even though crmsh is not in pypi, I should be to install crm directly from github using pip.

With the current `setup.py` file the packages are installed but the command-line interface isn't.

Using this PR I can install locally using
```
$ cd ~/Projects/github/steenzout/crmsh
$ virtualenv env
$ source env/bin/activate
$ pip install -r requirements.txt
$ python setup.py install
$ which crm
~/Projects/github/steenzout/crmsh/env/bin/crm
```

Demo using my own branch and using pip pointing directly from github:
```
$ cd ~/
$ virtualenv env2
$ source env2/bin/activate

# I'll make another PR that will make this step obsolete
$ pip install -r ~/Projects/github/steenzout/crmsh/requirements.txt

$ pip install -e git+git://github.com/steenzout/crmsh.git@steenzout-setup-scripts#egg=crmsh

$ $ which crm
~/Projects/github/steenzout/crmsh/env2/bin/crm
```