### PR TITLE
low: cibconfig: use refresh instead of reset after commit

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2565,7 +2565,7 @@ class CibFactory(object):
             common_debug("CIB commit successful at %s" % (t))
             if is_live_cib():
                 self.last_commit_time = t
-            self.reset()
+            self.refresh()
         return rc
 
     def _update_schema(self):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -605,8 +605,6 @@ class CibConfig(command.UI):
         if force or config.core.force:
             common_info("commit forced")
             return cib_factory.commit(force=True, replace=replace)
-        if utils.ask("Do you still want to commit?"):
-            return cib_factory.commit(force=True, replace=replace)
         return False
 
     @command.skill_level('administrator')


### PR DESCRIPTION
if use reset, for example, after add a valid resource and commit it,
without leaving the configure level,
delete completer will not get any id to delete