### PR TITLE
low: ui_configure: fix for 309d2e, remove "id=" in a save way

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -726,7 +726,7 @@ class CibConfig(command.UI):
         if not args:
             return cib_factory.create_object(cmd, *args)
         if args[0].startswith("id="):
-            object_id = args[0].strip("id=")
+            object_id = args[0][3:]
         else:
             object_id = args[0]
         params = (object_id,) + args[1:]


### PR DESCRIPTION
When inputs like: id=ids, all 'id' words will be stripped
 