### PR TITLE
Low: ui_context: Continue completing when input is an alias

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -136,6 +136,8 @@ class Context(object):
                         if not ret or self.command_info.aliases:
                             if not token in self.current_level().get_completions():
                                 return self.current_level().get_completions()
+                        if self.command_name in self.command_info.aliases and not self.command_args:
+                            return [self.command_name]
                         return ret
                 # reached the end on a valid level.
                 # return the completions for the previous level.


### PR DESCRIPTION
For example:
   "master" is the alias name of "ms",
   input "crm configure master" will not complete, until input a space ' ';
   use this commit, "crm configure master" will continue completing after input "Tab"
  
This can make using crmsh more fluently:)

Regards,
xin 