### PR TITLE
Low: bootstrap: don't overwrite ssh key if already exists

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -670,9 +670,11 @@ def init_ssh():
     start_service("sshd.service")
     invoke("mkdir -m 700 -p /root/.ssh")
     if os.path.exists("/root/.ssh/id_rsa"):
-        if not os.path.exists("/root/.ssh/authorized_keys"):
-            append("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
-        return
+        if not confirm("/root/.ssh/id_rsa already exists - overwrite?"):
+            return
+        if _context.yes_to_all and _context.no_overwrite_sshkey:
+            return
+        rmfile("/root/.ssh/id_rsa")
     status("Generating SSH key")
     invoke("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
     append("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
@@ -2053,7 +2055,7 @@ def remove_localhost_check():
 
 def bootstrap_init(cluster_name="hacluster", ui_context=None, nic=None, ocfs2_device=None,
                    shared_device=None, sbd_device=None, diskless_sbd=False, quiet=False,
-                   template=None, admin_ip=None, yes_to_all=False,
+                   template=None, admin_ip=None, yes_to_all=False, no_overwrite_sshkey=False,
                    unicast=False, second_hb=False, ipv6=False, watchdog=None, qdevice=None, stage=None, args=None):
     """
     -i <nic>
@@ -2094,6 +2096,7 @@ def bootstrap_init(cluster_name="hacluster", ui_context=None, nic=None, ocfs2_de
     _context.watchdog = watchdog
     _context.ui_context = ui_context
     _context.qdevice = qdevice
+    _context.no_overwrite_sshkey = no_overwrite_sshkey
 
     def check_option():
         if _context.admin_ip and not valid_adminIP(_context.admin_ip):

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -670,9 +670,8 @@ def init_ssh():
     start_service("sshd.service")
     invoke("mkdir -m 700 -p /root/.ssh")
     if os.path.exists("/root/.ssh/id_rsa"):
-        if not confirm("/root/.ssh/id_rsa already exists - overwrite?"):
-            return
-        if _context.yes_to_all and _context.no_overwrite_sshkey:
+        if _context.yes_to_all and _context.no_overwrite_sshkey or \
+                not confirm("/root/.ssh/id_rsa already exists - overwrite?"):
             return
         rmfile("/root/.ssh/id_rsa")
     status("Generating SSH key")
@@ -684,7 +683,10 @@ def init_ssh_remote():
     """
     Called by ha-cluster-join
     """
-    authkeys = open("/root/.ssh/authorized_keys", "r+")
+    authorized_keys_file = "/root/.ssh/authorized_keys"
+    if not os.path.exists(authorized_keys_file):
+        open(authorized_keys_file, 'w').close()
+    authkeys = open(authorized_keys_file, "r+")
     authkeys_data = authkeys.read()
     for key in ("id_rsa", "id_dsa", "id_ecdsa", "id_ed25519"):
         fn = os.path.join("/root/.ssh", key)
@@ -692,7 +694,7 @@ def init_ssh_remote():
             continue
         keydata = open(fn + ".pub").read()
         if keydata not in authkeys_data:
-            append(fn + ".pub", "/root/.ssh/authorized_keys")
+            append(fn + ".pub", authorized_keys_file)
 
 
 def init_csync2():

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -670,9 +670,9 @@ def init_ssh():
     start_service("sshd.service")
     invoke("mkdir -m 700 -p /root/.ssh")
     if os.path.exists("/root/.ssh/id_rsa"):
-        if not confirm("/root/.ssh/id_rsa already exists - overwrite?"):
-            return
-        rmfile("/root/.ssh/id_rsa")
+        if not os.path.exists("/root/.ssh/authorized_keys"):
+            append("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+        return
     status("Generating SSH key")
     invoke("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
     append("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -187,7 +187,7 @@ Note:
         parser.add_option("-q", "--quiet", action="store_true", dest="quiet",
                           help="Be quiet (don't describe what's happening, just do it)")
         parser.add_option("-y", "--yes", action="store_true", dest="yes_to_all",
-                          help='Answer "yes" to all prompts (use with caution, this is destructive, especially during the "storage" stage)')
+                          help='Answer "yes" to all prompts (use with caution, this is destructive, especially during the "storage" stage. The /root/.ssh/id_rsa key will be overwritten unless the option "--no-overwrite-sshkey" is used)')
         parser.add_option("-t", "--template", dest="template",
                           help='Optionally configure cluster with template "name" (currently only "ocfs2" is valid here)')
         parser.add_option("-n", "--name", metavar="NAME", dest="name", default="hacluster",
@@ -200,6 +200,8 @@ Note:
                           help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_option("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",
                           help="Use the given watchdog device")
+        parser.add_option("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
+                          help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = optparse.OptionGroup(parser, "Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_option("-i", "--interface", dest="nic", metavar="IF",
@@ -278,6 +280,7 @@ Note:
             template=options.template,
             admin_ip=options.admin_ip,
             yes_to_all=options.yes_to_all,
+            no_overwrite_sshkey=options.no_overwrite_sshkey,
             unicast=options.unicast,
             second_hb=options.second_hb,
             ipv6=options.ipv6,

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1,0 +1,146 @@
+"""
+Unitary tests for crmsh/bootstrap.py
+
+:author: xinliang
+:organization: SUSE Linux GmbH
+:contact: XLiang@suse.de
+
+:since: 2019-10-21
+"""
+
+# pylint:disable=C0103,C0111,W0212,W0611
+
+import os
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from crmsh import bootstrap
+
+
+class TestBootstrap(unittest.TestCase):
+    """
+    Unitary tests for crmsh/bootstrap.py
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    #@mock.patch('crmsh.bootstrap.Context')
+    def setUp(self):
+        """
+        Test setUp.
+        """
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.bootstrap.start_service')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_no_exist_keys(self, mock_invoke, mock_start_service,
+                                    mock_exists, mock_status, mock_append):
+        mock_exists.return_value = False
+
+        bootstrap.init_ssh()
+
+        mock_start_service.assert_called_once_with("sshd.service")
+        mock_invoke.assert_has_calls([
+            mock.call("mkdir -m 700 -p /root/.ssh"),
+            mock.call("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
+        ])
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_status.assert_called_once_with("Generating SSH key")
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+
+    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.rmfile')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.bootstrap.start_service')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_exits_keys_yes_to_all_confirm(self, mock_invoke, mock_start_service,
+                         mock_exists, mock_confirm, mock_rmfile, mock_status, mock_append):
+        mock_exists.return_value = True
+        bootstrap._context = mock.Mock(yes_to_all=True, no_overwrite_sshkey=False)
+        mock_confirm.return_value = True
+
+        bootstrap.init_ssh()
+
+        mock_start_service.assert_called_once_with("sshd.service")
+        mock_invoke.assert_has_calls([
+            mock.call("mkdir -m 700 -p /root/.ssh"),
+            mock.call("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
+        ])
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_confirm.assert_called_once_with("/root/.ssh/id_rsa already exists - overwrite?")
+        mock_rmfile.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_status.assert_called_once_with("Generating SSH key")
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+
+    @mock.patch('crmsh.bootstrap.rmfile')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.bootstrap.start_service')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_exits_keys_no_overwrite(self, mock_invoke, mock_start_service,
+                                              mock_exists, mock_confirm, mock_rmfile):
+        mock_exists.return_value = True
+        bootstrap._context = mock.Mock(yes_to_all=True, no_overwrite_sshkey=True)
+
+        bootstrap.init_ssh()
+
+        mock_start_service.assert_called_once_with("sshd.service")
+        mock_invoke.assert_called_once_with("mkdir -m 700 -p /root/.ssh")
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_confirm.assert_not_called()
+        mock_rmfile.assert_not_called()
+
+    @mock.patch('builtins.open')
+    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('os.path.join')
+    @mock.patch('os.path.exists')
+    def test_init_ssh_remote_no_sshkey(self, mock_exists, mock_join, mock_append, mock_open_file):
+        mock_exists.side_effect = [False, True, False, False, False]
+        mock_join.side_effect = ["/root/.ssh/id_rsa",
+                                 "/root/.ssh/id_dsa",
+                                 "/root/.ssh/id_ecdsa",
+                                 "/root/.ssh/id_ed25519"]
+        mock_open_file.side_effect = [
+            mock.mock_open().return_value,
+            mock.mock_open(read_data="data1 data2").return_value,
+            mock.mock_open(read_data="data1111").return_value
+        ]
+
+        bootstrap.init_ssh_remote()
+
+        mock_open_file.assert_has_calls([
+            mock.call("/root/.ssh/authorized_keys", 'w'),
+            mock.call("/root/.ssh/authorized_keys", "r+"),
+            mock.call("/root/.ssh/id_rsa.pub")
+        ])
+        mock_exists.assert_has_calls([
+            mock.call("/root/.ssh/authorized_keys"),
+            mock.call("/root/.ssh/id_rsa"),
+            mock.call("/root/.ssh/id_dsa"),
+            mock.call("/root/.ssh/id_ecdsa"),
+            mock.call("/root/.ssh/id_ed25519"),
+        ])
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")


### PR DESCRIPTION
## Problem
Using **--yes/-y** option with **ha-cluster-init** will cause re-generate/overwrite ssh key if ssh key already exists.
That may cause problem or inconvenient for user.
#### Problem 1
One colleague complain to me that he can not access the node passwordless after configured HA cluster because ssh key changed
I think this is the inconvenient point other user might have
#### Problem 2
That will cause inconvenient during regression test for #464.
In [.travis.yml](https://github.com/liangxin1300/crmsh/blob/b8198e60405473c3201730adbbc212c17f53930a/.travis.yml#L42), I start two nodes for cluster, another one node for qnetd.
Since both setup cluster and setup qdevice/qnetd need to input password, I deploy ssh key firstly in image ([Dockerfile](https://github.com/liangxin1300/myDockerfiles/blob/0b3d55e110f3d3902e1123032efa91341b02118c/HA/habase/tumbleweed/Dockerfile#L20)), to make sure the whole process are passwordless/non-interactive.
But the process will block when setup qdevice/qnetd because my initial ssh key has been overwrite.
## Solution
I suggest if ssh key already exists before HA cluster configuring, we do not overwrite it, just return and continue to do next init steps.
## Affect
From my view, there is no side effect for any interfaces