### PR TITLE
Fix: bootstrap: change default ip address way for both mcast and unic…

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -235,6 +235,21 @@ def wait_for_cluster():
     status_done()
 
 
+def pick_default_value(default_list, prev_list):
+    """
+    Provide default value for function 'prompt_for_string'.
+    Make sure give different default value in multi-ring mode.
+
+    Parameters:
+    * default_list - default value list for config item
+    * prev_list    - previous value for config item in multi-ring mode
+    """
+    for value in default_list:
+        if value not in prev_list:
+            return value
+    return ""
+
+
 def start_service(service):
     """
     Start and enable systemd service
@@ -886,11 +901,6 @@ def valid_port(port, prev_value=None):
 
 
 def init_corosync_unicast():
-    def pick_default_value(vlist, ilist):
-        # give a different value for second config items
-        if len(ilist) == 1:
-            vlist.remove(ilist[0])
-        return vlist[0]
 
     if _context.yes_to_all:
         status("Configuring corosync (unicast)")
@@ -911,27 +921,18 @@ Configure Corosync (unicast):
     mcastport_res = []
     default_ports = ["5405", "5407"]
     two_rings = False
-    default_networks = []
 
-    if _context.ipv6:
-        network_list = []
-        all_ = utils.network_v6_all()
-        for item in all_.values():
-            network_list.extend(item)
-        default_networks = [utils.get_ipv6_network(x) for x in network_list]
-    else:
-        network_list = utils.network_all()
-        if len(network_list) > 1:
-            default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
-        else:
-            default_networks = [_context.ip_network]
-    if not default_networks:
+    local_iplist = utils.ip_in_local(_context.ipv6)
+    len_iplist = len(local_iplist)
+    if len_iplist == 0:
         error("No network configured at {}!".format(utils.this_node()))
+
+    default_ip = [_context.ip_address] + [ip for ip in local_iplist if ip != _context.ip_address]
 
     for i in 0, 1:
         ringXaddr = prompt_for_string('Address for ring{}'.format(i),
                                       r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                      _context.ip_address if i == 0 and _context.ip_address else "",
+                                      pick_default_value(default_ip, ringXaddr_res),
                                       valid_ucastIP,
                                       ringXaddr_res)
         if not ringXaddr:
@@ -948,7 +949,7 @@ Configure Corosync (unicast):
         mcastport_res.append(mcastport)
 
         if i == 1 or \
-           len(default_networks) == 1 or \
+           len_iplist == 1 or \
            not _context.second_hb or \
            not confirm("\nAdd another heartbeat line?"):
             break
@@ -975,12 +976,6 @@ def init_corosync_multicast():
             random.randint(0, 255),
             random.randint(0, 255),
             random.randint(1, 255))
-
-    def pick_default_value(vlist, ilist):
-        # give a different value for second config items
-        if len(ilist) == 1:
-            vlist.remove(ilist[0])
-        return vlist[0]
 
     if _context.yes_to_all:
         status("Configuring corosync")
@@ -1013,7 +1008,8 @@ Configure Corosync:
     else:
         network_list = utils.network_all()
         if len(network_list) > 1:
-            default_networks = [_context.ip_network, network_list.remove(_context.ip_network)]
+            network_list.remove(_context.ip_network)
+            default_networks = [_context.ip_network, network_list[0]]
         else:
             default_networks = [_context.ip_network]
     if not default_networks:
@@ -1712,12 +1708,19 @@ def join_cluster(seed_host):
     # if unicast, we need to add our node to $corosync.conf()
     is_unicast = "nodelist" in open(corosync.conf()).read()
     if is_unicast:
+        local_iplist = utils.ip_in_local(_context.ipv6)
+        len_iplist = len(local_iplist)
+        if len_iplist == 0:
+            error("No network configured at {}!".format(utils.this_node()))
+
+        default_ip = [_context.ip_address] + [ip for ip in local_iplist if ip != _context.ip_address]
+
         ringXaddr_res = []
         for i in 0, 1:
             while True:
                 ringXaddr = prompt_for_string('Address for ring{}'.format(i),
                                               r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                              _context.ip_address if i == 0 and _context.ip_address else "",
+                                              pick_default_value(default_ip, ringXaddr_res),
                                               valid_ucastIP,
                                               ringXaddr_res)
                 if not ringXaddr:


### PR DESCRIPTION
…at(bsc#1109975,bsc#1109974)
Problems solved:
**in mcast mode:**
run command `crm cluster init -M -y` failed
error messages are:
"ERROR: cluster.init: No value for bindnetaddr"

**in unicast mode:**
run command `crm cluster init -M -y` failed
error messages are:
"ERROR: cluster.init: No value for ring1"

**These because we forgot provide the second default value for non interactive mode**

And for unicat
Provide two default ip values both for init and join process.
So no matter whether or not the init node using multi rings, in join node, the command always be:
crm cluster join -c peer_ip -y
no need more options like '-l' to provide ip list:)