### PR TITLE
Replace csync2

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1868,9 +1868,6 @@ def join_csync2(seed_host):
     # subseqent join of another node can fail its sync of corosync.conf
     # when it updates expected_votes.  Grrr...
 
-    # sync CSYNC2_CFG to other nodes
-    sync_file(CSYNC2_CFG)
-
     status_done()
 
 
@@ -2006,6 +2003,8 @@ def join_cluster(seed_host):
             corosync.set_value("totem.nodeid", nodeid)
 
     setup_passwordless_with_other_nodes(seed_host)
+    # sync CSYNC2_CFG to other nodes
+    sync_file(CSYNC2_CFG)
 
     shutil.copy(corosync.conf(), COROSYNC_CONF_ORIG)
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1913,7 +1913,7 @@ def remote_checksum(local_path, nodes, this_node):
         print("%-16s: %s" % (host, hashlib.sha1(open(path).read()).hexdigest()))
 
 
-def cluster_copy_file(local_path, nodes=None):
+def cluster_copy_file(local_path, nodes=None, output=True):
     """
     Copies given file to all other cluster nodes.
     """
@@ -1926,6 +1926,7 @@ def cluster_copy_file(local_path, nodes=None):
         nodes.remove(this_node())
     opts = parallax.Options()
     opts.timeout = 60
+    opts.ssh_options += ['StrictHostKeyChecking=no']
     opts.ssh_options += ['ControlPersist=no']
     ok = True
     for host, result in parallax.copy(nodes,
@@ -1935,7 +1936,8 @@ def cluster_copy_file(local_path, nodes=None):
             err_buf.error("Failed to push %s to %s: %s" % (local_path, host, result))
             ok = False
         else:
-            err_buf.ok(host)
+            if output:
+                err_buf.ok(host)
     return ok
 
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -139,11 +139,10 @@ class TestSBDManager(unittest.TestCase):
             ])
         mock_error.assert_called_once_with("Failed to initialize SBD device /dev/sdc1")
 
-    @mock.patch('crmsh.bootstrap.csync2_update')
     @mock.patch('crmsh.utils.sysconfig_set')
     @mock.patch('crmsh.bootstrap.detect_watchdog_device')
     @mock.patch('shutil.copyfile')
-    def test_update_configuration(self, mock_copy, mock_detect, mock_sysconfig, mock_update):
+    def test_update_configuration(self, mock_copy, mock_detect, mock_sysconfig):
         self.sbd_inst._sbd_devices = ["/dev/sdb1", "/dev/sdc1"]
         mock_detect.return_value = "/dev/watchdog"
 
@@ -152,7 +151,6 @@ class TestSBDManager(unittest.TestCase):
         mock_copy.assert_called_once_with("/usr/share/fillup-templates/sysconfig.sbd", "/etc/sysconfig/sbd")
         mock_detect.assert_called_once_with()
         mock_sysconfig.assert_called_once_with("/etc/sysconfig/sbd", SBD_PACEMAKER='yes', SBD_STARTMODE='always', SBD_DELAY_START='no', SBD_WATCHDOG_DEV='/dev/watchdog', SBD_DEVICE='/dev/sdb1;/dev/sdc1')
-        mock_update.assert_called_once_with("/etc/sysconfig/sbd")
 
     @mock.patch('crmsh.bootstrap.utils.parse_sysconfig')
     def test_get_sbd_device_from_config_none(self, mock_parse):
@@ -651,7 +649,7 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.stop_service')
-    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.corosync.conf')
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')
@@ -685,7 +683,7 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.stop_service')
-    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.corosync.conf')
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')


### PR DESCRIPTION
Since using csync2 when bootstrap cluster is not stable, we want to replace it with python-parallax.

Mainly changes in bootstrap:
* keep csync2 configure related code unchanged
* when running bootstrap_join, fetch possible config files from peer-init node
* when config file changed, use utils.cluster_copy_file to sync changed files