### PR TITLE
Low: Travis-CI: make sure exit value is not 0 while unittest failed

### DIFF
--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -22,6 +22,7 @@ regression_tests() {
 }
 
 unit_tests
+rc_unittest=$?
 configure
 make_install
-regression_tests
+regression_tests && exit $rc_unittest


### PR DESCRIPTION
Hi krig:
    I create this request because I want the whole Travis-CI return failed status when unittest failed and testcases success