### PR TITLE
reject append ipaddress to config file if already have(bsc#1127095, 1127096)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1745,7 +1745,10 @@ def join_cluster(seed_host):
                 break
         print("")
         invoke("rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*")
-        corosync.add_node_ucast(ringXaddr_res)
+        try:
+            corosync.add_node_ucast(ringXaddr_res)
+        except ValueError as e:
+            warn(e)
         csync2_update(corosync.conf())
         invoke("ssh -o StrictHostKeyChecking=no root@{} corosync-cfgtool -R".format(seed_host))
 

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -386,6 +386,15 @@ def add_node_ucast(IParray, node_name=None):
     f = open(conf()).read()
     p = Parser(f)
 
+    # to check if the same IP already configured
+    exist_iplist = []
+    for path in p.all_paths():
+        if re.search('nodelist.node.ring[0-9]*_addr', path):
+            exist_iplist.extend(p.get_all(path))
+    for ip in IParray:
+        if ip in exist_iplist:
+            raise ValueError("IP {} was already configured".format(ip))
+
     node_id = get_free_nodeid(p)
     node_value = []
     for i, addr in enumerate(IParray):

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -92,6 +92,27 @@ class TestCorosyncParser(unittest.TestCase):
         _valid(p)
         self.assertEqual(p.count('nodelist.node'), nid - 1)
 
+    def test_add_node_ucast(self):
+        from crmsh.corosync import add_node_ucast, get_values
+
+        os.environ["COROSYNC_MAIN_CONFIG_FILE"] = os.path.join(os.path.dirname(__file__), 'corosync.conf.2')
+
+        exist_iplist = get_values('nodelist.node.ring0_addr')
+        try:
+            add_node_ucast(['10.10.10.11'])
+        except ValueError:
+            self.fail("corosync.add_node_ucast raised ValueError unexpectedly!")
+        now_iplist = get_values('nodelist.node.ring0_addr')
+        self.assertEqual(len(exist_iplist) + 1, len(now_iplist))
+        self.assertTrue('10.10.10.11' in get_values('nodelist.node.ring0_addr'))
+
+        # bsc#1127095, 1127096; address 10.10.10.11 already exist
+        with self.assertRaises(ValueError) as err:
+            add_node_ucast(['10.10.10.11'])
+        self.assertEqual("IP 10.10.10.11 was already configured", str(err.exception))
+        now_iplist = get_values('nodelist.node.ring0_addr')
+        self.assertEqual(len(exist_iplist) + 1, len(now_iplist))
+
     def test_add_node_nodelist(self):
         from crmsh.corosync import make_section, make_value, get_free_nodeid
 


### PR DESCRIPTION
I have two nodes, node1 using 'crm cluster init -u' and node2 using 'crm cluster join', it works;

But then I run 'crm cluster stop; crm cluster join' on node2, corosync.conf will become 3 nodes cluster config file, cause node2's ip address appended it again