### PR TITLE
New constraints rules syntax

### DIFF
--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1415,15 +1415,17 @@ def set_date_expression(expr, tag, values):
     expr: <date_expression/>
     values: [nvpair...]
     """
+    subtag = None
     if set(nvp.get('name') for nvp in values) == set(constants.in_range_attrs):
         for nvp in values:
             expr.set(nvp.get('name'), nvp.get('value'))
         return expr
-    subtag = child(expr, tag)
+    if tag:
+        subtag = child(expr, tag)
     for nvp in values:
         if nvp.get('name') in constants.in_range_attrs:
             expr.set(nvp.get('name'), nvp.get('value'))
-        else:
+        elif subtag is not None:
             subtag.set(nvp.get('name'), nvp.get('value'))
     return expr
 

--- a/data-manifest
+++ b/data-manifest
@@ -102,6 +102,8 @@ test/testcases/history.post
 test/testcases/history.pre
 test/testcases/newfeatures
 test/testcases/newfeatures.exp
+test/testcases/new-syntax
+test/testcases/new-syntax.exp
 test/testcases/node
 test/testcases/node.exp
 test/testcases/options

--- a/test/testcases/basicset
+++ b/test/testcases/basicset
@@ -16,3 +16,4 @@ newfeatures
 commit
 bugs
 scripts
+new-syntax

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -24,7 +24,7 @@
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
 .INP: ms m5 s5
 .INP: ms m6 s6
-.INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
+.INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2 	op start interval=0 timeout=60s 	op_params 2: rule #uname eq node1 op_param=dummy 	op_params 1: op_param=smart 	op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m 	op_meta 1: start-delay=60m
 .INP: location l1 g1 100: node1
 .INP: location l2 c 	rule $id=l2-rule1 100: #uname eq node1
 .INP: location l3 m5 	rule inf: #uname eq node1 and pingd gt 0
@@ -116,7 +116,11 @@ location l4 m5 \
 location l5 m5 \
 	rule -inf: not_defined pingd or pingd lte 0 \
 	rule #uname eq node1 and pingd gt 0 \
-	rule date lt 2009-05-26 and date in start=2009-05-26 end=2009-07-26 and date in start=2009-05-26 years=2009 and date spec years=2009 hours=09-17
+	rule \
+	date lt 2009-05-26 and \
+	date in start=2009-05-26 end=2009-07-26 and \
+	date in start=2009-05-26 years=2009 and \
+	date spec years=2009 hours=09-17
 location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \

--- a/test/testcases/new-syntax
+++ b/test/testcases/new-syntax
@@ -1,0 +1,92 @@
+show Basic configure
+node node1
+delete node1
+node node1 \
+        attributes mem=16G
+node node2 utilization cpu=4
+primitive st stonith:ssh \
+        params hostlist='node1 node2' \
+        meta target-role="Started" requires=nothing \
+        op start timeout=60s \
+        op monitor interval=60m timeout=60s
+primitive d1 ocf:pacemaker:Dummy \
+        operations $id=d1-ops \
+        op monitor interval=60m \
+        op monitor interval=120m OCF_CHECK_LEVEL=10
+monitor d1 60s:30s
+primitive d2 ocf:heartbeat:Delay \
+        params mondelay=60 \
+        op start timeout=60s \
+        op stop timeout=60s
+monitor d2:Started 60s:30s
+group g1 d1 d2
+primitive d3 ocf:pacemaker:Dummy
+clone c d3 \
+        meta clone-max=1
+primitive d4 ocf:pacemaker:Dummy
+ms m d4
+delete m
+master m d4
+primitive s5 ocf:pacemaker:Stateful \
+        operations $id-ref=d1-ops
+primitive s6 ocf:pacemaker:Stateful \
+        operations $id-ref=d1
+ms m5 s5
+ms m6 s6
+primitive d7 Dummy \
+        params fake=1 extra rule score=inf \
+        expression attribute=#uname operation=eq value=node1 \
+        params fake=2 extra rule score=inf \
+        expression attribute=#uname operation=eq value=node2 \
+        op start interval=0 timeout=60s \
+        extra score=2 op_param=dummy \
+        rule expression attribute=#uname operation=eq value=node1 \
+        extra score=1 op_param=smart \
+        extra op_type=meta score=2 start-delay=120m \
+        rule expression attribute=#ra-version operation=gt value=1.0 type=version \
+        extra op_type=meta score=1 start-delay=60m
+location l1 g1 on node1 score=100
+location l2 c \
+        rule $id=l2-rule1 score=100 expression attribute=#uname operation=eq value=node1
+location l3 m5 \
+        rule score=inf \
+        expression attribute=#uname operation=eq value=node1 and \
+        expression attribute=pingd operation=gt value=0
+location l4 m5 \
+        rule score=-inf \
+        expression attribute=pingd operation=not_defined or \
+        expression attribute=pingd operation=lte value=0
+location l5 m5 \
+        rule score=-inf \
+        expression attribute=pingd operation=not_defined or \
+        expression attribute=pingd operation=lte value=0 \
+        rule score=0 \
+        expression attribute="#uname" operation=eq value=node1 and \
+        expression attribute=pingd operation=gt value=0 \
+        rule \
+        date operation=lt end=2009-05-26 and \
+        date operation=in_range start=2009-05-26 end=2009-07-26 and \
+        date operation=in_range start=2009-05-26 duration years=2009 and \
+        date operation=date_spec years=2009 hours=09-17
+primitive x1 ocf:pacemaker:Dummy
+primitive x2 ocf:pacemaker:Dummy
+primitive x3 ocf:pacemaker:Dummy
+primitive x4 ocf:pacemaker:Dummy
+primitive x5 ocf:pacemaker:Dummy
+primitive x6 ocf:pacemaker:Dummy
+primitive x7 ocf:pacemaker:Dummy
+primitive x8 ocf:pacemaker:Dummy
+colocation c1 x1 with x2 options score=inf
+colocation c2 x3 role=Master with x4 with_role=Started options score=inf
+order o1 first x1 then x2 options kind=Mandatory
+order o2 first x3 first-action=start then x4 then-action=promote options kind=Optional
+order o3 first x5 then x6 options kind=Serialize
+order o4 first x7 then x8
+rsc_ticket ticket-A_x1 ticket=ticket-A x1
+rsc_ticket ticket-B_x2_x3 ticket=ticket-B \
+        resource_set x2 x3 \
+        options loss-policy=fence
+rsc_ticket ticket-C_master ticket=ticket-C \
+        resource_set x4 \
+        resource_set x5 role=Master \
+        options loss-policy=fence

--- a/test/testcases/new-syntax.exp
+++ b/test/testcases/new-syntax.exp
@@ -1,0 +1,153 @@
+.TRY Basic configure
+.INP: configure
+.INP: _regtest on
+.INP: erase
+.INP: erase nodes
+.INP: node node1
+.INP: delete node1
+.INP: node node1         attributes mem=16G
+.INP: node node2 utilization cpu=4
+.INP: primitive st stonith:ssh         params hostlist='node1 node2'         meta target-role="Started" requires=nothing         op start timeout=60s         op monitor interval=60m timeout=60s
+.INP: primitive d1 ocf:pacemaker:Dummy         operations $id=d1-ops         op monitor interval=60m         op monitor interval=120m OCF_CHECK_LEVEL=10
+.INP: monitor d1 60s:30s
+.INP: primitive d2 ocf:heartbeat:Delay         params mondelay=60         op start timeout=60s         op stop timeout=60s
+.INP: monitor d2:Started 60s:30s
+.INP: group g1 d1 d2
+.INP: primitive d3 ocf:pacemaker:Dummy
+.INP: clone c d3         meta clone-max=1
+.INP: primitive d4 ocf:pacemaker:Dummy
+.INP: ms m d4
+.INP: delete m
+.INP: master m d4
+.INP: primitive s5 ocf:pacemaker:Stateful         operations $id-ref=d1-ops
+.INP: primitive s6 ocf:pacemaker:Stateful         operations $id-ref=d1
+.INP: ms m5 s5
+.INP: ms m6 s6
+.INP: primitive d7 Dummy         params fake=1 extra rule score=inf         expression attribute=#uname operation=eq value=node1         params fake=2 extra rule score=inf         expression attribute=#uname operation=eq value=node2         op start interval=0 timeout=60s         extra score=2 op_param=dummy         rule expression attribute=#uname operation=eq value=node1         extra score=1 op_param=smart         extra op_type=meta score=2 start-delay=120m         rule expression attribute=#ra-version operation=gt value=1.0 type=version         extra op_type=meta score=1 start-delay=60m
+.INP: location l1 g1 on node1 score=100
+.INP: location l2 c         rule $id=l2-rule1 score=100 expression attribute=#uname operation=eq value=node1
+.INP: location l3 m5         rule score=inf         expression attribute=#uname operation=eq value=node1 and         expression attribute=pingd operation=gt value=0
+.INP: location l4 m5         rule score=-inf         expression attribute=pingd operation=not_defined or         expression attribute=pingd operation=lte value=0
+.INP: location l5 m5         rule score=-inf         expression attribute=pingd operation=not_defined or         expression attribute=pingd operation=lte value=0         rule score=0         expression attribute="#uname" operation=eq value=node1 and         expression attribute=pingd operation=gt value=0         rule         date operation=lt end=2009-05-26 and         date operation=in_range start=2009-05-26 end=2009-07-26 and         date operation=in_range start=2009-05-26 duration years=2009 and         date operation=date_spec years=2009 hours=09-17
+.INP: primitive x1 ocf:pacemaker:Dummy
+.INP: primitive x2 ocf:pacemaker:Dummy
+.INP: primitive x3 ocf:pacemaker:Dummy
+.INP: primitive x4 ocf:pacemaker:Dummy
+.INP: primitive x5 ocf:pacemaker:Dummy
+.INP: primitive x6 ocf:pacemaker:Dummy
+.INP: primitive x7 ocf:pacemaker:Dummy
+.INP: primitive x8 ocf:pacemaker:Dummy
+.INP: colocation c1 x1 with x2 options score=inf
+.INP: colocation c2 x3 role=Master with x4 with_role=Started options score=inf
+.INP: order o1 first x1 then x2 options kind=Mandatory
+.INP: order o2 first x3 first-action=start then x4 then-action=promote options kind=Optional
+.INP: order o3 first x5 then x6 options kind=Serialize
+.INP: order o4 first x7 then x8
+.INP: rsc_ticket ticket-A_x1 ticket=ticket-A x1
+.INP: rsc_ticket ticket-B_x2_x3 ticket=ticket-B         resource_set x2 x3         options loss-policy=fence
+.INP: rsc_ticket ticket-C_master ticket=ticket-C         resource_set x4         resource_set x5 role=Master         options loss-policy=fence
+.INP: show
+node node1 \
+	attributes mem=16G
+node node2 \
+	utilization cpu=4
+primitive d1 ocf:pacemaker:Dummy \
+	operations $id=d1-ops \
+	op monitor interval=60m \
+	op monitor interval=120m \
+	    extra OCF_CHECK_LEVEL=10 \
+	op monitor interval=60s timeout=30s
+primitive d2 Delay \
+	params mondelay=60 \
+	op start timeout=60s interval=0 \
+	op stop timeout=60s interval=0 \
+	op monitor role=Started interval=60s timeout=30s
+primitive d3 ocf:pacemaker:Dummy
+primitive d4 ocf:pacemaker:Dummy
+primitive d7 Dummy \
+	params fake=1 \
+	    extra \
+	    rule expression attribute="#uname" operation=eq value=node1 \
+	params fake=2 \
+	    extra \
+	    rule expression attribute="#uname" operation=eq value=node2 \
+	op start interval=0 timeout=60s \
+	    extra score=2 op_param=dummy \
+	    rule expression attribute="#uname" operation=eq value=node1 \
+	    extra score=1 op_param=smart \
+	    extra score=2 start-delay=120m op_type=meta \
+	    rule expression attribute="#ra-version" operation=gt value=1.0 type=version \
+	    extra score=1 start-delay=60m op_type=meta
+primitive s5 ocf:pacemaker:Stateful \
+	operations  $id-ref=d1-ops
+primitive s6 ocf:pacemaker:Stateful \
+	operations  $id-ref=d1-ops
+primitive st stonith:ssh \
+	params hostlist="node1 node2" \
+	meta target-role=Started requires=nothing \
+	op start timeout=60s interval=0 \
+	op monitor interval=60m timeout=60s
+primitive x1 ocf:pacemaker:Dummy
+primitive x2 ocf:pacemaker:Dummy
+primitive x3 ocf:pacemaker:Dummy
+primitive x4 ocf:pacemaker:Dummy
+primitive x5 ocf:pacemaker:Dummy
+primitive x6 ocf:pacemaker:Dummy
+primitive x7 ocf:pacemaker:Dummy
+primitive x8 ocf:pacemaker:Dummy
+group g1 d1 d2
+ms m d4
+ms m5 s5
+ms m6 s6
+clone c d3 \
+	meta clone-max=1
+colocation c1 x1 with x2 \
+	options score=inf
+colocation c2 x3 role=Master with x4 with_role=Started \
+	options score=inf
+location l1 g1 on node1 score=100
+location l2 c \
+	rule score=100 \
+	expression attribute="#uname" operation=eq value=node1
+location l3 m5 \
+	rule \
+	expression attribute="#uname" operation=eq value=node1 and \
+	expression attribute=pingd operation=gt value=0
+location l4 m5 \
+	rule score=-inf \
+	expression attribute=pingd operation=not_defined or \
+	expression attribute=pingd operation=lte value=0
+location l5 m5 \
+	rule score=-inf \
+	expression attribute=pingd operation=not_defined or \
+	expression attribute=pingd operation=lte value=0 \
+	rule score=0 \
+	expression attribute="#uname" operation=eq value=node1 and \
+	expression attribute=pingd operation=gt value=0 \
+	rule \
+	date operation=lt end=2009-05-26 and \
+	date operation=in_range start=2009-05-26 end=2009-07-26 and \
+	date operation=in_range start=2009-05-26 duration years=2009 and \
+	date operation=date_spec years=2009 hours=09-17
+order o1 first x1 then x2 \
+	options kind=Mandatory
+order o2 first x3 first-action=start then x4 then-action=promote \
+	options kind=Optional
+order o3 first x5 then x6 \
+	options kind=Serialize
+order o4 first x7 then x8
+rsc_ticket ticket-A_x1 ticket=ticket-A x1
+rsc_ticket ticket-B_x2_x3 ticket=ticket-B \
+	resource_set x2 x3 \
+	options loss-policy=fence
+rsc_ticket ticket-C_master ticket=ticket-C \
+	resource_set x4 \
+	resource_set x5 role=Master \
+	options loss-policy=fence
+.INP: commit
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
+.EXT crm_resource --show-metadata ocf:heartbeat:Delay
+.EXT crm_resource --show-metadata ocf:pacemaker:Stateful
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy


### PR DESCRIPTION
#### Changes about constraints/rules/resource_set completer and constraints syntax

#### Motivation
- current syntax is not very clear
```
e.g.
  
location l1 g1 100: node1
  
location l3 m5 rule inf: #uname eq node1 and pingd gt 0

order o-2 Serialize: A ( B C )

collocation c2 inf: m5:Master d1:Started

rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence
```
- no rules/resource_set/options completer, input manually is hard because xml.rng is complicate and huge
- no options help messages by interactive

#### Features:
- Explicit syntax
```
e.g.
location id=l1 g1 on node1 score=100

location l3 m5 \
        rule score=inf \
        expression attribute=#uname operation=eq value=node1 and \
        expression attribute=pingd operation=gt value=0

order o-2 \
        resource_set A \
        resource_set B C sequential=false \
        options kind=Serialize

colocation c2 m5 role=Master with d1 with_role=Started options score=inf

rsc_ticket ticket-C_master ticket=ticket-C \
        resource_set m6 \
        resource_set m5 role=Master \
        options loss-policy=fence
```
- complete each steps which from latest constraints.rng and rule.rng
- all options have help messages in interactive mode

#### Demo
- [location](https://asciinema.org/a/172520)
- [order](https://asciinema.org/a/172521)
- [colocation](https://asciinema.org/a/172522)