### PR TITLE
Take off the completion limit for resource agent params help messages

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -125,15 +125,8 @@ class CompletionHelp(object):
     '''
     Print some help on whatever last word in the line.
     '''
-    timeout = 60  # don't print again and again
-    laststamp = 0
-    lasttopic = ''
-
     @classmethod
-    def help(cls, topic, helptxt):
-        if cls.lasttopic == topic and \
-                time.time() - cls.laststamp < cls.timeout:
-            return
+    def help(cls, helptxt):
         if helptxt:
             import readline
             cmdline = readline.get_line_buffer()
@@ -143,8 +136,6 @@ class CompletionHelp(object):
                                 cmdline),
             else:
                 print "%s%s" % (constants.prompt, cmdline),
-            cls.laststamp = time.time()
-            cls.lasttopic = topic
 
 
 def _prim_params_completer(agent, args):
@@ -154,7 +145,7 @@ def _prim_params_completer(agent, args):
     if completing.endswith('='):
         if len(completing) > 1 and options.interactive:
             topic = completing[:-1]
-            CompletionHelp.help(topic, agent.meta_parameter(topic))
+            CompletionHelp.help(agent.meta_parameter(topic))
         return []
     elif '=' in completing:
         return []

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -182,7 +182,7 @@ class Context(object):
             return word.split()[-1].startswith(text)
 
         line = utils.get_line_buffer() + readline.get_line_buffer()
-        if line != self._rl_line:
+        if line != self._rl_line or line.endswith("="):
             try:
                 self._rl_line = line
                 completions = self.complete(line)


### PR DESCRIPTION
hi krig:
    I changed this patch and create PR again :)
    I think it's important to keep the completion rule simple and consistent;
    That can make crmsh use more **fluently**

   BTW，take another case for example:

   user input "crm->" and "configure primitive vip ocf:Heartbeat:IPaddr ip=" and Tab,
   there are some help messages line out,
   and then, user delete the input line, and use some other command,
   and last, this user input "configure primitive vip ocf:Heartbeat:IPaddr ip=" and Tab again,
   if the time gap less than 1 min, no help messages out
  **That is not fluently use** 

Regards,
    xin