### PR TITLE
high: hbreport: adjustment for hbreport(bsc#1088784)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -491,7 +491,7 @@ def create_tempfile(suffix='', dir=None):
 
 
 @contextmanager
-def open_atomic(filepath, mode="r", buffering=-1, fsync=False):
+def open_atomic(filepath, mode="r", buffering=-1, fsync=False, encoding=None):
     """ Open temporary file object that atomically moves to destination upon
     exiting.
 
@@ -510,7 +510,7 @@ def open_atomic(filepath, mode="r", buffering=-1, fsync=False):
     """
 
     with create_tempfile(dir=os.path.dirname(os.path.abspath(filepath))) as tmppath:
-        with open(tmppath, mode, buffering) as file:
+        with open(tmppath, mode, buffering, encoding=encoding) as file:
             try:
                 yield file
             finally:
@@ -525,7 +525,7 @@ def str2file(s, fname):
     Write a string to a file.
     '''
     try:
-        with open_atomic(fname, 'w') as dst:
+        with open_atomic(fname, 'w', encoding='utf-8') as dst:
             dst.write(to_ascii(s))
     except IOError as msg:
         common_err(msg)

--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -656,7 +656,7 @@ def find_log():
     """
     if constants.EXTRA_LOGS:
         for l in constants.EXTRA_LOGS.split():
-            if os.path.isfile(l) and l not in constants.PCMK_LOG.split():
+            if os.path.isfile(l):
                 return l
 
         tmp_f = os.path.join(constants.WORKDIR, constants.JOURNAL_F)


### PR DESCRIPTION
  * encoding utf-8 when open a file
    if journal.log include some special characters(ASCII number >=128), UnicodeEncodeError will raise when write to a file(call str2file)

  * pacemaker.log should not exclude as HA_LOG
   or ha-cluster-bootstrap.log will see as HA_LOG, pacemaker.log will not be collected 