### PR TITLE
medium: ui_configure: do not remind user they can still commit when error

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2565,7 +2565,7 @@ class CibFactory(object):
             common_debug("CIB commit successful at %s" % (t))
             if is_live_cib():
                 self.last_commit_time = t
-            self.reset()
+            self.refresh()
         return rc
 
     def _update_schema(self):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -603,10 +603,9 @@ class CibConfig(command.UI):
         if rc1 and rc2:
             return cib_factory.commit(replace=replace)
         if force or config.core.force:
-            common_info("commit forced")
+            common_warn("commit forced!")
             return cib_factory.commit(force=True, replace=replace)
-        if utils.ask("Do you still want to commit?"):
-            return cib_factory.commit(force=True, replace=replace)
+        cib_factory.reset()
         return False
 
     @command.skill_level('administrator')


### PR DESCRIPTION
commit sets:
1)  medium: ui_configure: do not remind user they can still commit when error
     when add a resource, meet a fatal error, such as required parameter xxx not defined,
      it's dangerous to remind user they also have an option "y" to continue,
      even at this time, error message have poped up.
    
      If we close this remind, and reset the cib_factory,
      maybe can lead user to do the right configuration.
    
      It's dangerous enough to have "force" option for commit,
      so there should be a warning when running "commit force".

2) low: cibconfig: use refresh instead of reset after commit
   if use reset, for example, after add a valid resource and commit it,
      without leaving the configure level,
      delete completer will not get the ids to delete