### PR TITLE
high: cibconfig: Use correct CIB as patch base (bsc#1127716)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -46,6 +46,7 @@ from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
 from .xmlutil import get_rsc_operations, delete_rscref, xml_equals, lookup_node, RscState
 from .xmlutil import cibtext2elem, is_related, check_id_ref, xml_tostring
+from .xmlutil import sanitize_cib_for_patching
 from .cliformat import get_score, nvpairs2list, abs_pos_score, cli_acl_roleref, nvpair_format
 from .cliformat import cli_nvpair, cli_acl_rule, rsc_set_constraint, get_kind, head_id_format
 from .cliformat import simple_rsc_constraint, cli_rule, cli_format
@@ -2679,7 +2680,7 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        tmpf = cibdump2tmp()
+        tmpf = cibdump2tmp(filterfn=sanitize_cib_for_patching)
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -40,7 +40,7 @@ from .xmlutil import rename_rscref, is_ms, silly_constraint, is_container, fix_c
 from .xmlutil import sanity_check_nvpairs, merge_nodes, op2list, mk_rsc_type, is_resource
 from .xmlutil import stuff_comments, is_comment, is_constraint, read_cib, processing_sort_cli
 from .xmlutil import find_operation, get_rsc_children_ids, is_primitive, referenced_resources
-from .xmlutil import cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
+from .xmlutil import cibdump2tmp, cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
 from .xmlutil import remove_id_used_attributes, get_top_cib_nodes
 from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
@@ -2679,8 +2679,7 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        cib_s = xml_tostring(self.cib_orig, pretty_print=True)
-        tmpf = str2tmp(cib_s, suffix=".xml")
+        tmpf = cibdump2tmp()
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)


### PR DESCRIPTION
crmsh was passing a sanitized CIB version as the basis for
patches. This works as long as the CIB is already sanitized
(apparently almost always the case) but generates strange
diffs otherwise.