### PR TITLE
medium: ui_node: Check corosync state before clearstate (bsc#1129702)

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -259,9 +259,11 @@ class NodeMgmt(command.UI):
             cib_elem = xmlutil.cibdump2elem()
             if cib_elem is None:
                 return False
-            node_state = cib_elem.xpath("//node_state[@uname=\"%s\"]/@crmd" % node)
-            if node_state == ['online']:
+            if cib_elem.xpath("//node_state[@uname=\"%s\"]/@crmd" % node) == ["online"]:
                 return utils.ext_cmd(self.node_cleanup_resources % node) == 0
+            elif cib_elem.xpath("//node_state[@uname=\"%s\"]/@in_ccm" % node) == ["true"]:
+                common_warn("Node is offline according to Pacemaker, but online according to corosync. First shut down node '%s'" % node)
+                return False
             else:
                 return utils.ext_cmd(self.node_clear_state_118 % node) == 0
         else:

--- a/test/testcases/node
+++ b/test/testcases/node
@@ -8,3 +8,5 @@ node ready node1
 node attribute node1 set a1 "1 2 3"
 node attribute node1 show a1
 node attribute node1 delete a1
+node clearstate node1
+

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -160,3 +160,24 @@ Deleted nodes attribute: id=nodes-node1-a1 name=a1
   </configuration>
 </cib>
 
+.TRY node clearstate node1
+.INP: configure
+.INP: _regtest on
+.INP: show xml node1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes>
+      <node uname="node1" id="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-standby" name="standby" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources/>
+    <constraints/>
+  </configuration>
+</cib>
+


### PR DESCRIPTION
Sometimes nodes are in "pending" state which is not really "offline".
But "stonith_admin --confirm" will tell pacemaker the node is down...
So basically we need narrow down the cases that we run
"stonith_admin --confirm" for.