### PR TITLE
medium: bootstrap: configure with IPv6(mcast)

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -11,6 +11,7 @@ import socket
 from . import utils
 from . import tmpfiles
 from .msg import err_buf, common_debug
+import time
 
 
 def conf():
@@ -490,6 +491,8 @@ totem {
     }
 
 %(transport)s
+    %(ipv6)s
+    %(ipv6_nodeid)s
 }
 logging {
     fileline:   off
@@ -519,7 +522,9 @@ def create_configuration(clustername="hacluster",
                          bindnetaddr=None,
                          mcastaddr=None,
                          mcastport=None,
-                         transport=None):
+                         transport=None,
+                         ipv6=False,
+                         nodeid=None):
 
     if transport == "udpu":
         nodelist_tmpl = """nodelist {
@@ -547,12 +552,20 @@ def create_configuration(clustername="hacluster",
     else:
         bindnetaddr_tmpl = "bindnetaddr: %s" % bindnetaddr
 
+    ipv6_tmpl = ""
+    ipv6_nodeid = ""
+    if ipv6:
+        ipv6_tmpl = "ip_version:  ipv6"
+        ipv6_nodeid = "nodeid:  %d" % nodeid
+
     config = {
         "clustername": clustername,
         "nodelist": nodelist_tmpl,
         "bindnetaddr": bindnetaddr_tmpl,
         "mcast": mcast_tmpl,
         "transport": transport_tmpl,
+        "ipv6": ipv6_tmpl,
+        "ipv6_nodeid": ipv6_nodeid
     }
 
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config, conf())

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -203,6 +203,8 @@ Note:
                                  "Default is multicast unless an environment where multicast cannot be used is detected.")
         network_group.add_option("-A", "--admin-ip", dest="admin_ip", metavar="IP",
                                  help="Configure IP address as an administration virtual IP")
+        network_group.add_option("-I", "--ipv6", action="store_true", dest="ipv6",
+                                 help="Configure corosync use IPv6")
         parser.add_option_group(network_group)
 
         storage_group = optparse.OptionGroup(parser, "Storage configuration", "Options for configuring shared storage.")
@@ -248,6 +250,7 @@ Note:
             admin_ip=options.admin_ip,
             yes_to_all=options.yes_to_all,
             unicast=options.unicast,
+            ipv6=options.ipv6,
             watchdog=options.watchdog,
             stage=stage,
             args=args)


### PR DESCRIPTION
  Changes include:
  1) use "-I" option stand for IPv6 in ui_cluster
  2) totem.ip_version should set as "ipv6"
  3) choose one interface which has IPv6 address as default values
  4) each node must have an uniqe nodeid when using IPv6,
     the nodeid came from IPv6 address in default interface
  5) for IPv6 network computation, learn from
     https://github.com/tehmaze/ipcalc