### PR TITLE
medium: bootstrap: cluster join lock

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1576,6 +1576,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
         if watchdog is not None:
             init_watchdog()
         init_ssh()
+        join_lock()
         init_csync2()
         init_corosync()
         if template == 'ocfs2':
@@ -1586,6 +1587,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
         if template == 'ocfs2':
             init_vgfs()
         init_admin()
+        join_unlock()
 
     status("Done (log saved to %s)" % (LOG_FILE))
 
@@ -1644,14 +1646,22 @@ def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, w
     status("Done (log saved to %s)" % (LOG_FILE))
 
 
-def join_lock(node):
-    if not invoke("ssh root@{} 'touch {}'".format(node, JOIN_LOCK_FILE)):
-        error("touch join lock faild!")
+def join_lock(node=None):
+    if not node:
+        if not invoke("touch {}".format(JOIN_LOCK_FILE)):
+            error("touch join lock faild!")
+    else:
+        if not invoke("ssh root@{} 'touch {}'".format(node, JOIN_LOCK_FILE)):
+            error("touch join lock faild!")
 
 
-def join_unlock(node):
-    if not invoke("ssh root@{} 'rm -f {}'".format(node, JOIN_LOCK_FILE)):
-        error("remove join lock faild!")
+def join_unlock(node=None):
+    if not node:
+        if not invoke("rm -f {}".format(JOIN_LOCK_FILE)):
+            error("remove join lock faild!")
+    else:
+        if not invoke("ssh root@{} 'rm -f {}'".format(node, JOIN_LOCK_FILE)):
+            error("remove join lock faild!")
 
 
 def is_join_locked(node):

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1635,6 +1635,8 @@ def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, w
             _context.cluster_node = cluster_node
 
         join_ssh(cluster_node)
+        # lock the joining node self
+        join_lock() 
         if is_join_locked(cluster_node):
             wait_for_joinlock(cluster_node)
         join_lock(cluster_node)
@@ -1642,6 +1644,8 @@ def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, w
         join_ssh_merge(cluster_node)
         join_cluster(cluster_node)
         join_unlock(cluster_node)
+        # unlock the joining node self
+        join_unlock()
 
     status("Done (log saved to %s)" % (LOG_FILE))
 


### PR DESCRIPTION
This commit is the implementation of issue #243
 
When having more than two nodes to configure cluster,
It's better to join a configured node one by one, or
the csync2 will failed when some nodes join simultaneously

the differences from #243 are:
1) when have waiting every 30s, ask user to confirm whether still want to wait,
2) do not add "do_lock" and "do_unlock" in ui_cluster
3) no "--ignore-lock" option, asking user to confirm is enough, it can force to join in when always blocking:)

  