### PR TITLE
[crmsh-3.0]Feature: bootstrap: support multi disk sbd configure

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1272,11 +1272,6 @@ Configure SBD:
   specify here will be destroyed.
 """)
 
-        configured_dev = configured_sbd_device()
-        if configured_dev:
-            if not confirm("SBD is already configured to use %s - overwrite?" % (configured_dev)):
-                return
-
         if not confirm("Do you wish to use SBD?"):
             warn("Not configuring SBD - STONITH will be disabled.")
             # Comment out SBD devices if present
@@ -1292,6 +1287,11 @@ Configure SBD:
 
         if utils.is_program("sbd") is None:
             error("sbd executable not found! Cannot configure SBD.")
+
+        configured_dev = configured_sbd_device()
+        if configured_dev:
+            if not confirm("SBD is already configured to use %s - overwrite?" % (configured_dev)):
+                return
 
         dev = ""
         dev_looks_sane = False

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -173,8 +173,8 @@ Note:
         storage_group = optparse.OptionGroup(parser, "Storage configuration", "Options for configuring shared storage.")
         storage_group.add_option("-p", "--partition-device", dest="shared_device", metavar="DEVICE",
                                  help='Partition this shared storage device (only used in "storage" stage)')
-        storage_group.add_option("-s", "--sbd-device", dest="sbd_device", metavar="DEVICE",
-                                 help="Block device to use for SBD fencing")
+        storage_group.add_option("-s", "--sbd-device", dest="sbd_device", metavar="DEVICE", action="append",
+                                 help="Block device to use for SBD fencing, use \";\" as separator for multi path")
         storage_group.add_option("-o", "--ocfs2-device", dest="ocfs2_device", metavar="DEVICE",
                                  help='Block device to use for OCFS2 (only used in "vgfs" stage)')
         parser.add_option_group(storage_group)


### PR DESCRIPTION
#### backport to crmsh-3.0
Both for command line and interactive mode.

For command line:
```
crm cluster init -s /dev/sda1 -s /dev/sdb1
```

For interactive mode:
Prompt string is 
```
Path to storage device (e.g. /dev/disk/by-id/...), or "none", use ";" as separator for multi path
```
use `;` as separator is the same way mentioned in `/etc/sysconfig/sbd`