### PR TITLE
brace expansion with single quotation marks in scp command is not safe

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1577,7 +1577,7 @@ def join_csync2(seed_host):
     #   || error "Can't retrieve /etc/hosts from seed_host"
     # install_tmp $tmp_conf /etc/hosts
 
-    if not invoke("scp root@%s:'/etc/csync2/{csync2.cfg,key_hagroup}' /etc/csync2" % (seed_host)):
+    if not invoke("scp root@%s:/etc/csync2/{csync2.cfg,key_hagroup} /etc/csync2" % (seed_host)):
         error("Can't retrieve csync2 config from %s" % (seed_host))
 
     start_service("csync2.socket")


### PR DESCRIPTION
for bsc#1123028, affter updating openssh, this bug can be reproduced in my own environment
this is most likely caused by bsc#1122695,