### PR TITLE
Fix: cibconfig: #425 The ID attribute is not required for select and …

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -686,7 +686,7 @@ def fix_node_ids(node, oldnode):
         'alerts': 'alert',
         }
 
-    idless = set(['operations', 'fencing-topology', 'network', 'docker', 'rkt', 'storage'])
+    idless = set(['operations', 'fencing-topology', 'network', 'docker', 'rkt', 'storage', 'select', 'select_attributes'])
     isref = set(['resource_ref', 'obj_ref', 'crmsh-ref'])
 
     def needs_id(node):

--- a/test/testcases/newfeatures
+++ b/test/testcases/newfeatures
@@ -27,6 +27,11 @@ alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh \
         trap_node_states="non-trap" \
         trap_resource_tasks="start,stop,monitor,promote,demote" \
         to "192.168.40.9"
+alert notify_10 /usr/share/pacemaker/alerts/alert_snmp.sh \
+        attributes \
+        trap_add_hires_timestamp_oid="false" \
+        select attributes { master-prmStateful test1 } \
+        to 192.168.28.188
 show tag:ones and type:location
 show tag:ones and p1
 show

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -19,6 +19,7 @@
 .INP: primitive node1 Dummy
 .INP: tag ones l1 p1
 .INP: alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh         attributes         trap_add_hires_timestamp_oid="false"         trap_node_states="non-trap"         trap_resource_tasks="start,stop,monitor,promote,demote"         to "192.168.40.9"
+.INP: alert notify_10 /usr/share/pacemaker/alerts/alert_snmp.sh         attributes         trap_add_hires_timestamp_oid="false"         select attributes { master-prmStateful test1 }         to 192.168.28.188
 .INP: show tag:ones and type:location
 location l1 { p0 p1 p2 } inf: node1
 .INP: show tag:ones and p1
@@ -45,6 +46,10 @@ location l1 { p0 p1 p2 } inf: node1
 property cib-bootstrap-options: \
 	rule #uname eq node1 \
 	stonith-enabled=no
+alert notify_10 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
+	attributes trap_add_hires_timestamp_oid=false \
+        select attributes { master-prmStateful test1 } \
+	to 192.168.28.188
 alert notify_9 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
 	attributes trap_add_hires_timestamp_oid=false trap_node_states=non-trap trap_resource_tasks="start,stop,monitor,promote,demote" \
 	to 192.168.40.9


### PR DESCRIPTION
…select_attributes

Mentioned in #425 ,
The ID attribute is not required for select and select_attributes, according to https://github.com/ClusterLabs/pacemaker/blob/059e2e26baece1f652b963b3df4af9dfbd49525e/xml/alerts-2.10.rng#L22