### PR TITLE
Dev: replace optparse with argparse

### DIFF
--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -84,58 +84,58 @@ def cib_prompt():
 
 
 def make_option_parser():
-    from optparse import OptionParser
-    parser = OptionParser(usage="""%prog [-h|--help] [OPTIONS] [SUBCOMMAND ARGS...]
-or %prog help SUBCOMMAND
+    from argparse import ArgumentParser, REMAINDER
+    parser = ArgumentParser(prog='crm', usage="""%(prog)s [-h|--help] [OPTIONS] [SUBCOMMAND ARGS...]
+or %(prog)s help SUBCOMMAND
 
-For a list of available subcommands, use %prog help.
+For a list of available subcommands, use %(prog)s help.
 
-Use %prog without arguments for an interactive session.
+Use %(prog)s without arguments for an interactive session.
 Call a subcommand directly for a "single-shot" use.
-Call %prog with a level name as argument to start an interactive
+Call %(prog)s with a level name as argument to start an interactive
 session from that level.
 
-See the crm(8) man page or call %prog help for more details.""",
-                          version="%prog " + config.CRM_VERSION)
-    parser.disable_interspersed_args()
-    parser.add_option("-f", "--file", dest="filename", metavar="FILE",
-                      help="Load commands from the given file. If a dash (-) " +
-                      "is used in place of a file name, crm will read commands " +
-                      "from the shell standard input (stdin).")
-    parser.add_option("-c", "--cib", dest="cib", metavar="CIB",
-                      help="Start the session using the given shadow CIB file. " +
-                      "Equivalent to `cib use <CIB>`.")
-    parser.add_option("-D", "--display", dest="display", metavar="OUTPUT_TYPE",
-                      help="Choose one of the output options: plain, color-always, color, or uppercase. " +
-                      "The default is color if the terminal emulation supports colors, " +
-                      "else plain.")
-    parser.add_option("-F", "--force", action="store_true", default=False, dest="force",
-                      help="Make crm proceed with applying changes where it would normally " +
-                      "ask the user to confirm before proceeding. This option is mainly useful " +
-                      "in scripts, and should be used with care.")
-    parser.add_option("-n", "--no", action="store_true", default=False, dest="ask_no",
-                      help="Automatically answer no when prompted")
-    parser.add_option("-w", "--wait", action="store_true", default=False, dest="wait",
-                      help="Make crm wait for the cluster transition to finish " +
-                      "(for the changes to take effect) after each processed line.")
-    parser.add_option("-H", "--history", dest="history", metavar="DIR|FILE|SESSION",
-                      help="A directory or file containing a cluster report to load " +
-                      "into history, or the name of a previously saved history session.")
-    parser.add_option("-d", "--debug", action="store_true", default=False, dest="debug",
-                      help="Print verbose debugging information.")
-    parser.add_option("-R", "--regression-tests", action="store_true", default=False,
-                      dest="regression_tests",
-                      help="Enables extra verbose trace logging used by the regression " +
-                      "tests. Logs all external calls made by crmsh.")
-    parser.add_option("--scriptdir", dest="scriptdir", metavar="DIR",
-                      help="Extra directory where crm looks for cluster scripts, or a list " +
-                      "of directories separated by semi-colons (e.g. /dir1;/dir2;etc.).")
-    parser.add_option("-X", dest="profile", metavar="PROFILE",
-                      help="Collect profiling data and save in PROFILE.")
-    parser.add_option("-o", "--opt", action="append", type="string", metavar="OPTION=VALUE",
-                      help="Set crmsh option temporarily. If the options are saved using" +
-                      "+options save+ then the value passed here will also be saved." +
-                      "Multiple options can be set by using +-o+ multiple times.")
+See the crm(8) man page or call %(prog)s help for more details.""")
+    parser.add_argument('--version', action='version', version="%(prog)s " + config.CRM_VERSION)
+    parser.add_argument("-f", "--file", dest="filename", metavar="FILE",
+                        help="Load commands from the given file. If a dash (-) " +
+                        "is used in place of a file name, crm will read commands " +
+                        "from the shell standard input (stdin).")
+    parser.add_argument("-c", "--cib", dest="cib", metavar="CIB",
+                        help="Start the session using the given shadow CIB file. " +
+                        "Equivalent to `cib use <CIB>`.")
+    parser.add_argument("-D", "--display", dest="display", metavar="OUTPUT_TYPE",
+                        help="Choose one of the output options: plain, color-always, color, or uppercase. " +
+                        "The default is color if the terminal emulation supports colors, " +
+                        "else plain.")
+    parser.add_argument("-F", "--force", action="store_true", default=False, dest="force",
+                        help="Make crm proceed with applying changes where it would normally " +
+                        "ask the user to confirm before proceeding. This option is mainly useful " +
+                        "in scripts, and should be used with care.")
+    parser.add_argument("-n", "--no", action="store_true", default=False, dest="ask_no",
+                        help="Automatically answer no when prompted")
+    parser.add_argument("-w", "--wait", action="store_true", default=False, dest="wait",
+                        help="Make crm wait for the cluster transition to finish " +
+                        "(for the changes to take effect) after each processed line.")
+    parser.add_argument("-H", "--history", dest="history", metavar="DIR|FILE|SESSION",
+                        help="A directory or file containing a cluster report to load " +
+                        "into history, or the name of a previously saved history session.")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, dest="debug",
+                        help="Print verbose debugging information.")
+    parser.add_argument("-R", "--regression-tests", action="store_true", default=False,
+                        dest="regression_tests",
+                        help="Enables extra verbose trace logging used by the regression " +
+                        "tests. Logs all external calls made by crmsh.")
+    parser.add_argument("--scriptdir", dest="scriptdir", metavar="DIR",
+                        help="Extra directory where crm looks for cluster scripts, or a list " +
+                        "of directories separated by semi-colons (e.g. /dir1;/dir2;etc.).")
+    parser.add_argument("-X", dest="profile", metavar="PROFILE",
+                        help="Collect profiling data and save in PROFILE.")
+    parser.add_argument("-o", "--opt", action="append", type=str, metavar="OPTION=VALUE",
+                        help="Set crmsh option temporarily. If the options are saved using" +
+                        "+options save+ then the value passed here will also be saved." +
+                        "Multiple options can be set by using +-o+ multiple times.")
+    parser.add_argument("SUBCOMMAND", nargs=REMAINDER)
     return parser
 
 
@@ -302,7 +302,7 @@ def compgen():
 
 
 def parse_options():
-    opts, args = option_parser.parse_args()
+    opts, args = option_parser.parse_known_args()
     config.core.debug = "yes" if opts.debug else config.core.debug
     options.profile = opts.profile or options.profile
     options.regression_tests = opts.regression_tests or options.regression_tests
@@ -323,7 +323,7 @@ def parse_options():
             config.set_option(s, n, v)
         except ValueError as e:
             raise ValueError("Expected -o <section>.<name>=<value>: %s" % (e))
-    return args
+    return opts.SUBCOMMAND
 
 
 def profile_run(context, user_args):

--- a/data-manifest
+++ b/data-manifest
@@ -73,6 +73,7 @@ test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
+test/features/steps/const.py
 test/features/steps/__init__.py
 test/features/steps/step_implenment.py
 test/features/steps/utils.py

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -11,6 +11,25 @@ Feature: crmsh bootstrap process - options
   Tag @clean means need to stop cluster service if the service is available
 
   @clean
+  Scenario: Check help output
+    When    Run "crm -h" on "hanode1"
+    Then    Output is the same with expected "crm" help output
+    When    Run "crm cluster init -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster init" help output
+    When    Run "crm cluster join -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster join" help output
+    When    Run "crm cluster add -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster add" help output
+    When    Run "crm cluster remove -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster remove" help output
+    When    Run "crm cluster geo-init -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster geo-init" help output
+    When    Run "crm cluster geo-join -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster geo-join" help output
+    When    Run "crm cluster geo-init-arbitrator -h" on "hanode1"
+    Then    Output is the same with expected "crm cluster geo-init-arbitrator" help output
+
+  @clean
   Scenario: Init whole cluster service on node "hanode1" using "--nodes" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -1,0 +1,241 @@
+CRM_H_OUTPUT = '''usage: crm [-h|--help] [OPTIONS] [SUBCOMMAND ARGS...]
+or crm help SUBCOMMAND
+
+For a list of available subcommands, use crm help.
+
+Use crm without arguments for an interactive session.
+Call a subcommand directly for a "single-shot" use.
+Call crm with a level name as argument to start an interactive
+session from that level.
+
+See the crm(8) man page or call crm help for more details.
+
+positional arguments:
+  SUBCOMMAND
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  -f FILE, --file FILE  Load commands from the given file. If a dash (-) is
+                        used in place of a file name, crm will read commands
+                        from the shell standard input (stdin).
+  -c CIB, --cib CIB     Start the session using the given shadow CIB file.
+                        Equivalent to `cib use <CIB>`.
+  -D OUTPUT_TYPE, --display OUTPUT_TYPE
+                        Choose one of the output options: plain, color-always,
+                        color, or uppercase. The default is color if the
+                        terminal emulation supports colors, else plain.
+  -F, --force           Make crm proceed with applying changes where it would
+                        normally ask the user to confirm before proceeding.
+                        This option is mainly useful in scripts, and should be
+                        used with care.
+  -n, --no              Automatically answer no when prompted
+  -w, --wait            Make crm wait for the cluster transition to finish
+                        (for the changes to take effect) after each processed
+                        line.
+  -H DIR|FILE|SESSION, --history DIR|FILE|SESSION
+                        A directory or file containing a cluster report to
+                        load into history, or the name of a previously saved
+                        history session.
+  -d, --debug           Print verbose debugging information.
+  -R, --regression-tests
+                        Enables extra verbose trace logging used by the
+                        regression tests. Logs all external calls made by
+                        crmsh.
+  --scriptdir DIR       Extra directory where crm looks for cluster scripts,
+                        or a list of directories separated by semi-colons
+                        (e.g. /dir1;/dir2;etc.).
+  -X PROFILE            Collect profiling data and save in PROFILE.
+  -o OPTION=VALUE, --opt OPTION=VALUE
+                        Set crmsh option temporarily. If the options are saved
+                        using+options save+ then the value passed here will
+                        also be saved.Multiple options can be set by using
+                        +-o+ multiple times.'''
+
+
+CRM_CLUSTER_INIT_H_OUTPUT = '''usage: init [options] [STAGE]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution, this is
+                        destructive, especially during the "storage" stage.
+                        The /root/.ssh/id_rsa key will be overwritten unless
+                        the option "--no-overwrite-sshkey" is used)
+  -t TEMPLATE, --template TEMPLATE
+                        Optionally configure cluster with template "name"
+                        (currently only "ocfs2" is valid here)
+  -n NAME, --name NAME  Set the name of the configured cluster.
+  -N NODES, --nodes NODES
+                        Additional nodes to add to the created cluster. May
+                        include the current node, which will always be the
+                        initial cluster node.
+  -S, --enable-sbd      Enable SBD even if no SBD device is configured
+                        (diskless mode)
+  -w WATCHDOG, --watchdog WATCHDOG
+                        Use the given watchdog device
+  --no-overwrite-sshkey
+                        Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is
+                        used (False by default)
+
+Network configuration:
+  Options for configuring the network and messaging layer.
+
+  -i IF, --interface IF
+                        Bind to IP address on interface IF
+  -u, --unicast         Configure corosync to communicate over unicast (UDP),
+                        and not multicast. Default is multicast unless an
+                        environment where multicast cannot be used is
+                        detected.
+  -A IP, --admin-ip IP  Configure IP address as an administration virtual IP
+  -M, --multi-heartbeats
+                        Configure corosync with second heartbeat line
+  -I, --ipv6            Configure corosync use IPv6
+  --qnetd-hostname HOST
+                        HOST or IP of the QNetd server to be used
+  --qdevice-port PORT   TCP PORT of QNetd server(default:5403)
+  --qdevice-algo ALGORITHM
+                        QNetd decision ALGORITHM(ffsplit/lms, default:ffsplit)
+  --qdevice-tie-breaker TIE_BREAKER
+                        QNetd TIE_BREAKER(lowest/highest/valid_node_id,
+                        default:lowest)
+  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd(on/off/required,
+                        default:on)
+  --qdevice-heuristics COMMAND
+                        COMMAND to run with absolute path. For multiple
+                        commands, use ";" to separate(details about heuristics
+                        can see man 8 corosync-qdevice)
+
+Storage configuration:
+  Options for configuring shared storage.
+
+  -p DEVICE, --partition-device DEVICE
+                        Partition this shared storage device (only used in
+                        "storage" stage)
+  -s DEVICE, --sbd-device DEVICE
+                        Block device to use for SBD fencing, use ";" as
+                        separator or -s multiple times for multi path (up to 3
+                        devices)
+  -o DEVICE, --ocfs2-device DEVICE
+                        Block device to use for OCFS2 (only used in "vgfs"
+                        stage)
+
+Stage can be one of:
+    ssh         Create SSH keys for passwordless SSH between cluster nodes
+    csync2      Configure csync2
+    corosync    Configure corosync
+    storage     Partition shared storage (ocfs2 template only)
+    sbd         Configure SBD (requires -s <dev>)
+    cluster     Bring the cluster online
+    vgfs        Create volume group and filesystem (ocfs2 template only,
+                requires -o <dev>)
+    admin       Create administration virtual IP (optional)
+    qdevice     Configure qdevice and qnetd
+
+Note:
+  - If stage is not specified, the script will run through each stage
+    in sequence, with prompts for required information.
+  - If using the ocfs2 template, the storage stage will partition a block
+    device into two pieces, one for SBD, the remainder for OCFS2.  This is
+    good for testing and demonstration, but not ideal for production.
+    To use storage you have already configured, pass -s and -o to specify
+    the block devices for SBD and OCFS2, and the automatic partitioning
+    will be skipped.'''
+
+
+CRM_CLUSTER_JOIN_H_OUTPUT = '''usage: join [options] [STAGE]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution)
+  -w WATCHDOG, --watchdog WATCHDOG
+                        Use the given watchdog device
+
+Network configuration:
+  Options for configuring the network and messaging layer.
+
+  -c HOST, --cluster-node HOST
+                        IP address or hostname of existing cluster node
+  -i IF, --interface IF
+                        Bind to IP address on interface IF
+
+Stage can be one of:
+    ssh         Obtain SSH keys from existing cluster node (requires -c <host>)
+    csync2      Configure csync2 (requires -c <host>)
+    ssh_merge   Merge root's SSH known_hosts across all nodes (csync2 must
+                already be configured).
+    cluster     Start the cluster on this node
+
+If stage is not specified, each stage will be invoked in sequence.'''
+
+
+CRM_CLUSTER_ADD_H_OUTPUT = '''usage: add [options] [node ...]
+
+optional arguments:
+  -h, --help  Show this help message
+  -y, --yes   Answer "yes" to all prompts (use with caution)'''
+
+
+CRM_CLUSTER_REMOVE_H_OUTPUT = '''usage: remove [options] [<node> ...]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution)
+  -c HOST, --cluster-node HOST
+                        IP address or hostname of cluster node which will be
+                        deleted
+  -F, --force           Remove current node
+  --qdevice             Remove QDevice configuration and service from cluster'''
+
+
+CRM_CLUSTER_GEO_INIT_H_OUTPUT = '''usage: geo-init [options]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution)
+  -a IP, --arbitrator IP
+                        IP address of geo cluster arbitrator
+  -s DESC, --clusters DESC
+                        Geo cluster description (see details below)
+  -t LIST, --tickets LIST
+                        Tickets to create (space-separated)
+
+Cluster Description
+
+  This is a map of cluster names to IP addresses.
+  Each IP address will be configured as a virtual IP
+  representing that cluster in the geo cluster
+  configuration.
+
+  Example with two clusters named paris and amsterdam:
+
+  --clusters "paris=192.168.10.10 amsterdam=192.168.10.11"
+
+  Name clusters using the --name parameter to
+  crm bootstrap init.'''
+
+
+CRM_CLUSTER_GEO_JOIN_H_OUTPUT = '''usage: geo-join [options]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution)
+  -c IP, --cluster-node IP
+                        IP address of an already-configured geo cluster or
+                        arbitrator
+  -s DESC, --clusters DESC
+                        Geo cluster description (see geo-init for details)'''
+
+
+CRM_CLUSTER_GEO_INIT_ARBIT_H_OUTPUT = '''usage: geo-init-arbitrator [options]
+
+optional arguments:
+  -h, --help            Show this help message
+  -q, --quiet           Be quiet (don't describe what's happening, just do it)
+  -y, --yes             Answer "yes" to all prompts (use with caution)
+  -c IP, --cluster-node IP
+                        IP address of an already-configured geo cluster'''

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -4,6 +4,7 @@ from behave import given, when, then
 from crmsh import corosync, parallax
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
                   run_command_local_or_remote
+import const
 
 
 @given('Cluster service is "{state}" on "{addr}"')
@@ -147,3 +148,18 @@ def step_impl(context, res, node, number):
     if out:
         result = re.search(r'name=fail-count-{} value={}'.format(res, number), out)
         assert result is not None
+
+
+@then('Output is the same with expected "{cmd}" help output')
+def step_impl(context, cmd):
+    cmd_help = {}
+    cmd_help["crm"] = const.CRM_H_OUTPUT
+    cmd_help["crm_cluster_init"] = const.CRM_CLUSTER_INIT_H_OUTPUT
+    cmd_help["crm_cluster_join"] = const.CRM_CLUSTER_JOIN_H_OUTPUT
+    cmd_help["crm_cluster_add"] = const.CRM_CLUSTER_ADD_H_OUTPUT
+    cmd_help["crm_cluster_remove"] = const.CRM_CLUSTER_REMOVE_H_OUTPUT
+    cmd_help["crm_cluster_geo-init"] = const.CRM_CLUSTER_GEO_INIT_H_OUTPUT
+    cmd_help["crm_cluster_geo-join"] = const.CRM_CLUSTER_GEO_JOIN_H_OUTPUT
+    cmd_help["crm_cluster_geo-init-arbitrator"] = const.CRM_CLUSTER_GEO_INIT_ARBIT_H_OUTPUT
+    key = '_'.join(cmd.split())
+    assert context.stdout == cmd_help[key]


### PR DESCRIPTION
Hi:
Since `optparse` is **deprecated**, I suggest we should replace it with `argparse`.

There are some differences between `optparse` and `argparse` that should be noticed in replacing:
- in usage message, `optparse` using `%prog` as format specifier, while `argparse` using `%(prog)s`
- `argparse` using `version` in `add_argument` function
- to keep code compatible,  in `argparse`, using `parse_known_arg` instead of `parse_args`
- `optparse` using `add_help_option` while `argparse` using `add_help`
- `optparse` using `disable_interspersed_args` to set parsing to stop on the first non-option.
   For example, if don't using `disable_interspersed_args`, `crm cluster init -h` will be parsed as `crm -h` and print `crm` help message;
   In `argparse`, we don't have interface `disable_interspersed_args`, even [parse_intermixed_args](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_intermixed_args) would not be existed until python3.7, so I use this `parser.add_argument("SUBCOMMAND", nargs=REMAINDER)` to restore the non-option extra options