### PR TITLE
[crmsh 2] crmsh cluster init : support GCE

### DIFF
--- a/scripts/init/configure.py
+++ b/scripts/init/configure.py
@@ -50,6 +50,11 @@ def run_install():
 def make_bindnetaddr():
     host = crm_script.host()
     hostinfo = crm_script.output(2)[host]
+
+    # Bind to the local IP address
+    if crm_script.param('bindipaddr'):
+        return hostinfo['net']['hostname']['ip']
+
     ba = crm_script.param('bindnetaddr')
     if ba:
         return ba

--- a/scripts/init/main.yml
+++ b/scripts/init/main.yml
@@ -24,6 +24,11 @@ parameters:
     type: ip_address
     value: ""
 
+  - name: bindipaddr
+    shortdesc: "If true, bind to the local IP address"
+    type: boolean
+    value: false
+
   - name: mcastaddr
     shortdesc: "Multicast address (e.g.: 239.x.x.x)"
     type: ip_address

--- a/scripts/init/verify.py
+++ b/scripts/init/verify.py
@@ -36,6 +36,8 @@ try:
 
     crm_init.verify(data)
 
+    if crm_script.param('bindipaddr') and crm_script.param('bindnetaddr'):
+        crm_script.exit_fail("You should use either 'bindipaddr' or 'bindnetaddr', but not both")
     ret = {}
     ret['iface'] = select_interfaces(crm_script.param('iface'), data)
 


### PR DESCRIPTION
Hello

I'm using crmsh to setup a cluster on GCP. Unfortunately GCE instances are configured in a pretty unsual way in that VM are all set a /32 IP, that is all LAN-destined trafic goes through the GCP gateway. So we may not configure Corosync to bind on the network address, we have to request it to use the local IP address.

I've noticed that these init scripts are now deprecated in the latest release, so I'd like to know if there is an interest in this code before spending time to port it to the newer init mechanism. If so, let me known what should be reworked or improved.

Regards 
dud