### PR TITLE
medium: bootstrap: use strict regrex for bindnetaddr/mcastaddr/adminIP

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -676,6 +676,15 @@ def init_corosync_auth():
     invoke("corosync-keygen -l")
 
 
+def valid_network(addr):
+    all_ = utils.get_all_networks()
+    if all_ and addr in all_:
+        return True
+    else:
+        print term.render(clidisplay.error("    Must one of {}".format(all_)))
+        return False
+
+
 def valid_port(port):
     if int(port) >= 1024 and int(port) <= 65535:
         return True
@@ -734,7 +743,8 @@ Configure Corosync:
 
     bindnetaddr = prompt_for_string('Network address to bind to (e.g.: 192.168.1.0)', 
                                     r'^{}$'.format(utils.network_regrex), 
-                                    _context.ip_network)
+                                    _context.ip_network,
+                                    valid_network)
     if not bindnetaddr:
         error("No value for bindnetaddr")
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -678,10 +678,11 @@ def init_corosync_auth():
 
 def valid_network(addr):
     all_ = utils.get_all_networks()
-    if all_ and addr in all_:
+    networks = [x.split('/')[0] for x in all_]
+    if all_ and addr in networks:
         return True
     else:
-        print term.render(clidisplay.error("    Must one of {}".format(all_)))
+        print term.render(clidisplay.error("    Must one of {}".format(networks)))
         return False
 
 
@@ -690,6 +691,18 @@ def valid_port(port):
         return True
     return False
 
+
+def valid_adminIP(ip):
+    all_ = utils.get_all_networks()
+    networks = []
+    for net,bits in [x.split('/') for x in all_]:
+        networks.append(net)
+        if utils.ipv4_in_network(ip, net, bits):
+            return True
+
+    print term.render(clidisplay.error("    Must in one of these networks {}".format(networks)))
+    return False
+    
 
 def init_corosync_unicast():
     if _context.yes_to_all:
@@ -1149,7 +1162,8 @@ Configure Administration IP Address:
 
         adminaddr = prompt_for_string('Administration Virtual IP', 
                                       r'^{}$'.format(utils.ipv4_regrex), 
-                                      "")
+                                      "",
+                                      valid_adminIP)
         if not adminaddr:
             error("No value for admin address")
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -732,11 +732,15 @@ Configure Corosync:
         if not confirm("%s already exists - overwrite?" % (corosync.conf())):
             return
 
-    bindnetaddr = prompt_for_string('Network address to bind to (e.g.: 192.168.1.0)', r'([0-9]+\.){3}[0-9]+', _context.ip_network)
+    bindnetaddr = prompt_for_string('Network address to bind to (e.g.: 192.168.1.0)', 
+                                    r'^{}$'.format(utils.network_regrex), 
+                                    _context.ip_network)
     if not bindnetaddr:
         error("No value for bindnetaddr")
 
-    mcastaddr = prompt_for_string('Multicast address (e.g.: 239.x.x.x)', r'([0-9]+\.){3}[0-9]+', gen_mcastaddr())
+    mcastaddr = prompt_for_string('Multicast address (e.g.: 239.x.x.x)', 
+                                  r'^{}$'.format(utils.mcast_regrex), 
+                                  gen_mcastaddr())
     if not mcastaddr:
         error("No value for mcastaddr")
 
@@ -1133,7 +1137,9 @@ Configure Administration IP Address:
         if not confirm("Do you wish to configure an administration IP?"):
             return
 
-        adminaddr = prompt_for_string('Administration Virtual IP', r'([0-9]+\.){3}[0-9]+', "")
+        adminaddr = prompt_for_string('Administration Virtual IP', 
+                                      r'^{}$'.format(utils.ipv4_regrex), 
+                                      "")
         if not adminaddr:
             error("No value for admin address")
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1598,6 +1598,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
         if template == 'ocfs2':
             init_vgfs()
         init_admin()
+        csync2_update('/')
 
     status("Done (log saved to %s)" % (LOG_FILE))
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -113,7 +113,7 @@ def prompt_for_string(msg, match=None, default='', valid_func=None):
         if re.match(match, val) is not None:
             if not valid_func or valid_func(val):
                 return val
-        print >>sys.stderr, "    Invalid value entered"
+        print term.render(clidisplay.error("    Invalid value entered"))
 
 
 def confirm(msg):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -88,14 +88,43 @@ def network_defaults(interface=None):
 
 def get_all_networks():
     """
-    return all the network at local node
+    return all the network/bits at local node
     """
     all_networks = []
     _, outp = get_stdout("/sbin/ip -o route show")
     for l in outp.split('\n'):
         if re.search(r'^{}/[0-9]+ '.format(network_regrex), l):
-            all_networks.append(l.split('/')[0])
+            all_networks.append(l.split()[0])
     return all_networks
+
+
+def ipv4_in_network(addr, net, bits):
+    """
+    check if an ip is in a network
+    """
+    # learn from 
+    # https://stackoverflow.com/questions/819355/how-can-i-check-if-an-ip-is-in-a-network-in-python
+    import socket, struct
+
+    def make_mask(n):
+        "return a mask of n bits as long integer"
+        return (2L<<n-1) - 1
+
+    def dotted_quad_to_num(ip):
+        "convert decimal dotted quad string to long integer"
+        return struct.unpack('<L', socket.inet_aton(ip))[0]
+
+    def network_mask(ip, bits):
+        "convert a network address to a long integer"
+        return dotted_quad_to_num(ip) & make_mask(bits)
+
+    def address_in_network(ip, net):
+        "is an address in a network"
+        return ip & net == net
+
+    address = dotted_quad_to_num(addr)
+    network = network_mask(net, int(bits))
+    return address_in_network(address, network)
 
 
 _cib_shadow = 'CIB_shadow'

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -23,6 +23,11 @@ from . import term
 from .msg import common_warn, common_info, common_debug, common_err, err_buf
 
 
+network_regrex = r'((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}0'
+ipv4_regrex = r'((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
+mcast_regrex = r'2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}'
+
+
 def memoize(function):
     "Decorator to invoke a function once only for any argument"
     memoized = {}

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -86,6 +86,18 @@ def network_defaults(interface=None):
     return tuple(info)
 
 
+def get_all_networks():
+    """
+    return all the network at local node
+    """
+    all_networks = []
+    _, outp = get_stdout("/sbin/ip -o route show")
+    for l in outp.split('\n'):
+        if re.search(r'^{}/[0-9]+ '.format(network_regrex), l):
+            all_networks.append(l.split('/')[0])
+    return all_networks
+
+
 _cib_shadow = 'CIB_shadow'
 _cib_in_use = ''
 


### PR DESCRIPTION
Commit sets for more robust bootstrap config:
1) medium: bootstrap: use strict regrex for bindnetaddr/mcastaddr/adminIP
2) low: bootstrap: color the input error message
3) low: bootstrap: valid bindnetaddr must one of the local networks
4) medium: bootstrap: csync2 update after all things done at local
       If don't do this, some files sync failed, when:
    step 1) a configured, running well cluster(two nodes for example);
    step 2) stop every node's service;
    step 3) on node A, run crm->cluster->init, reconfigure corosync;
    setp 4) after that, on node B, run crm->cluster->join;
    then bootstrap say "! csync2 run failed - some files may not be sync'd"
    and then, the cluster split as two one-node clusters,
    two nodes can't see each other!

    So, call csync2_update after all things done will solve this problem

5) medium: bootstrap: add valid_adminIP to valid adminIP
    The administration virtaul IP must:
    - have a valid ipv4 formation
    - belongs one of local networks