### PR TITLE
low: ui_cluster: changes about cluster name

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -364,7 +364,7 @@ If stage is not specified, each stage will be invoked in sequence.
         if len(args) != 1:
             context.fatal_error("Expected <clustername>")
         new_name = args[0]
-        old_name = cib_factory.get_property_w_default('cluster-name')
+        old_name = cib_factory.get_property('cluster-name')
         if old_name and new_name == old_name:
             context.fatal_error("Expected a different name")
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -37,6 +37,17 @@ def script_args(args):
     return _nvpairs2parameters(args)
 
 
+def get_cluster_name():
+    cluster_name = None
+    if not bootstrap.service_is_active("corosync.service"):
+        name = corosync.get_values('totem.cluster_name')
+        if name:
+            cluster_name = name[0]
+    else:
+        cluster_name = cib_factory.get_property('cluster-name')
+    return cluster_name
+    
+
 class Cluster(command.UI):
     '''
     Whole cluster management.
@@ -501,10 +512,12 @@ Cluster Description
         '''
         Quick cluster health status. Corosync status, DRBD status...
         '''
+
         stack = utils.cluster_stack()
         if not stack:
             err_buf.error("No supported cluster stack found (tried heartbeat|openais|corosync)")
         if utils.cluster_stack() == 'corosync':
+            print "Name: {}\n".format(get_cluster_name())
             print "Services:"
             for svc in ["corosync", "pacemaker"]:
                 info = utils.service_info(svc)


### PR DESCRIPTION

medium: ui_cluster: use get_property instead of get_property_w_default:
if the property not exist in cib, get_property_w_default('cluster-name') will raise an error

low: ui_cluster: show cluster name in cluster status command


