### PR TITLE
Feature: configure: make configure.set to update operation

### DIFF
--- a/data-manifest
+++ b/data-manifest
@@ -73,6 +73,7 @@ test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
+test/features/resource_set.feature
 test/features/steps/const.py
 test/features/steps/__init__.py
 test/features/steps/step_implenment.py

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -4149,22 +4149,27 @@ schema pacemaker-1.1
 ==== `set`
 
 Set the value of a configured attribute. The attribute must
-have a value configured previously, and can be an agent
-parameter, meta attribute or utilization value.
+configured previously, and can be an agent parameter, meta attribute,
+utilization value or operation value.
 
 The first argument to the command is a path to an attribute.
 This is a dot-separated sequence beginning with the name of
-the resource, and ending with the name of the attribute to
-set.
+the resource or object, and ending with the name of the attribute to
+set. To set operation value, `op_type` should be specified; when multi
+operations exist like multi monitors, `interval` should be specified.
 
 Usage:
 ...............
 set <path> <value>
+
+path:: id.[op_type.][interval.]name
 ...............
 Examples:
 ...............
 set vip1.ip 192.168.20.5
 set vm-a.force_stop 1
+set vip1.monitor.on-fail ignore
+set drbd.monitor.10s.interval 20s
 ...............
 
 [[cmdhelp_configure_show,display CIB objects]]

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -1,0 +1,47 @@
+@resource
+Feature: Use "crm configure set" to update attributes and operations
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  Background: Setup one node cluster and configure some resources
+    Given     Cluster service is "stopped" on "hanode1"
+    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    Then      Cluster service is "started" on "hanode1"
+    When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
+    Then      Resource "d" type "Dummy" is "Started"
+    When      Run "crm configure primitive vip IPaddr2 params ip=10.10.10.123 op monitor interval=3s" on "hanode1"
+    Then      Resource "vip" type "IPaddr2" is "Started"
+    And       Cluster virtual IP is "10.10.10.123"
+    When      Run "crm configure primitive s ocf:pacemaker:Stateful op monitor_Master interval=3s op monitor_Slave interval=5s" on "hanode1"
+    Then      Resource "s" type "Stateful" is "Started"
+
+  @clean
+  Scenario: Validation, input the wrong parameters
+    When    Try "crm configure set path"
+    Then    Except "ERROR: configure.set: Expected (path value), takes exactly 2 arguments (1 given)"
+    When    Try "crm configure set xxxx value"
+    Then    Except "ERROR: configure.set: Invalid path: "xxxx"; Valid path: "id.[op_type.][interval.]name""
+    When    Try "crm configure set xxxx.name value"
+    Then    Except "ERROR: configure.set: Object xxxx not found"
+    When    Try "crm configure set d.name value"
+    Then    Except "ERROR: configure.set: Attribute not found: d.name"
+    When    Try "crm configure set d.start.timeout 30"
+    Then    Except "ERROR: configure.set: Operation "start" not found for resource d"
+    When    Try "crm configure set d.monitor.100.timeout 10"
+    Then    Except "ERROR: configure.set: Operation "monitor" interval "100" not found for resource d"
+    When    Try "crm configure set s.monitor.interval 20"
+    Then    Except "ERROR: configure.set: Should specify interval of monitor"
+
+  @clean
+  Scenario: Using configure.set to update resource parameters and operation values
+    When    Run "crm configure set vip.ip 10.10.10.124" on "hanode1"
+    Then    Cluster virtual IP is "10.10.10.124"
+    When    Run "crm configure set d.monitor.on-fail ignore" on "hanode1"
+    And     Run "crm configure show d" on "hanode1"
+    Then    Expected "on-fail=ignore" in stdout
+    When    Run "crm configure set s.monitor.5s.interval 20s" on "hanode1"
+    And     Run "crm configure show s" on "hanode1"
+    Then    Expected "interval=20s" in stdout
+    When    Run "crm configure set op-options.timeout 101" on "hanode1"
+    And     Run "crm configure show op-options" on "hanode1"
+    Then    Expected "timeout=101" in stdout

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -51,6 +51,18 @@ def step_impl(context, msg):
     context.stdout = None
 
 
+@then('Expected multiple lines')
+def step_impl(context):
+    assert context.stdout == context.text
+    context.stdout = None
+
+
+@then('Expected "{msg}" in stdout')
+def step_impl(context, msg):
+    assert msg in context.stdout
+    context.stdout = None
+
+
 @then('Except "{msg}"')
 def step_impl(context, msg):
     assert context.command_error_output == msg


### PR DESCRIPTION
#### Problem
Like issue #474 mentioned, it's not convenient for modifying an existing resource op monitor parameter.
Using `edit` can modify it but it's not work if user want to script this process

#### Solution
This PR extend the functionalities of configure.set subcommand, while try to keep compatible, if we want to update/add op parameters for en existing resource, we can do it like this:
```
set vip1.monitor.on-fail ignore
set drbd.monitor.10s.interval 20s
```
usage for configure.set
```
set <path> <value>

path:: id.[op_type.][interval.]name
```

#### Test
Behave test file is [here](https://github.com/ClusterLabs/crmsh/blob/38047ca78b46164b9f65b8d448cc66e15971b972/test/features/resource_set.feature)
include validation and normal using for configure.set