### PR TITLE
Replace csync2 with python-parallax

### DIFF
--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -61,12 +61,6 @@ BuildRequires:  python3-lxml
 BuildRequires:  python3-setuptools
 
 %if 0%{?suse_version}
-# only require csync2 on SUSE since bootstrap
-# only works for SUSE at the moment anyway
-Requires:       csync2
-%endif
-
-%if 0%{?suse_version}
 Requires:       python3-PyYAML
 # Suse splits this off into a separate package
 Requires:       python3-curses

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -164,7 +164,6 @@ class Cluster(command.UI):
 
 Stage can be one of:
     ssh         Create SSH keys for passwordless SSH between cluster nodes
-    csync2      Configure csync2
     corosync    Configure corosync
     storage     Partition shared storage (ocfs2 template only)
     sbd         Configure SBD (requires -s <dev>)
@@ -271,9 +270,7 @@ Note:
 
 Stage can be one of:
     ssh         Obtain SSH keys from existing cluster node (requires -c <host>)
-    csync2      Configure csync2 (requires -c <host>)
-    ssh_merge   Merge root's SSH known_hosts across all nodes (csync2 must
-                already be configured).
+    ssh_merge   Merge root's SSH known_hosts across all nodes
     cluster     Start the cluster on this node
 
 If stage is not specified, each stage will be invoked in sequence.
@@ -298,7 +295,7 @@ If stage is not specified, each stage will be invoked in sequence.
         stage = ""
         if len(args) == 1:
             stage = args[0]
-        if stage not in ("ssh", "csync2", "ssh_merge", "cluster", ""):
+        if stage not in ("ssh", "ssh_merge", "cluster", ""):
             parser.error("Invalid stage (%s)" % (stage))
             return False
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1986,7 +1986,7 @@ def remote_checksum(local_path, nodes, this_node):
         print("%-16s: %s" % (host, hashlib.sha1(open(path).read()).hexdigest()))
 
 
-def cluster_copy_file(local_path, nodes=None):
+def cluster_copy_file(local_path, nodes=None, output=True):
     """
     Copies given file to all other cluster nodes.
     """
@@ -2008,7 +2008,8 @@ def cluster_copy_file(local_path, nodes=None):
             err_buf.error("Failed to push %s to %s: %s" % (local_path, host, result))
             ok = False
         else:
-            err_buf.ok(host)
+            if output:
+                err_buf.ok(host)
     return ok
 
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1200,9 +1200,6 @@ Stage can be one of:
 *ssh*::
     Create SSH keys for passwordless SSH between cluster nodes
 
-*csync2*::
-    Configure csync2
-
 *corosync*::
     Configure corosync
 
@@ -1275,12 +1272,8 @@ Stage can be one of:
 *ssh*::
     Obtain SSH keys from existing cluster node (requires -c <host>)
 
-*csync2*::
-    Configure csync2 (requires -c <host>)
-
 *ssh_merge*::
-    Merge root's SSH known_hosts across all nodes (csync2 must
-    already be configured).
+    Merge root's SSH known_hosts across all nodes
 
 *cluster*::
     Start the cluster on this node

--- a/doc/website-v1/man-3.adoc
+++ b/doc/website-v1/man-3.adoc
@@ -1152,9 +1152,6 @@ Stage can be one of:
 *ssh*::
     Create SSH keys for passwordless SSH between cluster nodes
 
-*csync2*::
-    Configure csync2
-
 *corosync*::
     Configure corosync
 
@@ -1227,12 +1224,8 @@ Stage can be one of:
 *ssh*::
     Obtain SSH keys from existing cluster node (requires -c <host>)
 
-*csync2*::
-    Configure csync2 (requires -c <host>)
-
 *ssh_merge*::
-    Merge root's SSH known_hosts across all nodes (csync2 must
-    already be configured).
+    Merge root's SSH known_hosts across all nodes
 
 *cluster*::
     Start the cluster on this node

--- a/scripts/health/collect.py
+++ b/scripts/health/collect.py
@@ -8,7 +8,7 @@ import platform
 import crm_script
 data = crm_script.get_input()
 
-PACKAGES = ['booth', 'cluster-glue', 'corosync', 'crmsh', 'csync2', 'drbd',
+PACKAGES = ['booth', 'cluster-glue', 'corosync', 'crmsh', 'drbd',
             'fence-agents', 'gfs2', 'gfs2-utils', 'ha-cluster-bootstrap',
             'haproxy', 'hawk', 'libdlm', 'libqb', 'ocfs2', 'ocfs2-tools',
             'pacemaker', 'pacemaker-mgmt', 'resource-agents', 'sbd']
@@ -73,8 +73,6 @@ def disk_info():
 # configurations out of sync
 
 FILES = [
-    '/etc/csync2/key_hagroup',
-    '/etc/csync2/csync2.cfg',
     '/etc/corosync/corosync.conf',
     '/etc/sysconfig/sbd',
     '/etc/sysconfig/SuSEfirewall2',

--- a/utils/crm_init.py
+++ b/utils/crm_init.py
@@ -5,14 +5,12 @@ import platform
 import socket
 import crm_script
 
-PACKAGES = ['booth', 'cluster-glue', 'corosync', 'crmsh', 'csync2', 'drbd',
+PACKAGES = ['booth', 'cluster-glue', 'corosync', 'crmsh', 'drbd',
             'fence-agents', 'gfs2', 'gfs2-utils', 'hawk', 'ocfs2',
             'ocfs2-tools', 'pacemaker', 'pacemaker-mgmt',
             'resource-agents', 'sbd']
 SERVICES = ['sshd', 'ntp', 'corosync', 'pacemaker', 'hawk', 'SuSEfirewall2_init']
 SSH_KEY = os.path.expanduser('~/.ssh/id_rsa')
-CSYNC2_KEY = '/etc/csync2/key_hagroup'
-CSYNC2_CFG = '/etc/csync2/csync2.cfg'
 COROSYNC_CONF = '/etc/corosync/corosync.conf'
 SYSCONFIG_SBD = '/etc/sysconfig/sbd'
 SYSCONFIG_FW = '/etc/sysconfig/SuSEfirewall2'
@@ -81,8 +79,6 @@ def files_info():
             return os.path.expanduser(fn)
         return ''
     return {'ssh_key': check(SSH_KEY),
-            'csync2_key': check(CSYNC2_KEY),
-            'csync2_cfg': check(CSYNC2_CFG),
             'corosync_conf': check(COROSYNC_CONF),
             'sysconfig_sbd': check(SYSCONFIG_SBD),
             'sysconfig_fw': check(SYSCONFIG_FW),


### PR DESCRIPTION
Since using csync2 when bootstrap cluster is not stable, we want to replace it with python-parallax.

Mainly changes in bootstrap:
* when running bootstrap_join, fetch possible config files from peer-init node
* when config file changed, use utils.cluster_copy_file to sync changed files