### PR TITLE
medium: bootstrap: disable completion and history when running bootstrap

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -28,6 +28,7 @@ from . import corosync
 from . import tmpfiles
 from . import clidisplay
 from . import term
+import readline
 
 
 LOG_FILE = "/var/log/ha-cluster-bootstrap.log"
@@ -105,9 +106,13 @@ def prompt_for_string(msg, match=None, default='', valid_func=None):
     if _context.yes_to_all:
         return default
     while True:
+        disable_completion()
         val = utils.multi_input('  %s [%s]' % (msg, default))
+        enable_completion()
         if val is None or len(val) == 0:
             val = default
+        else:
+            readline.remove_history_item(readline.get_current_history_length()-1)
         if match is None:
             return val
         if re.match(match, val) is not None:
@@ -117,7 +122,23 @@ def prompt_for_string(msg, match=None, default='', valid_func=None):
 
 
 def confirm(msg):
-    return _context.yes_to_all or utils.ask(msg)
+    if _context.yes_to_all:
+        return True
+    disable_completion()
+    rc = utils.ask(msg)
+    enable_completion()
+    readline.remove_history_item(readline.get_current_history_length()-1)
+    return rc
+
+
+def disable_completion():
+    if _context.ui_context:
+        _context.ui_context.disable_completion()
+
+
+def enable_completion():
+    if _context.ui_context:
+        _context.ui_context.setup_readline()
 
 
 def invoke(*args):
@@ -1499,7 +1520,7 @@ def remove_localhost_check():
     return nodename == utils.this_node()
 
 
-def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
+def bootstrap_init(cluster_name="hacluster", ui_context=None, nic=None, ocfs2_device=None,
                    shared_device=None, sbd_device=None, diskless_sbd=False, quiet=False,
                    template=None, admin_ip=None, yes_to_all=False,
                    unicast=False, watchdog=None, stage=None, args=None):
@@ -1538,6 +1559,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
     _context.unicast = unicast
     _context.admin_ip = admin_ip
     _context.watchdog = watchdog
+    _context.ui_context = ui_context
 
     if stage is None:
         stage = ""
@@ -1589,7 +1611,7 @@ def bootstrap_init(cluster_name="hacluster", nic=None, ocfs2_device=None,
     status("Done (log saved to %s)" % (LOG_FILE))
 
 
-def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, watchdog=None, stage=None):
+def bootstrap_join(cluster_node=None, ui_context=None, nic=None, quiet=False, yes_to_all=False, watchdog=None, stage=None):
     """
     -c <cluster-node>
     -i <nic>
@@ -1606,6 +1628,7 @@ def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, w
     _context = Context(quiet=quiet, yes_to_all=yes_to_all, nic=nic)
     _context.cluster_node = cluster_node
     _context.watchdog = watchdog
+    _context.ui_context = ui_context
 
     check_tty()
 
@@ -1639,7 +1662,7 @@ def bootstrap_join(cluster_node=None, nic=None, quiet=False, yes_to_all=False, w
     status("Done (log saved to %s)" % (LOG_FILE))
 
 
-def bootstrap_remove(cluster_node=None, quiet=False, yes_to_all=False, force=False):
+def bootstrap_remove(cluster_node=None, ui_context=None, quiet=False, yes_to_all=False, force=False):
     """
     -c <cluster-node> - node to remove from cluster
     -q - quiet
@@ -1649,6 +1672,7 @@ def bootstrap_remove(cluster_node=None, quiet=False, yes_to_all=False, force=Fal
     global _context
     _context = Context(quiet=quiet, yes_to_all=yes_to_all)
     _context.cluster_node = cluster_node
+    _context.ui_context = ui_context
 
     if not yes_to_all and cluster_node is None:
         status("""Remove This Node from Cluster:
@@ -1750,12 +1774,13 @@ port="9929"
     os.chmod(BOOTH_CFG, 0o644)
 
 
-def bootstrap_init_geo(quiet, yes_to_all, arbitrator, clusters, tickets):
+def bootstrap_init_geo(quiet, yes_to_all, arbitrator, clusters, tickets, ui_context=None):
     """
     Configure as a geo cluster member.
     """
     global _context
     _context = Context(quiet=quiet, yes_to_all=yes_to_all)
+    _context.ui_context = ui_context
 
     if os.path.exists(BOOTH_CFG) and not confirm("This will overwrite {} - continue?".format(BOOTH_CFG)):
         return
@@ -1811,13 +1836,14 @@ group g-booth booth-ip booth-site meta target-role=Stopped
     crm_configure_load("update", crm_template.substitute(iprules=" ".join(iprule.format(k, v) for k, v in clusters.iteritems())))
 
 
-def bootstrap_join_geo(quiet, yes_to_all, node, clusters):
+def bootstrap_join_geo(quiet, yes_to_all, node, clusters, ui_context=None):
     """
     Run on second cluster to add to a geo configuration.
     It fetches its booth configuration from the other node (cluster node or arbitrator).
     """
     global _context
     _context = Context(quiet=quiet, yes_to_all=yes_to_all)
+    _context.ui_context = ui_context
     init_common_geo()
     check_tty()
     geo_fetch_config(node)
@@ -1826,13 +1852,14 @@ def bootstrap_join_geo(quiet, yes_to_all, node, clusters):
     geo_cib_config(clusters)
 
 
-def bootstrap_arbitrator(quiet, yes_to_all, node):
+def bootstrap_arbitrator(quiet, yes_to_all, node, ui_context=None):
     """
     Configure this machine as an arbitrator.
     It fetches its booth configuration from a cluster node already in the cluster.
     """
     global _context
     _context = Context(quiet=quiet, yes_to_all=yes_to_all)
+    _context.ui_context = ui_context
     init_common_geo()
     check_tty()
     geo_fetch_config(node)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -238,6 +238,7 @@ Note:
 
         bootstrap.bootstrap_init(
             cluster_name=options.name,
+            ui_context=context,
             nic=options.nic,
             ocfs2_device=options.ocfs2_device,
             shared_device=options.shared_device,
@@ -308,6 +309,7 @@ If stage is not specified, each stage will be invoked in sequence.
 
         bootstrap.bootstrap_join(
             cluster_node=options.cluster_node,
+            ui_context=context,
             nic=options.nic,
             quiet=options.quiet,
             yes_to_all=options.yes_to_all,
@@ -372,12 +374,14 @@ If stage is not specified, each stage will be invoked in sequence.
         if len(args) == 0:
             bootstrap.bootstrap_remove(
                 cluster_node=None,
+                ui_context=context,
                 quiet=options.quiet,
                 yes_to_all=options.yes_to_all)
         else:
             for node in args:
                 bootstrap.bootstrap_remove(
                     cluster_node=node,
+                    ui_context=context,
                     quiet=options.quiet,
                     yes_to_all=options.yes_to_all,
                     force=options.force)
@@ -485,7 +489,7 @@ Cluster Description
                 ticketlist = [t for t in re.split('[ ,;]+', options.tickets)]
             except ValueError:
                 parser.error("Invalid ticket list")
-        bootstrap.bootstrap_init_geo(options.quiet, options.yes_to_all, options.arbitrator, clustermap, ticketlist)
+        bootstrap.bootstrap_init_geo(options.quiet, options.yes_to_all, options.arbitrator, clustermap, ticketlist, ui_context=context)
         return True
 
     @command.name("geo_join")
@@ -518,7 +522,7 @@ Cluster Description
         clustermap = self._parse_clustermap(options.clusters)
         if clustermap is None:
             parser.error("Invalid cluster description format")
-        bootstrap.bootstrap_join_geo(options.quiet, options.yes_to_all, options.node, clustermap)
+        bootstrap.bootstrap_join_geo(options.quiet, options.yes_to_all, options.node, clustermap, ui_context=context)
         return True
 
     @command.name("geo_init_arbitrator")
@@ -540,7 +544,7 @@ Cluster Description
         if options.help:
             parser.print_help()
             return
-        bootstrap.bootstrap_arbitrator(options.quiet, options.yes_to_all, options.other)
+        bootstrap.bootstrap_arbitrator(options.quiet, options.yes_to_all, options.other, ui_context=context)
         return True
 
     @command.completers_repeating(compl.call(scripts.param_completion_list, 'health'))

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -174,6 +174,15 @@ class Context(object):
         except IOError:
             pass
 
+    def disable_completion(self):
+        import readline
+        readline.parse_and_bind('tab: complete')
+        readline.set_completer(self.disable_completer)
+
+    def disable_completer(self, text, state):
+        # complete nothing
+        return
+
     def clear_readline_cache(self):
         self._rl_line = None
         self._rl_words = []


### PR DESCRIPTION
  When running crm->cluster->init(or other bootstrap function),
  completion makes no sense, it's better to disable it

I think this is a better and clear way against #218 
1) When meet multi_input and ask in bootstrap, still have completion handler, but the handler will complete nothing
2) remove the history item after inputs in bootstrap, because these items cannot use for other crmsh's commands and levels

