### PR TITLE
[crmsh-4.1] Low: utils: update detect_cloud pattern for aws

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2130,7 +2130,7 @@ def detect_cloud():
     if not is_program("dmidecode"):
         return None
     rc, system_version = get_stdout("dmidecode -s system-version")
-    if re.search(r"\<.*\.amazon\>", system_version) is not None:
+    if re.search(r".*amazon.*", system_version) is not None:
         return "amazon-web-services"
     if rc != 0:
         return None

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -6,11 +6,18 @@ from __future__ import unicode_literals
 
 import os
 import re
+import imp
 from unittest import mock
 from itertools import chain
 from crmsh import utils
 from crmsh import config
 from crmsh import tmpfiles
+
+def setup_function():
+    utils._ip_for_cloud = None
+    # Mock memoize method and reload the module under test later with imp
+    mock.patch('crmsh.utils.memoize', lambda x: x).start()
+    imp.reload(utils)
 
 
 @mock.patch('re.search')
@@ -290,3 +297,146 @@ def test_sysconfig_set_bsc1145823():
     utils.sysconfig_set(fname, age="100")
     sc = utils.parse_sysconfig(fname)
     assert (sc.get("age") == "100")
+
+@mock.patch("crmsh.utils.is_program")
+def test_detect_cloud_not_dmidecode(mock_is_program):
+    mock_is_program.return_value = False
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+def test_detect_cloud_aws(mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.return_value = (0, "4.2.amazon")
+    assert utils.detect_cloud() == "amazon-web-services"
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_called_once_with("dmidecode -s system-version")
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+def test_detect_cloud_aws_error(mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.return_value = (1, "other")
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_called_once_with("dmidecode -s system-version")
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_microsoft(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [(0, "other"), (0, "microsoft corporation")]
+    mock_metadata.return_value = "10.10.10.10"
+    assert utils.detect_cloud() == "microsoft-azure"
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer")
+    ])
+    mock_metadata.assert_called_once_with(
+        "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
+        headers={"Metadata": "true"})
+    assert utils._ip_for_cloud == "10.10.10.10"
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_microsoft_error(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [
+        (0, "other"), (0, "microsoft corporation"), (0, "microsoft corporation")]
+    mock_metadata.return_value = None
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer")
+    ])
+    mock_metadata.assert_called_once_with(
+        "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
+        headers={"Metadata": "true"})
+    assert utils._ip_for_cloud is None
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_microsoft_rc_error(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [
+        (0, "other"), (1, "other"), (0, "other")]
+    mock_metadata.return_value = None
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer")
+    ])
+    assert mock_metadata.call_count == 0
+    assert utils._ip_for_cloud is None
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_gcp(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [
+        (0, "other"), (1, "other"), (0, "Google")]
+    mock_metadata.return_value = "10.10.10.10"
+    assert utils.detect_cloud() == "google-cloud-platform"
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s bios-vendor")
+    ])
+    mock_metadata.assert_called_once_with(
+        "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
+        headers={"Metadata-Flavor": "Google"})
+    assert utils._ip_for_cloud == "10.10.10.10"
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_gcp_error(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [
+        (0, "other"), (0, "other"), (0, "Google")]
+    mock_metadata.return_value = None
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s bios-vendor")
+    ])
+    mock_metadata.assert_called_once_with(
+        "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
+        headers={"Metadata-Flavor": "Google"})
+    assert utils._ip_for_cloud is None
+
+
+@mock.patch("crmsh.utils.is_program")
+@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.utils._cloud_metadata_request")
+def test_detect_cloud_gcp_rc_error(mock_metadata, mock_get_stdout, mock_is_program):
+    mock_is_program.return_value = True
+    mock_get_stdout.side_effect = [
+        (0, "other"), (0, "other"), (1, "other")]
+    mock_metadata.return_value = None
+    assert utils.detect_cloud() is None
+    mock_is_program.assert_called_once_with("dmidecode")
+    mock_get_stdout.assert_has_calls([
+        mock.call("dmidecode -s system-version"),
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s bios-vendor")
+    ])
+    assert mock_metadata.call_count == 0
+    assert utils._ip_for_cloud is None


### PR DESCRIPTION
Backport from #522 and backport unittest from #524 