### PR TITLE
remove bindnetaddr for unicast(bsc#1030437)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -678,19 +678,13 @@ Configure Corosync (unicast):
         if not confirm("%s already exists - overwrite?" % (corosync.conf())):
             return
 
-    bindnetaddr = prompt_for_string(
-        'Network address to bind to (e.g.: 192.168.1.0)',
-        r'([0-9]+\.){3}[0-9]+', _context.ip_network)
-    if not bindnetaddr:
-        error("No value for bindnetaddr")
-
     mcastport = prompt_for_string('Port', '[0-9]+', "5405")
     if not mcastport:
         error("No value for mcastport")
 
     corosync.create_configuration(
         clustername=_context.cluster_name,
-        bindnetaddr=bindnetaddr,
+        bindnetaddr=None,
         mcastport=mcastport,
         transport="udpu")
     csync2_update(corosync.conf())

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -484,7 +484,7 @@ totem {
 
     interface {
         ringnumber:     0
-        bindnetaddr:    %(bindnetaddr)s
+        %(bindnetaddr)s
 %(mcast)s
         ttl:        1
     }
@@ -542,10 +542,15 @@ def create_configuration(clustername="hacluster",
     if transport is not None:
         transport_tmpl = "    transport: {}\n".format(transport)
 
+    if bindnetaddr is None:
+        bindnetaddr_tmpl = ""
+    else:
+        bindnetaddr_tmpl = "bindnetaddr: %s" % bindnetaddr
+
     config = {
         "clustername": clustername,
         "nodelist": nodelist_tmpl,
-        "bindnetaddr": bindnetaddr,
+        "bindnetaddr": bindnetaddr_tmpl,
         "mcast": mcast_tmpl,
         "transport": transport_tmpl,
     }


### PR DESCRIPTION
In a two-node cluster, I 've one node configured with open-vswtich:
5: br-fixed: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue
state UNKNOWN group default
inet 192.168.124.88/24 scope global br-fixed
inet 192.168.124.87/24 scope global secondary br-fixed

In this case, if you use unicast, and set both nodelist and bindnetaddr,
corosync will mess up the address in some condition, and Jan Friesse
also pointed that specifiing both bind addr and nodelist is kind of "not
very often used" configuration.

This patch removes bindnetaddr for unicast.