### PR TITLE
low: bootstrap: give error hints when use sbd without watchdog

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1150,6 +1150,7 @@ Configure SBD:
                 return
             if not is_block_device(dev):
                 print >>sys.stderr, "    That doesn't look like a block device"
+                dev = ""
             else:
                 warn("All data on {} will be destroyed!".format(dev))
                 if confirm('Are you sure you wish to use this device?'):

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -900,7 +900,12 @@ def init_corosync():
 
 def is_block_device(dev):
     from stat import S_ISBLK
-    return S_ISBLK(os.stat(dev).st_mode)
+    try:
+        rc = S_ISBLK(os.stat(dev).st_mode)
+    except OSError as msg:
+        warn(msg)
+        return False
+    return rc
 
 
 def list_partitions(dev):

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1129,6 +1129,9 @@ Configure SBD:
                     csync2_update(SYSCONFIG_SBD)
             return
 
+        if not check_watchdog():
+            error("Watchdog device must be configured if want to use SBD!")
+
         if utils.is_program("sbd") is None:
             error("sbd executable not found! Cannot configure SBD.")
 


### PR DESCRIPTION
It's better stop config process here,
instead of trying to init local cluster