### PR TITLE
medium: bootstrap: check addr/hostname in local's /etc/hosts when joi…

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -347,6 +347,12 @@ def check_etc_hosts(node):
     return False
 
 
+def check_peer_etc_hosts(peer, node):
+    if invoke("ssh root@{} \"grep -E '(\s|^){}(\s|$)' /etc/hosts\"".format(peer, node)):
+        return True
+    return False
+
+
 def grep_output(cmd, txt):
     _rc, outp, _err = utils.get_stdout_stderr(cmd)
     return txt in outp
@@ -2048,6 +2054,8 @@ def bootstrap_join(cluster_node=None, ui_context=None, nic=None, quiet=False, ye
             _context.cluster_node = cluster_node
 
         join_ssh(cluster_node)
+        if not check_peer_etc_hosts(cluster_node, utils.this_node()):
+            error("Need configure \"{}\" in /etc/hosts on {} if want to join it".format(utils.this_node(), cluster_node))
         join_csync2(cluster_node)
         join_ssh_merge(cluster_node)
         join_cluster(cluster_node)

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -339,6 +339,14 @@ def check_tty():
         error("No pseudo-tty detected! Use -t option to ssh if calling remotely.")
 
 
+def check_etc_hosts(node):
+    with open("/etc/hosts") as f:
+        for line in f.read().splitlines():
+            if re.search(r'(\s|^)%s(\s|$)' % node, line):
+                return True
+    return False
+
+
 def grep_output(cmd, txt):
     _rc, outp, _err = utils.get_stdout_stderr(cmd)
     return txt in outp
@@ -2035,6 +2043,8 @@ def bootstrap_join(cluster_node=None, ui_context=None, nic=None, quiet=False, ye
   password of the existing node.
 """)
             cluster_node = prompt_for_string("IP address or hostname of existing node (e.g.: 192.168.1.1)", ".+")
+            if not check_etc_hosts(cluster_node):
+                error("Need configure \"{}\" in /etc/hosts first if want to join it".format(cluster_node))
             _context.cluster_node = cluster_node
 
         join_ssh(cluster_node)


### PR DESCRIPTION
…ning

When nodeB want to join nodeA, it's better to check whether nodeB in /etc/hosts(local),
this can avoid csync2 error later which may hard to debug