### PR TITLE
'configure show changed' includes deleted elements

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3223,7 +3223,7 @@ class CibFactory(object):
         obj_set = orderedset.oset([])
         and_filter, and_set = False, None
         for spec in filters:
-            if spec == "or":
+            if spec in ["or", "from_show"]:
                 continue
             elif spec == "and":
                 and_filter, and_set = True, obj_set
@@ -3231,6 +3231,8 @@ class CibFactory(object):
                 continue
             if spec == "changed":
                 obj_set |= orderedset.oset(self.modified_elems())
+                if "from_show" in filters:
+                    obj_set |= orderedset.oset(self.remove_queue)
             elif spec.startswith("type:"):
                 obj_set |= orderedset.oset(self.get_elems_on_type(spec))
             elif spec.startswith("tag:"):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -551,6 +551,8 @@ class CibConfig(command.UI):
         from .utils import obscure
         osargs = [arg[8:] for arg in args if arg.startswith('obscure:')]
         args = [arg for arg in args if not arg.startswith('obscure:')]
+        if "changed" in args:
+            args.append("from_show")
         with obscure(osargs):
             set_obj = mkset_obj(*args)
             return set_obj.show()

--- a/test/testcases/commit
+++ b/test/testcases/commit
@@ -33,6 +33,7 @@ commit
 filter "sed '/g1/s/p1/d1/'"
 group g2 d3 d2
 delete d2
+show changed
 commit
 _test
 verify

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -43,10 +43,14 @@ INFO: 24: modified colocation:cl1 from c1 to g1
 .INP: filter "sed '/g1/s/p1/d1/'"
 .INP: group g2 d3 d2
 .INP: delete d2
+.INP: show changed
+primitive d2 Dummy
+group g1 d1 p2
+group g2 d3
 .INP: commit
 .INP: _test
 .INP: verify
-WARNING: 35: st: unknown attribute 'yoyo-meta'
+WARNING: 36: st: unknown attribute 'yoyo-meta'
 .INP: show
 node node1 \
 	attributes mem=16G
@@ -70,5 +74,5 @@ order o1 inf: p3 g1
 op_defaults op-options: \
 	timeout=2m
 .INP: commit
-INFO: 37: apparently there is nothing to commit
-INFO: 37: try changing something first
+INFO: 38: apparently there is nothing to commit
+INFO: 38: try changing something first


### PR DESCRIPTION
**Problem:**
Our user complain that after  delete resource(before commit), 'crm configure show changed' not list the elements just deleted.
> Working with crm in SLES12 SP4 I noticed that when you delete resources in "crm configure", a > "show changed" just displays nothing.
> How hard would it be to show commands like "delete xyz" for each deleted resource?

**Solution:**
So I append this line:
```
obj_set |= orderedset.oset(self.remove_queue)
```
in `filter_objects` function, cibconfig.py file.

**Test:**
I also append lines in `test/testcases/commit`:
```
delete d3
show changed
```
to test this scenarios.
Behave seems not suitable to test interactive scenarios.