### PR TITLE
Fix:bootstrap warning messages should better start with like "WARNING:"

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -96,7 +96,7 @@ def warn(*args):
     Log and display a warning message.
     """
     log("WARNING: {}".format(" ".join(str(arg) for arg in args)))
-    print(term.render(clidisplay.warn("! {}".format(" ".join(str(arg) for arg in args)))))
+    print(term.render(clidisplay.warn("WARNING: {}".format(" ".join(str(arg) for arg in args)))))
 
 
 @utils.memoize


### PR DESCRIPTION
e.g. 
"! Failed to detect firewall: Could not open ports", this makes user feel like it's an error, not a warning