### PR TITLE
fix: hb_report: Don't create *.log.info file if not in timespan

### DIFF
--- a/hb_report/hb_report.in
+++ b/hb_report/hb_report.in
@@ -85,8 +85,8 @@ def get_log():
         getstampproc = utillib.find_getstampproc(constants.HA_LOG)
         if getstampproc:
             constants.GET_STAMP_FUNC = getstampproc
-            utillib.dump_logset(constants.HA_LOG, constants.FROM_TIME, constants.TO_TIME, outf)
-            utillib.log_size(constants.HA_LOG, outf+'.info')
+            if utillib.dump_logset(constants.HA_LOG, constants.FROM_TIME, constants.TO_TIME, outf):
+                utillib.log_size(constants.HA_LOG, outf+'.info')
         else:
             utillib.log_warning("could not figure out the log format of %s" % constants.HA_LOG)
 

--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -298,8 +298,8 @@ def collect_info():
         if getstampproc:
             constants.GET_STAMP_FUNC = getstampproc
             outf = os.path.join(constants.WORKDIR, os.path.basename(l))
-            dump_logset(l, constants.FROM_TIME, constants.TO_TIME, outf)
-            log_size(l, outf+'.info')
+            if dump_logset(l, constants.FROM_TIME, constants.TO_TIME, outf):
+                log_size(l, outf+'.info')
         else:
             log_warning("could not figure out the log format of %s" % l)
 
@@ -453,10 +453,10 @@ def dump_logset(logf, from_time, to_time, outf):
     find log/set of logs which are interesting for us
     """
     if os.stat(logf).st_size == 0:
-        return
+        return False
     logf_set = arch_logs(logf, from_time, to_time)
     if not logf_set:
-        return
+        return False
     num_logs = len(logf_set)
     oldest = logf_set[-1]
     newest = logf_set[0]
@@ -476,6 +476,7 @@ def dump_logset(logf, from_time, to_time, outf):
         out_string += print_logseg(newest, 0, to_time)
 
     crmutils.str2file(out_string, outf)
+    return True
 
 
 def dump_state(workdir):


### PR DESCRIPTION
If not match any log content in given timeframe for a log file, 
collect this log.info is not necessary.

I will fire a bug if this commit make sense 