### PR TITLE
Dev: bootstrap: binding interface when calling "crm cluster init" internally

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1652,8 +1652,8 @@ def join_ssh(seed_host):
     # authorized_keys file (again, to help with the case where the
     # user has done manual initial setup without the assistance of
     # ha-cluster-init).
-    if not invoke("ssh root@%s crm cluster init ssh_remote" % (seed_host)):
-        error("Can't invoke crm cluster init ssh_remote on %s" % (seed_host))
+    if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.nic)):
+        error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.nic, seed_host))
 
 
 def join_csync2(seed_host):
@@ -1674,8 +1674,8 @@ def join_csync2(seed_host):
 
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
-    if not invoke("ssh -o StrictHostKeyChecking=no root@{} crm cluster init csync2_remote {}".format(seed_host, utils.this_node())):
-        error("Can't invoke crm cluster init init csync2_remote on {}".format(seed_host))
+    if not invoke("ssh -o StrictHostKeyChecking=no root@{} crm cluster init -i {} csync2_remote {}".format(seed_host, _context.nic, utils.this_node())):
+        error("Can't invoke crm cluster init -i {} init csync2_remote on {}".format(_context.nic, seed_host))
 
     # This is necessary if syncing /etc/hosts (to ensure everyone's got the
     # same list of hosts)


### PR DESCRIPTION
#### Problem
In some network scenarios, there is no default route configured.
In that environment, when specifying interface while running `crm cluster init -i nic`, running `ssh_remote` and `csync2_remote` stages will fail as `Failed to determine default network interface`, because internally, bootstrap program try to find default network interface through route

#### Solution
Binding interface when calling "crm cluster init" in `ssh_remote` and `csync2_remote` stages can avoid such issue happened