### PR TITLE
Fix: bindnetaddr should accept both network and specific IP

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -801,15 +801,18 @@ def init_remote_auth():
 
 def valid_network(addr, prev_value=None):
     """
-    bindnetaddr(IPv4) must be one of the local networks
+    bindnetaddr(IPv4) must one of the local networks or local IP addresses
     """
     if prev_value and addr == prev_value[0]:
         warn("  Network address '{}' is already in use!".format(addr))
         return False
-    all_ = utils.network_all()
-    if all_ and addr in all_:
+
+    all_networks = utils.network_all()
+    all_ips = utils.ip_in_local()
+    if addr in all_networks or \
+       addr in all_ips:
         return True
-    warn("  Address '{}' invalid, expected one of {}".format(addr, all_))
+    warn("  Address '{}' invalid, expected one of {}".format(addr, all_networks + all_ips))
     return False
 
 
@@ -1037,7 +1040,7 @@ Configure Corosync:
 
         else:
             bindnetaddr = prompt_for_string('Network address to bind to (e.g.: 192.168.1.0)',
-                                            r'([0-9]+\.){3}0$',
+                                            r'([0-9]+\.){3}[0-9]+',
                                             pick_default_value(default_networks, bindnetaddr_res),
                                             valid_network,
                                             bindnetaddr_res)


### PR DESCRIPTION
> When running 'crm cluster init' to try to configure cluster with mcast,
in  step "Network address to bind to", that is "bindnetaddr" in corosync.conf, when inputting specific IP address which is a real address in local node, crmsh considers it's invalid.
While according to 'man corosync.conf', this way is totally valid.