### PR TITLE
Replace nose with pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    */tests/*
+    */test/*
+    *setup.py*
+    tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,23 @@ env:
 jobs:
   include:
     - stage: test
-      name: "original regression test"
+      name: "unit test"
+      before_install:
+        - docker pull liangxin1300/haleap:15.2
+      script:
+        - docker run -t -v "$(pwd):/app" liangxin1300/haleap:15.2 /bin/sh -c "cd /app; TOXENV=py36-codeclimate; tox"
+
+    - name: "original regression test"
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
         - ./cc-test-reporter before-build
-
       before_install:
-        - docker pull krig/crmsh:latest
-
+        - docker pull liangxin1300/haleap:15.2
       script:
-        - docker run -t -v "$(pwd):/app" krig/crmsh /bin/sh -c "systemctl start dbus; cd /app; ./test/run-in-travis.sh"
-
+        - docker run -t -v "$(pwd):/app" liangxin1300/haleap:15.2 /bin/sh -c "cd /app; ./test/run-in-travis.sh"
       after_failure:
         - sudo cat $TRAVIS_BUILD_DIR/crmtestout/regression.out $TRAVIS_BUILD_DIR/crmtestout/crm.*
-
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 

--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -110,7 +110,7 @@ Requires:       crmsh
 Requires(post):  mailx
 Requires(post):  procps
 Requires(post):  python3-python-dateutil
-Requires(post):  python3-nose
+Requires(post):  python3-tox
 %if 0%{?suse_version} > 1320
 Requires(post):  python3-parallax
 %else
@@ -179,7 +179,7 @@ touch -r doc/crm.8.adoc{.timestamp,}
 make %{_smp_mflags} VERSION="%{version}" sysconfdir=%{_sysconfdir} localstatedir=%{_var}
 
 %if %{with regression_tests}
-./test/run --quiet
+tox -q
 if [ ! $? ]; then
     echo "Unit tests failed."
     exit 1

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -304,21 +304,21 @@ class _Configuration(object):
         self._user = None
 
     def load(self):
-        self._defaults = configparser.SafeConfigParser()
+        self._defaults = configparser.ConfigParser()
         for section, keys in DEFAULTS.items():
             self._defaults.add_section(section)
             for key, opt in keys.items():
                 self._defaults.set(section, key, opt.default)
 
         if os.path.isfile(_SYSTEMWIDE):
-            self._systemwide = configparser.SafeConfigParser()
+            self._systemwide = configparser.ConfigParser()
             self._systemwide.read([_SYSTEMWIDE])
         # for backwards compatibility with <=2.1.1 due to ridiculous bug
         elif os.path.isfile("/etc/crm/crmsh.conf"):
-            self._systemwide = configparser.SafeConfigParser()
+            self._systemwide = configparser.ConfigParser()
             self._systemwide.read(["/etc/crm/crmsh.conf"])
         if os.path.isfile(_PERUSER):
-            self._user = configparser.SafeConfigParser()
+            self._user = configparser.ConfigParser()
             self._user.read([_PERUSER])
 
     def save(self):
@@ -351,7 +351,7 @@ class _Configuration(object):
             raise ValueError("Setting invalid option %s.%s" % (section, name))
         DEFAULTS[section][name].validate(value)
         if self._user is None:
-            self._user = configparser.SafeConfigParser()
+            self._user = configparser.ConfigParser()
         if not self._user.has_section(section):
             self._user.add_section(section)
         self._user.set(section, name, _stringify(value))
@@ -369,7 +369,7 @@ class _Configuration(object):
 
     def reset(self):
         '''reset to what is on disk'''
-        self._user = configparser.SafeConfigParser()
+        self._user = configparser.ConfigParser()
         self._user.read([_PERUSER])
 
 

--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -910,7 +910,7 @@ class Report(object):
         - detail
         TODO
         '''
-        p = configparser.SafeConfigParser()
+        p = configparser.ConfigParser()
         p.add_section(self.rpt_section)
         p.set(self.rpt_section, 'dir',
               self.source == "live" and sdir or self.source)
@@ -934,7 +934,7 @@ class Report(object):
         '''
         Load the history state from a file.
         '''
-        p = configparser.SafeConfigParser()
+        p = configparser.ConfigParser()
         fname = os.path.join(sdir, self.state_file)
         try:
             p.read(fname)
@@ -1014,7 +1014,7 @@ class Report(object):
         '''Exclude messages from log files.
         arg: None (show, clear)
              regex (add)
-             instance of ConfigParser.SafeConfigParser (load, save)
+             instance of ConfigParser.ConfigParser (load, save)
         '''
         if not self.prepare_source(no_live_update=True):
             return False

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1471,7 +1471,7 @@ def save_graphviz_file(ini_f, attr_d):
         common_err(msg)
         return False
     import configparser
-    p = configparser.SafeConfigParser()
+    p = configparser.ConfigParser()
     for section, sect_d in attr_d.items():
         p.add_section(section)
         for n, v in sect_d.items():
@@ -1493,7 +1493,7 @@ def load_graphviz_file(ini_f):
     if not os.path.isfile(ini_f):
         return True, None
     import configparser
-    p = configparser.SafeConfigParser()
+    p = configparser.ConfigParser()
     try:
         p.read(ini_f)
     except Exception as msg:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test_*.py
+testpaths = crmsh
+norecursedirs =

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 lxml
 PyYAML
-nosexcover
 py-dateutil
 parallax

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-Tumbleweed_image='liangxin1300/hatbw'
+Docker_image='liangxin1300/haleap:15.2'
 HA_packages='pacemaker corosync corosync-qdevice'
 TEST_TYPE='bootstrap qdevice hb_report'
 
 before() {
-  docker pull ${Tumbleweed_image}
+  docker pull ${Docker_image}
   docker network create --subnet 10.10.10.0/24 second_net
 
   # deploy first node hanode1
   docker run -d --name=hanode1 --hostname hanode1 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Tumbleweed_image}
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Docker_image}
   docker network connect --ip=10.10.10.2 second_net hanode1
   docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
@@ -21,7 +21,7 @@ before() {
 
   # deploy second node hanode2
   docker run -d --name=hanode2 --hostname hanode2 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Tumbleweed_image}
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Docker_image}
   docker network connect --ip=10.10.10.3 second_net hanode2
   docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
@@ -34,14 +34,14 @@ before() {
   if [ x"$1" == x"qdevice" ];then
     # deploy node qnetd-node for qnetd service
     docker run -d --name=qnetd-node --hostname qnetd-node \
-	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Tumbleweed_image}
+	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Docker_image}
     docker network connect --ip=10.10.10.9 second_net qnetd-node
     docker exec -t qnetd-node /bin/sh -c "zypper -n in corosync-qnetd"
     docker exec -t qnetd-node /bin/sh -c "systemctl start sshd.service"
 
     # deploy node without ssh.service running for validation
     docker run -d --name=node-without-ssh --hostname node-without-ssh \
-	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Tumbleweed_image}
+	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Docker_image}
     docker network connect --ip=10.10.10.10 second_net node-without-ssh
     docker exec -t node-without-ssh /bin/sh -c "systemctl stop sshd.service"
   fi

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
-
-unit_tests() {
-	echo "** Unit tests"
-	./test/run
-}
-
 configure() {
 	echo "** Autogen / Configure"
 	./autogen.sh
@@ -36,9 +30,7 @@ case "$1" in
 		functional_tests $1 $2
 		exit $?;;
 	*)
-		unit_tests
-		rc_unittest=$?
 		configure
 		make_install
-		regression_tests && exit $rc_unittest;;
+		regression_tests;;
 esac

--- a/test/testcases/commit
+++ b/test/testcases/commit
@@ -15,7 +15,7 @@ primitive p3 ocf:heartbeat:Dummy
 group g1 p1 p2
 clone c1 g1
 location l1 p3 100: node1
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 colocation cl1 inf: c1 p3
 primitive d1 ocf:heartbeat:Dummy
 primitive d2 ocf:heartbeat:Dummy

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -17,7 +17,7 @@ WARNING: 7: st: unknown attribute 'yoyo-meta'
 .INP: group g1 p1 p2
 .INP: clone c1 g1
 .INP: location l1 p3 100: node1
-.INP: order o1 inf: p3 c1
+.INP: order o1 Mandatory: p3 c1
 .INP: colocation cl1 inf: c1 p3
 .INP: primitive d1 ocf:heartbeat:Dummy
 .INP: primitive d2 ocf:heartbeat:Dummy
@@ -66,7 +66,7 @@ group g1 d1 p2
 group g2 d3
 colocation cl1 inf: g1 p3
 location l1 p3 100: node1
-order o1 inf: p3 g1
+order o1 Mandatory: p3 g1
 op_defaults op-options: \
 	timeout=2m
 .INP: commit

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -71,7 +71,7 @@ collocation c2 inf: m5:Master d1:Started
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6
-order o4 inf: m5 m6
+order o4 Mandatory: m5 m6
 rsc_ticket ticket-A_m6 ticket-A: m6
 rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
 rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence

--- a/test/testcases/confbasic-xml
+++ b/test/testcases/confbasic-xml
@@ -58,7 +58,7 @@ collocation c2 inf: m5:Master d1:Started
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6
-order o4 inf: m5 m6
+order o4 Mandatory: m5 m6
 rsc_ticket ticket-A_m6 ticket-A: m6
 rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
 rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence

--- a/test/testcases/confbasic-xml.exp
+++ b/test/testcases/confbasic-xml.exp
@@ -148,7 +148,7 @@
       <rsc_location id="l7" rsc="m5">
         <rule id-ref="l2-rule1"/>
       </rsc_location>
-      <rsc_order id="o4" score="INFINITY" first="m5" then="m6"/>
+      <rsc_order id="o4" kind="Mandatory" first="m5" then="m6"/>
     </constraints>
     <rsc_defaults>
       <meta_attributes id="rsc-options">

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -45,7 +45,7 @@
 .INP: order o1 Mandatory: m5 m6
 .INP: order o2 Optional: d1:start m5:promote
 .INP: order o3 Serialize: m5 m6
-.INP: order o4 inf: m5 m6
+.INP: order o4 Mandatory: m5 m6
 .INP: rsc_ticket ticket-A_m6 ticket-A: m6
 .INP: rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
 .INP: rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence
@@ -131,7 +131,7 @@ location l7 m5 \
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6
-order o4 inf: m5 m6
+order o4 Mandatory: m5 m6
 fencing_topology st st2
 rsc_ticket ticket-A_m6 ticket-A: m6
 rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -21,7 +21,7 @@ filter "sed '/clone/s/p2/g1/;s/p3/p2/'" c1 g1
 filter "sed '1,$d'" c1 g1
 filter "sed -e '$aclone c1 g1' -e '$agroup g1 p1 p2'"
 location l1 p3 100: node1
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 colocation cl1 inf: c1 p3
 filter "sed '/cl1/s/p3/p2/'"
 filter "sed '/cl1/d'"

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -51,7 +51,7 @@ op_defaults op-options: \
 .INP: filter "sed '1,$d'" c1 g1
 .INP: filter "sed -e '$aclone c1 g1' -e '$agroup g1 p1 p2'"
 .INP: location l1 p3 100: node1
-.INP: order o1 inf: p3 c1
+.INP: order o1 Mandatory: p3 c1
 .INP: colocation cl1 inf: c1 p3
 .INP: filter "sed '/cl1/s/p3/p2/'"
 .INP: filter "sed '/cl1/d'"
@@ -122,7 +122,7 @@ property cib-bootstrap-options:
 .INP: tag t-d45: d4 d5
 .INP: show type:order
 order o-d456 d4 d5 d6
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 .INP: show related:d4
 primitive d4 Dummy
 tag t-d45 d4 d5
@@ -156,7 +156,7 @@ location loc-d1 d1 \
 	rule -inf: not_defined a2 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 property cib-bootstrap-options:
 rsc_defaults rsc_options: \
 	failure-timeout=10m
@@ -231,7 +231,7 @@ location loc-d1 d1 \
 	rule -inf: not_defined a2 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 property cib-bootstrap-options:
 rsc_defaults rsc_options: \
 	failure-timeout=10m
@@ -283,7 +283,7 @@ location loc-d1 d1 \
 	rule -inf: not_defined a2 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
-order o1 inf: p3 c1
+order o1 Mandatory: p3 c1
 property cib-bootstrap-options:
 rsc_defaults rsc_options: \
 	failure-timeout=10m

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -45,12 +45,12 @@ envfile (string): Environment dump file
 
 Operations' defaults (advisory minimum):
 
-    start         timeout=20
-    stop          timeout=20
-    monitor       timeout=20 interval=10
-    reload        timeout=20
-    migrate_to    timeout=20
-    migrate_from  timeout=20
+    start         timeout=20s
+    stop          timeout=20s
+    monitor       timeout=20s interval=10s
+    reload        timeout=20s
+    migrate_to    timeout=20s
+    migrate_from  timeout=20s
 .INP: info stonith:external/ssh
 .EXT crm_resource --show-metadata stonith:external/ssh
 .EXT stonithd metadata
@@ -72,7 +72,6 @@ livedangerously (enum): Live Dangerously!!
     setting this parameter to yes makes it an even worse idea.
     Viva la Vida Loca!
 
-priority (integer, [0]): The priority of the stonith resource. Devices are tried in order of highest priority to lowest.
 pcmk_host_argument (string, [port]): Advanced use only: An alternate parameter to supply instead of 'port'
     Some devices do not support the standard 'port' parameter or may provide additional ones.
     Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced.
@@ -83,7 +82,7 @@ pcmk_host_map (string): A mapping of host names to ports numbers for devices tha
 
 pcmk_host_list (string): A list of machines controlled by this device (Optional unless pcmk_host_check=static-list).
 pcmk_host_check (string, [dynamic-list]): How to determine which machines are controlled by the device.
-    Allowed values: dynamic-list (query the device), static-list (check the pcmk_host_list attribute), none (assume every device can fence every machine)
+    Allowed values: dynamic-list (query the device via the 'list' command), static-list (check the pcmk_host_list attribute), status (query the device via the 'status' command), none (assume every device can fence every machine)
 
 pcmk_delay_max (time, [0s]): Enable a random delay for stonith actions and specify the maximum of random delay.
     This prevents double fencing when using slow devices such as sbd.

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -189,8 +189,7 @@ INFO: Removed migration constraints for p3
 .SETENV showobj=p0
 .TRY resource param p0 set a0 "1 2 3"
 .EXT crm_resource --resource 'p0' --set-parameter 'a0' --parameter-value '1 2 3'
-
-Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0=1 2 3
+Set 'p0' option: id=p0-instance_attributes-a0 set=p0-instance_attributes name=a0 value=1 2 3
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -254,8 +253,7 @@ Deleted 'p0' option: id=p0-instance_attributes-a0 name=a0
 
 .TRY resource meta p0 set m0 123
 .EXT crm_resource --meta --resource 'p0' --set-parameter 'm0' --parameter-value '123'
-
-Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0=123
+Set 'p0' option: id=p0-meta_attributes-m0 set=p0-meta_attributes name=m0 value=123
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -924,10 +922,10 @@ Node node1: UNCLEAN (offline)
  st	(stonith:null):	Stopped 
  Clone Set: c1 [p1] (unmanaged)
      Stopped: [ node1 ]
- Master/Slave Set: m1 [p2]
+ Clone Set: m1 [p2] (promotable)
      Stopped: [ node1 ]
  p3	(ocf::heartbeat:Dummy):	Stopped ( disabled ) 
- Master/Slave Set: msg [g]
+ Clone Set: msg [g] (promotable)
      Stopped: [ node1 ]
 
 Allocation scores and utilization information:

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -6,24 +6,22 @@ from __future__ import unicode_literals
 
 from crmsh import cibconfig
 from lxml import etree
-from nose.tools import eq_, with_setup
 from crmsh import xmlutil
 
 factory = cibconfig.cib_factory
 
 
-def setup_func():
+def setup_function():
     "set up test fixtures"
     from crmsh import idmgmt
     idmgmt.clear()
     factory._push_state()
 
 
-def teardown_func():
+def teardown_function():
     factory._pop_state()
 
 
-@with_setup(setup_func, teardown_func)
 def test_bug41660_1():
     xml = """<primitive id="bug41660" class="ocf" provider="pacemaker" type="Dummy"> \
     <meta_attributes id="bug41660-meta"> \
@@ -45,13 +43,11 @@ def test_bug41660_1():
         factory.commit = lambda *args: True
         from crmsh.ui_resource import set_deep_meta_attr
         set_deep_meta_attr("bug41660", "target-role", "Started")
-        eq_(['Started'],
-            obj.node.xpath('.//nvpair[@name="target-role"]/@value'))
+        assert ['Started'] == obj.node.xpath('.//nvpair[@name="target-role"]/@value')
     finally:
         factory.commit = commit_holder
 
 
-@with_setup(setup_func, teardown_func)
 def test_bug41660_2():
     xml = """
 <clone id="libvirtd-clone">
@@ -88,13 +84,11 @@ def test_bug41660_2():
         print("PRE", etree.tostring(obj.node))
         set_deep_meta_attr("libvirtd-clone", "target-role", "Started")
         print("POST", etree.tostring(obj.node))
-        eq_(['Started'],
-            obj.node.xpath('.//nvpair[@name="target-role"]/@value'))
+        assert ['Started'] == obj.node.xpath('.//nvpair[@name="target-role"]/@value')
     finally:
         factory.commit = commit_holder
 
 
-@with_setup(setup_func, teardown_func)
 def test_bug41660_3():
     xml = """
 <clone id="libvirtd-clone">
@@ -125,13 +119,11 @@ def test_bug41660_3():
         factory.commit = lambda *args: True
         from crmsh.ui_resource import set_deep_meta_attr
         set_deep_meta_attr("libvirtd-clone", "target-role", "Started")
-        eq_(['Started'],
-            obj.node.xpath('.//nvpair[@name="target-role"]/@value'))
+        assert ['Started'] == obj.node.xpath('.//nvpair[@name="target-role"]/@value')
     finally:
         factory.commit = commit_holder
 
 
-@with_setup(setup_func, teardown_func)
 def test_comments():
     xml = """<cib epoch="25" num_updates="1" admin_epoch="0" validate-with="pacemaker-1.2" cib-last-written="Thu Mar  6 15:53:49 2014" update-origin="beta1" update-client="cibadmin" update-user="root" crm_feature_set="3.0.8" have-quorum="1" dc-uuid="1">
   <configuration>
@@ -175,7 +167,6 @@ def test_comments():
     assert xmlutil.xml_tostring(elems).count("COMMENT TEXT") == 3
 
 
-@with_setup(setup_func, teardown_func)
 def test_eq1():
     xml1 = """<cluster_property_set id="cib-bootstrap-options">
     <nvpair id="cib-bootstrap-options-stonith-enabled" name="stonith-enabled" value="true"></nvpair>
@@ -206,7 +197,6 @@ def test_eq1():
     assert xmlutil.xml_equals(e1, e2, show=True)
 
 
-@with_setup(setup_func, teardown_func)
 def test_pcs_interop_1():
     """
     pcs<>crmsh interop bug
@@ -235,7 +225,6 @@ def test_pcs_interop_1():
     assert len(elem.xpath(".//meta_attributes/nvpair[@name='target-role']")) == 1
 
 
-@with_setup(setup_func, teardown_func)
 def test_bnc878128():
     """
     L3: "crm configure show" displays XML information instead of typical crm output.
@@ -259,7 +248,6 @@ end="2014-05-17 17:56:11Z"/>
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_order_without_score_kind():
     """
     Spec says order doesn't require score or kind to be set
@@ -276,7 +264,6 @@ def test_order_without_score_kind():
 
 
 
-@with_setup(setup_func, teardown_func)
 def test_bnc878112():
     """
     crm configure group can hijack a cloned primitive (and then crash)
@@ -290,7 +277,6 @@ def test_bnc878112():
     assert obj3 is False
 
 
-@with_setup(setup_func, teardown_func)
 def test_copy_nvpairs():
     from crmsh.cibconfig import copy_nvpairs
 
@@ -305,8 +291,8 @@ def test_copy_nvpairs():
     </node>
     '''))
 
-    eq_(['stonith-enabled'], to.xpath('./nvpair/@name'))
-    eq_(['false'], to.xpath('./nvpair/@value'))
+    assert ['stonith-enabled'] == to.xpath('./nvpair/@name')
+    assert ['false'] == to.xpath('./nvpair/@value')
 
     copy_nvpairs(to, etree.fromstring('''
     <node>
@@ -314,11 +300,10 @@ def test_copy_nvpairs():
     </node>
     '''))
 
-    eq_(['stonith-enabled'], to.xpath('./nvpair/@name'))
-    eq_(['true'], to.xpath('./nvpair/@value'))
+    assert ['stonith-enabled'] == to.xpath('./nvpair/@name')
+    assert ['true'] == to.xpath('./nvpair/@value')
 
 
-@with_setup(setup_func, teardown_func)
 def test_pengine_test():
     xml = '''<primitive class="ocf" id="rsc1" provider="pacemaker" type="Dummy">
         <instance_attributes id="rsc1-instance_attributes-1">
@@ -347,7 +332,6 @@ def test_pengine_test():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_tagset():
     xml = '''<primitive class="ocf" id="%s" provider="pacemaker" type="Dummy"/>'''
     tag = '''<tag id="t0"><obj_ref id="r1"/><obj_ref id="r2"/></tag>'''
@@ -358,7 +342,7 @@ def test_tagset():
     elems = factory.get_elems_on_tag("tag:t0")
     assert set(x.obj_id for x in elems) == set(['r1', 'r2'])
 
-@with_setup(setup_func, teardown_func)
+
 def test_ratrace():
     xml = '''<primitive class="ocf" id="%s" provider="pacemaker" type="Dummy"/>'''
     factory.create_from_node(etree.fromstring(xml % ('r1')))
@@ -378,7 +362,6 @@ def test_ratrace():
     assert set(obj.node.xpath('./operations/op/@name')) == set(['start', 'stop'])
 
 
-@with_setup(setup_func, teardown_func)
 def test_op_role():
     xml = '''<primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy">
         <operations>
@@ -395,7 +378,6 @@ def test_op_role():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_nvpair_no_value():
     xml = '''<primitive class="ocf" id="rsc3" provider="heartbeat" type="Dummy">
         <instance_attributes id="rsc3-instance_attributes-1">
@@ -414,7 +396,6 @@ def test_nvpair_no_value():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_delete_ticket():
     xml0 = '<primitive id="daa0" class="ocf" provider="heartbeat" type="Dummy"/>'
     xml1 = '<primitive id="daa1" class="ocf" provider="heartbeat" type="Dummy"/>'
@@ -435,7 +416,6 @@ def test_delete_ticket():
     assert factory.find_object('taa0') is not None
 
 
-@with_setup(setup_func, teardown_func)
 def test_quotes():
     """
     Parsing escaped quotes
@@ -456,7 +436,6 @@ def test_quotes():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_nodeattrs():
     """
     bug with parsing node attrs
@@ -480,7 +459,6 @@ def test_nodeattrs():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_nodeattrs2():
     xml = """<node id="h04" uname="h04"> \
  <utilization id="h04-utilization"> \
@@ -500,7 +478,6 @@ def test_nodeattrs2():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_group_constraint_location():
     """
     configuring a location constraint on a grouped resource is OK
@@ -514,7 +491,6 @@ def test_group_constraint_location():
     assert c and c.check_sanity() == 0
 
 
-@with_setup(setup_func, teardown_func)
 def test_group_constraint_colocation():
     """
     configuring a colocation constraint on a grouped resource is bad
@@ -527,7 +503,6 @@ def test_group_constraint_colocation():
     assert c and c.check_sanity() > 0
 
 
-@with_setup(setup_func, teardown_func)
 def test_group_constraint_colocation_rscset():
     """
     configuring a constraint on a grouped resource is bad
@@ -541,7 +516,6 @@ def test_group_constraint_colocation_rscset():
     assert c and c.check_sanity() > 0
 
 
-@with_setup(setup_func, teardown_func)
 def test_clone_constraint_colocation_rscset():
     """
     configuring a constraint on a cloned resource is bad
@@ -555,7 +529,6 @@ def test_clone_constraint_colocation_rscset():
     assert c and c.check_sanity() > 0
 
 
-@with_setup(setup_func, teardown_func)
 def test_existing_node_resource():
     factory.create_object('primitive', 'ha-one', 'Dummy')
 
@@ -574,7 +547,6 @@ def test_existing_node_resource():
     assert ok
 
 
-@with_setup(setup_func, teardown_func)
 def test_existing_node_resource_2():
     obj = cibconfig.mkset_obj()
     assert obj is not None
@@ -594,7 +566,6 @@ def test_existing_node_resource_2():
     assert sorted(text.split('\n')) == sorted(text2.split('\n'))
 
 
-@with_setup(setup_func, teardown_func)
 def test_id_collision_breakage_1():
     from crmsh import clidisplay
 
@@ -675,7 +646,6 @@ primitive p1 ocf:heartbeat:Dummy \
         assert original_cib == obj.repr()
 
 
-@with_setup(setup_func, teardown_func)
 def test_id_collision_breakage_3():
     from crmsh import clidisplay
 
@@ -719,7 +689,6 @@ primitive node1 Dummy params fake=something
         assert original_cib == obj.repr()
 
 
-@with_setup(setup_func, teardown_func)
 def test_id_collision_breakage_2():
     from crmsh import clidisplay
 
@@ -813,7 +782,6 @@ op_defaults op-options: \
         assert original_cib == obj.repr()
 
 
-@with_setup(setup_func, teardown_func)
 def test_bug_110():
     """
     configuring attribute-based fencing-topology
@@ -831,7 +799,6 @@ def test_bug_110():
             assert o.check_sanity() == 0
 
 
-@with_setup(setup_func, teardown_func)
 def test_reordering_resource_sets():
     """
     Can we reorder resource sets?
@@ -858,7 +825,6 @@ def test_reordering_resource_sets():
         assert "order o1 p4 p3 p2 p1" == obj2.repr().strip()
 
 
-@with_setup(setup_func, teardown_func)
 def test_bug959895():
     """
     Allow importing XML with cloned groups
@@ -884,13 +850,11 @@ def test_bug959895():
         factory.commit = lambda *args: True
         from crmsh.ui_resource import set_deep_meta_attr
         set_deep_meta_attr("c-bug959895", "target-role", "Started")
-        eq_(['Started'],
-            obj.node.xpath('.//nvpair[@name="target-role"]/@value'))
+        assert ['Started'] == obj.node.xpath('.//nvpair[@name="target-role"]/@value')
     finally:
         factory.commit = commit_holder
 
 
-@with_setup(setup_func, teardown_func)
 def test_node_util_attr():
     """
     Handle node with utitilization before attributes correctly
@@ -915,7 +879,6 @@ def test_node_util_attr():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_dup_create():
     """
     Creating two objects with the same name
@@ -926,7 +889,6 @@ def test_dup_create():
     assert not ok
 
 
-@with_setup(setup_func, teardown_func)
 def test_dup_create():
     """
     Creating property sets with unknown properties

--- a/test/unittests/test_cib.py
+++ b/test/unittests/test_cib.py
@@ -4,23 +4,21 @@ from __future__ import unicode_literals
 # See COPYING for license information.
 from crmsh import cibconfig
 from lxml import etree
-from nose.tools import eq_, with_setup
 import copy
 
 factory = cibconfig.cib_factory
 
 
-def setup_func():
+def setup_function():
     "set up test fixtures"
     from crmsh import idmgmt
     idmgmt.clear()
 
 
-def teardown_func():
+def teardown_function():
     pass
 
 
-@with_setup(setup_func, teardown_func)
 def test_cib_schema_change():
     "Changing the validate-with CIB attribute"
     copy_of_cib = copy.copy(factory.cib_orig)
@@ -30,5 +28,5 @@ def test_cib_schema_change():
     factory.change_schema("pacemaker-1.1")
     factory.cib_objects = tmp_cib_objects
     factory._copy_cib_attributes(copy_of_cib, factory.cib_orig)
-    eq_(factory.cib_attrs["validate-with"], "pacemaker-1.1")
-    eq_(factory.cib_elem.get("validate-with"), "pacemaker-1.1")
+    assert factory.cib_attrs["validate-with"] == "pacemaker-1.1"
+    assert factory.cib_elem.get("validate-with") == "pacemaker-1.1"

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -9,7 +9,6 @@ from crmsh import cibconfig
 from crmsh import parse
 from lxml import etree
 from .test_parse import MockValidation
-from nose.tools import eq_, with_setup
 
 factory = cibconfig.cib_factory
 
@@ -40,29 +39,28 @@ def roundtrip(cli, debug=False, expected=None, format_mode=-1, strip_color=False
         print("EXP:", cli)
     assert obj.cli_use_validate()
     if expected is not None:
-        eq_(expected, s)
+        assert expected == s
     else:
-        eq_(cli, s)
+        assert cli == s
     assert not debug
 
 
-def setup_func():
+def setup_function():
     "set up test fixtures"
     from crmsh import idmgmt
     idmgmt.clear()
 
 
-def teardown_func():
+def teardown_function():
     "tear down test fixtures"
 
 
-@with_setup(setup_func, teardown_func)
 def test_rscset():
     roundtrip('colocation foo inf: a b')
     roundtrip('order order_2 Mandatory: [ A B ] C')
     roundtrip('rsc_template public_vm Xen')
 
-@with_setup(setup_func, teardown_func)
+
 def test_normalize():
     """
     Test automatic normalization of parameter names:
@@ -73,23 +71,19 @@ def test_normalize():
               expected='primitive vm1 Xen params shutdown_timeout=0')
 
 
-@with_setup(setup_func, teardown_func)
 def test_group():
     factory.create_from_cli('primitive p1 Dummy')
     roundtrip('group g1 p1 params target-role=Stopped')
 
 
-@with_setup(setup_func, teardown_func)
 def test_bnc863736():
     roundtrip('order order_3 Mandatory: [ A B ] C symmetrical=true')
 
 
-@with_setup(setup_func, teardown_func)
 def test_sequential():
     roundtrip('colocation rsc_colocation-master inf: [ vip-master vip-rep sequential=true ] [ msPostgresql:Master sequential=true ]')
 
 
-@with_setup(setup_func, teardown_func)
 def test_broken_colo():
     xml = """<rsc_colocation id="colo-2" score="INFINITY">
   <resource_set id="colo-2-0" require-all="false">
@@ -104,33 +98,28 @@ def test_broken_colo():
     obj = factory.create_from_node(data)
     assert_is_not_none(obj)
     data = obj.repr_cli(format_mode=-1)
-    eq_('colocation colo-2 inf: [ vip1 vip2 sequential=true ] [ apache:Master sequential=true ]', data)
+    assert 'colocation colo-2 inf: [ vip1 vip2 sequential=true ] [ apache:Master sequential=true ]' == data
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_comment():
     roundtrip("# comment 1\nprimitive d0 ocf:pacemaker:Dummy", format_mode=0, strip_color=True)
 
 
-@with_setup(setup_func, teardown_func)
 def test_comment2():
     roundtrip("# comment 1\n# comment 2\n# comment 3\nprimitive d0 ocf:pacemaker:Dummy", format_mode=0, strip_color=True)
 
 
-@with_setup(setup_func, teardown_func)
 def test_nvpair_ref1():
     factory.create_from_cli("primitive dummy-0 Dummy params $fiz:buz=bin")
     roundtrip('primitive dummy-1 Dummy params @fiz:boz')
 
 
-@with_setup(setup_func, teardown_func)
 def test_idresolve():
     factory.create_from_cli("primitive dummy-5 Dummy params buz=bin")
     roundtrip('primitive dummy-1 Dummy params @dummy-5-instance_attributes-buz')
 
 
-@with_setup(setup_func, teardown_func)
 def test_ordering():
     xml = """<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"> \
   <operations> \
@@ -149,11 +138,10 @@ value="Stopped"/> \
     data = obj.repr_cli(format_mode=-1)
     print(data)
     exp = 'primitive dummy ocf:pacemaker:Dummy op start timeout=60 interval=0 op stop timeout=60 interval=0 op monitor interval=60 timeout=30 meta target-role=Stopped'
-    eq_(exp, data)
+    assert exp == data
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_ordering2():
     xml = """<primitive id="dummy2" class="ocf" provider="pacemaker" type="Dummy"> \
   <meta_attributes id="dummy2-meta_attributes"> \
@@ -174,11 +162,10 @@ value="Stopped"/> \
     exp = 'primitive dummy2 ocf:pacemaker:Dummy meta target-role=Stopped ' \
           'op start timeout=60 interval=0 op stop timeout=60 interval=0 ' \
           'op monitor interval=60 timeout=30'
-    eq_(exp, data)
+    assert exp == data
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_fencing():
     xml = """<fencing-topology>
     <fencing-level devices="st1" id="fencing" index="1"
@@ -194,11 +181,10 @@ target="ha-one"></fencing-level>
     data = obj.repr_cli(format_mode=-1)
     print(data)
     exp = 'fencing_topology st1'
-    eq_(exp, data)
+    assert exp == data
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_fencing2():
     xml = """<fencing-topology>
     <fencing-level devices="apple" id="fencing" index="1"
@@ -216,11 +202,10 @@ target-pattern="red.*"></fencing-level>
     data = obj.repr_cli(format_mode=-1)
     print(data)
     exp = 'fencing_topology pattern:green.* apple pear pattern:red.* pear apple'
-    eq_(exp, data)
+    assert exp == data
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_master():
     xml = """<master id="ms-1">
     <crmsh-ref id="dummy3" />
@@ -235,7 +220,6 @@ def test_master():
     assert obj.cli_use_validate()
 
 
-@with_setup(setup_func, teardown_func)
 def test_param_rules():
     roundtrip('primitive foo Dummy ' +
               'params rule #uname eq wizbang laser=yes ' +
@@ -247,7 +231,6 @@ def test_param_rules():
               'params 1: interface=eth0 port=9999')
 
 
-@with_setup(setup_func, teardown_func)
 def test_operation_rules():
     roundtrip('primitive test Dummy ' +
               'op start interval=0 '
@@ -257,7 +240,6 @@ def test_operation_rules():
               'op_meta 1: timeout=60s')
 
 
-@with_setup(setup_func, teardown_func)
 def test_multiple_attrsets():
     roundtrip('primitive mySpecialRsc me:Special ' +
               'params 3: interface=eth1 ' +
@@ -267,84 +249,74 @@ def test_multiple_attrsets():
               'meta 2: port=8888')
 
 
-@with_setup(setup_func, teardown_func)
 def test_new_acls():
     roundtrip('role fum description=test read description=test2 xpath:"*[@name=karl]"')
 
 
-@with_setup(setup_func, teardown_func)
 def test_acls_reftype():
     roundtrip('role boo deny ref:d0 type:nvpair',
               expected='role boo deny ref:d0 deny type:nvpair')
 
 
-@with_setup(setup_func, teardown_func)
 def test_acls_oldsyntax():
     roundtrip('role boo deny ref:d0 tag:nvpair',
               expected='role boo deny ref:d0 deny type:nvpair')
 
 
-@with_setup(setup_func, teardown_func)
 def test_rules():
     roundtrip('primitive p1 Dummy params ' +
               'rule $role=Started date in start=2009-05-26 end=2010-05-26 ' +
               'or date gt 2014-01-01 state=2')
 
 
-@with_setup(setup_func, teardown_func)
 def test_new_role():
     roundtrip('role silly-role-2 read xpath:"//nodes//attributes" ' +
               'deny type:nvpair deny ref:d0 deny type:nvpair')
 
 
-@with_setup(setup_func, teardown_func)
 def test_topology_1114():
     roundtrip('fencing_topology attr:rack=1 node1,node2')
 
-@with_setup(setup_func, teardown_func)
+
 def test_topology_1114_pattern():
     roundtrip('fencing_topology pattern:.* network disk')
 
 
-@with_setup(setup_func, teardown_func)
 def test_locrule():
     roundtrip('location loc-testfs-with-eth1 testfs rule ethmonitor-eth1 eq 1')
 
 
-@with_setup(setup_func, teardown_func)
 def test_is_value_sane():
     roundtrip('''primitive p1 Dummy params state="bo'o"''')
 
 
-@with_setup(setup_func, teardown_func)
 def test_is_value_sane_2():
     roundtrip('primitive p1 Dummy params state="bo\\"o"')
 
 
-@with_setup(setup_func, teardown_func)
 def test_alerts_1():
     roundtrip('alert alert1 "/tmp/foo.sh" to "/tmp/bar.log"')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_2():
     roundtrip('alert alert2 "/tmp/foo.sh" attributes foo=bar to "/tmp/bar.log"')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_3():
     roundtrip('alert alert3 "a path here" meta baby to "/tmp/bar.log"')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_4():
     roundtrip('alert alert4 "/also/a/path"')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_5():
     roundtrip('alert alert5 "/a/path" to { "/another/path" } meta timeout=30s')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_6():
     roundtrip('alert alert6 "/a/path" select fencing attributes { standby } to { "/another/path" } meta timeout=30s')
 
-@with_setup(setup_func, teardown_func)
+
 def test_alerts_7():
     roundtrip('alert alert7 "/a/path" select fencing attributes foo=bar to { "/another/path" } meta timeout=30s')

--- a/test/unittests/test_handles.py
+++ b/test/unittests/test_handles.py
@@ -4,58 +4,57 @@ from __future__ import unicode_literals
 
 
 from crmsh import handles
-from nose.tools import eq_
 
 
 def test_basic():
     t = """{{foo}}"""
-    eq_("hello", handles.parse(t, {'foo': 'hello'}))
+    assert "hello" == handles.parse(t, {'foo': 'hello'})
     t = """{{foo:bar}}"""
-    eq_("hello", handles.parse(t, {'foo': {'bar': 'hello'}}))
+    assert "hello" == handles.parse(t, {'foo': {'bar': 'hello'}})
     t = """{{wiz}}"""
-    eq_("", handles.parse(t, {'foo': {'bar': 'hello'}}))
+    assert "" == handles.parse(t, {'foo': {'bar': 'hello'}})
     t = """{{foo}}.{{wiz}}"""
-    eq_("a.b", handles.parse(t, {'foo': "a", 'wiz': "b"}))
+    assert "a.b" == handles.parse(t, {'foo': "a", 'wiz': "b"})
     t = """Here's a line of text
     followed by another line
     followed by some {{foo}}.{{wiz}}
     and then some at the end"""
-    eq_("""Here's a line of text
+    assert """Here's a line of text
     followed by another line
     followed by some a.b
-    and then some at the end""", handles.parse(t, {'foo': "a", 'wiz': "b"}))
+    and then some at the end""" == handles.parse(t, {'foo': "a", 'wiz': "b"})
 
 
 def test_weird_chars():
     t = "{{foo#_bar}}"
-    eq_("hello", handles.parse(t, {'foo#_bar': 'hello'}))
+    assert "hello" == handles.parse(t, {'foo#_bar': 'hello'})
     t = "{{_foo$bar_}}"
-    eq_("hello", handles.parse(t, {'_foo$bar_': 'hello'}))
+    assert "hello" == handles.parse(t, {'_foo$bar_': 'hello'})
 
 
 def test_conditional():
     t = """{{#foo}}before{{foo:bar}}after{{/foo}}"""
-    eq_("beforehelloafter", handles.parse(t, {'foo': {'bar': 'hello'}}))
-    eq_("", handles.parse(t, {'faa': {'bar': 'hello'}}))
+    assert "beforehelloafter" == handles.parse(t, {'foo': {'bar': 'hello'}})
+    assert "" == handles.parse(t, {'faa': {'bar': 'hello'}})
 
     t = """{{#cond}}before{{foo:bar}}after{{/cond}}"""
-    eq_("beforehelloafter", handles.parse(t, {'foo': {'bar': 'hello'}, 'cond': True}))
-    eq_("", handles.parse(t, {'foo': {'bar': 'hello'}, 'cond': False}))
+    assert "beforehelloafter" == handles.parse(t, {'foo': {'bar': 'hello'}, 'cond': True})
+    assert "" == handles.parse(t, {'foo': {'bar': 'hello'}, 'cond': False})
 
 
 def test_iteration():
     t = """{{#foo}}!{{foo:bar}}!{{/foo}}"""
-    eq_("!hello!!there!", handles.parse(t, {'foo': [{'bar': 'hello'}, {'bar': 'there'}]}))
+    assert "!hello!!there!" == handles.parse(t, {'foo': [{'bar': 'hello'}, {'bar': 'there'}]})
 
 
 def test_result():
     t = """{{obj}}
     group g1 {{obj:id}}
 """
-    eq_("""primitive d0 Dummy
+    assert """primitive d0 Dummy
     group g1 d0
-""", handles.parse(t, {'obj': handles.value({'id': 'd0'}, 'primitive d0 Dummy')}))
-    eq_("\n    group g1 \n", handles.parse(t, {}))
+""" == handles.parse(t, {'obj': handles.value({'id': 'd0'}, 'primitive d0 Dummy')})
+    assert "\n    group g1 \n" == handles.parse(t, {})
 
 
 def test_result2():
@@ -65,11 +64,11 @@ def test_result2():
 {{obj}}
 {{/obj}}
 """
-    eq_("""primitive d0 Dummy
+    assert """primitive d0 Dummy
     group g1 d0
 primitive d0 Dummy
-""", handles.parse(t, {'obj': handles.value({'id': 'd0'}, 'primitive d0 Dummy')}))
-    eq_("\n    group g1 \n", handles.parse(t, {}))
+""" == handles.parse(t, {'obj': handles.value({'id': 'd0'}, 'primitive d0 Dummy')})
+    assert "\n    group g1 \n" == handles.parse(t, {})
 
 
 def test_mustasche():
@@ -86,10 +85,10 @@ Well, {{taxed_value}} dollars, after taxes.
         "in_ca": True
     }
 
-    eq_("""Hello Chris
+    assert """Hello Chris
 You have just won 10000 dollars!
 Well, 6000.0 dollars, after taxes.
-""", handles.parse(t, v))
+""" == handles.parse(t, v)
 
 
 def test_invert():
@@ -104,9 +103,9 @@ No repos :(
         "repo": []
     }
 
-    eq_("""
+    assert """
 No repos :(
-""", handles.parse(t, v))
+""" == handles.parse(t, v)
 
 
 def test_invert_2():
@@ -123,10 +122,10 @@ bar
         "repo": []
     }
 
-    eq_("""foo
+    assert """foo
 No repos :(
 bar
-""", handles.parse(t, v))
+""" == handles.parse(t, v)
 
 
 def test_cib():
@@ -164,4 +163,4 @@ colocation nfs-with-rootfs inf: g-nfs c-rfs
         'virtual-ip': handles.value({'id': 'vip'},
                                     'primitive vip IPaddr2\n  params ip=192.168.0.2'),
     }
-    eq_(r, handles.parse(t, v))
+    assert r == handles.parse(t, v)

--- a/test/unittests/test_objset.py
+++ b/test/unittests/test_objset.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 
 from crmsh import cibconfig
-from nose.tools import eq_, with_setup
 
 factory = cibconfig.cib_factory
 
@@ -15,27 +14,25 @@ def assert_in(needle, haystack):
         raise AssertionError(message)
 
 
-def setup_func():
+def setup_function():
     "set up test fixtures"
     from crmsh import idmgmt
     idmgmt.clear()
 
 
-def teardown_func():
+def teardown_function():
     pass
 
 
-@with_setup(setup_func, teardown_func)
 def test_nodes_nocli():
     for n in factory.node_id_list():
         obj = factory.find_object(n)
         if obj is not None:
             assert obj.node is not None
-            eq_(True, obj.cli_use_validate())
-            eq_(False, obj.nocli)
+            assert True == obj.cli_use_validate()
+            assert False == obj.nocli
 
 
-@with_setup(setup_func, teardown_func)
 def test_show():
     setobj = cibconfig.mkset_obj()
     s = setobj.repr_nopretty()

--- a/test/unittests/test_report.py
+++ b/test/unittests/test_report.py
@@ -2,9 +2,9 @@ import sys
 import os
 import shutil
 from datetime import datetime
-from nose.tools import eq_, ok_
 from unittest import mock
 
+sys.path.append('../..')
 from hb_report.utillib import which, ts_to_dt, sub_string, random_string,\
                               head, create_tempfile, tail, grep,\
                               get_stamp_rfc5424, get_stamp_syslog,\
@@ -61,16 +61,16 @@ some dddd"""
 def test_arch_logs():
     # test blank file
     temp_file = create_tempfile()
-    ok_(not arch_logs(temp_file, time_before, time_between))
+    assert not arch_logs(temp_file, time_before, time_between)
 
     # from_time > last_time
-    ok_(not arch_logs(pacemaker_log, time_after, time_between))
+    assert not arch_logs(pacemaker_log, time_after, time_between)
     # from_time >= first_time
-    eq_(arch_logs(pacemaker_log, time_before, time_between)[0], pacemaker_log)
+    assert arch_logs(pacemaker_log, time_before, time_between)[0] == pacemaker_log
     # to_time == 0
-    eq_(arch_logs(pacemaker_log, time_before, 0)[0], pacemaker_log)
+    assert arch_logs(pacemaker_log, time_before, 0)[0] == pacemaker_log
     # to_time >= first_time
-    eq_(arch_logs(pacemaker_log, time_before, first_time)[0], pacemaker_log)
+    assert arch_logs(pacemaker_log, time_before, first_time)[0] == pacemaker_log
 
     os.remove(temp_file)
 
@@ -84,15 +84,15 @@ def test_Tempfile():
     tmpfile = create_tempfile()
     t.add(tmpfile)
 
-    ok_(os.path.isdir(tmpdir))
-    ok_(os.path.isfile(tmpfile))
-    ok_(os.path.isfile(t.file))
+    assert os.path.isdir(tmpdir)
+    assert os.path.isfile(tmpfile)
+    assert os.path.isfile(t.file)
 
     t.drop()
 
-    ok_(not os.path.isdir(tmpdir))
-    ok_(not os.path.isfile(tmpfile))
-    ok_(not os.path.isfile(t.file))
+    assert not os.path.isdir(tmpdir)
+    assert not os.path.isfile(tmpfile)
+    assert not os.path.isfile(t.file)
 
 
 def test_filter_lines():
@@ -102,47 +102,47 @@ def test_filter_lines():
     out1 = filter_lines(pacemaker_log, begin_line)
     out2 = filter_lines(pacemaker_log, begin_line, end_line)
 
-    eq_(len(out1.split('\n')), 924)
-    eq_(len(out2.split('\n')), 804)
+    assert len(out1.split('\n')) == 924
+    assert len(out2.split('\n')) == 804
 
 
 def test_filter_lines_unicode():
     with open(evil_unicode_log, 'wb') as f:
         f.write(invalid_utf8)
     out1 = filter_lines(evil_unicode_log, 1, 3)
-    eq_(len(out1.split('\n')), 2)
+    assert len(out1.split('\n')) == 2
     os.remove(evil_unicode_log)
 
     out2 = filter_lines(pacemaker_unicode_log, 1, 30)
-    eq_(len(out2.split('\n')), 31)
+    assert len(out2.split('\n')) == 31
 
 
 def test_find_decompressor():
     log_file = "testfile"
-    eq_(find_decompressor(log_file), "cat")
+    assert find_decompressor(log_file) == "cat"
     log_file = "log.bz2"
-    eq_(find_decompressor(log_file), "bzip2 -dc")
+    assert find_decompressor(log_file) == "bzip2 -dc"
     log_file = "log.gz"
-    eq_(find_decompressor(log_file), "gzip -dc")
+    assert find_decompressor(log_file) == "gzip -dc"
     log_file = "log.tar.xz"
-    eq_(find_decompressor(log_file), "xz -dc")
+    assert find_decompressor(log_file) == "xz -dc"
 
     log_file = create_tempfile()
     with open(log_file, 'w') as f:
         f.write("test")
-    eq_(find_decompressor(log_file), "cat")
+    assert find_decompressor(log_file) == "cat"
     os.remove(log_file)
 
 
 def test_find_first_ts():
     with open(pacemaker_log, 'r') as f:
         res = find_first_ts(f.read().split('\n'))
-        eq_(ts_to_dt(res).strftime("%Y/%m/%d %H:%M:%S"), "%d/04/03 11:01:18" % year)
+        assert ts_to_dt(res).strftime("%Y/%m/%d %H:%M:%S") == "%d/04/03 11:01:18" % year
 
 
 def test_find_files():
-    ok_(not find_files("test", "testtime", time_after))
-    ok_(not find_files("test", 0, time_after))
+    assert not find_files("test", "testtime", time_after)
+    assert not find_files("test", 0, time_after)
 
     dirs = make_temp_dir()
     tmpfile1 = create_tempfile(time_between)
@@ -155,8 +155,8 @@ def test_find_files():
     t.add(tmpfile1)
     t.add(tmpfile2)
 
-    eq_(sorted(find_files(dirs, time_before, 0)), sorted([os.path.join(dirs, os.path.basename(tmpfile1)), os.path.join(dirs, os.path.basename(tmpfile2))]))
-    eq_(find_files(dirs, time_before, time_between), [os.path.join(dirs, os.path.basename(tmpfile1))])
+    assert sorted(find_files(dirs, time_before, 0)) == sorted([os.path.join(dirs, os.path.basename(tmpfile1)), os.path.join(dirs, os.path.basename(tmpfile2))])
+    assert find_files(dirs, time_before, time_between) == [os.path.join(dirs, os.path.basename(tmpfile1))]
 
     t.drop()
 
@@ -168,76 +168,76 @@ def test_find_getstampproc():
 efg"""
     with open(temp_file, 'w') as f:
         f.write(in_string1)
-    ok_(not find_getstampproc(temp_file))
+    assert not find_getstampproc(temp_file)
 
     in_string2 = """%s
 %s""" % (line5424_1, line5424_2)
     with open(temp_file, 'w') as f:
         f.write(in_string2)
-    eq_(find_getstampproc(temp_file), "rfc5424")
+    assert find_getstampproc(temp_file) == "rfc5424"
 
     in_string3 = """%s
 %s""" % (linesyslog_1, linesyslog_2)
     with open(temp_file, 'w') as f:
         f.write(in_string3)
-    eq_(find_getstampproc(temp_file), "syslog")
+    assert find_getstampproc(temp_file) == "syslog"
 
     os.remove(temp_file)
 
 
 def test_find_getstampproc_unicode():
-    eq_(find_getstampproc(pacemaker_unicode_log), "syslog")
+    assert find_getstampproc(pacemaker_unicode_log) == "syslog"
 
     with open(evil_unicode_log, 'wb') as f:
         f.write(invalid_utf8)
-    eq_(find_getstampproc(evil_unicode_log), "syslog")
+    assert find_getstampproc(evil_unicode_log) == "syslog"
     os.remove(evil_unicode_log)
 
 
 def test_find_getstampproc_raw():
-    eq_(find_getstampproc_raw(line5424_1), "rfc5424")
-    eq_(find_getstampproc_raw(line5424_2), "rfc5424")
-    eq_(find_getstampproc_raw(linesyslog_1), "syslog")
-    eq_(find_getstampproc_raw(linesyslog_2), "syslog")
+    assert find_getstampproc_raw(line5424_1) == "rfc5424"
+    assert find_getstampproc_raw(line5424_2) == "rfc5424"
+    assert find_getstampproc_raw(linesyslog_1) == "syslog"
+    assert find_getstampproc_raw(linesyslog_2) == "syslog"
 
 
 def test_findln_by_time():
     # time before log happen
-    eq_(findln_by_time(pacemaker_log, time_before), 1)
+    assert findln_by_time(pacemaker_log, time_before) == 1
     # time after log happen
-    eq_(findln_by_time(pacemaker_log, time_after), 923)
+    assert findln_by_time(pacemaker_log, time_after) == 923
     # time between log happen
-    eq_(findln_by_time(pacemaker_log, time_between), 803)
+    assert findln_by_time(pacemaker_log, time_between) == 803
 
 
 def test_findln_by_time():
-    eq_(findln_by_time(pacemaker_unicode_log, time_before), 1)
+    assert findln_by_time(pacemaker_unicode_log, time_before) == 1
 
     with open(evil_unicode_log, 'wb') as f:
         f.write(invalid_utf8)
-    eq_(findln_by_time(evil_unicode_log, time_before), 1)
+    assert findln_by_time(evil_unicode_log, time_before) == 1
     os.remove(evil_unicode_log)
 
 
 def test_get_stamp_rfc5424():
-    ok_(get_stamp_rfc5424(line5424_1))
-    ok_(get_stamp_rfc5424(line5424_2))
+    assert get_stamp_rfc5424(line5424_1)
+    assert get_stamp_rfc5424(line5424_2)
 
 
 def test_get_stamp_syslog():
-    ok_(get_stamp_syslog(linesyslog_1))
-    ok_(get_stamp_syslog(linesyslog_2))
+    assert get_stamp_syslog(linesyslog_1)
+    assert get_stamp_syslog(linesyslog_2)
 
 
 def test_get_ts():
-    eq_(ts_to_dt(get_ts(line5424_1)).strftime("%Y/%m/%d %H:%M"), "2017/01/26 03:04")
-    eq_(ts_to_dt(get_ts(linesyslog_1)).strftime("%m/%d %H:%M:%S"), "05/17 15:52:40")
+    assert ts_to_dt(get_ts(line5424_1)).strftime("%Y/%m/%d %H:%M") == "2017/01/26 03:04"
+    assert ts_to_dt(get_ts(linesyslog_1)).strftime("%m/%d %H:%M:%S") == "05/17 15:52:40"
 
 
 def test_grep():
     res = grep("^Name", incmd="rpm -qi bash")[0]
     _, out = get_command_info("rpm -qi bash|grep \"^Name\"")
-    eq_(res, out.strip("\n"))
+    assert res == out.strip("\n")
 
     in_string = """aaaa
 bbbb
@@ -248,7 +248,7 @@ bbbb
     res = grep("aaaa", infile=temp_file, flag='v')[0]
     _, out = get_command_info("grep -v aaaa %s"%temp_file)
     os.remove(temp_file)
-    eq_(res, out.strip("\n"))
+    assert res == out.strip("\n")
 
 
 def test_grep_unicode():
@@ -256,10 +256,10 @@ def test_grep_unicode():
         f.write(invalid_utf8)
     res = grep("11:01", infile=evil_unicode_log)[0]
     os.remove(evil_unicode_log)
-    eq_(res, 'Apr 03 11:01:18 [13042] \ufffdabc')
+    assert res == 'Apr 03 11:01:18 [13042] \ufffdabc'
 
     res = grep("test_unicode", infile=pacemaker_unicode_log)[0]
-    eq_(res, 'Apr 03 13:37:23 15sp1-1 pacemaker-controld  [1948] (handle_ping)        notice: \\xfc\\xa1\\xa1\\xa1\\xa1\\xa1 test_unicode')
+    assert res == 'Apr 03 13:37:23 15sp1-1 pacemaker-controld  [1948] (handle_ping)        notice: \\xfc\\xa1\\xa1\\xa1\\xa1\\xa1 test_unicode'
 
 
 def test_head():
@@ -272,50 +272,50 @@ def test_head():
     res = head(3, data)
 
     os.remove(temp_file)
-    eq_(out.rstrip('\n'), '\n'.join(res))
+    assert out.rstrip('\n') == '\n'.join(res)
 
 
 def test_is_our_log():
     # empty log
     temp_file = create_tempfile()
-    eq_(is_our_log(temp_file, time_before, time_between), 0)
+    assert is_our_log(temp_file, time_before, time_between) == 2
 
     # from_time > last_time
-    eq_(is_our_log(pacemaker_log, time_after, time_between), 2)
+    assert is_our_log(pacemaker_log, time_after, time_between) == 2
     # from_time >= first_time
-    eq_(is_our_log(pacemaker_log, time_between, time_after), 3)
+    assert is_our_log(pacemaker_log, time_between, time_after) == 3
     # to_time == 0
-    eq_(is_our_log(pacemaker_log, time_before, 0), 1)
+    assert is_our_log(pacemaker_log, time_before, 0) == 1
     # to_time >= first_time
-    eq_(is_our_log(pacemaker_log, time_before, first_time), 1)
+    assert is_our_log(pacemaker_log, time_before, first_time) == 1
 
     os.remove(temp_file)
 
 
 def test_is_our_log_unicode():
-    eq_(is_our_log(pacemaker_unicode_log, time_before, 0), 1)
+    assert is_our_log(pacemaker_unicode_log, time_before, 0) == 1
 
     with open(evil_unicode_log, 'wb') as f:
         f.write(invalid_utf8)
-    eq_(is_our_log(evil_unicode_log, time_before, 0), 1)
+    assert is_our_log(evil_unicode_log, time_before, 0) == 1
     os.remove(evil_unicode_log)
 
 
 def test_line_time():
-    eq_(ts_to_dt(line_time(pacemaker_log, 2)).strftime("%Y/%m/%d %H:%M:%S"), "%d/04/03 11:01:18" % year)
-    eq_(ts_to_dt(line_time(pacemaker_log, 195)).strftime("%Y/%m/%d %H:%M:%S"),"%d/04/03 11:01:40" % year)
+    assert ts_to_dt(line_time(pacemaker_log, 2)).strftime("%Y/%m/%d %H:%M:%S") == "%d/04/03 11:01:18" % year
+    assert ts_to_dt(line_time(pacemaker_log, 195)).strftime("%Y/%m/%d %H:%M:%S") == "%d/04/03 11:01:40" % year
 
 
 def test_line_time_unicode():
-    eq_(ts_to_dt(line_time(pacemaker_unicode_log, 3)).strftime("%Y/%m/%d %H:%M:%S"), "%d/04/03 11:01:18" % year)
+    assert ts_to_dt(line_time(pacemaker_unicode_log, 3)).strftime("%Y/%m/%d %H:%M:%S") == "%d/04/03 11:01:18" % year
     with open(evil_unicode_log, 'wb') as f:
         f.write(invalid_utf8)
-    eq_(ts_to_dt(line_time(evil_unicode_log, 1)).strftime("%Y/%m/%d %H:%M:%S"), "%d/04/03 11:01:18" % year)
+    assert ts_to_dt(line_time(evil_unicode_log, 1)).strftime("%Y/%m/%d %H:%M:%S") == "%d/04/03 11:01:18" % year
     os.remove(evil_unicode_log)
 
 
 def test_random_string():
-    eq_(len(random_string(8)), 8)
+    assert len(random_string(8)) == 8
 
 
 def test_sub_string():
@@ -333,7 +333,7 @@ I like name="password" value="******" some="more".
 some number some number
 """
     pattern = "passw.* OSS"
-    eq_(sub_string(in_string, pattern), out_string)
+    assert sub_string(in_string, pattern) == out_string
 
 
 def test_tail():
@@ -346,7 +346,7 @@ def test_tail():
     res = tail(3, data)
 
     os.remove(temp_file)
-    eq_(out.rstrip('\n'), '\n'.join(res))
+    assert out.rstrip('\n') == '\n'.join(res)
 
 
 def test_ts_to_dt():
@@ -356,22 +356,22 @@ def test_ts_to_dt():
     ts4 = crmsh.utils.parse_to_timestamp("09-Sep-15 2:00")
     ts5 = crmsh.utils.parse_to_timestamp("2017-06-01T14:27:08.412531+08:00")
 
-    eq_(ts_to_dt(ts1).strftime("%-I%P"), "2pm")
-    eq_(ts_to_dt(ts2).strftime("%Y/%-m/%-d %H:%M"), "2007/9/5 12:30")
-    eq_(ts_to_dt(ts3).strftime("%-H:%M"), "1:00")
-    eq_(ts_to_dt(ts4).strftime("%d-%b-%y %-H:%M"), "09-Sep-15 2:00")
-    eq_(ts_to_dt(ts5).strftime("%Y/%m/%d %H:%M:%S"), "2017/06/01 06:27:08")
+    assert ts_to_dt(ts1).strftime("%-I%P") == "2pm"
+    assert ts_to_dt(ts2).strftime("%Y/%-m/%-d %H:%M") == "2007/9/5 12:30"
+    assert ts_to_dt(ts3).strftime("%-H:%M") == "1:00"
+    assert ts_to_dt(ts4).strftime("%d-%b-%y %-H:%M") == "09-Sep-15 2:00"
+    assert ts_to_dt(ts5).strftime("%Y/%m/%d %H:%M:%S") == "2017/06/01 06:27:08"
 
 
 def test_which():
-    ok_(which("ls"))
-    ok_(not which("llll"))
+    assert which("ls")
+    assert not which("llll")
 
 
 @mock.patch('crmsh.utils.get_stdout_stderr')
 def test_dump_D_process_None(mock_get_stdout_stderr):
     mock_get_stdout_stderr.return_value = (0, None, None)
-    eq_(hb_report.utillib.dump_D_process(), "Dump D-state process stack: 0\n")
+    assert hb_report.utillib.dump_D_process() == "Dump D-state process stack: 0\n"
     mock_get_stdout_stderr.assert_called_once_with("ps aux|awk '$8 ~ /^D/{print $2}'")
 
 
@@ -385,7 +385,7 @@ def test_dump_D_process_None(mock_get_stdout_stderr):
             (0, "stack_out for 10002", None)
             ]
     out_string = "Dump D-state process stack: 2\npid: 10001     comm: comm_out for 10001\nstack_out for 10001\n\npid: 10002     comm: comm_out for 10002\nstack_out for 10002\n\n"
-    eq_(hb_report.utillib.dump_D_process(), out_string)
+    assert hb_report.utillib.dump_D_process() == out_string
     mock_get_stdout_stderr.assert_has_calls([
         mock.call("ps aux|awk '$8 ~ /^D/{print $2}'"),
         mock.call("cat /proc/10001/comm"),

--- a/test/unittests/test_time.py
+++ b/test/unittests/test_time.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 from crmsh import utils
 from crmsh import logtime
-from nose.tools import eq_
 import time
 import datetime
 import dateutil.tz
@@ -15,11 +14,11 @@ def test_time_convert1():
     loctz = dateutil.tz.tzlocal()
     tm = time.localtime(utils.datetime_to_timestamp(utils.make_datetime_naive(datetime.datetime(2015, 6, 1, 10, 0, 0).replace(tzinfo=loctz))))
     dt = utils.parse_time('Jun 01, 2015 10:00:00')
-    eq_(logtime.human_date(dt), time.strftime('%Y-%m-%d %H:%M:%S', tm))
+    assert logtime.human_date(dt) == time.strftime('%Y-%m-%d %H:%M:%S', tm)
 
 
 def test_time_convert2():
     loctz = dateutil.tz.tzlocal()
     tm = time.localtime(utils.datetime_to_timestamp(utils.make_datetime_naive(datetime.datetime(2015, 6, 1, 10, 0, 0).replace(tzinfo=loctz))))
     ts = time.localtime(utils.parse_to_timestamp('Jun 01, 2015 10:00:00'))
-    eq_(time.strftime('%Y-%m-%d %H:%M:%S', ts), time.strftime('%Y-%m-%d %H:%M:%S', tm))
+    assert time.strftime('%Y-%m-%d %H:%M:%S', ts) == time.strftime('%Y-%m-%d %H:%M:%S', tm)

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -8,7 +8,6 @@ import os
 import socket
 import re
 from unittest import mock
-from nose.tools import eq_
 from itertools import chain
 from crmsh import utils
 from crmsh import config
@@ -22,7 +21,7 @@ def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
     mock_re_search_inst = mock.Mock()
     mock_re_search.return_value = mock_re_search_inst
     res = utils.get_nodeid_from_name("node1")
-    eq_(res, None)
+    assert res is None
     mock_get_stdout.assert_called_once_with('crm_node -l')
     mock_re_search.assert_not_called()
 
@@ -33,7 +32,7 @@ def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
     mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
     mock_re_search.return_value = None
     res = utils.get_nodeid_from_name("node111")
-    eq_(res, None)
+    assert res is None
     mock_get_stdout.assert_called_once_with('crm_node -l')
     mock_re_search.assert_called_once_with(r'^([0-9]+) node111 ', mock_get_stdout.return_value[1], re.M)
 
@@ -46,7 +45,7 @@ def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
     mock_re_search.return_value = mock_re_search_inst
     mock_re_search_inst.group.return_value = '172168231'
     res = utils.get_nodeid_from_name("node2")
-    eq_(res, '172168231')
+    assert res == '172168231'
     mock_get_stdout.assert_called_once_with('crm_node -l')
     mock_re_search.assert_called_once_with(r'^([0-9]+) node2 ', mock_get_stdout.return_value[1], re.M)
     mock_re_search_inst.group.assert_called_once_with(1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,27 @@
+# content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = {py34}
-skipsdist = True
+envlist = py36
 
+[base]
+deps =
+    pylint
+    pytest
+    pytest-cov
 
 [testenv]
-usedevelop = True
+changedir=test/unittests
 deps =
-    -rrequirements.txt
-
-passenv = HOME
+    {[base]deps}
 
 commands =
-    sh test/run --with-coverage
+    py.test -vv --cov=crmsh --cov-config .coveragerc --cov-report term --cov-report html {posargs}
 
-whitelist_externals =
-    /bin/sh
+[testenv:py36-codeclimate]
+passenv = TRAVIS TRAVIS_*
+changedir=test/unittests
+deps =
+    {[base]deps}
+
+commands =
+    py.test -vv --cov=crmsh --cov-config .coveragerc --cov-report term --cov-report xml
+


### PR DESCRIPTION
Since `nose` was deprecated, this PR is for replacing nose with `pytest`

Changed include:
* Update Dockerfile and docker image (branch master use liangxin1300/haleap:15.2, which is based on opensuse/leap:15.2)
* Split `regression test` into `unit test` and `regression test`
* Adjust crmsh code according to pytest warning(Low: replace configparser.SafeConfigParser as configparser.ConfigParser)
* Repace nose with pytest in unittest code
* Adjust regression(test/testcases) scripts based on related pacemaker version at opensuse 15.2