### PR TITLE
Fix: utils: fix logic for process non comments line(bsc#1145823)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1904,18 +1904,18 @@ def sysconfig_set(sysconfig_file, **values):
                 outp += line
             else:
                 matched = False
-            try:
-                key, _ = line.split("=", 1)
-                for k, v in values.items():
-                    if k == key:
-                        matched = True
-                        outp += '%s=%s\n' % (k, doublequote(v))
-                        del values[k]
-                        break
-                if not matched:
+                try:
+                    key, _ = line.split("=", 1)
+                    for k, v in values.items():
+                        if k == key:
+                            matched = True
+                            outp += '%s=%s\n' % (k, doublequote(v))
+                            del values[k]
+                            break
+                    if not matched:
+                        outp += line
+                except ValueError:
                     outp += line
-            except ValueError:
-                outp += line
 
     for k, v in values.items():
         outp += '%s=%s\n' % (k, doublequote(v))

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -177,3 +177,14 @@ FW_SERVICES_ACCEPT_EXT="0/0,tcp,22,,hitcount=3,blockseconds=60,recentname=ssh"
     sc = utils.parse_sysconfig(fname)
     assert (sc.get("FW_SERVICES_ACCEPT_EXT") == "foo=bar")
     assert (sc.get("FOO") == "bar")
+
+def test_sysconfig_set_bsc1145823():
+    s = '''# this is test
+#age=1000
+'''
+    fd, fname = tmpfiles.create()
+    with open(fname, 'w') as f:
+        f.write(s)
+    utils.sysconfig_set(fname, age="100")
+    sc = utils.parse_sysconfig(fname)
+    assert (sc.get("age") == "100")


### PR DESCRIPTION
This bug is brought by #433 
logic will double process the comment line,
and will raise the error like `UnboundLocalError: local variable 'matched' referenced before assignment` when configuring sbd using bootstrap