### PR TITLE
low: ui_configure: fix for db4fc62, not complete if previous' value c…

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -229,8 +229,9 @@ def _prim_op_completer(agent, args):
     if args[-2] in actions:
         res = []
         for k, v in actions[args[-2]].items():
+            if args[-1].startswith(k+'='):
+                continue
             res += ["%s=%s" % (k, v)]
-        res.remove(args[-1])
         return res
 
     return []


### PR DESCRIPTION
…hanged

For example:
in command "primitive vip ocf:Heartbeat:IPaddr2 op monitor interval=10s timeout=20s",
if I change interval to 11s, then "timeout=20s" will not be competed

Regards,
xin