### PR TITLE
Fix: Not allowed space value for option(bsc#1141976)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,13 @@ jobs:
 
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-  
+
+    - name: "regression test for bootstrap bugs"
+      before_install:
+        - $FUNCTIONAL_TEST bootstrap before_install
+      script:
+        - $FUNCTIONAL_TEST bootstrap run bugs
+
     - name: "functional test for bootstrap - init, join and remove"
       before_install:
         - $FUNCTIONAL_TEST bootstrap before_install
@@ -46,12 +52,6 @@ jobs:
         - $FUNCTIONAL_TEST bootstrap before_install
       script:
         - $FUNCTIONAL_TEST bootstrap run options
-
-    - name: "regression test for bootstrap bugs"
-      before_install:
-        - $FUNCTIONAL_TEST bootstrap before_install
-      script:
-        - $FUNCTIONAL_TEST bootstrap run bugs
 
     - name: "functional test for qdevice - setup and remove"
       before_install:

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -303,6 +303,7 @@ def compgen():
 
 def parse_options():
     opts, args = option_parser.parse_known_args()
+    utils.check_space_option_value(opts)
     config.core.debug = "yes" if opts.debug else config.core.debug
     options.profile = opts.profile or options.profile
     options.regression_tests = opts.regression_tests or options.regression_tests
@@ -376,5 +377,6 @@ def run():
             traceback.print_exc()
             sys.stdout.flush()
         common_err(str(e))
+        sys.exit(1)
 
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -19,6 +19,18 @@ class ArgParser(ArgumentParser):
         return self.epilog or ""
 
 
+def parse_options(parser, args):
+    try:
+        options, args = parser.parse_known_args(list(args))
+    except:
+        return None, None
+    if options.help:
+        parser.print_help()
+        return None, None
+    utils.check_space_option_value(options)
+    return options, args
+
+
 def _remove_completer(args):
     try:
         n = utils.list_cluster_nodes()
@@ -246,12 +258,8 @@ Note:
         storage_group.add_argument("-o", "--ocfs2-device", dest="ocfs2_device", metavar="DEVICE",
                                    help='Block device to use for OCFS2 (only used in "vgfs" stage)')
 
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
 
         stage = ""
@@ -259,15 +267,12 @@ Note:
             stage = args[0]
         if stage not in bootstrap.INIT_STAGES and stage != "":
             parser.error("Invalid stage (%s)" % (stage))
-            return False
 
         if options.template and options.template != "ocfs2":
             parser.error("Invalid template (%s)" % (options.template))
-            return False
 
         # if options.geo and options.name == "hacluster":
         #    parser.error("For a geo cluster, each cluster must have a unique name (use --name to set)")
-        #    return False
 
         qdevice = None
         if options.qdevice:
@@ -338,12 +343,8 @@ If stage is not specified, each stage will be invoked in sequence.
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
         network_group.add_argument("-i", "--interface", dest="nic", help="Bind to IP address on interface IF", metavar="IF")
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
 
         stage = ""
@@ -351,7 +352,6 @@ If stage is not specified, each stage will be invoked in sequence.
             stage = args[0]
         if stage not in ("ssh", "csync2", "ssh_merge", "cluster", ""):
             parser.error("Invalid stage (%s)" % (stage))
-            return False
 
         bootstrap.bootstrap_join(
             cluster_node=options.cluster_node,
@@ -384,13 +384,10 @@ If stage is not specified, each stage will be invoked in sequence.
         parser = ArgParser(usage="add [options] [node ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
-        if options.help:
-            parser.print_help()
-            return
+
         for node in args:
             if not self._add_node(node, yes_to_all=options.yes_to_all):
                 return False
@@ -409,14 +406,10 @@ If stage is not specified, each stage will be invoked in sequence.
         parser.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of cluster node which will be deleted", metavar="HOST")
         parser.add_argument("-F", "--force", dest="force", help="Remove current node", action="store_true")
         parser.add_argument("--qdevice", dest="qdevice", help="Remove QDevice configuration and service from cluster", action="store_true")
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
+            return
 
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
-            return
         if options.cluster_node is not None and options.cluster_node not in args:
             args = list(args) + [options.cluster_node]
         if len(args) == 0:
@@ -512,12 +505,8 @@ Cluster Description
         parser.add_argument("-a", "--arbitrator", help="IP address of geo cluster arbitrator", dest="arbitrator", metavar="IP")
         parser.add_argument("-s", "--clusters", help="Geo cluster description (see details below)", dest="clusters", metavar="DESC")
         parser.add_argument("-t", "--tickets", help="Tickets to create (space-separated)", dest="tickets", metavar="LIST")
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
 
         if options.clusters is None:
@@ -551,12 +540,8 @@ Cluster Description
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         parser.add_argument("-c", "--cluster-node", help="IP address of an already-configured geo cluster or arbitrator", dest="node", metavar="IP")
         parser.add_argument("-s", "--clusters", help="Geo cluster description (see geo-init for details)", dest="clusters", metavar="DESC")
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
         errs = []
         if options.node is None:
@@ -583,12 +568,8 @@ Cluster Description
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         parser.add_argument("-c", "--cluster-node", help="IP address of an already-configured geo cluster", dest="other", metavar="IP")
-        try:
-            options, args = parser.parse_known_args(list(args))
-        except:
-            return
-        if options.help:
-            parser.print_help()
+        options, args = parse_options(parser, args)
+        if options is None or args is None:
             return
         bootstrap.bootstrap_arbitrator(options.quiet, options.yes_to_all, options.other, ui_context=context)
         return True

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -15,6 +15,7 @@ import bz2
 import fnmatch
 import gc
 import ipaddress
+import argparse
 from contextlib import contextmanager, closing
 from . import config
 from . import userdir
@@ -2264,4 +2265,14 @@ def get_nodeid_from_name(name):
         return res.group(1)
     else:
         return None
+
+
+def check_space_option_value(options):
+    if not isinstance(options, argparse.Namespace):
+        raise ValueError("Expected type of \"options\" is \"argparse.Namespace\", not \"{}\"".format(type(options)))
+
+    for opt in vars(options):
+        value = getattr(options, opt)
+        if isinstance(value, str) and len(value.strip()) == 0:
+            raise ValueError("Space value not allowed for dest \"{}\"".format(opt))
 # vim:ts=4:sw=4:et:

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -3,7 +3,8 @@ Feature: Regression test for bootstrap bugs
 
   Tag @clean means need to stop cluster service if the service is available
 
-  Background: Setup a two nodes cluster
+  @clean
+  Scenario: Set placement-strategy value as "default"(bsc#1129462)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
@@ -13,8 +14,22 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
     And     Show cluster status on "hanode1"
-
-  @clean
-  Scenario: Set placement-strategy value as "default"(bsc#1129462)
     When    Run "crm configure get_property placement-strategy" on "hanode1"
     Then    Got output "default"
+
+  @clean
+  Scenario: Space value not allowed for option(bsc#1141976)
+    When    Try "crm -c ' '"
+    Then    Except "ERROR: Space value not allowed for dest "cib""
+    When    Try "crm cluster init --name ' '"
+    Then    Except "ERROR: cluster.init: Space value not allowed for dest "name""
+    When    Try "crm cluster join -c ' '"
+    Then    Except "ERROR: cluster.join: Space value not allowed for dest "cluster_node""
+    When    Try "crm cluster remove -c ' '"
+    Then    Except "ERROR: cluster.remove: Space value not allowed for dest "cluster_node""
+    When    Try "crm cluster geo-init -a ' '"
+    Then    Except "ERROR: cluster.geo_init: Space value not allowed for dest "arbitrator""
+    When    Try "crm cluster geo-join -c ' '"
+    Then    Except "ERROR: cluster.geo_join: Space value not allowed for dest "node""
+    When    Try "crm cluster geo-init-arbitrator -c ' '"
+    Then    Except "ERROR: cluster.geo_init_arbitrator: Space value not allowed for dest "other""


### PR DESCRIPTION
space value like 
```
crm cluster init -i "  "
crm -c " "
crm cluster init --name " "
```
is harmful, should raise `ValueError`