### PR TITLE
high: ui_resource: Undeprecate refresh and remove reprobe (bsc#1084736)

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -217,7 +217,7 @@ cd            help          param         show          unmove
 cleanup       list          promote       start         up
 demote        manage        quit          status        utilization
 end           meta          refresh       stop
-exit          migrate       reprobe       unmanage
+exit          migrate       unmanage
 
 crm(live)configure# primitive fence-1 <TAB><TAB>
 heartbeat:  lsb:    ocf:    stonith:
@@ -1947,9 +1947,11 @@ ban <rsc> [<node>] [<lifetime>] [force]
 [[cmdhelp_resource_cleanup,cleanup resource status]]
 ==== `cleanup`
 
-Cleanup resource status. Typically done after the resource has
-temporarily failed. If a node is omitted, cleanup on all nodes.
-If there are many nodes, the command may take a while.
+If resource has any past failures, clear its history and fail
+count. Typically done after the resource has temporarily
+failed.
+
+If a node is omitted, cleanup on all nodes.
 
 +(Pacemaker 1.1.14)+ Pass force to cleanup the resource itself,
 otherwise the cleanup command will apply to the parent resource (if
@@ -1957,7 +1959,7 @@ any).
 
 Usage:
 ...............
-cleanup <rsc> [<node>] [force]
+cleanup [<rsc>] [<node>] [force]
 ...............
 
 [[cmdhelp_resource_clear,Clear any relocation constraint]]
@@ -2126,36 +2128,14 @@ Usage:
 promote <rsc>
 ...............
 
-[[cmdhelp_resource_refresh,refresh CIB from the LRM status]]
+[[cmdhelp_resource_refresh,Recheck current resource status and drop failure history]]
 ==== `refresh`
 
-Refresh CIB from the LRM status.
-
-.Note
-****************************
-`refresh` has been deprecated and is now
-an alias for `cleanup`.
-****************************
+Delete resource's history (including failures) so its current state is rechecked.
 
 Usage:
 ...............
-refresh [<node>]
-...............
-
-[[cmdhelp_resource_reprobe,probe for resources not started by the CRM]]
-==== `reprobe`
-
-Probe for resources not started by the CRM.
-
-.Note
-****************************
-`reprobe` has been deprecated and is now
-an alias for `cleanup`.
-****************************
-
-Usage:
-...............
-reprobe [<node>]
+refresh [<rsc>] [<node>] [force]
 ...............
 
 [[cmdhelp_resource_restart,restart resources]]

--- a/test/testcases/resource
+++ b/test/testcases/resource
@@ -40,10 +40,24 @@ resource stop p0
 resource start cg
 resource stop cg
 resource stop p3
+%setenv showobj=
 configure rename p3 p4
 configure primitive p3 Dummy
 resource stop p3
-%setenv showobj=
+resource start p3
+resource cleanup
+resource cleanup p3
+resource cleanup p3 node1
+resource cleanup force
+resource cleanup p3 force
+resource cleanup p3 node1 force
+resource refresh
+resource refresh p3
+resource refresh p3 node1
+resource refresh force
+resource refresh p3 force
+resource refresh p3 node1 force
+resource stop p3
 configure rm cg
 configure ms msg g
 resource scores

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1,5 +1,5 @@
 .TRY resource status p0
-.EXT crm_resource --locate -r 'p0'
+.EXT crm_resource --locate --resource 'p0'
 resource p0 is NOT running
 .SETENV showobj=p3
 .TRY resource start p3
@@ -87,7 +87,7 @@ resource p0 is NOT running
 
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1
-.EXT crm_resource --quiet --move -r 'p3' --node='node1'
+.EXT crm_resource --quiet --move --resource 'p3' --node 'node1'
 INFO: Move constraint created for p3 to node1
 .INP: configure
 .INP: _regtest on
@@ -106,11 +106,11 @@ INFO: Move constraint created for p3 to node1
 
 .SETENV showobj=
 .TRY resource unmigrate p3
-.EXT crm_resource --quiet --clear -r 'p3'
+.EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1 force
-.EXT crm_resource --quiet --move -r 'p3' --node='node1' --force
+.EXT crm_resource --quiet --move --resource 'p3' --node 'node1' --force
 INFO: Move constraint created for p3 to node1
 .INP: configure
 .INP: _regtest on
@@ -129,11 +129,11 @@ INFO: Move constraint created for p3 to node1
 
 .SETENV showobj=
 .TRY resource unmigrate p3
-.EXT crm_resource --quiet --clear -r 'p3'
+.EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=p0
 .TRY resource param p0 set a0 "1 2 3"
-.EXT crm_resource -r 'p0' -p 'a0' -v '1 2 3'
+.EXT crm_resource --resource 'p0' --set-parameter 'a0' --parameter-value '1 2 3'
 
 Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0=1 2 3
 .INP: configure
@@ -156,7 +156,7 @@ Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0
 </cib>
 
 .TRY resource param p0 show a0
-.EXT crm_resource -r 'p0' -g 'a0'
+.EXT crm_resource --resource 'p0' --get-parameter 'a0'
 1 2 3
 .INP: configure
 .INP: _regtest on
@@ -178,7 +178,7 @@ Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0
 </cib>
 
 .TRY resource param p0 delete a0
-.EXT crm_resource -r 'p0' -d 'a0'
+.EXT crm_resource --resource 'p0' --delete-parameter 'a0'
 Deleted 'p0' option: id=p0-instance_attributes-a0 name=a0
 .INP: configure
 .INP: _regtest on
@@ -198,7 +198,7 @@ Deleted 'p0' option: id=p0-instance_attributes-a0 name=a0
 </cib>
 
 .TRY resource meta p0 set m0 123
-.EXT crm_resource --meta -r 'p0' -p 'm0' -v '123'
+.EXT crm_resource --meta --resource 'p0' --set-parameter 'm0' --parameter-value '123'
 
 Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0=123
 .INP: configure
@@ -222,7 +222,7 @@ Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0=123
 </cib>
 
 .TRY resource meta p0 show m0
-.EXT crm_resource --meta -r 'p0' -g 'm0'
+.EXT crm_resource --meta --resource 'p0' --get-parameter 'm0'
 123
 .INP: configure
 .INP: _regtest on
@@ -245,7 +245,7 @@ Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0=123
 </cib>
 
 .TRY resource meta p0 delete m0
-.EXT crm_resource --meta -r 'p0' -d 'm0'
+.EXT crm_resource --meta --resource 'p0' --delete-parameter 'm0'
 Deleted 'p0' option: id=p0-meta_attributes-m0 name=m0
 .INP: configure
 .INP: _regtest on
@@ -822,100 +822,57 @@ INFO: Trace set, restart p0 to trace the stop operation
   </configuration>
 </cib>
 
+.SETENV showobj=
 .TRY configure rename p3 p4
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
-.INP: configure
-.INP: _regtest on
-.INP: show xml p0
-<?xml version="1.0" ?>
-<cib>
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <clone id="cg">
-        <meta_attributes id="cg-meta_attributes">
-          <nvpair id="cg-meta_attributes-target-role" name="target-role" value="Stopped"/>
-        </meta_attributes>
-        <group id="g">
-          <primitive id="p0" class="ocf" provider="pacemaker" type="Dummy"/>
-          <primitive id="p4" class="ocf" provider="pacemaker" type="Dummy">
-            <meta_attributes id="p3-meta_attributes">
-              <nvpair id="p3-meta_attributes-target-role" name="target-role" value="Stopped"/>
-            </meta_attributes>
-          </primitive>
-        </group>
-      </clone>
-    </resources>
-    <constraints/>
-  </configuration>
-</cib>
-
 .TRY configure primitive p3 Dummy
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
-.INP: configure
-.INP: _regtest on
-.INP: show xml p0
-<?xml version="1.0" ?>
-<cib>
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <clone id="cg">
-        <meta_attributes id="cg-meta_attributes">
-          <nvpair id="cg-meta_attributes-target-role" name="target-role" value="Stopped"/>
-        </meta_attributes>
-        <group id="g">
-          <primitive id="p0" class="ocf" provider="pacemaker" type="Dummy"/>
-          <primitive id="p4" class="ocf" provider="pacemaker" type="Dummy">
-            <meta_attributes id="p3-meta_attributes">
-              <nvpair id="p3-meta_attributes-target-role" name="target-role" value="Stopped"/>
-            </meta_attributes>
-          </primitive>
-        </group>
-      </clone>
-    </resources>
-    <constraints/>
-  </configuration>
-</cib>
-
 .TRY resource stop p3
-.INP: configure
-.INP: _regtest on
-.INP: show xml p0
-<?xml version="1.0" ?>
-<cib>
-  <configuration>
-    <crm_config/>
-    <nodes/>
-    <resources>
-      <clone id="cg">
-        <meta_attributes id="cg-meta_attributes">
-          <nvpair id="cg-meta_attributes-target-role" name="target-role" value="Stopped"/>
-        </meta_attributes>
-        <group id="g">
-          <primitive id="p0" class="ocf" provider="pacemaker" type="Dummy"/>
-          <primitive id="p4" class="ocf" provider="pacemaker" type="Dummy">
-            <meta_attributes id="p3-meta_attributes">
-              <nvpair id="p3-meta_attributes-target-role" name="target-role" value="Stopped"/>
-            </meta_attributes>
-          </primitive>
-        </group>
-      </clone>
-    </resources>
-    <constraints/>
-  </configuration>
-</cib>
-
-.SETENV showobj=
+.TRY resource start p3
+.TRY resource cleanup
+.EXT crm_resource --cleanup
+Error performing operation: Transport endpoint is not connected
+.TRY resource cleanup p3
+.EXT crm_resource --cleanup --resource p3
+Error performing operation: Transport endpoint is not connected
+.TRY resource cleanup p3 node1
+.EXT crm_resource --cleanup --resource p3 --node node1
+Error performing operation: Transport endpoint is not connected
+.TRY resource cleanup force
+.EXT crm_resource --cleanup --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource cleanup p3 force
+.EXT crm_resource --cleanup --resource p3 --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource cleanup p3 node1 force
+.EXT crm_resource --cleanup --resource p3 --node node1 --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh
+.EXT crm_resource --refresh
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh p3
+.EXT crm_resource --refresh --resource p3
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh p3 node1
+.EXT crm_resource --refresh --resource p3 --node node1
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh force
+.EXT crm_resource --refresh --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh p3 force
+.EXT crm_resource --refresh --resource p3 --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource refresh p3 node1 force
+.EXT crm_resource --refresh --resource p3 --node node1 --force
+Error performing operation: Transport endpoint is not connected
+.TRY resource stop p3
 .TRY configure rm cg
 .TRY configure ms msg g
 .TRY resource scores

--- a/test/unittests/test_resource.py
+++ b/test/unittests/test_resource.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Kristoffer Gronlund <kgronlund@suse.com>
+# Copyright (C) 2014-2018 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
 
@@ -26,10 +26,10 @@ def test_maintenance():
         utils.ext_cmd = mockcmd
         rscui = ui_resource.RscMgmt()
         assert rscui.do_maintenance(mc, 'rsc1') is True
-        assert commands[-1] == ("crm_resource -r 'rsc1' --meta -p maintenance -v 'true'",)
+        assert commands[-1] == ("crm_resource --resource 'rsc1' --meta --set-parameter maintenance --parameter-value 'true'",)
         assert rscui.do_maintenance(mc, 'rsc1', 'on') is True
-        assert commands[-1] == ("crm_resource -r 'rsc1' --meta -p maintenance -v 'true'",)
+        assert commands[-1] == ("crm_resource --resource 'rsc1' --meta --set-parameter maintenance --parameter-value 'true'",)
         assert rscui.do_maintenance(mc, 'rsc1', 'off') is True
-        assert commands[-1] == ("crm_resource -r 'rsc1' --meta -p maintenance -v 'false'",)
+        assert commands[-1] == ("crm_resource --resource 'rsc1' --meta --set-parameter maintenance --parameter-value 'false'",)
     finally:
         utils.ext_cmd = _pre_ext_cmd


### PR DESCRIPTION
As of Pacemaker 2.0, refresh now deletes all resource history,
which matches the old behaviour of cleanup.

Cleanup now only cleans up any resource failures.