### PR TITLE
dev: Run regression test suite on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,29 @@
 ---
-sudo: false
+sudo: required
+dist: trusty
 language: python
 python:
-  - 2.6
-  - 2.7
+  - "2.6"
+  - "2.7_with_system_site_packages"
+
+before_install:
+  - sudo add-apt-repository ppa:syseleven-platform/linux-ha -y
+  - sudo apt-get -qq update
+  - sudo apt-get install -y pacemaker libcluster-glue-dev automake autoconf python-lxml python-dateutil python-setuptools python-yaml asciidoc pkg-config
+  - sudo dpkg -r --force-depends crmsh
 
 install:
   - pip install tox-travis
 
 script:
   - tox
+  - test/travis-tests.sh
+
+after_failure:
+  - sudo cat $TRAVIS_BUILD_DIR/crmtestout/regression.out $TRAVIS_BUILD_DIR/crmtestout/crm.* /etc/apt/sources.list
+  - lsb_release -a
+  - whoami
+  - printenv | sort
 
 notifications:
   irc:

--- a/data-manifest
+++ b/data-manifest
@@ -127,6 +127,8 @@ test/testcases/scripts.filter
 test/testcases/shadow
 test/testcases/shadow.exp
 test/testcases/xmlonly.sh
+test/travis-expected-pacemaker-1.1.12.patch
+test/travis-tests.sh
 test/unittests/bug-862577_corosync.conf
 test/unittests/corosync.conf.1
 test/unittests/corosync.conf.2

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,4 @@ setup(name='crmsh',
       install_requires=['parallax', 'lxml', 'PyYAML', 'python-dateutil'],
       scripts=['crm'],
       data_files=[('/usr/share/crmsh', ['doc/crm.8.adoc'])],
-      include_package_data = True)
+      include_package_data=True)

--- a/test/evaltest.sh
+++ b/test/evaltest.sh
@@ -3,7 +3,7 @@
 # See COPYING for license information.
 
 : ${TESTDIR:=testcases}
-: ${CRM:=/usr/sbin/crm}
+: ${CRM:=crm}
 CRM_NO_REG="$CRM"
 CRM="$CRM -R"
 export PYTHONUNBUFFERED=1

--- a/test/regression.sh
+++ b/test/regression.sh
@@ -195,6 +195,6 @@ if egrep -wv '(BEGIN|END) testcase' $OUTF >/dev/null
 then
 	echo "seems like some tests failed or else something not expected"
 	echo "check $OUTF and diff files in $OUTDIR"
-	echo "in case you wonder what lrmd was doing, read $CRM_LOGF and $CRM_DEBUGF"
+	echo "in case you wonder what lrmd was doing, read $(abspath $CRM_LOGF) and $(abspath $CRM_DEBUGF)"
 	exit 1
 fi >&3

--- a/test/testcases/history.excl
+++ b/test/testcases/history.excl
@@ -1,1 +1,3 @@
 ^ptest.*:
+^\.EXT tar -C ['][^']+['] -cj -f ['][^']+['] _crmsh_regtest
+^Report saved in ['][^']+

--- a/test/testcases/history.exp
+++ b/test/testcases/history.exp
@@ -379,8 +379,6 @@ d1
 .INP: session
 current session: _crmsh_regtest
 .INP: session pack
-.EXT tar -C '/var/cache/crm/history-root/session/_crmsh_regtest/..' -cj -f '/root/_crmsh_regtest.tar.bz2' _crmsh_regtest
-Report saved in '/root/_crmsh_regtest.tar.bz2'
 .TRY History 2
 .INP: history
 .INP: session load _crmsh_regtest

--- a/test/travis-expected-pacemaker-1.1.12.patch
+++ b/test/travis-expected-pacemaker-1.1.12.patch
@@ -1,0 +1,93 @@
+--- a/test/testcases/edit.exp	2016-10-20 22:50:33.744542999 +0000
++++ b/test/testcases/edit.exp	2016-10-20 22:50:39.591102718 +0000
+@@ -83,3 +83,6 @@
+ ERROR: 46: g1 refers to missing object nosuch
+-.INP: filter "sed 's/^/# this is a comment\n/'" loc-d1
++.INP: filter "sed 's/^/# this is a comment
++ERROR: 47: configure.modgroup: No closing quotation
++.INP: /'" loc-d1
++ERROR: 48: configure.modgroup: No closing quotation
+ .INP: rsc_defaults $id="rsc_options" failure-timeout=10m
+--- a/test/testcases/resource.exp	2016-10-20 22:50:33.768542999 +0000
++++ b/test/testcases/resource.exp	2016-10-20 22:51:02.357001702 +0000
+@@ -136,4 +136,2 @@
+ .EXT crm_resource -r 'p0' -p 'a0' -v '1 2 3'
+-
+-Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0=1 2 3
+ .INP: configure
+@@ -181,3 +179,3 @@
+ .EXT crm_resource -r 'p0' -d 'a0'
+-Deleted 'p0' option: id=p0-instance_attributes-a0 name=a0
++Deleted p0 option: id=p0-instance_attributes-a0 name=a0
+ .INP: configure
+@@ -201,4 +199,2 @@
+ .EXT crm_resource --meta -r 'p0' -p 'm0' -v '123'
+-
+-Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0=123
+ .INP: configure
+@@ -248,3 +244,3 @@
+ .EXT crm_resource --meta -r 'p0' -d 'm0'
+-Deleted 'p0' option: id=p0-meta_attributes-m0 name=m0
++Deleted p0 option: id=p0-meta_attributes-m0 name=m0
+ .INP: configure
+@@ -922,3 +918,2 @@
+ .EXT crm_simulate -sUL
+-3 of 6 resources DISABLED and 0 BLOCKED from being started due to failures
+ 
+@@ -932,3 +927,3 @@
+      Stopped: [ node1 ]
+- p3	(ocf::heartbeat:Dummy):	Stopped ( disabled ) 
++ p3	(ocf::heartbeat:Dummy):	Stopped 
+  Master/Slave Set: msg [g]
+--- a/test/testcases/ra.exp	2016-10-20 22:50:33.764542999 +0000
++++ b/test/testcases/ra.exp	2016-10-20 22:51:07.084514246 +0000
+@@ -24,8 +24,5 @@
+ 
+-state (string, [/var/run/Dummy-Dummy.state]): State file
++state (string, [/var/run//Dummy-{OCF_RESOURCE_INSTANCE}.state]): State file
+     Location to store the resource state in.
+ 
+-passwd (string): Password
+-    Fake password field
+-
+ fake (string, [dummy]): 
+@@ -37,10 +34,2 @@
+ 
+-fail_start_on (string): Report bogus start failure on specified host
+-    Start actions will return failure if running on the host specified here, but
+-    the resource will start successfully anyway (future monitor calls will find it
+-    running). This can be used to test on-fail=ignore.
+-
+-envfile (string): Environment dump file
+-    If this is set, the environment will be dumped to this file for every call.
+-
+ Operations' defaults (advisory minimum):
+@@ -74,2 +63,5 @@
+ 
++stonith-timeout (time, [60s]): How long to wait for the STONITH action to complete per a stonith device.
++    Overrides the stonith-timeout cluster property
++
+ priority (integer, [0]): The priority of the stonith resource. Devices are tried in order of highest priority to lowest.
+@@ -87,10 +79,2 @@
+ 
+-pcmk_delay_max (time, [0s]): Enable random delay for stonith actions and specify the maximum of random delay
+-    This prevents double fencing when using slow devices such as sbd.
+-    Use this to enable random delay for stonith actions and specify the maximum of random delay.
+-
+-pcmk_action_limit (integer, [1]): The maximum number of actions can be performed in parallel on this device
+-    Pengine property concurrent-fencing=true needs to be configured first.
+-    Then use this to specify the maximum number of actions can be performed in parallel on this device. -1 is unlimited.
+-
+ pcmk_reboot_action (string, [reboot]): Advanced use only: An alternate command to run instead of 'reboot'
+--- a/test/testcases/newfeatures.exp	2016-10-20 22:50:33.756542999 +0000
++++ b/test/testcases/newfeatures.exp	2016-10-20 22:51:11.803701832 +0000
+@@ -18,2 +18,3 @@
+ .INP: alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh         attributes         trap_add_hires_timestamp_oid="false"         trap_node_states="non-trap"         trap_resource_tasks="start,stop,monitor,promote,demote"         to "192.168.40.9"
++ERROR: 17: alert not supported by the RNG schema
+ .INP: show tag:ones and type:location
+@@ -44,5 +45,2 @@
+ 	stonith-enabled=no
+-alert notify_9 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
+-	attributes trap_add_hires_timestamp_oid=false trap_node_states=non-trap trap_resource_tasks="start,stop,monitor,promote,demote" \
+-	to 192.168.40.9
+ .INP: _test

--- a/test/travis-tests.sh
+++ b/test/travis-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ev
+patch -p1 < test/travis-expected-pacemaker-1.1.12.patch
+./autogen.sh
+./configure --prefix=/usr
+sudo make install
+sudo cp -f /usr/bin/crm /usr/sbin/crm
+if [  "$TRAVIS_PYTHON_VERSION" = "2.7_with_system_site_packages" ]; then
+	pip -v --isolated install parallax
+	sudo /usr/share/crmsh/tests/regression.sh
+	cd /usr/share/crmsh/tests
+	sudo ./cib-tests.sh
+fi


### PR DESCRIPTION
Travis runs on Ubuntu trusty, which is limited to Pacemaker 1.1.12. The regression tests are unfortunately somewhat dependent on the Pacemaker version, and tend to follow the latest release. So we have to patch the expected output to match what we get when running against 1.1.12.

