### PR TITLE
Low: utils: update detect_cloud pattern for aws

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2130,7 +2130,7 @@ def detect_cloud():
     if not is_program("dmidecode"):
         return None
     rc, system_version = get_stdout("dmidecode -s system-version")
-    if re.search(r"\<.*\.amazon\>", system_version) is not None:
+    if re.search(r".*amazon.*", system_version) is not None:
         return "amazon-web-services"
     if rc != 0:
         return None


### PR DESCRIPTION
I have found that at least the new AWS instances are not detected with the `detect_cloud` method.

This is the current output: 
```
ec2-user@xarbulu-hana01:~> sudo dmidecode -s system-version
4.2.amazon
```