### PR TITLE
Take off the completion limit for resource agent params help messages

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -125,15 +125,8 @@ class CompletionHelp(object):
     '''
     Print some help on whatever last word in the line.
     '''
-    timeout = 60  # don't print again and again
-    laststamp = 0
-    lasttopic = ''
-
     @classmethod
     def help(cls, topic, helptxt):
-        if cls.lasttopic == topic and \
-                time.time() - cls.laststamp < cls.timeout:
-            return
         if helptxt:
             import readline
             cmdline = readline.get_line_buffer()
@@ -143,8 +136,6 @@ class CompletionHelp(object):
                                 cmdline),
             else:
                 print "%s%s" % (constants.prompt, cmdline),
-            cls.laststamp = time.time()
-            cls.lasttopic = topic
 
 
 def _prim_params_completer(agent, args):


### PR DESCRIPTION
Hi:
  I know the codes I removed means simplify the output,
  the help message wouldn't fill full of the terminal;

  What's I mean is that: **Completion rule should be unified.**

  For example:
  1) User input crm->configure, and type "Tab" many times,
     then configure complete results output every time

  2) User input crm->configure primitive vip ocf:Heartbeat:IPaddr,
     and just type "Tab", do not input space or "2", 
     complete results "ocf:Heartbeat:IPaddr   ocf:Heartbeat:IPaddr2" will be completed all the way

  So, when User input crm->configure primitive vip ocf:Heartbeat:IPaddr params ip=
  and just type "Tab", if there have help message, just let it show;
  We have inputs history, people would not lost.

  I think that can make user less confued:)

  Regards
  Xin