### PR TITLE
low: doc: change usage and doc for group

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -742,7 +742,6 @@ class CibConfig(command.UI):
     @command.completers_repeating(compl.attr_id, _group_completer)
     def do_group(self, context, *args):
         """usage: group <name> <rsc> [<rsc>...]
-        [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
         return self.__conf_object(context.get_command_name(), *args)
 
@@ -750,7 +749,6 @@ class CibConfig(command.UI):
     @command.completers_repeating(compl.attr_id, _f_children_id_list, _clone_completer)
     def do_clone(self, context, *args):
         """usage: clone <name> <rsc>
-        [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
         return self.__conf_object(context.get_command_name(), *args)
 
@@ -759,7 +757,6 @@ class CibConfig(command.UI):
     @command.completers_repeating(compl.attr_id, _f_children_id_list, _ms_completer)
     def do_ms(self, context, *args):
         """usage: ms <name> <rsc>
-        [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
         return self.__conf_object(context.get_command_name(), *args)
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3045,9 +3045,7 @@ single primitive resource or one group of resources.
 Usage:
 ...............
 clone <name> <rsc>
-  [description=<description>]
   [meta <attr_list>]
-  [params <attr_list>]
 
 attr_list :: [$id=<id>] <attr>=<val> [<attr>=<val>...] | $id-ref=<id>
 ...............
@@ -3383,26 +3381,17 @@ Grouped resources are started in the order they appear in the group,
 and stopped in the reverse order. If a resource in the group cannot
 run anywhere, resources following it in the group will not start.
 
-`group` can be passed the "container" meta attribute, to indicate that
-it is to be used to group VM resources monitored using Nagios. The
-resource referred to by the container attribute must be of type
-`ocf:heartbeat:Xen`, `oxf:heartbeat:VirtualDomain` or `ocf:heartbeat:lxc`.
-
 Usage:
 ...............
 group <name> <rsc> [<rsc>...]
-  [description=<description>]
   [meta attr_list]
-  [params attr_list]
 
 attr_list :: [$id=<id>] <attr>=<val> [<attr>=<val>...] | $id-ref=<id>
 ...............
 Example:
 ...............
 group internal_www disk0 fs0 internal_ip apache \
-  meta target_role=stopped
-
-group vm-and-services vm vm-sshd meta container="vm"
+  meta target-role=stopped
 ...............
 
 [[cmdhelp_configure_load,import the CIB from a file]]
@@ -3565,9 +3554,7 @@ single primitive resource or one group of resources.
 Usage:
 ...............
 ms <name> <rsc>
-  [description=<description>]
   [meta attr_list]
-  [params attr_list]
 
 attr_list :: [$id=<id>] <attr>=<val> [<attr>=<val>...] | $id-ref=<id>
 ...............


### PR DESCRIPTION

1. In http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html-single/Pacemaker_Explained/index.html#_changed, "The attributes container tag was removed"

2. According to http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html-single/Pacemaker_Explained/index.html#group-resources,
These is no params, so I delete it from usage