### PR TITLE
low: command: a clear and better way replace for commit 4ac8d4

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -9,7 +9,6 @@ from . import options
 from .msg import common_err, common_info, common_warn
 from . import ui_utils
 from . import userdir
-import re
 
 
 # import logging
@@ -132,10 +131,7 @@ class Context(object):
                         # use the completer for the command
                         ret = self.command_info.complete(self, tokens)
                         if tokens:
-                            if not re.search(r'\.\./.*', tokens[0]):
-                                ret = [t for t in ret if t.startswith(tokens[-1])]
-                            else:
-                                ret = [t for t in ret]
+                            ret = [t for t in ret if t.startswith(tokens[-1])]
 
                         if not ret or self.command_info.aliases:
                             if not token in self.current_level().get_completions():
@@ -185,25 +181,19 @@ class Context(object):
     def readline_completer(self, text, state):
         import readline
 
-        def matching(word, starts_text=text):
+        def matching(word):
             'we are only completing the last word in the line'
-            return word.split()[-1].startswith(starts_text)
+            return word.split()[-1].startswith(text)
 
         line = utils.get_line_buffer() + readline.get_line_buffer()
         if line != self._rl_line:
             try:
                 self._rl_line = line
                 completions = self.complete(line)
-
-                if text and not re.search(r'\.\./.*', text):
+                if text:
                     self._rl_words = [w for w in completions if matching(w) and not w.startswith("_")]
                 else:
-                    if re.search(r'\.\./.+', text):
-                        self._rl_words = ['../'+w for w in completions 
-                                          if matching(w, starts_text=text.split('/')[1]) 
-                                          and not w.startswith("_")]
-                    else:
-                        self._rl_words = [w for w in completions if not w.startswith("_")]
+                    self._rl_words = [w for w in completions if not w.startswith("_")]
 
             except Exception:  # , msg:
                 # logging.exception(msg)


### PR DESCRIPTION
(Improved cd completion)

* code changes happened just in command:_cd_completer function
* on the root level, complete sublevel names after "cd ":
  complete the 'cd' command self
* on the sublevel, complete other sublevel path after "cd ../":
  e.g. on the "configure" level, type "cd ../" and "tab", you can get "../cib ../ra ../script ../node" etc.
* complete sublevel names if this sublevel also have some sublevel names:
  e.g. type "cd configure/" and "tab", you can get "configure/assist configure/cib configure/ra" etc.
* prevent '..' complete after every tab