### PR TITLE
High: cibconfig: Correctly sanitize the original CIB as patch base (bsc#1127716, bsc#1138405)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -40,7 +40,7 @@ from .xmlutil import rename_rscref, is_ms, silly_constraint, is_container, fix_c
 from .xmlutil import sanity_check_nvpairs, merge_nodes, op2list, mk_rsc_type, is_resource
 from .xmlutil import stuff_comments, is_comment, is_constraint, read_cib, processing_sort_cli
 from .xmlutil import find_operation, get_rsc_children_ids, is_primitive, referenced_resources
-from .xmlutil import cibdump2tmp, cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
+from .xmlutil import cibdump2elem, processing_sort, get_rsc_ref_ids, merge_tmpl_into_prim
 from .xmlutil import remove_id_used_attributes, get_top_cib_nodes
 from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
@@ -2680,7 +2680,8 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        tmpf = cibdump2tmp()
+        cib_s = xml_tostring(self.cib_orig, pretty_print=True)
+        tmpf = str2tmp(cib_s, suffix=".xml")
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2680,7 +2680,7 @@ class CibFactory(object):
             # now increase the epoch by 1
             self.bump_epoch()
         self._set_cib_attributes(self.cib_elem)
-        tmpf = cibdump2tmp(filterfn=sanitize_cib_for_patching)
+        tmpf = cibdump2tmp()
         if not tmpf or not ensure_sudo_readable(tmpf):
             return False
         tmpfiles.add(tmpf)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2690,6 +2690,7 @@ class CibFactory(object):
         # produce a diff:
         # dump_new_conf | crm_diff -o self.cib_orig -n -
 
+        common_debug("Basis: %s" % (open(tmpf).read()))
         common_debug("Input: %s" % (xml_tostring(self.cib_elem)))
         rc, cib_diff = filter_string("%s -o %s -n -" %
                                      (self._crm_diff_cmd, tmpf),

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2796,9 +2796,10 @@ class CibFactory(object):
             cib = cibtext2elem(cib)
         if not self._import_cib(cib):
             return False
-        sanitize_cib(self.cib_elem)
         if cibadmin_can_patch():
             self.cib_orig = copy.deepcopy(self.cib_elem)
+            sanitize_cib_for_patching(self.cib_orig)
+        sanitize_cib(self.cib_elem)
         show_unrecognized_elems(self.cib_elem)
         self._populate()
         return self.check_structure()

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -87,17 +87,9 @@ def cibdump2file(fname):
     return None
 
 
-def cibdump2tmp(filterfn=None):
+def cibdump2tmp():
     try:
         _, outp, _ = sudocall(cib_dump)
-        if filterfn is not None:
-            try:
-                cib_elem = etree.fromstring(outp)
-            except etree.ParseError as msg:
-                common_err(msg)
-                return None
-            filterfn(cib_elem)
-            outp = etree.tostring(cib_elem, pretty_print=True)
         if outp is not None:
             return str2tmp(outp)
     except IOError as msg:
@@ -675,7 +667,6 @@ def remove_text(e_list):
 
 
 def sanitize_cib(doc):
-
     xml_processnodes(doc, is_status_node, rmnodes)
     # xml_processnodes(doc, true, printid)
     # xml_processnodes(doc, is_emptynvpairs, rmnodes)

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -62,6 +62,34 @@ order o-d456 d4 d5 d6
 tag t-d45: d4 d5
 show type:order
 show related:d4
+show
+commit
+_test
+verify
+primitive a0 ocf:heartbeat:Dummy
+primitive a1 ocf:heartbeat:Dummy
+primitive a2 ocf:heartbeat:Dummy
+primitive a3 ocf:heartbeat:Dummy
+primitive a4 ocf:heartbeat:Dummy
+primitive a5 ocf:heartbeat:Dummy
+primitive a6 ocf:heartbeat:Dummy
+primitive a7 ocf:heartbeat:Dummy
+primitive a8 ocf:heartbeat:Dummy
+primitive a9 ocf:heartbeat:Dummy
+primitive aErr ocf:heartbeat:Dummy
+group as a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aErr
+commit
+cd ..
+cd configure
+filter "sed '/as/s/a9//'"
+filter "sed '/as/s/a1/a1 a9/'"
+commit
+cd ..
+cd configure
+filter "sed '/abs/s/a9//'"
+filter "sed '/abs/s/a8/a8 a9/'"
+show
+commit
 _test
 verify
 .

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -127,11 +127,6 @@ order o1 inf: p3 c1
 primitive d4 Dummy
 tag t-d45 d4 d5
 order o-d456 d4 d5 d6
-.INP: _test
-.INP: verify
-.EXT crmd metadata
-.EXT pengine metadata
-.EXT cib metadata
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -168,3 +163,132 @@ rsc_defaults rsc_options: \
 op_defaults op-options: \
 	timeout=60s
 .INP: commit
+.EXT crmd metadata
+.EXT pengine metadata
+.EXT cib metadata
+.INP: _test
+.INP: verify
+.INP: primitive a0 ocf:heartbeat:Dummy
+.INP: primitive a1 ocf:heartbeat:Dummy
+.INP: primitive a2 ocf:heartbeat:Dummy
+.INP: primitive a3 ocf:heartbeat:Dummy
+.INP: primitive a4 ocf:heartbeat:Dummy
+.INP: primitive a5 ocf:heartbeat:Dummy
+.INP: primitive a6 ocf:heartbeat:Dummy
+.INP: primitive a7 ocf:heartbeat:Dummy
+.INP: primitive a8 ocf:heartbeat:Dummy
+.INP: primitive a9 ocf:heartbeat:Dummy
+.INP: primitive aErr ocf:heartbeat:Dummy
+.INP: group as a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aErr
+.INP: commit
+.INP: cd ..
+.INP: cd configure
+.INP: filter "sed '/as/s/a9//'"
+.INP: filter "sed '/as/s/a1/a1 a9/'"
+.INP: commit
+.INP: cd ..
+.INP: cd configure
+.INP: filter "sed '/abs/s/a9//'"
+.INP: filter "sed '/abs/s/a8/a8 a9/'"
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive a0 Dummy
+primitive a1 Dummy
+primitive a2 Dummy
+primitive a3 Dummy
+primitive a4 Dummy
+primitive a5 Dummy
+primitive a6 Dummy
+primitive a7 Dummy
+primitive a8 Dummy
+primitive a9 Dummy
+primitive aErr Dummy
+primitive d1 Dummy
+primitive d2 Dummy
+primitive d3 Dummy
+primitive d4 Dummy
+primitive d5 Dummy
+primitive d6 Dummy
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive p3 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" requires=nothing \
+	op monitor interval=60m
+group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
+group g1 p1 p2 d3
+group g2 d1 d2
+clone c1 g1
+tag t-d45 d4 d5
+location l1 p3 100: node1
+location loc-d1 d1 \
+	rule -inf: not_defined webserver or mem number:lte 0 \
+	rule -inf: not_defined a2 \
+	rule webserver: defined webserver
+order o-d456 d4 d5 d6
+order o1 inf: p3 c1
+property cib-bootstrap-options:
+rsc_defaults rsc_options: \
+	failure-timeout=10m
+op_defaults op-options: \
+	timeout=60s
+.INP: commit
+INFO: 89: apparently there is nothing to commit
+INFO: 89: try changing something first
+.INP: _test
+.INP: verify
+.INP: show
+node node1 \
+	attributes mem=16G
+primitive a0 Dummy
+primitive a1 Dummy
+primitive a2 Dummy
+primitive a3 Dummy
+primitive a4 Dummy
+primitive a5 Dummy
+primitive a6 Dummy
+primitive a7 Dummy
+primitive a8 Dummy
+primitive a9 Dummy
+primitive aErr Dummy
+primitive d1 Dummy
+primitive d2 Dummy
+primitive d3 Dummy
+primitive d4 Dummy
+primitive d5 Dummy
+primitive d6 Dummy
+primitive p1 Dummy \
+	op monitor interval=60m \
+	op monitor interval=120m \
+	op_params OCF_CHECK_LEVEL=10
+primitive p2 Dummy
+primitive p3 Dummy
+primitive st stonith:null \
+	params hostlist=node1 \
+	meta description="some description here" requires=nothing \
+	op monitor interval=60m
+group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
+group g1 p1 p2 d3
+group g2 d1 d2
+clone c1 g1
+tag t-d45 d4 d5
+location l1 p3 100: node1
+location loc-d1 d1 \
+	rule -inf: not_defined webserver or mem number:lte 0 \
+	rule -inf: not_defined a2 \
+	rule webserver: defined webserver
+order o-d456 d4 d5 d6
+order o1 inf: p3 c1
+property cib-bootstrap-options:
+rsc_defaults rsc_options: \
+	failure-timeout=10m
+op_defaults op-options: \
+	timeout=60s
+.INP: commit
+INFO: 93: apparently there is nothing to commit
+INFO: 93: try changing something first


### PR DESCRIPTION
Rather than retrieving the latest CIB again to pass it to "crm_diff -o",
we should stick with what "self.cib_elem" is originally based on no
matter if there's any new changes from the live CIB in the meantime.
Otherwise there's race condition that the generated CIB diff reverts the
changes made right before.

self.cib_orig should be sanitized with sanitize_cib_for_patching() based
on the original self.cib_elem that hasn't yet been sanitized.