### PR TITLE
medium: ui_context: Stop completing when an id is required

### DIFF
--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -16,7 +16,7 @@ def choice(lst):
 
 
 null = choice([])
-
+attr_id = choice(["id="])
 
 def call(fn, *fnargs):
     '''

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -214,6 +214,8 @@ class Context(object):
             ret = None
         # logging.debug("line:%s, text:%s, ret:%s, state:%s", repr(line), repr(text), ret, state)
         if not text or (ret and line.split()[-1].endswith(ret)):
+            if ret == "id=":
+                return ret
             return ret + ' '
         return ret
 


### PR DESCRIPTION
Hi krig,
   I have an idea popped when doing bundle work.
   "id" is required in many places, 
   e.g. in do_primitive, we can replace compl.null to compl.attr_id, 
   and stop completing when meeting "id=",
   this can make configure process more fluent because compl.attr_id give hints for users:)

   But, this can lead errors in test or in hawk, we can make it portable no matter "id=" is used or not.

   If this commit make sense, I will continue to do the replace work and port work:)

   Regards,
   xin