### PR TITLE
medium: ui_context: Make all the options can be completed

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -136,6 +136,10 @@ class Context(object):
                                 ret = [t for t in ret if t.startswith(tokens[-1])]
                             else:
                                 ret = [t for t in ret]
+
+                        if not ret or self.command_info.aliases:
+                            if not token in self.current_level().get_completions():
+                                return self.current_level().get_completions()
                         return ret
                 # reached the end on a valid level.
                 # return the completions for the previous level.


### PR DESCRIPTION
  Currently, not all the options can be completed by 'Tab', for example:
    crm->configure->verify
    crm->configure->back
    crm->configure->master
    crm->cluster->init
  Maybe because the subcommand doesn't have completer yet;
  Maybe because the subcommand itself is an alias of other command;

  This commit will completed all of the options.