### PR TITLE
low: ui_cluster: change cluster name need restart cluster service

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -370,9 +370,8 @@ If stage is not specified, each stage will be invoked in sequence.
         if not cib_factory.commit():
             context.fatal_error("Change property cluster-name failed!")
 
-        # Change in corosync-cmapctl
-        context.info("Reload the configuration on all nodes")
-        self.do_run(context, "corosync-cmapctl -s totem.cluster_name str {}".format(new_name))
+        # it's a safe way to give user a hints that need to restart service
+        context.info("To apply the change, restart the cluster service at convenient time")
 
     def _parse_clustermap(self, clusters):
         '''


### PR DESCRIPTION
as the bug [1048187](https://bugzilla.suse.com/show_bug.cgi?id=1048187) discussion,
it's a safe way to give user a hints that need to restart service

Regards, 
xin