### PR TITLE
high: cibconfig: Use correct CIB as patch base (bsc#1127716)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -40,7 +40,7 @@ from .xmlutil import rename_rscref, is_ms, silly_constraint, is_container, fix_c
 from .xmlutil import sanity_check_nvpairs, merge_nodes, op2list, mk_rsc_type, is_resource
 from .xmlutil import stuff_comments, is_comment, is_constraint, read_cib, processing_sort_cli
 from .xmlutil import find_operation, get_rsc_children_ids, is_primitive, referenced_resources
-from .xmlutil import cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
+from .xmlutil import cibdump2tmp, cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
 from .xmlutil import remove_id_used_attributes, get_top_cib_nodes
 from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
@@ -2603,8 +2603,7 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        cib_s = etree.tostring(self.cib_orig, pretty_print=True)
-        tmpf = str2tmp(cib_s, suffix=".xml")
+        tmpf = cibdump2tmp()
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -46,6 +46,7 @@ from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
 from .xmlutil import get_rsc_operations, delete_rscref, xml_equals, lookup_node, RscState
 from .xmlutil import cibtext2elem, is_related, check_id_ref
+from .xmlutil import sanitize_cib_for_patching
 from .cliformat import get_score, nvpairs2list, abs_pos_score, cli_acl_roleref, nvpair_format
 from .cliformat import cli_nvpair, cli_acl_rule, rsc_set_constraint, get_kind, head_id_format
 from .cliformat import cli_operations, simple_rsc_constraint, cli_rule, cli_format
@@ -2603,7 +2604,7 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        tmpf = cibdump2tmp()
+        tmpf = cibdump2tmp(filterfn=sanitize_cib_for_patching)
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2613,6 +2613,7 @@ class CibFactory(object):
         # produce a diff:
         # dump_new_conf | crm_diff -o self.cib_orig -n -
 
+        common_debug("Basis: %s" % (open(tmpf).read()))
         common_debug("Input: %s" % (etree.tostring(self.cib_elem)))
         rc, cib_diff = filter_string("%s -o %s -n -" %
                                      (self._crm_diff_cmd, tmpf),

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -87,9 +87,17 @@ def cibdump2file(fname):
     return None
 
 
-def cibdump2tmp():
+def cibdump2tmp(filterfn=None):
     try:
         _, outp, _ = sudocall(cib_dump)
+        if filterfn is not None:
+            try:
+                cib_elem = etree.fromstring(outp)
+            except etree.ParseError as msg:
+                common_err(msg)
+                return None
+            filterfn(cib_elem)
+            outp = etree.tostring(cib_elem, pretty_print=True)
         if outp is not None:
             return str2tmp(outp)
     except IOError, msg:
@@ -664,6 +672,7 @@ def remove_text(e_list):
 
 
 def sanitize_cib(doc):
+
     xml_processnodes(doc, is_status_node, rmnodes)
     # xml_processnodes(doc, true, printid)
     # xml_processnodes(doc, is_emptynvpairs, rmnodes)
@@ -675,6 +684,17 @@ def sanitize_cib(doc):
     xml_processnodes(doc, true, remove_text)
     xmltraverse(doc, drop_attr_defaults)
 
+def sanitize_cib_for_patching(doc):
+    """
+    Custom version of sanitize_cib which
+    doesn't sort container children, to use
+    for processing the original CIB when
+    generating a patch to apply using crm_diff.
+    """
+    xml_processnodes(doc, is_status_node, rmnodes)
+    xml_processnodes(doc, is_entity, rmnodes)
+    xml_processnodes(doc, true, remove_dflt_attrs)
+    xml_processnodes(doc, true, remove_text)
 
 def is_simpleconstraint(node):
     return len(node.xpath("resource_set/resource_ref")) == 0

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -63,6 +63,34 @@ order o-d456 d4 d5 d6
 tag t-d45: d4 d5
 show type:order
 show related:d4
+show
+commit
+_test
+verify
+primitive a0 ocf:heartbeat:Dummy
+primitive a1 ocf:heartbeat:Dummy
+primitive a2 ocf:heartbeat:Dummy
+primitive a3 ocf:heartbeat:Dummy
+primitive a4 ocf:heartbeat:Dummy
+primitive a5 ocf:heartbeat:Dummy
+primitive a6 ocf:heartbeat:Dummy
+primitive a7 ocf:heartbeat:Dummy
+primitive a8 ocf:heartbeat:Dummy
+primitive a9 ocf:heartbeat:Dummy
+primitive aErr ocf:heartbeat:Dummy
+group as a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aErr
+commit
+cd ..
+cd configure
+filter "sed '/as/s/a9//'"
+filter "sed '/as/s/a1/a1 a9/'"
+commit
+cd ..
+cd configure
+filter "sed '/abs/s/a9//'"
+filter "sed '/abs/s/a8/a8 a9/'"
+show
+commit
 _test
 verify
 .

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -111,11 +111,6 @@ order o1 inf: p3 c1
 primitive d4 Dummy
 tag t-d45 d4 d5
 order o-d456 d4 d5 d6
-.INP: _test
-.INP: verify
-.EXT crmd metadata
-.EXT pengine metadata
-.EXT cib metadata
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -151,3 +146,130 @@ property cib-bootstrap-options: \
 rsc_defaults rsc_options: \
 	failure-timeout=10m
 .INP: commit
+.EXT crmd metadata
+.EXT pengine metadata
+.EXT cib metadata
+.INP: _test
+.INP: verify
+.INP: primitive a0 ocf:heartbeat:Dummy
+.INP: primitive a1 ocf:heartbeat:Dummy
+.INP: primitive a2 ocf:heartbeat:Dummy
+.INP: primitive a3 ocf:heartbeat:Dummy
+.INP: primitive a4 ocf:heartbeat:Dummy
+.INP: primitive a5 ocf:heartbeat:Dummy
+.INP: primitive a6 ocf:heartbeat:Dummy
+.INP: primitive a7 ocf:heartbeat:Dummy
+.INP: primitive a8 ocf:heartbeat:Dummy
+.INP: primitive a9 ocf:heartbeat:Dummy
+.INP: primitive aErr ocf:heartbeat:Dummy
+.INP: group as a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aErr
+.INP: commit
+.INP: cd ..
+.INP: cd configure
+.INP: filter "sed '/as/s/a9//'"
+.INP: filter "sed '/as/s/a1/a1 a9/'"
+.INP: commit
+.INP: cd ..
+.INP: cd configure
+.INP: filter "sed '/abs/s/a9//'"
+.INP: filter "sed '/abs/s/a8/a8 a9/'"
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive a0 Dummy
+primitive a1 Dummy
+primitive a2 Dummy
+primitive a3 Dummy
+primitive a4 Dummy
+primitive a5 Dummy
+primitive a6 Dummy
+primitive a7 Dummy
+primitive a8 Dummy
+primitive a9 Dummy
+primitive aErr Dummy
+primitive d1 Dummy
+primitive d2 Dummy
+primitive d3 Dummy
+primitive d4 Dummy
+primitive d5 Dummy
+primitive d6 Dummy
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive p3 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" \
+	op start requires=nothing interval=0 \
+	op monitor interval=60m
+group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
+group g1 p1 p2 d3
+group g2 d1 d2
+clone c1 g1
+tag t-d45 d4 d5
+location l1 p3 100: node1
+location loc-d1 d1 \
+	rule -inf: not_defined webserver or mem number:lte 0 \
+	rule -inf: not_defined a2 \
+	rule webserver: defined webserver
+order o-d456 d4 d5 d6
+order o1 inf: p3 c1
+property cib-bootstrap-options: \
+	default-action-timeout=60s
+rsc_defaults rsc_options: \
+	failure-timeout=10m
+.INP: commit
+INFO: 89: apparently there is nothing to commit
+INFO: 89: try changing something first
+.INP: _test
+.INP: verify
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive a0 Dummy
+primitive a1 Dummy
+primitive a2 Dummy
+primitive a3 Dummy
+primitive a4 Dummy
+primitive a5 Dummy
+primitive a6 Dummy
+primitive a7 Dummy
+primitive a8 Dummy
+primitive a9 Dummy
+primitive aErr Dummy
+primitive d1 Dummy
+primitive d2 Dummy
+primitive d3 Dummy
+primitive d4 Dummy
+primitive d5 Dummy
+primitive d6 Dummy
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive p3 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" \
+	op start requires=nothing interval=0 \
+	op monitor interval=60m
+group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
+group g1 p1 p2 d3
+group g2 d1 d2
+clone c1 g1
+tag t-d45 d4 d5
+location l1 p3 100: node1
+location loc-d1 d1 \
+	rule -inf: not_defined webserver or mem number:lte 0 \
+	rule -inf: not_defined a2 \
+	rule webserver: defined webserver
+order o-d456 d4 d5 d6
+order o1 inf: p3 c1
+property cib-bootstrap-options: \
+	default-action-timeout=60s
+rsc_defaults rsc_options: \
+	failure-timeout=10m
+.INP: commit
+INFO: 93: apparently there is nothing to commit
+INFO: 93: try changing something first


### PR DESCRIPTION
crmsh was passing a sanitized CIB version as the basis for
patches. This works as long as the CIB is already sanitized
(apparently almost always the case) but generates strange
diffs otherwise.