### PR TITLE
High: bootstrap: change default ip address way for both mcast and unicat

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -911,27 +911,19 @@ Configure Corosync (unicast):
     mcastport_res = []
     default_ports = ["5405", "5407"]
     two_rings = False
-    default_networks = []
 
-    if _context.ipv6:
-        network_list = []
-        all_ = utils.network_v6_all()
-        for item in all_.values():
-            network_list.extend(item)
-        default_networks = [utils.get_ipv6_network(x) for x in network_list]
-    else:
-        network_list = utils.network_all()
-        if len(network_list) > 1:
-            default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
-        else:
-            default_networks = _context.ip_network
-    if not default_networks:
+    local_iplist = utils.ip_in_local(_context.ipv6)
+    len_iplist = len(local_iplist)
+    if len_iplist == 0:
         error("No network configured at {}!".format(utils.this_node()))
+
+    local_iplist.remove(_context.ip_address)
+    default_ip = [_context.ip_address, local_iplist[0]]
 
     for i in 0, 1:
         ringXaddr = prompt_for_string('Address for ring{}'.format(i),
                                       r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                      _context.ip_address if i == 0 and _context.ip_address else "",
+                                      default_ip[i],
                                       valid_ucastIP,
                                       ringXaddr_res)
         if not ringXaddr:
@@ -948,7 +940,7 @@ Configure Corosync (unicast):
         mcastport_res.append(mcastport)
 
         if i == 1 or \
-           len(default_networks) == 1 or \
+           len_iplist == 1 or \
            not _context.second_hb or \
            not confirm("\nAdd another heartbeat line?"):
             break
@@ -1013,7 +1005,8 @@ Configure Corosync:
     else:
         network_list = utils.network_all()
         if len(network_list) > 1:
-            default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
+            network_list.remove(_context.ip_network)
+            default_networks = [_context.ip_network, network_list[0]]
         else:
             default_networks = _context.ip_network
     if not default_networks:
@@ -1712,12 +1705,20 @@ def join_cluster(seed_host):
     # if unicast, we need to add our node to $corosync.conf()
     is_unicast = "nodelist" in open(corosync.conf()).read()
     if is_unicast:
+        local_iplist = utils.ip_in_local(_context.ipv6)
+        len_iplist = len(local_iplist)
+        if len_iplist == 0:
+            error("No network configured at {}!".format(utils.this_node()))
+
+        local_iplist.remove(_context.ip_address)
+        default_ip = [_context.ip_address, local_iplist[0]]
+
         ringXaddr_res = []
         for i in 0, 1:
             while True:
                 ringXaddr = prompt_for_string('Address for ring{}'.format(i),
                                               r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                              _context.ip_address if i == 0 and _context.ip_address else "",
+                                              default_ip[i],
                                               valid_ucastIP,
                                               ringXaddr_res)
                 if not ringXaddr:


### PR DESCRIPTION
Problems solved:
* For mcast
  `crm cluster init -M -y` 
   will failed, cause the second default ip value is None

* For unicat
  Provide two default ip values both for init and join process.
  So no matter whether or not the init node using multi rings, in join node, the command always be:
  `crm cluster join -c peer_ip -y`
  no need more options like '-l' to provide ip list:)