### PR TITLE
medium: bootstrap: run "csync2_update" for all files after new joinin…

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -655,7 +655,7 @@ def init_csync2_remote():
         if not re.search(r"^\s*host.*\s+%s\s*;" % (newhost), curr_cfg, flags=re.M):
             curr_cfg = re.sub(r"\bhost.*\s+\S+\s*;", r"\g<0>\n\thost %s;" % (utils.doublequote(newhost)), curr_cfg, count=1)
             utils.str2file(curr_cfg, CSYNC2_CFG)
-            invoke("csync2", "-c", CSYNC2_CFG)
+            csync2_update("/")
         else:
             log(": Not updating %s - remote host %s already exists" % (CSYNC2_CFG, newhost))
     finally:


### PR DESCRIPTION
…g node call csync2_remote

  If don't do this, some files sync failed, when:
    step 1) a configured, running well cluster(two nodes for example);
    step 2) stop every node's service;
    step 3) on node A, run crm->cluster->init, reconfigure corosync;
    setp 4) after that, on node B, run crm->cluster->join;
    then bootstrap say "! csync2 run failed - some files may not be sync'd"
    and then, the cluster split as two one-node clusters,
    two nodes can't see each other!

 So, call csync2_update for all files when join node call csync2_remote
 can reslove this problem