### PR TITLE
Support new alert syntax (#280)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2138,6 +2138,17 @@ class CibAlert(CibObject):
     def _repr_cli_child(self, c, format_mode):
         if c.tag in self.set_names:
             return self._attr_set_str(c)
+        elif c.tag == "select":
+            r = ["select"]
+            for sel in c.iterchildren():
+                if not sel.tag.startswith('select_'):
+                    continue
+                r.append(sel.tag.lstrip('select_'))
+                if sel.tag == 'select_attributes':
+                    r.append('{')
+                    r.extend(sel.xpath('attribute/@name'))
+                    r.append('}')
+            return ' '.join(r)
         elif c.tag == "recipient":
             r = ["to"]
             is_complex = self._is_complex()

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2998,6 +2998,7 @@ Usage:
 alert <id> <path> \
   [attributes <nvpair> ...] \
   [meta <nvpair> ...] \
+  [select [nodes | fencing | resources | attributes '{' <attribute> ... '}' ] ...] \
   [to [{] <recipient>
     [attributes <nvpair> ...] \
     [meta <nvpair> ...] [}] \
@@ -3012,6 +3013,11 @@ alert alert-1 /srv/pacemaker/pcmk_alert_sample.sh \
 alert alert-2 /srv/pacemaker/example_alert.sh \
     meta timeout=60s \
     to { /var/log/cluster-alerts.log }
+
+alert alert-3 /srv/pacemaker/example_alert.sh \
+    select fencing \
+    to { /var/log/fencing-alerts.log }
+
 ...............
 
 [[cmdhelp_configure_bundle,Container bundle]]

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -330,3 +330,11 @@ def test_alerts_4():
 @with_setup(setup_func, teardown_func)
 def test_alerts_5():
     roundtrip('alert alert5 "/a/path" to { "/another/path" } meta timeout=30s')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_6():
+    roundtrip('alert alert6 "/a/path" select fencing attributes { standby } to { "/another/path" } meta timeout=30s')
+
+@with_setup(setup_func, teardown_func)
+def test_alerts_7():
+    roundtrip('alert alert7 "/a/path" select fencing attributes foo=bar to { "/another/path" } meta timeout=30s')

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -511,6 +511,16 @@ class TestCliParser(unittest.TestCase):
         self.assertEqual(['10s'],
                          out.xpath('/alert/recipient/meta_attributes/nvpair[@name="timeout"]/@value'))
 
+    def test_alerts_selectors(self):
+        "Test alerts w/ selectors (1.1.17+)"
+        out = self._parse('alert alert3 /tmp/foo.sh select nodes fencing attributes { standby shutdown } to { /tmp/bar.log meta timeout=10s }')
+        self.assertEqual(out.get('id'), 'alert3')
+        self.assertEqual(1, len(out.xpath('/alert/select/select_nodes')))
+        self.assertEqual(1, len(out.xpath('/alert/select/select_fencing')))
+        self.assertEqual(['standby', 'shutdown'],
+                         out.xpath('/alert/select/select_attributes/attribute/@name'))
+
+
     def _parse_lines(self, lines):
         out = []
         for line in lines2cli(lines):


### PR DESCRIPTION
Adds support for new select tag in alert syntax (as of Pacemaker 1.1.17).
