### PR TITLE
medium: ui_cluster: Add cluster rename command

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1321,6 +1321,17 @@ remove [options] [<node> ...]
 ...............
 
 
+[[cmdhelp_cluster_rename,Rename the cluster]]
+==== `rename`
+
+Rename the cluster name 
+
+Usage:
+...............
+rename <new_cluster_name>
+...............
+
+
 [[cmdhelp_cluster_run,Execute an arbitrary command on all nodes]]
 ==== `run`
 


### PR DESCRIPTION
  * Update /etc/corosync/corosync.conf with the new name on all nodes
  * Change the cluster-name property in the CIB
  * Reload the corosync configuration on all nodes(use corosync-cmapctl)
    
  other:
  * command corosync-cfgtool -R can not reload totem.cluster_name
  * I have no idea how to update any references to the cluster name
  * this is for the issue #219