### PR TITLE
low: ui_context: reset term when using "help command+ctrlC"

### DIFF
--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -414,6 +414,7 @@ Examples:
         """usage: help topic|level|command"""
         h = help_module.help_contextual(context.level_name(), subject, subtopic)
         h.paginate()
+        context.command_name = ""
 
     def get_completions(self):
         '''

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -332,7 +332,10 @@ class Context(object):
         '''
         ok = self.current_level().end_game()
         if options.interactive and not options.batch:
-            print("bye")
+            if self.command_name != "help":
+                print("bye")
+            else:
+                utils.ext_cmd("reset")
         if ok is False and rc == 0:
             rc = 1
         sys.exit(rc)


### PR DESCRIPTION
  If dont do this, type "ctrl+C" when using "help command" will cause
  the term lost curses