### PR TITLE
Node do maintenance

### DIFF
--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1226,6 +1226,20 @@ def get_set_nodes(e, setname, create=False):
         l.append(elem)
     return l
 
+def get_set_instace_attributes(e, create=False):
+    '''
+    Return instance attributes set nodes (create one if requested)
+    '''
+    l = [c for c in e.iterchildren("instance_attributes")]
+    if l:
+        return l
+    if create:
+        from . import idmgmt
+        elem = etree.SubElement(e, "instance_attributes", id="")
+        elem.set("id", "nodes-"+e.attrib["id"])
+        l.append(elem)
+    return l
+
 
 _checker = doctestcompare.LXMLOutputChecker()
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2413,7 +2413,9 @@ fence <node>
 
 Set the node status to maintenance. This is equivalent to the
 cluster-wide `maintenance-mode` property but puts just one node
-into the maintenance mode.
+into the maintenance mode. If there are maintenaned resources on
+the node, the user will be proposed to remove the maintenance
+property from them.
 
 The node parameter defaults to the node where the command is run.
 

--- a/doc/website-v1/man-2.0.adoc
+++ b/doc/website-v1/man-2.0.adoc
@@ -2101,7 +2101,9 @@ fence <node>
 
 Set the node status to maintenance. This is equivalent to the
 cluster-wide `maintenance-mode` property but puts just one node
-into the maintenance mode.
+into the maintenance mode. If there are maintenaned resources on
+the node, the user will be proposed to remove the maintenance
+property from them.
 
 The node parameter defaults to the node where the command is run.
 

--- a/doc/website-v1/man-3.adoc
+++ b/doc/website-v1/man-3.adoc
@@ -2362,7 +2362,9 @@ fence <node>
 
 Set the node status to maintenance. This is equivalent to the
 cluster-wide `maintenance-mode` property but puts just one node
-into the maintenance mode.
+into the maintenance mode. If there are maintenaned resources on
+the node, the user will be proposed to remove the maintenance
+property from them.
 
 The node parameter defaults to the node where the command is run.
 

--- a/test/testcases/node
+++ b/test/testcases/node
@@ -3,7 +3,11 @@ node show node1
 %setenv showobj=node1
 node standby node1
 node online node1
-node maintenance node1
+configure primitive p5 Dummy
+configure group g0 p5
+resource maintenance g0
+resource maintenance p5
+-F node maintenance node1
 node ready node1
 node attribute node1 set a1 "1 2 3"
 node attribute node1 show a1

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -45,8 +45,12 @@ node1: member
   </configuration>
 </cib>
 
-.TRY node maintenance node1
-.EXT crm_attribute -t nodes -N 'node1' -n maintenance -v 'on'
+.TRY configure primitive p5 Dummy
+.EXT crm_resource --show-metadata ocf:heartbeat:Dummy
+.EXT crm_resource --show-metadata ocf:pacemaker:Dummy
+.EXT crm_resource --show-metadata stonith:null
+.EXT stonithd metadata
+.EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -58,7 +62,89 @@ node1: member
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
           <nvpair id="nodes-node1-standby" name="standby" value="off"/>
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="on"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources/>
+    <constraints/>
+  </configuration>
+</cib>
+
+.TRY configure group g0 p5
+.INP: configure
+.INP: _regtest on
+.INP: show xml node1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes>
+      <node uname="node1" id="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources/>
+    <constraints/>
+  </configuration>
+</cib>
+
+.TRY resource maintenance g0
+.INP: configure
+.INP: _regtest on
+.INP: show xml node1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes>
+      <node uname="node1" id="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources/>
+    <constraints/>
+  </configuration>
+</cib>
+
+.TRY resource maintenance p5
+.INP: configure
+.INP: _regtest on
+.INP: show xml node1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes>
+      <node uname="node1" id="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-standby" name="standby" value="off"/>
+        </instance_attributes>
+      </node>
+    </nodes>
+    <resources/>
+    <constraints/>
+  </configuration>
+</cib>
+
+.TRY -F node maintenance node1
+INFO: 'maintenance' attribute already exists in p5. Remove it? [YES]
+INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
+.INP: configure
+.INP: _regtest on
+.INP: show xml node1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes>
+      <node uname="node1" id="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-standby" name="standby" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="true"/>
         </instance_attributes>
       </node>
     </nodes>


### PR DESCRIPTION
The crmsh will change the cib.xml itself, instead of using the crm_attribute when changing the maintenance status of a node. Besides, it will inform the user if there are resources in the maintenance or is-manage mode.