### PR TITLE
low: utils: convert bytes to str(bsc#1067823)

### DIFF
--- a/utils/crm_pkg.py
+++ b/utils/crm_pkg.py
@@ -71,7 +71,7 @@ class Zypper(PackageManager):
         rc, stdout, stderr = run(cmd)
         if rc == 0:
             for line in stdout.splitlines():
-                if name in line:
+                if name in line.decode('utf-8'):
                     return line.strip()
         return None
 
@@ -234,8 +234,8 @@ def manage_package(pkg, state):
         if exe:
             rc, stdout, stderr, changed = mgr().dispatch(pkg, state)
             return {'rc': rc,
-                    'stdout': stdout,
-                    'stderr': stderr,
+                    'stdout': stdout.decode('utf-8'),
+                    'stderr': stderr.decode('utf-8'),
                     'changed': changed
                     }
     fail(msg="No supported package manager found")
@@ -262,6 +262,6 @@ def main():
     if not args.name or not args.state:
         raise IOError("Bad arguments: %s" % (sys.argv))
     data = manage_package(args.name, args.state)
-    print(json.dumps(data))
+    print(json.dumps(str(data)))
 
 main()

--- a/utils/crm_script.py
+++ b/utils/crm_script.py
@@ -131,7 +131,7 @@ def package(name, state):
     rc, out, err = sudo_call(['./crm_pkg.py', '-n', name, '-s', state])
     if rc != 0:
         raise IOError("%s / %s" % (out, err))
-    outp = json.loads(out)
+    outp = json.loads(out.decode('utf-8'))
     if isinstance(outp, dict) and 'rc' in outp:
         rc = int(outp['rc'])
         if rc != 0:


### PR DESCRIPTION
bsc#1067823 still not work
apply this commit, some errors disappeared, 
but some strange status shown in wizards page
e.g. I use wizards page to install apache2 and configure vip,
apache2 package can be successfully installed,
the resource group also started successfully,
but some strange status like: b''
b'true\n'
b'"status" already present\n'
shown in page


when I use command line "crm script run apache virtual-ip:id=vip virtual-ip:ip=10.10.10.123 virtual-ip:cidr_netmask=24 install=true id=fs"
it works well