### PR TITLE
tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ patches/*
 contrib/build/
 contrib/dist/
 contrib/pygments_crmsh_lexers.egg-info/
+
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,15 @@
 sudo: false
 language: python
 python:
-  - "2.6"
-  - "2.7"
+  - 2.6
+  - 2.7
+
 install:
-  - "pip install -r requirements.txt"
-script: ./test/run --with-coverage
+  - pip install tox-travis
+
+script:
+  - tox
+
 notifications:
   irc:
     channels:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = {py26,py27}
+skipsdist = True
+
+
+[testenv]
+usedevelop = True
+deps =
+    -rrequirements.txt
+
+passenv = HOME
+
+commands =
+    sh test/run --with-coverage
+
+whitelist_externals =
+    /bin/sh


### PR DESCRIPTION
- use [tox](http://tox.readthedocs.io) to setup Python 2.6 and 2.7 virtualenvs and easily run tests against both
- make travis-ci use tox to run its tests
- ignore .tox directory when virtualenvs are created
