### PR TITLE
Create class Parallax to simplify using parallax

### DIFF
--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2019 Xin Liang <XLiang@suse.com>
+# See COPYING for license information.
+
+
+import os
+import parallax
+
+
+class Parallax(object):
+    """
+    # Parallax SSH API
+    # call: Executes the given command on a set of hosts, collecting the output
+    # copy: Copies files from the local machine to a set of remote hosts
+    # slurp: Copies files from a set of remote hosts to local folders
+    """
+    def __init__(self, nodes, cmd=None, localdir=None, filename=None,
+                 src=None, dst=None, askpass=False, ssh_options=None):
+        self.nodes = nodes
+        self.askpass = askpass
+        self.ssh_options = ssh_options
+
+        # used for call
+        self.cmd = cmd
+        # used for slurp
+        self.localdir = localdir
+        self.filename = filename
+        # used for copy
+        self.src = src
+        self.dst = dst
+
+        self.opts = self.prepare()
+
+    def prepare(self):
+        opts = parallax.Options()
+        if self.ssh_options is None:
+            self.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
+        opts.ssh_options = self.ssh_options
+        opts.askpass = self.askpass
+        # warn_message will available from parallax-1.0.5
+        if hasattr(opts, 'warn_message'):
+            opts.warn_message = False
+        opts.localdir = self.localdir
+        return opts
+
+    def handle(self, results):
+        for host, result in results:
+            if isinstance(result, parallax.Error):
+                raise ValueError("Failed on {}: {}".format(host, result))
+        return results
+
+    def call(self):
+        results = parallax.call(self.nodes, self.cmd, self.opts)
+        return self.handle(list(results.items()))
+
+    def slurp(self):
+        dst = os.path.basename(self.filename)
+        results = parallax.slurp(self.nodes, self.filename, dst, self.opts)
+        return self.handle(list(results.items()))
+
+    def copy(self):
+        results = parallax.copy(self.nodes, self.src, self.dst, self.opts)
+        return self.handle(list(results.items()))
+
+
+def parallax_call(nodes, cmd, askpass=False, ssh_options=None):
+    """
+    Executes the given command on a set of hosts, collecting the output
+    nodes:       a set of hosts
+    cmd:         command
+    askpass:     Ask for a password if passwordless not configured
+    ssh_options: Extra options to pass to SSH
+    Returns [(host, (rc, stdout, stdin)), ...] or ValueError exception
+    """
+    p = Parallax(nodes, cmd=cmd, askpass=askpass, ssh_options=ssh_options)
+    return p.call()
+
+
+def parallax_slurp(nodes, localdir, filename, askpass=False, ssh_options=None):
+    """
+    Copies from the remote node to the local node
+    nodes:       a set of hosts
+    localdir:    localpath
+    filename:    remote filename want to slurp
+    askpass:     Ask for a password if passwordless not configured
+    ssh_options: Extra options to pass to SSH
+    Returns [(host, (rc, stdout, stdin, localpath)), ...] or ValueError exception
+    """
+    p = Parallax(nodes, localdir=localdir, filename=filename,
+                 askpass=askpass, ssh_options=ssh_options)
+    return p.slurp()
+
+
+def parallax_copy(nodes, src, dst, askpass=False, ssh_options=None):
+    """
+    Copies from the local node to a set of remote hosts
+    nodes:       a set of hosts
+    src:         local path
+    dst:         remote path
+    askpass:     Ask for a password if passwordless not configured
+    ssh_options: Extra options to pass to SSH
+    Returns [(host, (rc, stdout, stdin)), ...] or ValueError exception
+    """
+    p = Parallax(nodes, src=src, dst=dst, askpass=askpass, ssh_options=ssh_options)
+    return p.copy()

--- a/data-manifest
+++ b/data-manifest
@@ -155,6 +155,7 @@ test/unittests/scripts/v2/main.yml
 test/unittests/scripts/vipinc/main.yml
 test/unittests/scripts/vip/main.yml
 test/unittests/scripts/workflows/10-webserver.xml
+test/unittests/test_bootstrap.py
 test/unittests/test_bugs.py
 test/unittests/test_cib.py
 test/unittests/test_cliformat.py

--- a/test/unittests/test_parallax.py
+++ b/test/unittests/test_parallax.py
@@ -1,0 +1,127 @@
+from __future__ import unicode_literals
+# Copyright (C) 2019 Xin Liang <XLiang@suse.com>
+# See COPYING for license information.
+#
+# unit tests for parallax.py
+
+
+import os
+import unittest
+from unittest import mock
+import parallax
+from crmsh import parallax as cparallax
+
+
+class TestParallax(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        # Use the setup to create a fresh instance for each test
+        self.parallax_call_instance = cparallax.Parallax(["node1"], cmd="ls")
+        self.parallax_slurp_instance = cparallax.Parallax(["node1"], localdir="/opt", filename="/opt/file.c")
+        self.parallax_copy_instance = cparallax.Parallax(["node1", "node2"], src="/opt/file.c", dst="/tmp")
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch("parallax.call")
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    def test_call(self, mock_handle, mock_call):
+        mock_call.return_value = {"node1": (0, None, None)}
+        mock_handle.return_value = [("node1", (0, None, None))]
+
+        result = self.parallax_call_instance.call()
+        self.assertEqual(result, mock_handle.return_value)
+
+        mock_call.assert_called_once_with(["node1"], "ls", self.parallax_call_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
+
+    @mock.patch("parallax.Error")
+    @mock.patch("parallax.call")
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    def test_call_exception(self, mock_handle, mock_call, mock_error):
+        mock_error = mock.Mock()
+        mock_call.return_value = {"node1": mock_error}
+        mock_handle.side_effect = ValueError("error happen")
+
+        with self.assertRaises(ValueError) as err:
+            self.parallax_call_instance.call()
+        self.assertEqual("error happen", str(err.exception))
+
+        mock_call.assert_called_once_with(["node1"], "ls", self.parallax_call_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
+
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    @mock.patch("parallax.slurp")
+    @mock.patch("os.path.basename")
+    def test_slurp(self, mock_basename, mock_slurp, mock_handle):
+        mock_basename.return_value = "file.c"
+        mock_slurp.return_value = {"node1": (0, None, None, "/opt")}
+        mock_handle.return_value = [("node1", (0, None, None, "/opt"))]
+
+        result = self.parallax_slurp_instance.slurp()
+        self.assertEqual(result, mock_handle.return_value)
+
+        mock_basename.assert_called_once_with("/opt/file.c")
+        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", self.parallax_slurp_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_slurp.return_value.items()))
+
+    @mock.patch("parallax.Error")
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    @mock.patch("parallax.slurp")
+    @mock.patch("os.path.basename")
+    def test_slurp_exception(self, mock_basename, mock_slurp, mock_handle, mock_error):
+        mock_basename.return_value = "file.c"
+        mock_error = mock.Mock()
+        mock_slurp.return_value = {"node1": mock_error}
+        mock_handle.side_effect = ValueError("error happen")
+
+        with self.assertRaises(ValueError) as err:
+            self.parallax_slurp_instance.slurp()
+        self.assertEqual("error happen", str(err.exception))
+
+        mock_basename.assert_called_once_with("/opt/file.c")
+        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", self.parallax_slurp_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_slurp.return_value.items()))
+
+    @mock.patch("parallax.copy")
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    def test_copy(self, mock_handle, mock_copy):
+        mock_copy.return_value = {"node1": (0, None, None), "node2": (0, None, None)}
+        mock_handle.return_value = [("node1", (0, None, None)), ("node2", (0, None, None))]
+
+        result = self.parallax_copy_instance.copy()
+        self.assertEqual(result, mock_handle.return_value)
+
+        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", self.parallax_copy_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_copy.return_value.items()))
+
+    @mock.patch("parallax.Error")
+    @mock.patch("parallax.copy")
+    @mock.patch("crmsh.parallax.Parallax.handle")
+    def test_copy_exception(self, mock_handle, mock_copy, mock_error):
+        mock_error = mock.Mock()
+        mock_copy.return_value = {"node1": mock_error, "node2": (0, None, None)}
+        mock_handle.side_effect = ValueError("error happen")
+
+        with self.assertRaises(ValueError) as err:
+            self.parallax_copy_instance.copy()
+        self.assertEqual("error happen", str(err.exception))
+
+        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", self.parallax_copy_instance.opts)
+        mock_handle.assert_called_once_with(list(mock_copy.return_value.items()))


### PR DESCRIPTION
#### Motivation
crmsh use parallax a lot, recently:
* #464 In qdevice/qnetd TLS certification process, need call remote command and exchange remote key files
* #483  Doing regression test on bootstrap process using python-behave, need call remote command

So we should simplify and provide a standard way to use parallax, to avoid set parallax options and handle the exceptions each time or forget to set something like ssh options