### PR TITLE
Improve multi sbd case usability

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1321,10 +1321,27 @@ def init_sbd():
     SBD can also run in diskless mode if no device
     is configured.
     """
-    if not _context.sbd_device and _context.diskless_sbd:
+    def get_dev_list(dev_list):
+        result_list = []
+        for dev in dev_list:
+            if ';' in dev:
+                result_list.extend(dev.strip(';').split(';'))
+            else:
+                result_list.append(dev)
+        return result_list
+
+    # non-interactive case
+    if _context.sbd_device:
+        _context.sbd_device = get_dev_list(_context.sbd_device)
+        for dev in _context.sbd_device:
+            if not is_block_device(dev):
+                error("{} doesn't look like a block device".format(dev))
+    # diskless sbd
+    elif _context.diskless_sbd:
         init_sbd_diskless()
         return
-    elif not _context.sbd_device:
+    # interactive case
+    else:
         # SBD device not set up by init_storage (ocfs2 template) and
         # also not passed in as command line argument - prompt user
         if _context.yes_to_all:
@@ -1384,10 +1401,6 @@ Configure SBD:
                         break
 
         _context.sbd_device = dev_list
-
-    for dev in _context.sbd_device:
-        if not is_block_device(dev):
-            error("SBD device %s doesn't seem to exist" % (dev))
 
     # TODO: need to ensure watchdog is available
     # (actually, should work if watchdog unavailable, it'll just whine in the logs...)

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1333,6 +1333,8 @@ def init_sbd():
     # non-interactive case
     if _context.sbd_device:
         _context.sbd_device = get_dev_list(_context.sbd_device)
+        if len(_context.sbd_device) > 3:
+            error("Maximum number of SBD device is 3")
         for dev in _context.sbd_device:
             if not is_block_device(dev):
                 error("{} doesn't look like a block device".format(dev))
@@ -1387,9 +1389,12 @@ Configure SBD:
                 init_sbd_diskless()
                 return
             dev_list = dev.strip(';').split(';')
+            if len(dev_list) > 3:
+                error("Maximum number of SBD device is 3")
+                continue
             for dev_item in dev_list:
                 if not is_block_device(dev_item):
-                    print("    {} doesn't look like a block device".format(dev_item), file=sys.stderr)
+                    error("{} doesn't look like a block device".format(dev_item))
                     dev_looks_sane = False
                     break
                 else:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -244,7 +244,7 @@ Note:
         storage_group.add_option("-p", "--partition-device", dest="shared_device", metavar="DEVICE",
                                  help='Partition this shared storage device (only used in "storage" stage)')
         storage_group.add_option("-s", "--sbd-device", dest="sbd_device", metavar="DEVICE", action="append",
-                                 help="Block device to use for SBD fencing, use \";\" as separator for multi path")
+                                 help="Block device to use for SBD fencing, use \";\" as separator or -s multiple times for multi path (up to 3 devices)")
         storage_group.add_option("-o", "--ocfs2-device", dest="ocfs2_device", metavar="DEVICE",
                                  help='Block device to use for OCFS2 (only used in "vgfs" stage)')
         parser.add_option_group(storage_group)


### PR DESCRIPTION
This PR is improvement for #489 
Changes include:
* Support both '-s device1 -s device2' and '-s 'device1;device2' for command line option
* Improve the logic of code
* Maximum number of SBD device is 3

BTW, this PR need to backport to branch crmsh-3.0 and crmsh-4.1