### PR TITLE
For udpu, don't check join node's ip was in the same network

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1909,21 +1909,6 @@ def join_cluster(seed_host):
                                               ringXaddr_res)
                 if not ringXaddr:
                     error("No value for ring{}".format(i))
-
-                # this check does not work on GCP (bsc#1106946)
-                if utils.detect_cloud() != "google-cloud-platform":
-                    _, outp = utils.get_stdout("ip addr show")
-                    tmp = re.findall(r' {}/[0-9]+ '.format(ringXaddr), outp, re.M)[0].strip()
-                    peer_ip = corosync.get_value("nodelist.node.ring{}_addr".format(i))
-                    # peer ring0_addr and local ring0_addr must be configured in the same network
-                    if not utils.ip_in_network(peer_ip, tmp):
-                        errmsg = "    Peer IP {} is not in the same network: {}".format(peer_ip, tmp)
-                        if _context.yes_to_all:
-                            error(errmsg)
-                        else:
-                            print(term.render(clidisplay.error(errmsg)))
-                            continue
-
                 ringXaddr_res.append(ringXaddr)
                 break
             if not rrp_flag:

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -811,24 +811,47 @@ class IPAlreadyConfiguredError(Exception):
     pass
 
 
-def add_node_ucast(IParray, node_id=None):
+def find_configured_ip(ip_list):
+    """
+    find if the same IP already configured
+    If so, raise IPAlreadyConfiguredError
+    """
+    with open(conf()) as f:
+        p = Parser(f.read())
+
+    # get exist ip list from corosync.conf
+    corosync_iplist = []
+    for path in set(p.all_paths()):
+        if re.search('nodelist.node.ring[0-9]*_addr', path):
+            corosync_iplist.extend(p.get_all(path))
+
+    # all_possible_ip is a ip set to check whether one of them already configured
+    all_possible_ip = set(ip_list)
+    # get local ip list
+    local_ip_list = utils.ip_in_local(utils.is_ipv6(ip_list[0]))
+    # extend all_possible_ip if ip_list contain local ip
+    # to avoid this scenarios in join node:
+    #   eth0's ip already configured in corosync.conf
+    #   eth1's ip also want to add in nodelist
+    # if this scenarios happened, raise IPAlreadyConfiguredError
+    if bool(set(ip_list) & set(local_ip_list)):
+        all_possible_ip |= set(local_ip_list)
+    configured_ip = list(all_possible_ip & set(corosync_iplist))
+    if configured_ip:
+        raise IPAlreadyConfiguredError("IP {} was already configured".format(','.join(configured_ip)))
+
+
+def add_node_ucast(ip_list, node_id=None):
+
+    find_configured_ip(ip_list)
 
     f = open(conf()).read()
     p = Parser(f)
 
-    # to check if the same IP already configured
-    exist_iplist = []
-    for path in p.all_paths():
-        if re.search('nodelist.node.ring[0-9]*_addr', path):
-            exist_iplist.extend(p.get_all(path))
-    for ip in IParray:
-        if ip in exist_iplist:
-            raise IPAlreadyConfiguredError("IP {} was already configured".format(ip))
-
     if node_id is None:
         node_id = get_free_nodeid(p)
     node_value = []
-    for i, addr in enumerate(IParray):
+    for i, addr in enumerate(ip_list):
         node_value += make_value('nodelist.node.ring{}_addr'.format(i), addr)
     node_value += make_value('nodelist.node.nodeid', str(node_id))
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2083,6 +2083,11 @@ class IP:
     def version(self):
         return self.addr.version
 
+
+def is_ipv6(addr):
+    return IP(addr).version() == 6
+
+
 # Set by detect_cloud() or iplist_for_cloud()
 # to avoid multiple requests
 _ip_for_cloud = None

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -33,3 +33,15 @@ Feature: Regression test for bootstrap bugs
     Then    Except "ERROR: cluster.geo_join: Space value not allowed for dest "node""
     When    Try "crm cluster geo-init-arbitrator -c ' '"
     Then    Except "ERROR: cluster.geo_init_arbitrator: Space value not allowed for dest "other""
+
+  @clean
+  Scenario: Setup cluster with crossed network(udpu only)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -u -i eth0 -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    Then    Cluster service is "stopped" on "hanode2"
+    And     Except "Cannot see peer node "hanode1", please check the communication IP" in stderr
+    When    Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -35,6 +35,11 @@ def step_impl(context, cmd, addr):
     context.stdout = out
 
 
+@when('Try "{cmd}" on "{addr}"')
+def step_impl(context, cmd, addr):
+    run_command_local_or_remote(context, cmd, addr, err_record=True)
+
+
 @when('Try "{cmd}"')
 def step_impl(context, cmd):
     run_command(context, cmd, err_record=True)
@@ -66,6 +71,12 @@ def step_impl(context, msg):
 @then('Except "{msg}"')
 def step_impl(context, msg):
     assert context.command_error_output == msg
+    context.command_error_output = None
+
+
+@then('Except "{msg}" in stderr')
+def step_impl(context, msg):
+    assert msg in context.command_error_output
     context.command_error_output = None
 
 

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -19,14 +19,17 @@ def run_command(context, cmd, err_record=False):
     return out
 
 
-def run_command_local_or_remote(context, cmd, addr):
+def run_command_local_or_remote(context, cmd, addr, err_record=False):
     if addr == me():
-        out = run_command(context, cmd)
+        out = run_command(context, cmd, err_record)
         return out
     else:
         try:
             results = parallax.parallax_call([addr], cmd)
         except ValueError as err:
+            if err_record:
+                context.command_error_output = str(err)
+                return
             context.logger.error("\n{}\n".format(err))
             context.failed = True
         else:

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -93,6 +93,60 @@ class TestCorosyncParser(unittest.TestCase):
                            make_value('nodelist.node.nodeid', str(nid))))
         _valid(p)
         self.assertEqual(p.count('nodelist.node'), nid - 1)
+ 
+    @mock.patch("crmsh.utils.is_ipv6")
+    @mock.patch("crmsh.utils.ip_in_local")
+    @mock.patch("re.search")
+    @mock.patch("crmsh.corosync.Parser")
+    @mock.patch("crmsh.corosync.conf")
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="corosync conf data")
+    def test_find_configured_ip_no_exception(self, mock_open_file, mock_conf, mock_parser, mock_search, mock_ip_local, mock_isv6):
+        mock_conf.return_value = "/etc/corosync/corosync.conf"
+        mock_parser_inst = mock.Mock()
+        mock_parser.return_value = mock_parser_inst
+        mock_parser_inst.all_paths.return_value = ["nodelist.node.ring0_addr"]
+        mock_search.return_value = mock.Mock()
+        mock_parser_inst.get_all.return_value = ["10.10.10.1"]
+        mock_isv6.return_value = False
+        mock_ip_local.return_value = ["192.168.1.1", "10.10.10.2", "20.20.20.2"]
+
+        corosync.find_configured_ip(["10.10.10.2"])
+
+        mock_conf.assert_called_once_with()
+        mock_parser_inst.all_paths.assert_called_once_with()
+        mock_parser_inst.get_all.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_open_file.assert_called_once_with(mock_conf.return_value)
+        mock_isv6.assert_called_once_with("10.10.10.2")
+        mock_ip_local.assert_called_once_with(False)
+        mock_search.assert_called_once_with("nodelist.node.ring[0-9]*_addr", "nodelist.node.ring0_addr")
+
+    @mock.patch("crmsh.utils.is_ipv6")
+    @mock.patch("crmsh.utils.ip_in_local")
+    @mock.patch("re.search")
+    @mock.patch("crmsh.corosync.Parser")
+    @mock.patch("crmsh.corosync.conf")
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data="corosync conf data")
+    def test_find_configured_ip_exception(self, mock_open_file, mock_conf, mock_parser, mock_search, mock_ip_local, mock_isv6):
+        mock_conf.return_value = "/etc/corosync/corosync.conf"
+        mock_parser_inst = mock.Mock()
+        mock_parser.return_value = mock_parser_inst
+        mock_parser_inst.all_paths.return_value = ["nodelist.node.ring0_addr"]
+        mock_search.return_value = mock.Mock()
+        mock_parser_inst.get_all.return_value = ["10.10.10.1", "10.10.10.2"]
+        mock_isv6.return_value = False
+        mock_ip_local.return_value = ["192.168.1.1", "10.10.10.2", "20.20.20.2"]
+
+        with self.assertRaises(corosync.IPAlreadyConfiguredError) as err:
+            corosync.find_configured_ip(["10.10.10.2"])
+        self.assertEqual("IP 10.10.10.2 was already configured", str(err.exception))
+
+        mock_conf.assert_called_once_with()
+        mock_parser_inst.all_paths.assert_called_once_with()
+        mock_parser_inst.get_all.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_open_file.assert_called_once_with(mock_conf.return_value)
+        mock_isv6.assert_called_once_with("10.10.10.2")
+        mock_ip_local.assert_called_once_with(False)
+        mock_search.assert_called_once_with("nodelist.node.ring[0-9]*_addr", "nodelist.node.ring0_addr")
 
     def test_add_node_ucast(self):
         from crmsh.corosync import add_node_ucast, get_values


### PR DESCRIPTION
## Problem
While in node join process in udpu mode, we do have restriction that forcing the join node address being the same network with the init node's. Corosync doesn't have such limit, so we should loose this checking.

But, loosing this check may have side effect: for normal/non-cloud environment, corosync might be configured with **crossed** link, in which scenario each node can not see each other after joining.

Take an example for **crossed** link:
```
node1's interface: eth1, eth2
node2's interface: eth1, eth2
node1: use eth1 for corosync
node2: use eth2 for corosync
```

So we should have to check the cluster status during joining. 
**If join node itself is online while can't see init node**, bootstrap on join node will:
1. recover original corosync.conf and sync it to init node
2. stop corosync.service on join node
3. exit with an error message 

On join node, it will successfully joined in cluster until using the correct link

## Unit test
a170cb839cce7fb5539e639603058e35d6b57389

## Functional test
b42cbe8eb6bb5070362e3b1fb9dec786fef7e548