### PR TITLE
[crmsh-3.0] Fix: Corosync default ports should be 5405 and 5407(bsc#1066196)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -944,7 +944,7 @@ Configure Corosync:
     bindnetaddr_res = []
     mcastaddr_res = []
     mcastport_res = []
-    default_ports = ["5045", "5047"]
+    default_ports = ["5405", "5407"]
     two_rings = False
     default_networks = []
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -854,7 +854,7 @@ Configure Corosync (unicast):
 
     ringXaddr_res = []
     mcastport_res = []
-    default_ports = ["5045", "5047"]
+    default_ports = ["5405", "5407"]
     two_rings = False
     default_networks = []
 


### PR DESCRIPTION
We should back port this to crmsh-3.0