### PR TITLE
Low: bootstrap: No warning message when using '-q'

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -96,8 +96,7 @@ def warn(*args):
     Log and display a warning message.
     """
     log("WARNING: {}".format(" ".join(str(arg) for arg in args)))
-    if not _context.quiet:
-        print(term.render(clidisplay.warn("! {}".format(" ".join(str(arg) for arg in args)))))
+    print(term.render(clidisplay.warn("! {}".format(" ".join(str(arg) for arg in args)))))
 
 
 @utils.memoize


### PR DESCRIPTION
Warning message should be shown whether quiet option has been set.