### PR TITLE
low: cibconfig: use refresh instead of reset after commit

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2567,7 +2567,7 @@ class CibFactory(object):
             common_debug("CIB commit successful at %s" % (t))
             if is_live_cib():
                 self.last_commit_time = t
-            self.reset()
+            self.refresh()
         return rc
 
     def _update_schema(self):


### PR DESCRIPTION

if use reset, for example, after adding a valid resource and commit it,
without leaving the configure level,
delete completer will not get the id to delete