### PR TITLE
doc: Fix unbalanced example marker

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -840,7 +840,7 @@ P = duration. Y = year. M = month. W = week. D = day. T = time. H =
 hour. M = minute. S = second.
 
 Examples:
-................
+.................
 PT5M = 5 minutes later.
 3D = 3 days later.
 PT1H = 1 hour later.


### PR DESCRIPTION
Example marker begin and end lines have to have the same length, but
one place was unbalanced.  Fix it.

The error was caught by asciidoctor, which tends to be picker than
asciidoc.

Signed-off-by: Takashi Iwai <tiwai@suse.de>