### PR TITLE
[crmsh 3] crmsh cluster init : support GCE

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -108,10 +108,13 @@ def network_defaults(interface=None):
         sp = l.split()
         if info[0] is None and len(sp) >= 5 and sp[0] == 'default' and sp[1] == 'via':
             info[0] = sp[4]
-        if info[0] is not None:
-            if sp[0].find('/') >= 0 and valfor(sp, 'dev') == info[0]:
+        if info[0] is not None and valfor(sp, 'dev') == info[0] and sp[0] != 'default':
+            if sp[0].find('/') >= 0:
                 nw, length = sp[0].split('/')
                 info[1], info[2], info[3] = valfor(sp, 'src'), nw, length
+            # we are reading /32 route entry
+            else:
+                info[1], info[2], info[3] = valfor(sp, 'src'), sp[0], 32
     if info[0] is None:
         raise ValueError("Failed to determine default network interface")
     return tuple(info)


### PR DESCRIPTION
Hello

This PR permits the use of crmsh to configure cluster hosted on GCE.
GCE instances are peculiar because the network interface is configured with a /32 address.

Regards
dud