### PR TITLE
dev: a conservative way for commit 715f27

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -49,8 +49,9 @@ class Context(object):
         '''
         def trans_to_help(line):
             line_list = line.split()
-            if len(line_list) == 2 and line_list[1] in ["-h", "--help"]:
-                return "help " + line_list[0]
+            if line_list[-1] in ["-h", "--help"] and \
+               line_list[-2] == "property":
+                return " ".join(line_list[:-2] + ["help", "property"])
             else:
                 return line
 


### PR DESCRIPTION
I found commit #378, to resolve #367, have some problems:
1. commands in ui_cluster like init, join, add, remove, and geo_* already accept "-h" and "--help" option,
    #378 will overwrite them
2. var line_list maybe from root level like ["configure", "property", "-h"], its length not always be 2

I can not find a good way to solve this.
So I just focus on the "property" command temporary.