### PR TITLE
Feature: add versioned operations support

### DIFF
--- a/crmsh/cliformat.py
+++ b/crmsh/cliformat.py
@@ -44,23 +44,6 @@ def nvpair_format(n, v):
                          clidisplay.attr_value(quote_wrap(v))))
 
 
-def cli_operations(node, break_lines=True):
-    l = []
-    node_id = node.get("id")
-    s = ''
-    if node_id:
-        s = nvpair_format('$id', node_id)
-    idref = node.get("id-ref")
-    if idref:
-        s = '%s %s' % (s, nvpair_format('$id-ref', idref))
-    if s:
-        l.append("%s %s" % (clidisplay.keyword("operations"), s))
-    for c in node.iterchildren():
-        if c.tag == "op":
-            l.append(cli_op(c))
-    return cli_format(l, break_lines=break_lines)
-
-
 def cli_nvpair(nvp):
     'Converts an nvpair tag or a (name, value) pair to CLI syntax'
     from .cibconfig import cib_factory
@@ -100,27 +83,6 @@ def nvpairs2list(node, add_id=False):
         ret.append(xmlutil.nvpair('$id', node.get('id')))
     ret.extend(nvpairs)
     return ret
-
-
-def op_instattr(node):
-    """
-    Return nvpairs in <op><instance_attributes>...
-    """
-    pl = []
-    for c in node.xpath('./instance_attributes'):
-        pl.extend(nvpairs2list(c))
-    return pl
-
-
-def cli_op(node):
-    "CLI format for an <op> tag"
-    action, pl = xmlutil.op2list(node)
-    if not action:
-        return ""
-    ret = ["%s %s" % (clidisplay.keyword("op"), action)]
-    ret += [nvpair_format(n, v) for n, v in pl]
-    ret += [cli_nvpair(v) for v in op_instattr(node)]
-    return ' '.join(ret)
 
 
 def date_exp2cli(node):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -661,11 +661,13 @@ class CibConfig(command.UI):
     @command.alias('resource')
     def do_primitive(self, context, *args):
         """usage: primitive <rsc> {[<class>:[<provider>:]]<type>|@<template>}
-        [params <param>=<value> [<param>=<value>...]]
+        [[params] <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]
         [utilization <attribute>=<value> [<attribute>=<value>...]]
         [operations id_spec
-            [op op_type [<attribute>=<value>...] ...]]"""
+            [op op_type [<attribute>=<value>...]
+                        [[op_params] <param>=<value> [<param>=<value>...]]
+                        [op_meta <attribute>=<value> [<attribute>=<value>...]] ...]]"""
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('administrator')

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3705,7 +3705,9 @@ primitive <rsc> {[<class>:[<provider>:]]<type>|@<template>}
   [meta attr_list]
   [utilization attr_list]
   [operations id_spec]
-    [op op_type [<attribute>=<value>...] ...]
+    [op op_type [<attribute>=<value>...]
+                [[op_params] attr_list]
+                [op_meta attr_list] ...]
 
 attr_list :: [$id=<id>] [<score>:] [rule...]
              <attr>=<val> [<attr>=<val>...]] | $id-ref=<id>
@@ -3740,6 +3742,10 @@ primitive mySpecialRsc Special \
   params 2: rule #uname eq node2 interface=eth2 port=8888 \
   params 1: interface=eth0 port=9999
 
+primitive A ocf:pacemaker:Dummy \
+  op start \
+    op_meta 2: rule #ra-version version:gt 1.0 timeout=120s \
+    op_meta 1: timeout=60s
 ...............
 
 [[cmdhelp_configure_property,set a cluster property]]

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -57,7 +57,8 @@ primitive d1 Dummy
 primitive d3 Dummy
 primitive p1 Dummy \
 	op monitor interval=60m \
-	op monitor interval=120m OCF_CHECK_LEVEL=10
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
 primitive p2 Dummy
 primitive p3 Dummy
 primitive st stonith:null \

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -37,7 +37,12 @@ ms m5 s5
 ms m6 s6
 primitive d7 Dummy \
 	params rule inf: #uname eq node1 fake=1 \
-	params rule inf: #uname eq node2 fake=2
+	params rule inf: #uname eq node2 fake=2 \
+	op start interval=0 timeout=60s \
+	op_params 2: rule #uname eq node1 op_param=dummy \
+	op_params 1: op_param=smart \
+	op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m \
+	op_meta 1: start-delay=60m
 location l1 g1 100: node1
 location l2 c \
 	rule $id=l2-rule1 100: #uname eq node1

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -68,7 +68,8 @@ node node2 \
 primitive d1 ocf:pacemaker:Dummy \
 	operations $id=d1-ops \
 	op monitor interval=60m \
-	op monitor interval=120m OCF_CHECK_LEVEL=10 \
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10 \
 	op monitor interval=60s timeout=30s
 primitive d2 Delay \
 	params mondelay=45 \

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -24,7 +24,7 @@
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
 .INP: ms m5 s5
 .INP: ms m6 s6
-.INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2
+.INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
 .INP: location l1 g1 100: node1
 .INP: location l2 c 	rule $id=l2-rule1 100: #uname eq node1
 .INP: location l3 m5 	rule inf: #uname eq node1 and pingd gt 0
@@ -80,7 +80,12 @@ primitive d3 ocf:pacemaker:Dummy
 primitive d4 ocf:pacemaker:Dummy
 primitive d7 Dummy \
 	params rule #uname eq node1 fake=1 \
-	params rule #uname eq node2 fake=2
+	params rule #uname eq node2 fake=2 \
+	op start interval=0 timeout=60s \
+	op_params 2: rule #uname eq node1 op_param=dummy \
+	op_params 1: op_param=smart \
+	op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m \
+	op_meta 1: start-delay=60m
 primitive s5 ocf:pacemaker:Stateful \
 	operations  $id-ref=d1-ops
 primitive s6 ocf:pacemaker:Stateful \

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -14,7 +14,8 @@ node node1 \
 	attributes mem=16G
 primitive p1 Dummy \
 	op monitor interval=60m \
-	op monitor interval=120m OCF_CHECK_LEVEL=10
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
 primitive p2 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
@@ -30,7 +31,8 @@ node node1 \
 	attributes mem=16G
 primitive p1 Dummy \
 	op monitor interval=60m \
-	op monitor interval=120m OCF_CHECK_LEVEL=10
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
 primitive p2 Dummy
 primitive p3 Dummy
 primitive st stonith:null \
@@ -127,7 +129,8 @@ primitive d5 Dummy
 primitive d6 Dummy
 primitive p1 Dummy \
 	op monitor interval=60m \
-	op monitor interval=120m OCF_CHECK_LEVEL=10
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
 primitive p2 Dummy
 primitive p3 Dummy
 primitive st stonith:null \

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -236,6 +236,16 @@ def test_param_rules():
 
 
 @with_setup(setup_func, teardown_func)
+def test_operation_rules():
+    roundtrip('primitive test Dummy ' +
+              'op start interval=0 '
+              'op_params 2: rule #uname eq node1 fake=fake ' +
+              'op_params 1: fake=real ' +
+              'op_meta 2: rule #ra-version version:gt 1.0 timeout=120s ' +
+              'op_meta 1: timeout=60s')
+
+
+@with_setup(setup_func, teardown_func)
 def test_multiple_attrsets():
     roundtrip('primitive mySpecialRsc me:Special ' +
               'params 3: interface=eth1 ' +


### PR DESCRIPTION
This PR is to support versioned operations recently introduced by [#1127](https://github.com/ClusterLabs/pacemaker/pull/1127).

The syntax is as follows:
```
configure primitive A ocf:pacemaker:Dummy \
  op start \
    op_params 2: rule #ra-version version:lt 2.0 fake=real \
    op_params 1: fake=fake \
    op_meta 2: rule #ra-version version:gte 1.0 timeout=40s \
    op_meta 1: timeout=20s
```
generates
```
<primitive id="A" class="ocf" provider="pacemaker" type="Dummy">
  <operations>
    <op name="start" interval="0" id="A-start-0">
      <instance_attributes score="2" id="A-start-0-instance_attributes">
        <rule score="INFINITY" id="A-start-0-instance_attributes-rule">
          <expression attribute="#ra-version" operation="lt" value="2.0" type="version" id="A-start-0-instance_attributes-rule-expression"/>
        </rule>
        <nvpair name="fake" value="real" id="A-start-0-instance_attributes-fake"/>
      </instance_attributes>
      <instance_attributes score="1" id="A-start-0-instance_attributes-0">
        <nvpair name="fake" value="fake" id="A-start-0-instance_attributes-0-fake"/>
      </instance_attributes>
      <meta_attributes score="2" id="A-start-0-meta_attributes">
        <rule score="INFINITY" id="A-start-0-meta_attributes-rule">
          <expression attribute="#ra-version" operation="gte" value="1.0" type="version" id="A-start-0-meta_attributes-rule-expression"/>
        </rule>
        <nvpair name="timeout" value="40s" id="A-start-0-meta_attributes-timeout"/>
      </meta_attributes>
      <meta_attributes score="1" id="A-start-0-meta_attributes-0">
        <nvpair name="timeout" value="20s" id="A-start-0-meta_attributes-0-timeout"/>
      </meta_attributes>
    </op>
  </operations>
</primitive>
```

I think it's a good thing to be compatible with the former syntax as input:
```
primitive db0 mysql \
  params config=/etc/mysql/db0.conf \
  op monitor interval=60s \
  op monitor interval=300s OCF_CHECK_LEVEL=10
```
But I also think we should represent this with _crm configure show_ using the new one:
```
primitive db0 mysql \
  params config=/etc/mysql/db0.conf \
  op monitor interval=60s \
  op monitor interval=300s \
  op_params OCF_CHECK_LEVEL=10
```
That's why I've changed some of the tests.
