### PR TITLE
Doing functional test on bootstrap process using python-behave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   include:
     - stage: test
+      name: "original regression test"
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
@@ -33,6 +34,18 @@ jobs:
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   
+    - name: "functional test for bootstrap - init, join and remove"
+      before_install:
+        - $TRAVIS_BUILD_DIR/test/docker_scripts.sh bootstrap before_install
+      script:
+        - $TRAVIS_BUILD_DIR/test/docker_scripts.sh bootstrap run init_join_remove
+
+    - name: "functional test for bootstrap - options"
+      before_install:
+        - $TRAVIS_BUILD_DIR/test/docker_scripts.sh bootstrap before_install
+      script:
+        - $TRAVIS_BUILD_DIR/test/docker_scripts.sh bootstrap run options
+
     - stage: delivery
       if: type != pull_request AND branch = master
       env:

--- a/data-manifest
+++ b/data-manifest
@@ -63,7 +63,14 @@ test/containerized-regression-tests.sh
 test/crm-interface
 test/defaults
 test/descriptions
+test/docker_scripts.sh
 test/evaltest.sh
+test/features/bootstrap_init_join_remove.feature
+test/features/bootstrap_options.feature
+test/features/environment.py
+test/features/steps/__init__.py
+test/features/steps/step_bootstrap.py
+test/features/steps/utils.py
 test/history-test.tar.bz2
 test/list-undocumented-commands.py
 test/profile-history.sh
@@ -164,6 +171,7 @@ test/unittests/test_corosync.py
 test/unittests/test_gv.py
 test/unittests/test_handles.py
 test/unittests/test_objset.py
+test/unittests/test_parallax.py
 test/unittests/test_parse.py
 test/unittests/test_report.py
 test/unittests/test_scripts.py

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+Tumbleweed_image='liangxin1300/hatbw'
+HA_packages='pacemaker corosync corosync-qdevice csync2 python3 python3-lxml python3-python-dateutil python3-parallax libglue-devel python3-setuptools python3-tox asciidoc autoconf automake make pkgconfig which libxslt-tools mailx procps python3-nose python3-PyYAML python3-curses tar python3-behave iproute2 iputils vim bzip2'
+TEST_TYPE='bootstrap qdevice hb_report'
+
+before() {
+  docker pull ${Tumbleweed_image}
+  docker network create --subnet 10.10.10.0/24 second_net
+
+  # deploy first node hanode1
+  docker run -d --name=hanode1 --hostname hanode1 \
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Tumbleweed_image}
+  docker network connect --ip=10.10.10.2 second_net hanode1
+  docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
+  docker exec -t hanode1 /bin/sh -c "zypper -n in ${HA_packages}"
+
+  # deploy second node hanode2
+  docker run -d --name=hanode2 --hostname hanode2 \
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Tumbleweed_image}
+  docker network connect --ip=10.10.10.3 second_net hanode2
+  docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
+  docker exec -t hanode2 /bin/sh -c "zypper -n in ${HA_packages}"
+  docker exec -t hanode2 /bin/sh -c "systemctl start sshd.service"
+  docker exec -t hanode2 /bin/sh -c "cd /app; ./test/run-in-travis.sh build"
+}
+
+run() {
+  docker exec -t hanode1 /bin/sh -c "cd /app; ./test/run-in-travis.sh $1 $2"
+}
+
+usage() {
+  echo "Usage: ./test/`basename $0` <`echo ${TEST_TYPE// /|}`>"
+}
+
+# $1 could be "bootstrap", "hb_report", "qdevice" etc.
+# $2 could be "before_install" or "run"
+# $3 could be suffix of feature file
+case "$1/$2" in
+  */before_install)
+    before $1
+    ;;
+  */run)
+    run $1 $3
+    ;;
+  *)
+    if [ "$#" -eq 0 ] || ! [[ $TEST_TYPE =~ (^|[[:space:]])$1($|[[:space:]]) ]];then
+      usage
+      exit 1
+    fi
+    before $1
+    run $1
+    ;;
+esac

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -1,0 +1,36 @@
+@bootstrap
+Feature: crmsh bootstrap process - init, join and remove
+
+  Test crmsh bootstrap init/join/remove process
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Init cluster service on node "hanode1", and join on node "hanode2"
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+
+  @clean
+  Scenario: Remove peer node "hanode2"
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Run "crm cluster remove hanode2 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Online nodes are "hanode1"
+
+  @clean
+  Scenario: Remove local node "hanode1"
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Run "crm cluster remove hanode1 -y --force" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "started" on "hanode2"

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -1,0 +1,54 @@
+@bootstrap
+Feature: crmsh bootstrap process - options
+
+  Test crmsh bootstrap options:
+      "--nodes": Additional nodes to add to the created cluster
+      "-i":      Bind to IP address on interface IF
+      "-M":      Configure corosync with second heartbeat line
+      "-n":      Set the name of the configured cluster
+      "-A":      Configure IP address as an administration virtual IP
+      "-u":      Configure corosync to communicate over unicast
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Init whole cluster service on node "hanode1" using "--nodes" option
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey --nodes \"hanode1 hanode2\"" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+
+  @clean
+  Scenario: Bind specific network interface using "-i" option
+    Given   Cluster service is "stopped" on "hanode1"
+    And     IP "10.10.10.2" is belong to "eth1"
+    When    Run "crm cluster init -i eth1 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     IP "10.10.10.2" is used by corosync
+
+  @clean
+  Scenario: Using multiple network interface using "-M" option
+    Given   Cluster service is "stopped" on "hanode1"
+    And     IP "172.17.0.2" is belong to "eth0"
+    And     IP "10.10.10.2" is belong to "eth1"
+    When    Run "crm cluster init -M -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     IP "172.17.0.2" is used by corosync
+    And     IP "10.10.10.2" is used by corosync
+
+  @clean
+  Scenario: Setup cluster name and virtual IP using "-A" option
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "crm cluster init -n hatest -A 10.10.10.123 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster name is "hatest"
+    And     Cluster virtual IP is "10.10.10.123"
+
+  @clean
+  Scenario: Init cluster service with udpu using "-u" option
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "crm cluster init -u -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster is using udpu transport mode
+    And     IP "172.17.0.2" is used by corosync

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,0 +1,24 @@
+import logging
+import re
+from crmsh import utils, parallax
+
+
+def get_online_nodes():
+    _, out = utils.get_stdout('crm_node -l')
+    if out:
+        return re.findall(r'[0-9]+ (.*) member', out)
+    else:
+        return None
+
+
+def before_tag(context, tag):
+    context.logger = logging.getLogger("test.{}".format(tag))
+    # tag @clean means need to stop cluster service
+    if tag == "clean":
+        online_nodes = get_online_nodes()
+        if online_nodes:
+            try:
+                parallax.parallax_call(online_nodes, 'crm cluster stop')
+            except ValueError as err:
+                context.logger.error("{}\n".format(err))
+                context.failed = True

--- a/test/features/steps/step_bootstrap.py
+++ b/test/features/steps/step_bootstrap.py
@@ -1,0 +1,70 @@
+import re
+from behave import given, when, then
+from crmsh import corosync, parallax
+from utils import check_cluster_state, online, run_command, me
+
+
+@given('Cluster service is "{state}" on "{addr}"')
+def step_impl(context, state, addr):
+    assert check_cluster_state(context, state, addr) is True
+
+
+@given('Online nodes are "{nodelist}"')
+def step_impl(context, nodelist):
+    assert online(context, nodelist) is True
+
+
+@given('IP "{addr}" is belong to "{iface}"')
+def step_impl(context, addr, iface):
+    cmd = 'ip address show dev {}'.format(iface)
+    res = re.search(r' {}/'.format(addr), run_command(context, cmd))
+    assert bool(res) is True
+
+
+@when('Run "{cmd}" on "{addr}"')
+def step_impl(context, cmd, addr):
+    if addr == me():
+        out = run_command(context, cmd)
+        if out:
+            context.command_out = out
+    else:
+        try:
+            results = parallax.parallax_call([addr], cmd)
+        except ValueError as err:
+            context.logger.error("{}\n".format(err))
+            context.failed = True
+
+
+@then('Cluster service is "{state}" on "{addr}"')
+def step_impl(context, state, addr):
+    assert check_cluster_state(context, state, addr) is True
+
+
+@then('Online nodes are "{nodelist}"')
+def step_impl(context, nodelist):
+    assert online(context, nodelist) is True
+
+
+@then('IP "{addr}" is used by corosync')
+def step_impl(context, addr):
+    out = run_command(context, 'corosync-cfgtool -s')
+    res = re.search(r' {}\n'.format(addr), out)
+    assert bool(res) is True
+
+
+@then('Cluster name is "{name}"')
+def step_impl(context, name):
+    out = run_command(context, 'corosync-cmapctl -b totem.cluster_name')
+    assert out.split()[-1] == name
+
+
+@then('Cluster virtual IP is "{addr}"')
+def step_impl(context, addr):
+    out = run_command(context, 'crm configure show|grep -A1 IPaddr2')
+    res = re.search(r' ip={}'.format(addr), out)
+    assert bool(res) is True
+
+
+@then('Cluster is using udpu transport mode')
+def step_impl(context):
+    assert corosync.get_value('totem.transport') == 'udpu'

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -1,0 +1,44 @@
+import socket
+from crmsh import utils, bootstrap, parallax
+
+
+def me():
+    return socket.gethostname()
+
+
+def run_command(context, cmd):
+    rc, out, err = utils.get_stdout_stderr(cmd)
+    if rc != 0 and err:
+        context.logger.error("{}\n".format(err))
+        context.failed = True
+    return out
+
+
+def check_cluster_state(context, state, addr):
+    if state not in ["started", "stopped"]:
+        context.logger.error("Cluster service state should be \"started/stopped\"\n")
+        context.failed = True
+
+    state_dict = {"started": True, "stopped": False}
+
+    if addr == me():
+        return bootstrap.service_is_active('pacemaker.service') is state_dict[state]
+    else:
+        test_active = "systemctl -q is-active pacemaker.service"
+        try:
+            parallax.parallax_call([addr], test_active)
+        except ValueError:
+            return state_dict[state] is False
+        else:
+            return state_dict[state] is True
+
+
+def online(context, nodelist):
+    rc = True
+    _, out = utils.get_stdout("crm_node -l")
+    for node in nodelist.split():
+        node_info = "{} member".format(node)
+        if not node_info in out:
+            rc = False
+            context.logger.error("Node \"{}\" not online\n".format(node))
+    return rc

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -21,8 +21,26 @@ regression_tests() {
 	sh /usr/share/crmsh/tests/regression.sh
 }
 
-unit_tests
-rc_unittest=$?
-configure
-make_install
-regression_tests && exit $rc_unittest
+functional_tests() {
+	echo "**  $1 process tests using python-behave"
+        SUFFIX="${2:-*}"
+        behave --no-logcapture --tags "@$1" --tags "~@wip" /usr/share/crmsh/tests/features/$1_$SUFFIX.feature
+}
+
+case "$1" in
+	build)
+		configure
+		make_install
+		exit $?;;
+	bootstrap|qdevice|hb_report)
+		configure
+		make_install
+		functional_tests $1 $2
+		exit $?;;
+	*)
+		unit_tests
+		rc_unittest=$?
+		configure
+		make_install
+		regression_tests && exit $rc_unittest;;
+esac


### PR DESCRIPTION
#### Motivation
* Most of bugs for crmsh, came from bootstrap and hb_report, those two features which are also changed frequently, are lack of functional testing.
* New feature for supporting Qdevice also need functional testing. See #464 
* Existing regression test based on shell is not suitable to implement above two requirements.
* Python-behave is behaviour-driven development, Python style.
Integrated with TravisCI and docker, functional testing for above requirements are easy to implement and maintain.

#### Plan
* This PR is using behave to test basic functionalities of bootstrap;
  Drive this PR to merge, as a baseline.
* Apply python-behave on key features of crmsh, like qdevice and hb_report, which are lack of functional testing;
* Apply python-behave on new coming PRs of crmsh for functional testing;
* To replace existing functional test codes written by shell