### PR TITLE
Fix crm path

### DIFF
--- a/hb_report/utillib.sh
+++ b/hb_report/utillib.sh
@@ -524,7 +524,7 @@ crmconfig() {
 		CIB_file=$1/$CIB_F crm configure show >$1/$CIB_TXT_F 2>&1
 }
 get_crm_nodes() {
-	/usr/sbin/crm node server
+	crm node server
 }
 get_live_nodes() {
 	if [ `id -u` = 0 ] && which fping >/dev/null 2>&1; then


### PR DESCRIPTION
crm moved from /usr/sbin to /usr/bin causing an error:

```
# crm report -f 2pm report_1
/usr/share/crmsh/hb_report/hb_report: 527: /usr/share/crmsh/hb_report/hb_report: /usr/sbin/crm: not found
sid1: ERROR: could not figure out a list of nodes; is this a cluster node?
```
