### PR TITLE
low: Fix a setting example of the alert to become the error

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2688,8 +2688,8 @@ alert alert-1 /srv/pacemaker/pcmk_alert_sample.sh \
     to /var/log/cluster-alerts.log
 
 alert alert-2 /srv/pacemaker/example_alert.sh \
-    to { /var/log/cluster-alerts.log } \
-    meta timeout=60s
+    meta timeout=60s \
+    to { /var/log/cluster-alerts.log }
 ...............
 
 [[cmdhelp_configure_cib,CIB shadow management]]


### PR DESCRIPTION
can not describe this setting example when I obey relaxng rule of Pacemaker .