### PR TITLE
give the op's hint when type tab after 'op'

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -174,7 +174,7 @@ def _prim_op_completer(agent, args):
     if completing == 'op':
         return ['op']
     if args[-2] == 'op':
-        return constants.op_cli_names
+        return list(constants.op_cli_names)
 
     return []
 


### PR DESCRIPTION
When I add a new primitive resource and when I want add 'op' to this resource,
I input 'tab' after 'op', but the shell does not give me the hints, for example, "start", "stop" and "monitor"
So, I make the change

Regards,
Xin