### PR TITLE
medium: ui_configure: fix crash when no args given

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -702,6 +702,8 @@ class CibConfig(command.UI):
                 not cib_factory.is_elem_supported(cmd):
             common_err("%s not supported by the RNG schema" % cmd)
             return False
+        if not args:
+            return cib_factory.create_object(cmd, *args)
         if args[0].startswith("id="):
             object_id = args[0].strip("id=")
         else:


### PR DESCRIPTION
The crash came from commit 309d2e6 (medium: ui_configure: Replace compl.null to compl.attr_id where an id is required), which will cause IndexError: tuple index out of range