### PR TITLE
parse: Use original _TARGET_RE

### DIFF
--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -40,7 +40,7 @@ _TEMPLATE_RE = re.compile(r'@(.+)$')
 _RA_TYPE_RE = re.compile(r'[a-z0-9_:-]+$', re.IGNORECASE)
 _TAG_RE = re.compile(r"([a-zA-Z_][^\s:]*):?$")
 _ROLE2_RE = re.compile(r"role=(.+)$", re.IGNORECASE)
-_TARGET_RE = re.compile(r'([\w=-]+):$')
+_TARGET_RE = re.compile(r'([^:]+):$')
 _TARGET_ATTR_RE = re.compile(r'attr:([\w-]+)=([\w-]+)$', re.IGNORECASE)
 TERMINATORS = ('params', 'meta', 'utilization', 'operations', 'op', 'rule', 'attributes')
 


### PR DESCRIPTION
Commits 65fa115874f4fac5020eb4ffda9d8ee6db69dda1 and f971e47e248aee1649c3c04a3a53937bff894149
changed _TARGET_RE from r'([^:]+):$' to r'([\w=-]+):$'. The new regular expression no longer accepts
many character the old one would. One character for example is '.', which could be in the target
name if fully qualified domain names are used for the node names.

If it is more desired to keep the regex restrictive it could be changed to r'([\w=\.-]+):$' to allow '.' but that would still restrict characters which were once allowed but might not be legal in the node name.