### PR TITLE
low: ui_configure: required params first

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -390,7 +390,7 @@ class RAInfo(object):
         self.broken_ra = False
         return self.ra_elem
 
-    def params(self, completion=False):
+    def params(self, completion=False, required=False, advanced=False):
         '''
         Construct a dict of dicts: parameters are keys and
         dictionary of attributes/values are values. Cached too.
@@ -398,12 +398,22 @@ class RAInfo(object):
         completion:
         If true, filter some (advanced) parameters out.
         '''
-        if completion:
+        if completion or required or advanced:
             if self.mk_ra_node() is None:
                 return None
-            return [c.get("name")
-                    for c in self.ra_elem.xpath("//parameters/parameter")
-                    if c.get("name") and c.get("name") not in self.excluded_from_completion]
+            if completion:
+                return [c.get("name")
+                        for c in self.ra_elem.xpath("//parameters/parameter")
+                        if c.get("name") and c.get("name") not in self.excluded_from_completion]
+            if required:
+                return [c.get("name")
+                        for c in self.ra_elem.xpath("//parameters/parameter")
+                        if c.get("required") and int(c.get("required")) == 1]
+            if advanced:
+                return [c.get("name")
+                        for c in self.ra_elem.xpath("//parameters/parameter")
+                        if not c.get("required") or int(c.get("required")) != 1]
+
         ident = "ra_params-%s" % self
         if cache.is_cached(ident):
             return cache.retrieve(ident)

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -182,7 +182,17 @@ def _prim_params_completer(agent, args):
         return []
     elif '=' in completing:
         return []
-    return [s+'=' for s in agent.params(completion=True)]
+    required_params = agent.params(required=True)
+    if required_params:
+        count = 0
+        for item in required_params:
+            for arg in args:
+                if arg.startswith(item+'='):
+                    count += 1
+        # make sure we have inputed all of required params 
+        if len(required_params) != count:
+            return [s+'=' for s in agent.params(required=True)]
+    return [s+'=' for s in agent.params(advanced=True)]
 
 
 def _prim_meta_completer(agent, args):


### PR DESCRIPTION
When completing, complete required parameters firstly, which is more important.
When all of required parameters completed, then complete non-required parameters.
It's clear and can reduce configure errors

Regards,
xin