### PR TITLE
complete change about 'crm ra list [classes]'

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -237,6 +237,8 @@ def ra_providers_all(ra_class="ocf"):
     '''
     List of providers for a class.
     '''
+    if ra_class != "ocf":
+        return []
     ident = "ra_providers_all-%s" % ra_class
     if cache.is_cached(ident):
         return cache.retrieve(ident)


### PR DESCRIPTION
lsb, service, stonith and systemd don't have any providers;
so, it shouldn't be completed when type 'tab' after these ra classes.