### PR TITLE
low: ui_node: return False when cibdump2elem return None

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -328,6 +328,8 @@ class NodeMgmt(command.UI):
         server <node> ... -- print server hostname / address for node
         """
         cib = xmlutil.cibdump2elem()
+        if cib is None:
+            return False
         for node in cib.xpath('/cib/configuration/nodes/node'):
             if nodes and node not in nodes:
                 continue


### PR DESCRIPTION
or crm->node->server will crash when cluster have not configured any nodes or cluster service is not running
and crash message is:
AttributeError: 'NoneType' object has no attribute 'xpath'