### PR TITLE
dev: log_patterns: fix regexp warning for [[]

### DIFF
--- a/crmsh/log_patterns.py
+++ b/crmsh/log_patterns.py
@@ -33,7 +33,7 @@ _patterns_old = {
             "lrmd.*WARN: .* %% .*timed out$",
             "crmd.*LRM operation %%_(?:start|stop|promote|demote|migrate)_.*confirmed=true",
             "crmd.*LRM operation %%_.*Timed Out",
-            "[(]%%[)][[]",
+            "[(]%%[)]\[",
         ),
         (  # detail 1
             "lrmd.*%% (?:probe|notify)",
@@ -91,7 +91,7 @@ _patterns_118 = {
 
             "crmd.*LRM operation %%_(?:start|stop|promote|demote|migrate)_.*confirmed=true",
             "crmd.*LRM operation %%_.*Timed Out",
-            "[(]%%[)][[]",
+            "[(]%%[)]\[",
         ),
         (  # detail 1
             "crmd.*Initiating.*%%_(?:monitor_0|notify)",


### PR DESCRIPTION
Python 3.7 gives 'FutureWarning: Possible nested set' so
replace any regexp [[] with \[.