### PR TITLE
medium: ui_ra: Improve resource agents completion

### DIFF
--- a/crmsh/ui_ra.py
+++ b/crmsh/ui_ra.py
@@ -8,27 +8,60 @@ from . import utils
 from . import ra
 from . import constants
 from . import options
-
+import re
 
 def complete_class_provider_type(args):
     '''
-    This is just too complicated to complete properly...
+    When need to show the agent supported by cluster,
+    grouped by different classes or providers, Tab by Tab,
+    instead of completing all the agents at one time.
+
+    First completion:  agent classes
+    Second completion: providers of ocf or types of other classes
+    Last completion:   types of ocf agents
     '''
-    ret = set([])
+    c = args[-1]
     classes = ra.ra_classes()
-    for c in classes:
-        if c != 'ocf':
-            types = ra.ra_types(c)
-            for t in types:
-                ret.add('%s:%s' % (c, t))
+    if not c:
+        # First completion:  agent classes
+        return [l+":" for l in classes]
 
+    ret = set([])
     providers = ra.ra_providers_all('ocf')
-    for p in providers:
-        types = ra.ra_types('ocf', p)
-        for t in types:
-            ret.add('ocf:%s:%s' % (p, t))
-    return list(ret)
+    if c == 'ocf:' or re.search(r'ocf:[^:]+$', c):
+        # Second completion: providers of ocf
+        for p in providers:
+            if p == '.isolation':
+                continue
+            ret.add('%s:%s:' % ('ocf', p))
+        return list(ret)
 
+    if re.search(r'ocf:.+:', c):
+        # Last completion:   types of ocf agents
+        for p in providers:
+            if p == '.isolation':
+                continue
+            types = ra.ra_types('ocf', p)
+            for t in types:
+                ret.add('%s:%s:%s' % ('ocf', p, t))
+        return list(ret)
+
+    if c.endswith(':') and c.strip(':') in classes:
+        # Second completion: types of other classes
+        types = ra.ra_types(c)
+        for t in types:
+            ret.add('%s:%s' % (c.strip(':'), t))
+        return list(ret)
+        
+    if re.search(r'.+:.+', c):
+        # Second completion: types of other classes
+        types = ra.ra_types(c.split(':')[0])
+        for t in types:
+            ret.add('%s:%s' % (c.split(':')[0], t))
+        return list(ret)
+    
+    # First completion:  agent classes
+    return [l+":" for l in classes]
 
 class RA(command.UI):
     '''


### PR DESCRIPTION
When need to show the agent supported by cluster,
grouped by different classes or providers, Tab by Tab,
instead of completing all the agents at one time.

First completion:  agent classes
Second completion: providers of ocf or types of other classes
Last completion:   types of ocf agents