### PR TITLE
fix: bootstrap: remove cib.xml before corosync.add_node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1470,6 +1470,7 @@ def join_cluster(seed_host):
     # if unicast, we need to add our node to $corosync.conf()
     is_unicast = "nodelist" in open(corosync.conf()).read()
     if is_unicast:
+        invoke("rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*")
         corosync.add_node(utils.this_node())
         csync2_update(corosync.conf())
 


### PR DESCRIPTION
if don't do this, 
when this is a configured cluster, already have cib.xml, and if user want to reconfigure,
because list_cluster_nodes in corosync.add_node will read the cib.xml,
the add_node function will return and say "already in configuration",
and wouldn't update the nodelist in corosync.conf