### PR TITLE
low: bootstrap: some patches about cluster remove

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1651,6 +1651,10 @@ def bootstrap_remove(cluster_node=None, quiet=False, yes_to_all=False, force=Fal
 
     init()
     remove_ssh()
+
+    if not confirm("Do you want to remove node \"{}\" anyway?".format(cluster_node)):
+        return  
+
     if remove_localhost_check():
         if not config.core.force and not force:
             error("Removing self requires --force")

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1405,7 +1405,7 @@ def remove_get_hostname(seed_host):
             _context.host_status = 2
     else:
         if seed_host not in xmlutil.listnodes():
-            error("Specified node {} is not configured in cluster, can not remove".format(nodename))
+            error("Specified node {} is not configured in cluster, can not remove".format(seed_host))
 
         warn("Could not resolve hostname {}".format(seed_host))
         nodename = prompt_for_string('Please enter the IP address of the node to be removed (e.g: 192.168.0.1)', r'([0-9]+\.){3}[0-9]+', "")

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -281,6 +281,7 @@ If stage is not specified, each stage will be invoked in sequence.
             if not self._add_node(node, yes_to_all=options.yes_to_all):
                 return False
 
+    @command.alias("delete")
     @command.completers_repeating(_remove_completer)
     @command.skill_level('administrator')
     def do_remove(self, context, *args):


### PR DESCRIPTION
1) add "delete" alias for "remove" option

2) when given a node name which is not configured in cluster, program will crash
    so replace 'nodename' to 'seed_host' can resolve this

3) give a confirm message when remove node
    it will be nice hints