### PR TITLE
low: ui_cluster: complete node name once when input crm->cluster->remove

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -22,6 +22,9 @@ def _remove_completer(args):
         n = utils.list_cluster_nodes()
     except:
         n = []
+    for node in args[1:]:
+        if node in n:
+            n.remove(node)   
     return scripts.param_completion_list('remove') + n
 
 


### PR DESCRIPTION
 or the same node name will be completed many times with many "Tab"s