### PR TITLE
Dev: ui_resource: ask about ALL primitives when overriding attributes

### DIFF
--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -30,20 +30,6 @@ def rm_meta_attribute(node, attr, l, force_children=False):
                 (xmlutil.is_child_rsc(c) and not c.getparent().tag == "group"):
             rm_meta_attribute(c, attr, l, force_children=force_children)
 
-
-def get_children_with_different_attr(node, attr, value):
-    l = []
-    for p in node.xpath(".//primitive"):
-        diff_attr = False
-        for meta_set in xmlutil.get_set_nodes(p, "meta_attributes", create=False):
-            p_value = xmlutil.get_attr_value(meta_set, attr)
-            if p_value is not None and p_value != value:
-                diff_attr = True
-                break
-        if diff_attr:
-            l.append(p)
-    return l
-
 def get_children_with_attr(node, attr):
     l = []
     for p in node.xpath(".//primitive"):
@@ -83,8 +69,8 @@ def set_deep_meta_attr_node(target_node, attr, value):
                     common_debug("force remove meta attr %s from %s" %
                                 (conflicting_attr, c.get("id")))
                     rm_meta_attribute(c, conflicting_attr, nvpair_l, force_children=True)
-        # remove attributes with different values
-        odd_children = get_children_with_different_attr(target_node, attr, value)
+        # remove the same attributes from all children (if wanted)
+        odd_children = get_children_with_attr(target_node, attr)
         for c in odd_children:
             if config.core.manage_children == "always" or \
                     (config.core.manage_children == "ask" and

--- a/test/testcases/resource
+++ b/test/testcases/resource
@@ -78,3 +78,7 @@ resource start p5
 %setenv showobj=g1
 -F resource manage g1
 resource start p5
+%setenv showobj=p5
+-F resource maintenance p5 on
+%setenv showobj=g1
+-F resource maintenance g1

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -712,11 +712,7 @@ INFO: Trace set, restart p0 to trace the stop operation
           <nvpair id="cg-meta_attributes-target-role" name="target-role" value="Started"/>
         </meta_attributes>
         <group id="g">
-          <primitive id="p0" class="ocf" provider="pacemaker" type="Dummy">
-            <meta_attributes id="p0-meta_attributes">
-              <nvpair id="p0-meta_attributes-target-role" name="target-role" value="Started"/>
-            </meta_attributes>
-          </primitive>
+          <primitive id="p0" class="ocf" provider="pacemaker" type="Dummy"/>
           <primitive id="p3" class="ocf" provider="pacemaker" type="Dummy"/>
         </group>
       </clone>
@@ -1102,6 +1098,60 @@ INFO: 'is-managed' conflicts with 'maintenance' attribute. Remove 'maintenance' 
       <group id="g1">
         <meta_attributes id="g1-meta_attributes-0">
           <nvpair id="g1-meta_attributes-0-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+        <primitive id="p5" class="ocf" provider="heartbeat" type="Dummy">
+          <meta_attributes id="p5-meta_attributes">
+            <nvpair id="p5-meta_attributes-target-role" name="target-role" value="Started"/>
+          </meta_attributes>
+        </primitive>
+      </group>
+    </resources>
+    <constraints/>
+  </configuration>
+</cib>
+
+.SETENV showobj=p5
+.TRY -F resource maintenance p5 on
+.INP: configure
+.INP: _regtest on
+.INP: show xml p5
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <group id="g1">
+        <meta_attributes id="g1-meta_attributes-0">
+          <nvpair id="g1-meta_attributes-0-is-managed" name="is-managed" value="true"/>
+        </meta_attributes>
+        <primitive id="p5" class="ocf" provider="heartbeat" type="Dummy">
+          <meta_attributes id="p5-meta_attributes">
+            <nvpair id="p5-meta_attributes-target-role" name="target-role" value="Started"/>
+            <nvpair id="p5-meta_attributes-maintenance" name="maintenance" value="true"/>
+          </meta_attributes>
+        </primitive>
+      </group>
+    </resources>
+    <constraints/>
+  </configuration>
+</cib>
+
+.SETENV showobj=g1
+.TRY -F resource maintenance g1
+INFO: 'maintenance' conflicts with 'is-managed' attribute. Remove 'is-managed' for resource g1? [YES]
+.INP: configure
+.INP: _regtest on
+.INP: show xml g1
+<?xml version="1.0" ?>
+<cib>
+  <configuration>
+    <crm_config/>
+    <nodes/>
+    <resources>
+      <group id="g1">
+        <meta_attributes id="g1-meta_attributes">
+          <nvpair id="g1-meta_attributes-maintenance" name="maintenance" value="true"/>
         </meta_attributes>
         <primitive id="p5" class="ocf" provider="heartbeat" type="Dummy">
           <meta_attributes id="p5-meta_attributes">


### PR DESCRIPTION
When applying a maintenance attribute, the crmsh asked the user if he wanted to delete the maintenance attribute for those primitives that had a different value. It's more logical however to ask the user if he also wants to delete the maintenance attribute from the primitives that have the same value, because this is exactly the intention - to maintain the group not each primitive separately. Even if the user would like to customize each resource individually, he can answer 'No'.