### PR TITLE
Fix and test for agent parameters changing from dashed form to underscored form

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -470,6 +470,23 @@ class RAInfo(object):
         except:
             return None
 
+    def normalize_parameters(self, root):
+        """
+        Find all instance_attributes/nvpair objects,
+        check if parameter exists. If not, normalize name
+        and check if THAT exists (replacing - with _).
+        If so, change the name of the parameter.
+        """
+        params = self.params()
+        if not params:
+            return
+        for nvp in root.xpath("instance_attributes/nvpair"):
+            name = nvp.get("name")
+            if name is not None and name not in params:
+                name = name.replace("-", "_")
+                if name in params:
+                    nvp.attrib["name"] = name
+
     def sanity_check_params(self, ident, nvpairs, existence_only=False):
         '''
         nvpairs is a list of <nvpair> tags.

--- a/data-manifest
+++ b/data-manifest
@@ -125,6 +125,7 @@ test/travis-tests.sh
 test/unittests/bug-862577_corosync.conf
 test/unittests/corosync.conf.1
 test/unittests/corosync.conf.2
+test/unit-tests-in-container.sh
 test/unittests/__init__.py
 test/unittests/schemas/acls-1.1.rng
 test/unittests/schemas/acls-1.2.rng

--- a/test/containerized-regression-tests.sh
+++ b/test/containerized-regression-tests.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 docker pull krig/crmsh:latest
-docker run -t -v "$(pwd):/app" krig/crmsh /bin/sh -c "cd /app; ./test/run-in-container.sh $(id -un) $(id -gn) $(id -u) $(id -g)"
+
+if [ "$1" = "--unit-tests" ]; then
+	docker run -t -v "$(pwd):/app" krig/crmsh /bin/sh -c "cd /app; ./test/unit-tests-in-container.sh $(id -un) $(id -gn) $(id -u) $(id -g)"
+else
+	docker run -t -v "$(pwd):/app" krig/crmsh /bin/sh -c "cd /app; ./test/run-in-container.sh $(id -un) $(id -gn) $(id -u) $(id -g)"
+fi

--- a/test/testcases/acl.exp
+++ b/test/testcases/acl.exp
@@ -6,7 +6,10 @@
 .INP: node node1
 .INP: property enable-acl=true
 .INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" requires=nothing 	op start timeout=60s 	op monitor interval=60m timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive d0 ocf:pacemaker:Dummy
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .INP: primitive d1 ocf:pacemaker:Dummy
 .INP: role basic-read        read status        read type:node attribute:uname        read type:node attribute:type        read property
 .INP: role basic-read-basic 	read cib
@@ -19,9 +22,6 @@
 .INP: acl_target cyrus cyrus-role
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -5,7 +5,10 @@
 .INP: configure
 .INP: erase
 .INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.EXT crm_resource --show-metadata stonith:null
+.EXT stonithd metadata
 .INP: primitive p4 Dummy
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive p3 Dummy
 .INP: primitive p2 Dummy
 .INP: primitive p1 Dummy
@@ -36,9 +39,6 @@ primitive p6 Dummy
 clone cl-p5 p5
 colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: commit
-.EXT crm_resource --show-metadata stonith:null
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: _test
 .INP: verify
 .INP: show
@@ -61,6 +61,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: up
 .INP: configure
 .INP: load update bugs-test.txt
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: show
 node node1
 primitive st stonith:null \
@@ -87,7 +88,6 @@ op_defaults op-options: \
 .INP: commit
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: _test
 .INP: verify
 .TRY Unknown properties
@@ -97,6 +97,8 @@ INFO: 2: constraint colocation:c2 updated
 INFO: 2: constraint colocation:c2 updated
 INFO: 2: modified location:loc1 from g1 to gr2
 .INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.EXT crm_resource --show-metadata stonith:null
+.EXT stonithd metadata
 .INP: property SAPHanaSR:     hana_ha1_site_lss_WDF1=4
 .INP: show
 node node1
@@ -107,8 +109,6 @@ primitive st stonith:null \
 property SAPHanaSR: \
 	hana_ha1_site_lss_WDF1=4
 .INP: commit
-.EXT crm_resource --show-metadata stonith:null
-.EXT stonithd metadata
 .INP: _test
 .INP: verify
 .INP: property SAPHanaSR_2:     hana_ha1_site_iss_WDF1=cde     hana_ha1_site_bss_WDF1=abc

--- a/test/testcases/bundle.exp
+++ b/test/testcases/bundle.exp
@@ -8,16 +8,16 @@
 .INP: node node1 	attributes mem=16G
 .INP: node node2 utilization cpu=4
 .INP: primitive st stonith:ssh 	params hostlist='node1 node2' 	meta target-role="Started" requires=nothing 	op start timeout=60s 	op monitor interval=60m timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive st2 stonith:ssh 	params hostlist='node1 node2'
 .INP: bundle id=bundle-test1 docker image=test network ip-range-start=10.10.10.123 port-mapping id=port1 port=80 storage storage-mapping id=storage1 target-dir=test source-dir=test meta target-role=Stopped
 .INP: primitive id=dummy ocf:heartbeat:Dummy op monitor interval=10 meta target-role=Stopped
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: bundle id=bundle-test2 docker image=test network ip-range-start=10.10.10.123 primitive dummy meta target-role=Stopped priority=1
 .INP: property stonith-enabled=true
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -5,12 +5,13 @@
 .INP: erase nodes
 .INP: op_defaults timeout=2m
 .INP: primitive st stonith:null 	params hostlist='node1' 	meta yoyo-meta="yoyo 2" requires=nothing 	op monitor interval=60m
-.INP: commit
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
+.INP: commit
 WARNING: 7: st: unknown attribute 'yoyo-meta'
 .INP: node node1 	attributes mem=16G
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive p2 ocf:heartbeat:Dummy
 .INP: primitive p3 ocf:heartbeat:Dummy
 .INP: group g1 p1 p2
@@ -22,7 +23,6 @@ WARNING: 7: st: unknown attribute 'yoyo-meta'
 .INP: primitive d2 ocf:heartbeat:Dummy
 .INP: primitive d3 ocf:heartbeat:Dummy
 .INP: commit
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: rename p3 pp3
 INFO: 21: modified location:l1 from p3 to pp3
 INFO: 21: modified order:o1 from p3 to pp3

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -8,10 +8,14 @@
 .INP: node node1 	attributes mem=16G
 .INP: node node2 utilization cpu=4
 .INP: primitive st stonith:ssh 	params hostlist='node1 node2' 	meta target-role="Started" 	op start timeout=60s 	op monitor interval=60m timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive st2 stonith:ssh 	params hostlist='node1 node2'
 .INP: primitive d1 ocf:pacemaker:Dummy 	operations $id=d1-ops 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .INP: monitor d1 60s:30s
 .INP: primitive d2 ocf:heartbeat:Delay 	params mondelay=60 	op start timeout=60s 	op stop timeout=60s
+.EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .INP: monitor d2:Started 60s:30s
 .INP: group g1 d1 d2
 .INP: primitive d3 ocf:pacemaker:Dummy
@@ -21,10 +25,12 @@
 .INP: delete m
 .INP: master m d4
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
+.EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
 .INP: ms m5 s5
 .INP: ms m6 s6
 .INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: location l1 g1 100: node1
 .INP: location l2 c 	rule $id=l2-rule1 100: #uname eq node1
 .INP: location l3 m5 	rule inf: #uname eq node1 and pingd gt 0
@@ -50,12 +56,6 @@
 .INP: set d2.mondelay 45
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
-.EXT crm_resource --show-metadata ocf:heartbeat:Delay
-.EXT crm_resource --show-metadata ocf:pacemaker:Stateful
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 WARNING: 51: c2: resource d1 is grouped, constraints should apply to the group
 .EXT crmd metadata
 .EXT pengine metadata

--- a/test/testcases/delete.exp
+++ b/test/testcases/delete.exp
@@ -6,7 +6,10 @@
 .INP: node node1
 .INP: # create one stonith so that verify does not complain
 .INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" 	op start timeout=60s 	op monitor interval=60m timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive d1 ocf:pacemaker:Dummy
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .INP: primitive d2 ocf:pacemaker:Dummy
 .INP: location d1-pref d1 100: node1
 .INP: show
@@ -87,9 +90,6 @@ primitive st stonith:ssh \
 	op monitor interval=60m timeout=60s
 location d1-pref d1 100: node1
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .INP: # delete a group which is in a clone
 .INP: primitive d2 ocf:pacemaker:Dummy
 .INP: group g1 d2 d1

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -6,7 +6,10 @@
 .INP: op_defaults timeout=2m
 .INP: node node1 	attributes mem=16G
 .INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.EXT crm_resource --show-metadata stonith:null
+.EXT stonithd metadata
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: filter "sed '$aprimitive p2 ocf:heartbeat:Dummy'"
 .INP: filter "sed '$agroup g1 p1 p2'"
 .INP: show
@@ -126,9 +129,6 @@ tag t-d45 d4 d5
 order o-d456 d4 d5 d6
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:null
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -6,7 +6,10 @@
 .INP: node node1
 .INP: # create one stonith so that verify does not complain
 .INP: primitive st stonith:ssh 	params hostlist='node1' 	meta target-role="Started" requires=nothing 	op start timeout=60s 	op monitor interval=60m timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive p0 Dummy params $p0-state:state=1
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive p1 Dummy params     rule role=Started date in start=2009-05-26 end=2010-05-26 or date gt 2014-01-01     state=2
 .INP: primitive p2 Dummy params @p0-state
 .INP: property rule #uname eq node1 stonith-enabled=no
@@ -47,9 +50,6 @@ alert notify_9 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
 	to 192.168.40.9
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .EXT crmd metadata
 .EXT pengine metadata
 .EXT cib metadata

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -829,11 +829,11 @@ INFO: Trace set, restart p0 to trace the stop operation
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .TRY configure primitive p3 Dummy
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .TRY resource stop p3
 .TRY resource start p3
 .TRY resource cleanup

--- a/test/testcases/rset.exp
+++ b/test/testcases/rset.exp
@@ -5,8 +5,12 @@
 .INP: erase nodes
 .INP: node node1
 .INP: primitive st stonith:ssh 	params hostlist='node1' 	op start timeout=60s
+.EXT crm_resource --show-metadata stonith:ssh
+.EXT stonithd metadata
 .INP: primitive d1 ocf:pacemaker:Dummy
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .INP: primitive d2 ocf:heartbeat:Dummy
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive d3 ocf:heartbeat:Dummy
 .INP: primitive d4 ocf:heartbeat:Dummy
 .INP: primitive d5 ocf:heartbeat:Dummy
@@ -36,10 +40,6 @@ colocation c3 inf: d3 d1
 order o1 Serialize: d1 d3
 .INP: _test
 .INP: verify
-.EXT crm_resource --show-metadata stonith:ssh
-.EXT stonithd metadata
-.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
-.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: show
 node node1
 primitive d1 ocf:pacemaker:Dummy

--- a/test/unit-tests-in-container.sh
+++ b/test/unit-tests-in-container.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+oname=$1
+ogroup=$2
+ouid=$3
+ogid=$4
+
+cat /etc/group | awk '{ FS = ":" } { print $3 }' | grep -q "$ogid" || groupadd -g "$ogid"
+id -u $oname >/dev/null 2>&1 || useradd -u $ouid -g $ogid $oname
+
+preamble() {
+	systemctl start dbus
+}
+
+unit_tests() {
+	echo "** Unit tests"
+	su $oname -c "./test/run -v"
+}
+
+preamble
+unit_tests
+

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -303,12 +303,12 @@ def test_locrule():
 
 @with_setup(setup_func, teardown_func)
 def test_is_value_sane():
-    roundtrip('''primitive p1 dummy params state="bo'o"''')
+    roundtrip('''primitive p1 Dummy params state="bo'o"''')
 
 
 @with_setup(setup_func, teardown_func)
 def test_is_value_sane_2():
-    roundtrip('primitive p1 dummy params state="bo\\"o"')
+    roundtrip('primitive p1 Dummy params state="bo\\"o"')
 
 
 @with_setup(setup_func, teardown_func)

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -62,6 +62,16 @@ def test_rscset():
     roundtrip('order order_2 Mandatory: [ A B ] C')
     roundtrip('rsc_template public_vm Xen')
 
+@with_setup(setup_func, teardown_func)
+def test_normalize():
+    """
+    Test automatic normalization of parameter names:
+    "shutdown_timeout" is a parameter name, but
+    "shutdown-timeout" is not.
+    """
+    roundtrip('primitive vm1 Xen params shutdown-timeout=0',
+              expected='primitive vm1 Xen params shutdown_timeout=0')
+
 
 @with_setup(setup_func, teardown_func)
 def test_group():


### PR DESCRIPTION
For fence-agents in particular, some parameters were changed from `this-form` to `this_form`.

To combat this, we check if a configured parameter is missing from metadata but its `this_form` is present. In that case, we change the name to the existing parameter.

This patch does not handle the case where both `this_form` and `this-form` are configured.
