### PR TITLE
Set resource failcount correctly(bsc#1144241)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,12 @@ jobs:
       script:
         - $FUNCTIONAL_TEST qdevice run validate
 
+    - name: "functional test for resource subcommand"
+      before_install:
+        - $FUNCTIONAL_TEST resource before_install
+      script:
+        - $FUNCTIONAL_TEST resource run
+
     - stage: delivery
       if: type != pull_request AND branch = master
       env:

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -44,7 +44,7 @@ def join(*fns):
 booleans = choice(['yes', 'no', 'true', 'false', 'on', 'off'])
 
 
-def resources(args):
+def resources(args=None):
     cib_el = xmlutil.resources_xml()
     if cib_el is None:
         return []

--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -22,7 +22,7 @@ def _dispatch_attr_cmd(cmd, attr_cmd, rsc, subcmd, attr, value):
     def sanity_check(arg):
         if not utils.is_name_sane(arg):
             raise ValueError("Expected valid name, got '%s'" % (arg))
-    if subcmd == 'set':
+    if subcmd in ['set', 'set_p']:
         if value is None:
             raise ValueError("Missing value argument to set")
         sanity_check(rsc)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2253,4 +2253,15 @@ def valid_nodeid(nodeid):
 def is_unicast():
     from . import corosync
     return corosync.get_value("totem.transport") == "udpu"
+
+
+def get_nodeid_from_name(name):
+    rc, out = get_stdout('crm_node -l')
+    if rc != 0:
+        return None
+    res = re.search(r'^([0-9]+) {} '.format(name), out, re.M)
+    if res:
+        return res.group(1)
+    else:
+        return None
 # vim:ts=4:sw=4:et:

--- a/data-manifest
+++ b/data-manifest
@@ -71,6 +71,7 @@ test/features/environment.py
 test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature
 test/features/qdevice_validate.feature
+test/features/resource_failcount.feature
 test/features/steps/__init__.py
 test/features/steps/step_implenment.py
 test/features/steps/utils.py

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2011,10 +2011,13 @@ demote <rsc>
 ==== `failcount`
 
 Show/edit/delete the failcount of a resource.
+When `set` a non-zero value, `operation` and `interval` should be 
+provided when multiple operation failcount entries exist.
+`interval` is a value in seconds.
 
 Usage:
 ...............
-failcount <rsc> set <node> <value>
+failcount <rsc> set <node> <value> [operation] [interval]
 failcount <rsc> delete <node>
 failcount <rsc> show <node>
 ...............

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -11,6 +11,10 @@ def get_online_nodes():
         return None
 
 
+def resource_cleanup():
+    utils.get_stdout_stderr('crm resource cleanup')
+
+
 def before_step(context, step):
     context.logger = logging.getLogger("Step:{}".format(step.name))
 
@@ -20,6 +24,7 @@ def before_tag(context, tag):
     if tag == "clean":
         online_nodes = get_online_nodes()
         if online_nodes:
+            resource_cleanup()
             try:
                 parallax.parallax_call(online_nodes, 'crm cluster stop')
             except ValueError as err:

--- a/test/features/resource_failcount.feature
+++ b/test/features/resource_failcount.feature
@@ -1,0 +1,64 @@
+@resource
+Feature: Use "crm resource failcount" to manage failcounts
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  Background: Setup one node cluster and configure a Dummy resource
+    Given     Cluster service is "stopped" on "hanode1"
+    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    Then      Cluster service is "started" on "hanode1"
+    When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
+    Then      Resource "d" type "Dummy" is "Started"
+
+  @clean
+  Scenario: Validation, input the wrong parameters
+    When    Try "crm resource failcount ddd show hanode1"
+    Then    Except "ERROR: resource.failcount: Resource ddd not exists in this cluster"
+    When    Try "crm resource failcount d showss hanode1"
+    Then    Except "ERROR: resource.failcount: showss is not valid command(should be one of ['set', 'delete', 'show'])"
+    When    Try "crm resource failcount d set hanode11 0"
+    Then    Except "ERROR: resource.failcount: Node hanode11 not in this cluster"
+    When    Try "crm resource failcount d set hanode1 0"
+    Then    Except "ERROR: resource.failcount: No failcount on node hanode1 for resource d"
+
+  @clean
+  Scenario: Set the failcount to 0
+    When    Run "rm -f /run/resource-agents/Dummy-d.state" on "hanode1"
+    And     Wait "5" seconds
+    Then    Resource "d" failcount on "hanode1" is "1"
+    When    Run "crm resource failcount d set hanode1 0" on "hanode1"
+    Then    Resource "d" failcount on "hanode1" is "0"
+
+  @clean
+  Scenario: Set multiple failcounts to 0
+    When    Run "sed -i -e '/rm \${OCF_RESKEY_state}/a\' -e "else\nreturn \$OCF_ERR_GENERIC" /usr/lib/ocf/resource.d/heartbeat/Dummy" on "hanode1"
+    And     Run "rm -f /run/resource-agents/Dummy-d.state" on "hanode1"
+    And     Wait "5" seconds
+    Then    Resource "d" failcount on "hanode1" is "INFINITY"
+        """
+        now have two failcount entries, one is monitor, another is stop
+	"""
+    When    Run "crm resource failcount d set hanode1 0" on "hanode1"
+        """
+        set all failcounts to 0
+	"""
+    Then    Resource "d" failcount on "hanode1" is "0"
+    When    Run "crm resource cleanup" on "hanode1"
+    And     Wait "5" seconds
+    And     Run "rm -f /run/resource-agents/Dummy-d.state" on "hanode1"
+    And     Wait "5" seconds
+    Then    Resource "d" failcount on "hanode1" is "INFINITY"
+        """
+        now have two failcount entries, one is monitor, another is stop
+	"""
+    When    Run "crm resource failcount d set hanode1 0 stop" on "hanode1"
+        """
+        set stop failcounts to 0
+	"""
+    Then    Resource "d" failcount on "hanode1" is "1"
+    When    Run "crm resource failcount d set hanode1 0 monitor" on "hanode1"
+        """
+        set monitor failcounts to 0
+	"""
+    Then    Resource "d" failcount on "hanode1" is "0"
+

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -1,4 +1,5 @@
 import re
+import time
 from behave import given, when, then
 from crmsh import corosync, parallax
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
@@ -35,6 +36,11 @@ def step_impl(context, cmd, addr):
 @when('Try "{cmd}"')
 def step_impl(context, cmd):
     run_command(context, cmd, err_record=True)
+
+
+@when('Wait "{second}" seconds')
+def step_impl(context, second):
+    time.sleep(int(second))
 
 
 @then('Except "{msg}"')
@@ -109,3 +115,28 @@ def step_impl(context):
     out = run_command(context, "sed -n -e '/quorum/,/^}/ p' /etc/corosync/corosync.conf")
     if out:
         context.logger.info("\n{}".format(out))
+
+
+@then('Resource "{res}" type "{res_type}" is "{state}"')
+def step_impl(context, res, res_type, state):
+    try_count = 0
+    result = None
+    while try_count < 5:
+        time.sleep(1)
+        out = run_command(context, "crm_mon -1")
+        if out:
+            result = re.search(r'\s{}\s+.*:{}\):\s+{} '.format(res, res_type, state), out)
+            if not result:
+                try_count += 1
+            else:
+                break
+    assert result is not None
+
+
+@then('Resource "{res}" failcount on "{node}" is "{number}"')
+def step_impl(context, res, node, number):
+    cmd = "crm resource failcount {} show {}".format(res, node)
+    out = run_command(context, cmd)
+    if out:
+        result = re.search(r'name=fail-count-{} value={}'.format(res, number), out)
+        assert result is not None

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -32,7 +32,7 @@ case "$1" in
 		configure
 		make_install
 		exit $?;;
-	bootstrap|qdevice|hb_report)
+	bootstrap|qdevice|hb_report|resource)
 		functional_tests $1 $2
 		exit $?;;
 	*)

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -6,11 +6,50 @@ from __future__ import unicode_literals
 
 import os
 import socket
+import re
 from unittest import mock
+from nose.tools import eq_
 from itertools import chain
 from crmsh import utils
 from crmsh import config
 from crmsh import tmpfiles
+
+
+@mock.patch('re.search')
+@mock.patch('crmsh.utils.get_stdout')
+def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
+    mock_get_stdout.return_value = (1, None)
+    mock_re_search_inst = mock.Mock()
+    mock_re_search.return_value = mock_re_search_inst
+    res = utils.get_nodeid_from_name("node1")
+    eq_(res, None)
+    mock_get_stdout.assert_called_once_with('crm_node -l')
+    mock_re_search.assert_not_called()
+
+
+@mock.patch('re.search')
+@mock.patch('crmsh.utils.get_stdout')
+def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
+    mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
+    mock_re_search.return_value = None
+    res = utils.get_nodeid_from_name("node111")
+    eq_(res, None)
+    mock_get_stdout.assert_called_once_with('crm_node -l')
+    mock_re_search.assert_called_once_with(r'^([0-9]+) node111 ', mock_get_stdout.return_value[1], re.M)
+
+
+@mock.patch('re.search')
+@mock.patch('crmsh.utils.get_stdout')
+def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
+    mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
+    mock_re_search_inst = mock.Mock()
+    mock_re_search.return_value = mock_re_search_inst
+    mock_re_search_inst.group.return_value = '172168231'
+    res = utils.get_nodeid_from_name("node2")
+    eq_(res, '172168231')
+    mock_get_stdout.assert_called_once_with('crm_node -l')
+    mock_re_search.assert_called_once_with(r'^([0-9]+) node2 ', mock_get_stdout.return_value[1], re.M)
+    mock_re_search_inst.group.assert_called_once_with(1)
 
 
 def test_check_ssh_passwd_need_True():


### PR DESCRIPTION
#### Problem
Can't set the resource failcount correctly.
e.g.
Dummy resource `d` failed on monitor on node1, using
`crm resource failcount d show node1`
shows the failcount number
If we want to use this:
`crm resource failcount d set node1 0`
to reset the failcount to zero, it doesn't work 
#### Reason

> from SLE12SP3 and SLE15,  fail-counts are no longer recorded "per resource", instead they are recorded "per resource operation per node". 
> So if to make "crm resource failcount <rsc> set" correctly work again, the interface needs to be completed/extended, for example like:
> crm resource failcount \<rsc\> set \<node\> \<operation\> \<interval\> \<value\>

#### Solution
I changed this set sub-command like this:
`failcount <rsc> set <node> <value> [operation]`
If user want to set the failcount, program fetch the current failcount status from cib firstly, to get the operations and their interval.
If only one operation failure happened, option `operation` is no need to specify;
If there are multiple operation failures, user must specify option `operation` ;
Interval of operation always get internally.