### PR TITLE
Fix incorrect bindnetaddr in corosync.conf (bsc#1103833) (bsc#1103834)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -924,7 +924,7 @@ Configure Corosync (unicast):
         if len(network_list) > 1:
             default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
         else:
-            default_networks = _context.ip_network
+            default_networks = [_context.ip_network]
     if not default_networks:
         error("No network configured at {}!".format(utils.this_node()))
 
@@ -1015,7 +1015,7 @@ Configure Corosync:
         if len(network_list) > 1:
             default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
         else:
-            default_networks = _context.ip_network
+            default_networks = [_context.ip_network]
     if not default_networks:
         error("No network configured at {}!".format(utils.this_node()))
 


### PR DESCRIPTION
default_networks should be a list, otherwise the string is treated as a list of characters.