### PR TITLE
scripts: fix yaml loader warning

### DIFF
--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -428,7 +428,7 @@ def _parse_yaml(scriptname, scriptfile):
     try:
         import yaml
         with open(scriptfile) as f:
-            data = yaml.load(f)
+            data = yaml.load(f, Loader=yaml.SafeLoader)
             if isinstance(data, list):
                 data = data[0]
     except ImportError as e:
@@ -1035,7 +1035,7 @@ def load_script_string(script, yml):
     build_script_cache()
     import io
     import yaml
-    data = yaml.load(io.StringIO(yml))
+    data = yaml.load(io.StringIO(yml), Loader=yaml.SafeLoader)
     if isinstance(data, list):
         data = data[0]
     if 'parameters' in data:


### PR DESCRIPTION
unittests.test_scripts.test_load_legacy ... /usr/lib/python3/dist-packages/crmsh/scripts.py:431: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.