### PR TITLE
low: msg: add timestamp for DEBUG messages(bsc#1129380)

### DIFF
--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -360,6 +360,8 @@ def run():
             err_buf.reset_lineno()
             options.batch = True
         user_args = parse_options()
+        if config.core.debug:
+            print(utils.debug_timestamp())
         term.init()
         if options.profile:
             return profile_run(context, user_args)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2159,4 +2159,8 @@ def iplist_for_cloud():
     return []
 
 
+def debug_timestamp():
+    return datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')
+
+
 # vim:ts=4:sw=4:et:


### PR DESCRIPTION
This is from yan's requirement

> Many times when we asked users to provide the output of "crm -d ..." for the purpose of debugging, we'd almost always ask them to also run "date" and tell us the timestamp so that we could later dig into the corresponding specific context of the logs  meanwhile for example from hb_report, rather than getting lost in the dozens of thousands lines of them.
It'd be very convenient if "crm -d" could include a timestamp itself for example at the beginning of the output.