### PR TITLE
Dev: ui_configure: do_property: ask to remove maintenance from primitives and nodes

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3841,6 +3841,9 @@ Set cluster configuration properties. To list the
 available cluster configuration properties, use the
 <<cmdhelp_ra_info,`ra info`>> command with +pengine+, +crmd+,
 +cib+ and +stonithd+ as arguments.
+When setting the +maintenance-mode+ property, it will
+inform the user if there are nodes or resources that
+have the +maintenance+ property.
 
 For more information on rule expressions, see
 <<topics_Syntax_RuleExpressions,Syntax: Rule expressions>>.

--- a/doc/website-v1/man-2.0.adoc
+++ b/doc/website-v1/man-2.0.adoc
@@ -3471,6 +3471,9 @@ Set cluster configuration properties. To list the
 available cluster configuration properties, use the
 <<cmdhelp_ra_info,`ra info`>> command with +pengine+, +crmd+,
 +cib+ and +stonithd+ as arguments.
+When setting the +maintenance-mode+ property, it will
+inform the user if there are nodes or resources that
+have the +maintenance+ property.
 
 For more information on rule expressions, see
 <<topics_Syntax_RuleExpressions,Syntax: Rule expressions>>.

--- a/doc/website-v1/man-3.adoc
+++ b/doc/website-v1/man-3.adoc
@@ -3732,6 +3732,9 @@ Set cluster configuration properties. To list the
 available cluster configuration properties, use the
 <<cmdhelp_ra_info,`ra info`>> command with +pengine+, +crmd+,
 +cib+ and +stonithd+ as arguments.
+When setting the +maintenance-mode+ property, it will
+inform the user if there are nodes or resources that
+have the +maintenance+ property.
 
 For more information on rule expressions, see
 <<topics_Syntax_RuleExpressions,Syntax: Rule expressions>>.

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -85,3 +85,7 @@ set d2.mondelay 45
 _test
 verify
 .
+-F node maintenance node1
+-F resource maintenance g1 off
+-F resource maintenance d1
+-F configure property maintenance-mode=true

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -147,3 +147,13 @@ op_defaults opsdef2: \
 	record-pending=true
 .INP: commit
 WARNING: 55: c2: resource d1 is grouped, constraints should apply to the group
+.TRY -F node maintenance node1
+.TRY -F resource maintenance g1 off
+.TRY -F resource maintenance d1
+.TRY -F configure property maintenance-mode=true
+INFO: 'maintenance' attribute already exists in d1. Remove it? [YES]
+INFO: 'maintenance' attribute already exists in g1. Remove it? [YES]
+INFO: 'maintenance' attribute already exists in node1. Remove it? [YES]
+.EXT crmd metadata
+.EXT pengine metadata
+.EXT cib metadata


### PR DESCRIPTION
When setting the whole cluster into the maintenance mode by

  $ crm configure property maintenance=true

the crmsh will inform the user, that there are already nodes,
clones, groups or primitives that have the maintenance property.