### PR TITLE
low: script: drbd: drbd also have some advanced params at Hawk

### DIFF
--- a/scripts/drbd/main.yml
+++ b/scripts/drbd/main.yml
@@ -7,20 +7,20 @@ longdesc: >-
   Also creates a multistate resource managing the state of DRBD.
 
   Does not create or modify the referenced DRBD configuration.
+include:
+  - agent: ocf:linbit:drbd
+    name: drbd
+    parameters:
+      - name: id
+        shortdesc: DRBD Cluster Resource ID
+        required: true
+        type: resource
+      - name: drbd_resource
+        shortdesc: DRBD Resource Name
+        required: true
+        type: string
 
 parameters:
-  - name: id
-    shortdesc: DRBD Cluster Resource ID
-    required: true
-    value: drbd-data
-    type: resource
-  - name: drbd_resource
-    shortdesc: DRBD Resource Name
-    required: true
-    value: drbd0
-    type: string
-  - name: drbdconf
-    value: "/etc/drbd.conf"
   - name: install
     type: boolean
     shortdesc: Install packages for DRBD
@@ -34,7 +34,6 @@ actions:
       primitive {{id}} ocf:linbit:drbd
         params
           drbd_resource="{{drbd_resource}}"
-          drbdconf="{{drbdconf}}"
         op monitor interval="29s" role="Master"
         op monitor interval="31s" role="Slave"
       ms ms-{{id}} {{id}}


### PR DESCRIPTION
* drbd ocf script has some optional params,
  like adjust_master_score/stop_outdates_secondary/ignore_missing_notifications etc.,
  these should be shown as "Advanced" params in wizards at Hawk
* In wizard config page, for the simple reason, it's better to just keep required params,
  move all un-required params at "Advanced" select options.
  Less options, quick configure:)
* Leave these params' default value empty is right, these values are mutative
