### PR TITLE
Fix: ui_cluster: Improve crm cluster run command(bsc#1145520)

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -607,6 +607,8 @@ Cluster Description
             context.fatal_error("python package parallax is needed for this command")
 
         hosts = utils.list_cluster_nodes()
+        if hosts is None:
+            context.fatal_error("failed to get node list from cluster")
         if node and node in hosts:
             hosts = [node]
         opts = parallax.Options()

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -610,6 +610,7 @@ Cluster Description
         if node and node in hosts:
             hosts = [node]
         opts = parallax.Options()
+        opts.ssh_options = ['StrictHostKeyChecking=no']
         for host, result in parallax.call(hosts, cmd, opts).items():
             if isinstance(result, parallax.Error):
                 err_buf.error("[%s]: %s" % (host, result))

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -593,7 +593,7 @@ Cluster Description
             context.fatal_error("Timed out waiting for cluster (rc = %s)" % (ret))
 
     @command.skill_level('expert')
-    def do_run(self, context, cmd, node=None):
+    def do_run(self, context, cmd, *nodes):
         '''
         Execute the given command on all nodes/specific node, report outcome
         '''
@@ -606,13 +606,16 @@ Cluster Description
         if not _has_parallax:
             context.fatal_error("python package parallax is needed for this command")
 
-        hosts = utils.list_cluster_nodes()
-        if hosts is None:
-            context.fatal_error("failed to get node list from cluster")
-        if node and node in hosts:
-            hosts = [node]
+        if nodes:
+            hosts = list(nodes)
+        else:
+            hosts = utils.list_cluster_nodes()
+            if hosts is None:
+                context.fatal_error("failed to get node list from cluster")
+
         opts = parallax.Options()
         opts.ssh_options = ['StrictHostKeyChecking=no']
+        opts.askpass = utils.check_ssh_passwd_need(hosts)
         for host, result in parallax.call(hosts, cmd, opts).items():
             if isinstance(result, parallax.Error):
                 err_buf.error("[%s]: %s" % (host, result))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2189,4 +2189,13 @@ def get_member_iplist():
             ip_list.append(match.group(1))
     return ip_list
 
+
+def check_ssh_passwd_need(hosts):
+    ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
+    for host in hosts:
+        ssh_cmd = "ssh {} -T -o Batchmode=yes {} true".format(ssh_options, host)
+        rc, _, _ = get_stdout_stderr(ssh_cmd)
+        if rc != 0:
+            return True
+    return False
 # vim:ts=4:sw=4:et:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1346,18 +1346,18 @@ rename <new_cluster_name>
 ==== `run`
 
 This command takes a shell statement as argument, executes that
-statement on all nodes or a specific node in the cluster, 
+statement on all nodes in the cluster or a specific node,
 and reports the result.
 
 Usage:
 ...............
-run <command> [node]
+run <command> [node ...]
 ...............
 
 Example:
 ...............
 run "cat /proc/uptime" 
-run "ls" node2 
+run "ls" node1 node2
 ...............
 
 [[cmdhelp_cluster_start,Start cluster services]]


### PR DESCRIPTION
**Assumption:** Two nodes cluster(15sp1-1 and 15sp1-2)

---
**Problem:** For a running two nodes cluster, run `crm cluster run "ls"`, will give this error:
```
ERROR: [15sp1-1]: Exited with error code 255, Error output: The authenticity of host '15sp1-1 (10.10.10.51)' can't be established.
ECDSA key fingerprint is SHA256:gOm0UDlChIQvNXXWn0N+bzVa+yj5Y80krR/i0boe/Z8.
Are you sure you want to continue connecting (yes/no)? 
Host key verification failed.
```
**Suggested Solution:** Add `'StrictHostKeyChecking=no'` ssh_options for parallax
**Related commit:** 2f84449238f0212958813bf5ab5584f75ff47e3b

---
**Problem:** When cluster service is totally stopped, run `crm cluster run "ls" 15sp1-1`, crmsh crashed:
```
ERROR: running cibadmin -Ql: Connection to the CIB manager failed: Transport endpoint is not connected
Init failed, could not perform requested operations
Traceback (most recent call last):
  File "/usr/sbin/crm", line 46, in <module>
    rc = main.run()
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 369, in run
    return main_input_loop(context, user_args)
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 249, in main_input_loop
    rc = handle_noninteractive_use(context, user_args)
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 205, in handle_noninteractive_use
    if context.run(' '.join(l)):
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 86, in run
    rv = self.execute_command() is not False
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 276, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib/python3.6/site-packages/crmsh/ui_cluster.py", line 610, in do_run
    if node and node in hosts:
TypeError: argument of type 'NoneType' is not iterable
```
**Reason:** That is because function `list_cluster_nodes` trying to use `cibadmin` to get the node list from cib.xml, and return `None` when failed, while we miss handling `None` result here

**Suggested Solution:**
* Changing the implementation of function `list_cluster_nodes`:
   - when pacemaker running, using `crm_node` to fetch node list
   - when corosync running, using `corosync-cmapctl` to fetch the member IP address
   - static situation, get env  CIB_file or parse file `/var/lib/pacemaker/cib/cib.xml` to get the node list
* Handle the `None` situation, give error message like `failed to get node list from cluster`

**Related commit:** 0dfa747bd9db3235990f5a6510dfd21ca55597c0

---

**Problem:** Can not run command for non-cluster node
**Suggested Solution:** If specific node in arguments, no matter whether it's a cluster node, enable running command on this node(s); Should also test whether need password, if yes, set `askpass` to `True` for parallax options
**Related commit:** f3cd676438f16b1ae2c96bdcb10194da439332df