### PR TITLE
low: ra: Don't require deprecated parameters (#321)

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -414,7 +414,7 @@ class RAInfo(object):
             name = c.get("name")
             if not name:
                 continue
-            required = c.get("required")
+            required = c.get("required") if not c.get("deprecated") else "0"
             unique = c.get("unique")
             typ, default = _param_type_default(c)
             d[name] = {


### PR DESCRIPTION
The fence-agents package added a couple of new attributes:

deprecated: This parameter is no longer recommended
obsoletes: This parameter replaces an older deprecated parameter

This is a small workaround to avoid warning when deprecated
required parameters are not configured.