### PR TITLE
medium: bootstrap: csync2 update after all things done at local

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1585,6 +1585,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
         if template == 'ocfs2':
             init_vgfs()
         init_admin()
+        csync2_update('/')
 
     status("Done (log saved to %s)" % (LOG_FILE))
 


### PR DESCRIPTION
If don't do this, some files sync failed, when:
step 1) a configured, running well cluster(two nodes for example);
step 2) stop every node's service;
step 3) on node A, run crm->cluster->init, reconfigure corosync; 
setp 4) after that, on node B, run crm->cluster->join;
then bootstrap say "! csync2 run failed - some files may not be sync'd"
and then, the cluster split as two one-node clusters,
two nodes can't see each other!

So, call csync2_update after all things done will solve this problem