### PR TITLE
Fix bug of remove node(bsc#1165644)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -81,6 +81,7 @@ class Context(object):
         self.shared_device = None
         self.ocfs2_device = None
         self.cluster_node = None
+        self.cluster_node_ip = None
         self.force = None
         self.arbitrator = None
         self.clusters = None
@@ -96,6 +97,8 @@ class Context(object):
         self.default_ip_list = []
         self.local_ip_list = []
         self.local_network_list = []
+        self.rm_list = [SYSCONFIG_SBD, CSYNC2_CFG, corosync.conf(), CSYNC2_KEY,
+                COROSYNC_AUTH, "/var/lib/heartbeat/crm/*", "/var/lib/pacemaker/cib/*"]
 
     @classmethod
     def set_context(cls, options):
@@ -2159,82 +2162,25 @@ def start_qdevice_on_join_node(seed_host):
     status_done()
 
 
-def remove_ssh():
-    seed_host = _context.cluster_node
-    if not seed_host:
-        error("No existing IP/hostname specified (use -c option)")
-
-    # check whether corosync has been started on local node
-    if not utils.service_is_active("corosync.service"):
-        error("Cluster is not active - can't execute removing action")
-
-    remove_get_hostname(seed_host)
-
-
-def remove_get_hostname(seed_host):
+def set_cluster_node_ip():
     """
-    Get the nodename
+    ringx_addr might be hostname or IP
+    _context.cluster_node by now is always hostname
 
-    Sets _context.host_status to
-    0 = Disconnected
-    1 = Connected
-    2 = Connected through IP address
+    If ring0_addr is IP, we should get the configured iplist which belong _context.cluster_node
+    Then filter out which one is configured as ring0_addr
+    At last assign that ip to _context.cluster_node_ip which will be removed later
     """
-    _context.connect_name = seed_host
-    _context.host_status = 0
-
-    # if node is localhost, assume connected and hostname = cluster name
-    if seed_host == utils.this_node():
-        _context.cluster_node = seed_host
-        _context.host_status = 1
+    node = _context.cluster_node
+    addr_list = corosync.get_values('nodelist.node.ring0_addr')
+    if node in addr_list:
         return
 
-    _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(seed_host))
-    if outp:
-        _context.connect_name = seed_host
-        _context.cluster_node = outp.strip()
-        _context.host_status = 1
-    elif re.match(r'^[\[0-9].*', seed_host):
-        # IP address
-        warn("Could not connect to {}".format(seed_host))
-        nodename = prompt_for_string('Please enter the hostname of the node to be removed', '.+' "")
-        if not nodename:
-            error("Not a valid hostname")
-
-        if nodename not in xmlutil.listnodes():
-            error("Specified node {} is not configured in cluster, can not remove".format(nodename))
-
-        _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(nodename))
-        if outp:
-            _context.connect_name = seed_host
-            _context.cluster_node = nodename
-            _context.host_status = 1
-        else:
-            _context.host_status = 2
-    else:
-        if seed_host not in xmlutil.listnodes():
-            error("Specified node {} is not configured in cluster, can not remove".format(seed_host))
-
-        warn("Could not resolve hostname {}".format(seed_host))
-        nodename = prompt_for_string('Please enter the IP address of the node to be removed (e.g: 192.168.0.1)', r'([0-9]+\.){3}[0-9]+', "")
-        if not nodename:
-            error("Invalid IP address")
-
-        # try to use the IP address to connect
-        _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(nodename))
-        if outp:
-            ipaddr = nodename
-            nodename = outp.strip()
-            if nodename != seed_host:
-                warn("Specified IP address {ipaddr} is node {nodename}, not configured in cluster.".format(ipaddr=ipaddr, nodename=nodename))
-                warn("Trying to remove node {}".format(seed_host))
-                _context.host_status = 0
-                _context.cluster_node = nodename
-            else:
-                _context.host_status = 2
-                _context.connect_name = ipaddr
-        else:
-            _context.host_status = 0
+    ip_list = utils.get_iplist_from_name(node)
+    for ip in ip_list:
+        if ip in addr_list:
+            _context.cluster_node_ip = ip
+            break
 
 
 def remove_node_from_cluster():
@@ -2242,22 +2188,15 @@ def remove_node_from_cluster():
     Remove node from running cluster and the corosync / pacemaker configuration.
     """
     node = _context.cluster_node
+    set_cluster_node_ip()
 
-    if _context.host_status != 0:
-        status("Stopping the corosync service")
-        if not invoke('ssh -o StrictHostKeyChecking=no root@{} "systemctl stop corosync"'.format(_context.connect_name)):
-            error("Stopping corosync on {} failed".format(_context.connect_name))
+    status("Stopping the corosync service")
+    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "systemctl stop corosync"'.format(node)):
+        error("Stopping corosync on {} failed".format(node))
 
-        # delete configuration files from the node to be removed
-        toremove = [SYSCONFIG_SBD, CSYNC2_CFG, corosync.conf(), CSYNC2_KEY, COROSYNC_AUTH]
-        if not invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {} && rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*\\\""'.format(node, " ".join(toremove))):
-            error("Deleting the configuration files failed")
-    else:
-        # Check node status
-        _, outp = utils.get_stdout("crm_node --list")
-        if any("lost" in l for l in [l for l in outp.splitlines() if node in l.split()]):
-            if not confirm("The node has not been cleaned up... - remove it?"):
-                return
+    # delete configuration files from the node to be removed
+    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {}\\\""'.format(node, " ".join(_context.rm_list))):
+        error("Deleting the configuration files failed")
 
     # execute the command : crm node delete $HOSTNAME
     status("Removing the node {}".format(node))
@@ -2267,58 +2206,54 @@ def remove_node_from_cluster():
     if not invoke("sed -i /{}/d {}".format(node, CSYNC2_CFG)):
         error("Removing the node {} from {} failed".format(node, CSYNC2_CFG))
 
-    # Remove node from nodelist if this is a unicast configuration
-    if "nodelist" in open(corosync.conf()).read():
-        corosync.del_node(node)
+    # Remove node from nodelist
+    if corosync.get_values("nodelist.node.ring0_addr"):
+        del_target = _context.cluster_node_ip or node
+        corosync.del_node(del_target)
 
-    # Decrement expected_votes in corosync.conf
-    is_qdevice_configured = 1 if "net" in corosync.get_values("quorum.device.model") else 0
-    for vote in corosync.get_values("quorum.expected_votes"):
-        quorum = int(vote)
-        new_quorum = quorum - 1
-        if is_qdevice_configured > 0:
-            new_nodecount = 0
-            device_votes = 0
-            nodecount = 0
-
-            if corosync.get_value("quorum.device.net.algorithm") == "lms":
-                nodecount = int((quorum + 1)/2)
-                new_nodecount = nodecount - 1
-                device_votes = new_nodecount - 1
-
-            elif corosync.get_value("quorum.device.net.algorithm") == "ffsplit":
-                device_votes = 1
-                nodecount = quorum - device_votes
-                new_nodecount = nodecount - 1
-
-            if new_nodecount == 1:
-                device_votes = 0
-
-            corosync.set_value("quorum.device.votes", device_votes)
-            new_quorum = new_nodecount + device_votes
-
-        if is_qdevice_configured == 0:
-            corosync.set_value("quorum.two_node", 1 if new_quorum == 2 else 0)
-        corosync.set_value("quorum.expected_votes", str(new_quorum))
+    decrease_expected_votes()
 
     status("Propagating configuration changes across the remaining nodes")
     csync2_update(CSYNC2_CFG)
+    csync2_update(corosync.conf())
 
     # Trigger corosync config reload to ensure expected_votes is propagated
     invoke("corosync-cfgtool -R")
 
 
-def remove_localhost_check():
-    """
-    Check whether the specified node is a cluster member
-    or the local node.
-    """
-    nodename = _context.cluster_node
-    nodes = xmlutil.listnodes()
-    if nodename not in nodes:
-        error("Specified node {} is not configured in cluster! Unable to remove.".format(nodename))
+def decrease_expected_votes():
+    '''
+    Decrement expected_votes in corosync.conf
+    '''
+    vote = corosync.get_value("quorum.expected_votes")
+    if not vote:
+        return
+    quorum = int(vote)
+    new_quorum = quorum - 1
+    if utils.is_qdevice_configured():
+        new_nodecount = 0
+        device_votes = 0
+        nodecount = 0
 
-    return nodename == utils.this_node()
+        if corosync.get_value("quorum.device.net.algorithm") == "lms":
+            nodecount = int((quorum + 1)/2)
+            new_nodecount = nodecount - 1
+            device_votes = new_nodecount - 1
+
+        elif corosync.get_value("quorum.device.net.algorithm") == "ffsplit":
+            device_votes = 1
+            nodecount = quorum - device_votes
+            new_nodecount = nodecount - 1
+
+        if new_nodecount > 1:
+            new_quorum = new_nodecount + device_votes
+        else:
+            new_quorum = 0
+
+        corosync.set_value("quorum.device.votes", device_votes)
+    else:
+        corosync.set_value("quorum.two_node", 1 if new_quorum == 2 else 0)
+    corosync.set_value("quorum.expected_votes", str(new_quorum))
 
 
 def bootstrap_init(context):
@@ -2466,61 +2401,67 @@ def bootstrap_remove(context):
     """
     global _context
     _context = context
-    yes_to_all = _context.yes_to_all
-    cluster_node = _context.cluster_node
-    force = _context.force
+    force_flag = config.core.force or _context.force
+
+    init()
+
+    if not utils.service_is_active("corosync.service"):
+        error("Cluster is not active - can't execute removing action")
+
+    if _context.qdevice_rm_flag and _context.cluster_node:
+        error("Either remove node or qdevice")
 
     if _context.qdevice_rm_flag:
         remove_qdevice()
         return
 
-    if not yes_to_all and cluster_node is None:
+    if not _context.yes_to_all and _context.cluster_node is None:
         status("""Remove This Node from Cluster:
   You will be asked for the IP address or name of an existing node,
   which will be removed from the cluster. This command must be
   executed from a different node in the cluster.
 """)
-        cluster_node = prompt_for_string("IP address or hostname of cluster node (e.g.: 192.168.1.1)", ".+")
-        _context.cluster_node = cluster_node
+        _context.cluster_node = prompt_for_string("IP address or hostname of cluster node (e.g.: 192.168.1.1)", ".+")
 
-    init()
-    remove_ssh()
+    if not _context.cluster_node:
+        error("No existing IP/hostname specified (use -c option)")
 
-    if not force and not confirm("Removing node \"{}\" from the cluster: Are you sure?".format(cluster_node)):
+    _context.cluster_node = get_cluster_node_hostname()
+
+    if not force_flag and not confirm("Removing node \"{}\" from the cluster: Are you sure?".format(_context.cluster_node)):
         return
 
-    if remove_localhost_check():
-        if not config.core.force and not force:
+    if _context.cluster_node == utils.this_node():
+        if not force_flag:
             error("Removing self requires --force")
-        # get list of cluster nodes
-        me = utils.this_node()
-        nodes = xmlutil.listnodes(include_remote_nodes=False)
-        othernode = next((x for x in nodes if x != me), None)
-        if othernode is not None:
-            # remove from other node
-            cmd = "crm cluster remove{} -c {}".format(" -y" if yes_to_all else "", me)
-            rc = utils.ext_cmd_nosudo("ssh{} -o StrictHostKeyChecking=no {} '{}'".format("" if yes_to_all else " -t", othernode, cmd))
-            if rc != 0:
-                error("Failed to remove this node from {}".format(othernode))
-        else:
-            # stop cluster
-            if not stop_service("corosync"):
-                error("Stopping corosync failed")
+        remove_self()
+        return
 
-            # remove all trace of cluster from this node
-            # delete configuration files from the node to be removed
-            toremove = [
-                SYSCONFIG_SBD,
-                CSYNC2_CFG,
-                corosync.conf(),
-                CSYNC2_KEY,
-                COROSYNC_AUTH,
-                "/var/lib/heartbeat/crm/*",
-                "/var/lib/pacemaker/cib/*"]
-            if not invoke('bash -c "rm -f {}"'.format(" ".join(toremove))):
-                error("Deleting the configuration files failed")
-    else:
+    if _context.cluster_node in xmlutil.listnodes():
         remove_node_from_cluster()
+    else:
+        error("Specified node {} is not configured in cluster! Unable to remove.".format(_context.cluster_node))
+
+
+def remove_self():
+    me = _context.cluster_node
+    yes_to_all = _context.yes_to_all
+    nodes = xmlutil.listnodes(include_remote_nodes=False)
+    othernode = next((x for x in nodes if x != me), None)
+    if othernode is not None:
+        # remove from other node
+        cmd = "crm cluster remove{} -c {}".format(" -y" if yes_to_all else "", me)
+        rc = utils.ext_cmd_nosudo("ssh{} -o StrictHostKeyChecking=no {} '{}'".format("" if yes_to_all else " -t", othernode, cmd))
+        if rc != 0:
+            error("Failed to remove this node from {}".format(othernode))
+    else:
+        # stop cluster
+        if not stop_service("corosync"):
+            error("Stopping corosync failed")
+        # remove all trace of cluster from this node
+        # delete configuration files from the node to be removed
+        if not invoke('bash -c "rm -f {}"'.format(" ".join(_context.rm_list))):
+            error("Deleting the configuration files failed")
 
 
 def init_common_geo():

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -1131,19 +1131,6 @@ def del_node(addr):
     f.write(p.to_string())
     f.close()
 
-    # check for running config
-    try:
-        nodes = utils.list_cluster_nodes()
-    except Exception:
-        nodes = []
-    if nodes:
-        utils.ext_cmd(["corosync-cmapctl", "-D", "nodelist.node.%s.nodeid" % (nth)],
-                      shell=False)
-        utils.ext_cmd(["corosync-cmapctl", "-D", "nodelist.node.%s.ring0_addr" % (nth)],
-                      shell=False)
-        utils.ext_cmd(["corosync-cmapctl", "-D", "nodelist.node.%s.name" % (nth)],
-                      shell=False)
-
 
 _COROSYNC_CONF_TEMPLATE_HEAD = """# Please read the corosync.conf.5 manual page
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2173,6 +2173,21 @@ def get_nodeinfo_from_cmaptool():
     return nodeid_ip_dict
 
 
+def get_iplist_from_name(name):
+    """
+    Given node host name, return this host's ip list in corosync cmap
+    """
+    ip_list = []
+    nodeid = get_nodeid_from_name(name)
+    if not nodeid:
+        return ip_list
+    nodeinfo = {}
+    nodeinfo = get_nodeinfo_from_cmaptool()
+    if not nodeinfo:
+        return ip_list
+    return nodeinfo[nodeid]
+
+
 def valid_nodeid(nodeid):
     from . import bootstrap
     if not service_is_active('corosync.service'):

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -45,3 +45,19 @@ Feature: Regression test for bootstrap bugs
     And     Except "Cannot see peer node "hanode1", please check the communication IP" in stderr
     When    Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
+
+  @clean
+  Scenario: Remove correspond nodelist in corosync.conf while remove(bsc#1165644)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -u -i eth1 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    When    Run "crm corosync get nodelist.node.ring0_addr" on "hanode1"
+    Then    Expected "10.10.10.3" in stdout
+    When    Run "crm cluster remove hanode2 -y" on "hanode1"
+    Then    Online nodes are "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm corosync get nodelist.node.ring0_addr" on "hanode1"
+    Then    Expected "10.10.10.3" not in stdout

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -93,6 +93,12 @@ def step_impl(context, num):
     assert context.return_code == int(num)
 
 
+@then('Expected "{msg}" not in stdout')
+def step_impl(context, msg):
+    assert msg not in context.stdout
+    context.stdout = None
+
+
 @then('Except "{msg}"')
 def step_impl(context, msg):
     assert context.command_error_output == msg

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1090,3 +1090,482 @@ class TestValidation(unittest.TestCase):
 
         mock_ipv6.assert_called_once_with("10.10.10.1")
         mock_invoke.assert_called_once_with("ping -c 1 10.10.10.1")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_cluster_is_active(self, mock_context, mock_init, mock_active,
+            mock_error):
+        mock_context_inst = mock.Mock()
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+             bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_error.assert_called_once_with("Cluster is not active - can't execute removing action")
+
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_qdevice(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice):
+        mock_context_inst = mock.Mock(qdevice=True, cluster_node=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+
+        bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_error.assert_not_called()
+        mock_qdevice.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_qdevice_cluster_node(self, mock_context, mock_init, mock_active, mock_error):
+        mock_context_inst = mock.Mock(qdevice=True, cluster_node="node1")
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_error.assert_called_once_with("Either remove node or qdevice")
+
+    @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_no_cluster_node(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_status, mock_prompt):
+        mock_context_inst = mock.Mock(yes_to_all=False, cluster_node=None, qdevice_rm_flag=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_prompt.return_value = None
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_status.assert_called_once_with('Remove This Node from Cluster:\n  You will be asked for the IP address or name of an existing node,\n  which will be removed from the cluster. This command must be\n  executed from a different node in the cluster.\n')
+        mock_prompt.assert_called_once_with("IP address or hostname of cluster node (e.g.: 192.168.1.1)", ".+")
+        mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_no_confirm(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_hostname, mock_confirm):
+        mock_context_inst = mock.Mock(cluster_node="node1", force=False, qdevice_rm_flag=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_hostname.return_value = "node1"
+        mock_confirm.return_value = False
+
+        bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_error.assert_not_called()
+        mock_hostname.assert_called_once_with()
+        mock_confirm.assert_called_once_with('Removing node "node1" from the cluster: Are you sure?')
+
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_self_need_force(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node):
+        mock_context_inst = mock.Mock(cluster_node="node1", force=False, qdevice_rm_flag=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_hostname.return_value = "node1"
+        mock_confirm.return_value = True
+        mock_this_node.return_value = "node1"
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_hostname.assert_called_once_with()
+        mock_confirm.assert_called_once_with('Removing node "node1" from the cluster: Are you sure?')
+        mock_this_node.assert_called_once_with()
+        mock_error.assert_called_once_with("Removing self requires --force")
+
+    @mock.patch('crmsh.bootstrap.remove_self')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_self(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node, mock_self):
+        mock_context_inst = mock.Mock(cluster_node="node1", force=True, qdevice_rm_flag=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_hostname.return_value = "node1"
+        mock_this_node.return_value = "node1"
+
+        bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_hostname.assert_called_once_with()
+        mock_confirm.assert_not_called()
+        mock_this_node.assert_called_once_with()
+        mock_error.assert_not_called()
+        mock_self.assert_called_once_with()
+
+    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove_not_in_cluster(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node, mock_list):
+        mock_context_inst = mock.Mock(cluster_node="node2", force=True, qdevice_rm_flag=None)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_hostname.return_value = "node2"
+        mock_this_node.return_value = "node1"
+        mock_list.return_value = ["node1", "node3"]
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_hostname.assert_called_once_with()
+        mock_confirm.assert_not_called()
+        mock_this_node.assert_called_once_with()
+        mock_error.assert_called_once_with("Specified node node2 is not configured in cluster! Unable to remove.")
+
+    @mock.patch('crmsh.bootstrap.remove_node_from_cluster')
+    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.remove_qdevice')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.bootstrap.init')
+    @mock.patch('crmsh.bootstrap.Context')
+    def test_bootstrap_remove(self, mock_context, mock_init, mock_active,
+            mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node,
+            mock_list, mock_remove):
+        mock_context_inst = mock.Mock(cluster_node="node2", qdevice_rm_flag=None, force=True)
+        mock_context.return_value = mock_context_inst
+        mock_active.return_value = True
+        mock_hostname.return_value = "node2"
+        mock_this_node.return_value = "node1"
+        mock_list.return_value = ["node1", "node2"]
+
+        bootstrap.bootstrap_remove(mock_context_inst)
+
+        mock_init.assert_called_once_with()
+        mock_active.assert_called_once_with("corosync.service")
+        mock_qdevice.assert_not_called()
+        mock_hostname.assert_called_once_with()
+        mock_confirm.assert_not_called()
+        mock_this_node.assert_called_once_with()
+        mock_error.assert_not_called()
+        mock_remove.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice_not_configured(self, mock_configured, mock_error):
+        mock_configured.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.remove_qdevice()
+
+        mock_configured.assert_called_once_with()
+        mock_error.assert_called_once_with("No QDevice configuration in this cluster")
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice_not_confrim(self, mock_configured, mock_confirm):
+        mock_configured.return_value = True
+        mock_confirm.return_value = False
+
+        bootstrap.remove_qdevice()
+
+        mock_configured.assert_called_once_with()
+        mock_confirm.assert_called_once_with("Removing QDevice service and configuration from cluster: Are you sure?")
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.bootstrap.update_expected_votes')
+    @mock.patch('crmsh.corosync.QDevice')
+    @mock.patch('crmsh.corosync.get_value')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice(self, mock_configured, mock_confirm, mock_status, mock_invoke,
+            mock_long, mock_get_value, mock_qdevice, mock_expected, mock_done):
+        mock_configured.return_value = True
+        mock_confirm.return_value = True
+        mock_get_value.return_value = "node1"
+        mock_qdevice_inst = mock.Mock()
+        mock_qdevice.return_value = mock_qdevice_inst
+
+        bootstrap.remove_qdevice()
+
+        mock_configured.assert_called_once_with()
+        mock_confirm.assert_called_once_with("Removing QDevice service and configuration from cluster: Are you sure?")
+        mock_status.assert_has_calls([
+            mock.call("Disable corosync-qdevice.service"),
+            mock.call("Stopping corosync-qdevice.service")
+            ])
+        mock_invoke.assert_has_calls([
+            mock.call("crm cluster run 'systemctl disable corosync-qdevice'"),
+            mock.call("crm cluster run 'systemctl stop corosync-qdevice'"),
+            mock.call("crm cluster run 'crm corosync reload'")
+            ])
+        mock_long.assert_called_once_with("Removing QDevice configuration from cluster")
+        mock_get_value.assert_called_once_with("quorum.device.net.host")
+        mock_qdevice.assert_called_once_with("node1")
+        mock_qdevice_inst.remove_qdevice_config.assert_called_once_with()
+        mock_qdevice_inst.remove_qdevice_db.assert_called_once_with()
+        mock_expected.assert_called_once_with()
+        mock_done.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.ext_cmd_nosudo')
+    @mock.patch('crmsh.xmlutil.listnodes')
+    def test_remove_self_other_nodes(self, mock_list, mock_ext, mock_error):
+        mock_list.return_value = ["node1", "node2"]
+        mock_ext.return_value = 1
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True)
+            bootstrap.remove_self()
+
+        mock_list.assert_called_once_with(include_remote_nodes=False)
+        mock_ext.assert_called_once_with("ssh -o StrictHostKeyChecking=no node2 'crm cluster remove -y -c node1'")
+        mock_error.assert_called_once_with("Failed to remove this node from node2")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.stop_service')
+    @mock.patch('crmsh.xmlutil.listnodes')
+    def test_remove_self_stop_failed(self, mock_list, mock_stop_service, mock_error):
+        mock_list.return_value = ["node1"]
+        mock_stop_service.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True)
+            bootstrap.remove_self()
+
+        mock_list.assert_called_once_with(include_remote_nodes=False)
+        mock_stop_service.assert_called_once_with("corosync")
+        mock_error.assert_called_once_with("Stopping corosync failed")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.stop_service')
+    @mock.patch('crmsh.xmlutil.listnodes')
+    def test_remove_self_rm_failed(self, mock_list, mock_stop_service, mock_invoke, mock_error):
+        mock_list.return_value = ["node1"]
+        mock_stop_service.return_value = True
+        mock_invoke.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True, rm_list=["file1", "file2"])
+            bootstrap.remove_self()
+
+        mock_list.assert_called_once_with(include_remote_nodes=False)
+        mock_stop_service.assert_called_once_with("corosync")
+        mock_invoke.assert_called_once_with('bash -c "rm -f file1 file2"')
+        mock_error.assert_called_once_with("Deleting the configuration files failed")
+
+    @mock.patch('crmsh.utils.get_iplist_from_name')
+    @mock.patch('crmsh.corosync.get_values')
+    def test_set_cluster_node_ip_host(self, mock_get_values, mock_get_iplist):
+        mock_get_values.return_value = ["node1", "node2"]
+        bootstrap._context = mock.Mock(cluster_node="node1")
+        bootstrap.set_cluster_node_ip()
+        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_get_iplist.assert_not_called()
+
+    @mock.patch('crmsh.utils.get_iplist_from_name')
+    @mock.patch('crmsh.corosync.get_values')
+    def test_set_cluster_node_ip(self, mock_get_values, mock_get_iplist):
+        mock_get_values.return_value = ["10.10.10.1", "10.10.10.2"]
+        mock_get_iplist.return_value = ["10.10.10.1"]
+        bootstrap._context = mock.Mock(cluster_node="node1")
+        bootstrap.set_cluster_node_ip()
+        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_get_iplist.assert_called_once_with('node1')
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    def test_remove_node_from_cluster_stop_failed(self, mock_get_ip, mock_status,
+            mock_invoke, mock_error):
+        mock_invoke.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1")
+            bootstrap.remove_node_from_cluster()
+
+        mock_get_ip.assert_called_once_with()
+        mock_status.assert_called_once_with("Stopping the corosync service")
+        mock_invoke.assert_called_once_with('ssh -o StrictHostKeyChecking=no root@node1 "systemctl stop corosync"')
+        mock_error.assert_called_once_with("Stopping corosync on node1 failed")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    def test_remove_node_from_cluster_rm_failed(self, mock_get_ip, mock_status,
+            mock_invoke, mock_error):
+        mock_invoke.side_effect = [True, False]
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
+            bootstrap.remove_node_from_cluster()
+
+        mock_get_ip.assert_called_once_with()
+        mock_status.assert_called_once_with("Stopping the corosync service")
+        mock_invoke.assert_has_calls([
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "systemctl stop corosync"'),
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""')
+            ])
+        mock_error.assert_called_once_with("Deleting the configuration files failed")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    def test_remove_node_from_cluster_rm_node_failed(self, mock_get_ip, mock_status,
+            mock_invoke, mock_error):
+        mock_invoke.side_effect = [True, True, False]
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
+            bootstrap.remove_node_from_cluster()
+
+        mock_get_ip.assert_called_once_with()
+        mock_status.assert_has_calls([
+            mock.call("Stopping the corosync service"),
+            mock.call("Removing the node node1")
+            ])
+        mock_invoke.assert_has_calls([
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "systemctl stop corosync"'),
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
+            mock.call('crm node delete node1')
+            ])
+        mock_error.assert_called_once_with("Failed to remove node1")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    def test_remove_node_from_cluster_rm_csync_failed(self, mock_get_ip, mock_status,
+            mock_invoke, mock_error):
+        mock_invoke.side_effect = [True, True, True, False]
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
+            bootstrap.remove_node_from_cluster()
+
+        mock_get_ip.assert_called_once_with()
+        mock_status.assert_has_calls([
+            mock.call("Stopping the corosync service"),
+            mock.call("Removing the node node1")
+            ])
+        mock_invoke.assert_has_calls([
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "systemctl stop corosync"'),
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
+            mock.call('crm node delete node1'),
+            mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
+            ])
+        mock_error.assert_called_once_with("Removing the node node1 from {} failed".format(bootstrap.CSYNC2_CFG))
+
+    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.decrease_expected_votes')
+    @mock.patch('crmsh.corosync.del_node')
+    @mock.patch('crmsh.corosync.get_values')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    def test_remove_node_from_cluster_hostname(self, mock_get_ip, mock_status,
+            mock_invoke, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2):
+        mock_invoke.side_effect = [True, True, True, True, True]
+        mock_get_values.return_value = ["10.10.10.1"]
+
+        bootstrap._context = mock.Mock(cluster_node="node1", cluster_node_ip=None, rm_list=["file1", "file2"])
+        bootstrap.remove_node_from_cluster()
+
+        mock_get_ip.assert_called_once_with()
+        mock_status.assert_has_calls([
+            mock.call("Stopping the corosync service"),
+            mock.call("Removing the node node1"),
+            mock.call("Propagating configuration changes across the remaining nodes")
+            ])
+        mock_invoke.assert_has_calls([
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "systemctl stop corosync"'),
+            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
+            mock.call('crm node delete node1'),
+            mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG)),
+            mock.call("corosync-cfgtool -R")
+            ])
+        mock_error.assert_not_called()
+        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_del.assert_called_once_with("node1")
+        mock_decrease.assert_called_once_with()
+        mock_csync2.assert_has_calls([
+            mock.call(bootstrap.CSYNC2_CFG),
+            mock.call("/etc/corosync/corosync.conf")
+            ])

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1100,3 +1100,33 @@ class TestInterfacesInfo(unittest.TestCase):
         mock_interface_list.assert_called_once_with()
         mock_interface_inst_1.ip_in_network.assert_called_once_with("10.10.10.1")
         mock_interface_inst_2.ip_in_network.assert_called_once_with("10.10.10.1")
+
+
+@mock.patch("crmsh.utils.get_nodeid_from_name")
+def test_get_iplist_from_name_no_nodeid(mock_get_nodeid):
+    mock_get_nodeid.return_value = None
+    res = utils.get_iplist_from_name("test")
+    assert res == []
+    mock_get_nodeid.assert_called_once_with("test")
+
+
+@mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
+@mock.patch("crmsh.utils.get_nodeid_from_name")
+def test_get_iplist_from_name_no_nodeinfo(mock_get_nodeid, mock_get_nodeinfo):
+    mock_get_nodeid.return_value = "1"
+    mock_get_nodeinfo.return_value = None
+    res = utils.get_iplist_from_name("test")
+    assert res == []
+    mock_get_nodeid.assert_called_once_with("test")
+    mock_get_nodeinfo.assert_called_once_with()
+
+
+@mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
+@mock.patch("crmsh.utils.get_nodeid_from_name")
+def test_get_iplist_from_name(mock_get_nodeid, mock_get_nodeinfo):
+    mock_get_nodeid.return_value = "1"
+    mock_get_nodeinfo.return_value = {"1": ["10.10.10.1"], "2": ["10.10.10.2"]}
+    res = utils.get_iplist_from_name("test")
+    assert res == ["10.10.10.1"]
+    mock_get_nodeid.assert_called_once_with("test")
+    mock_get_nodeinfo.assert_called_once_with()


### PR DESCRIPTION
## Problem
After running `crm cluster remove peer-node`,
* On udpu mode, peer-node's address wouldn't be removed in corosync.conf
* Value of `expected_votes` and `two_node` changed, but not sync to other left cluster nodes
* `bootstrap_remove` function is huge, better to split into smaller one
* `remove_get_hostname` function is complex, I think it's not necessary to let user input once again,
just exit with error message. So I decide to delete this function
## Solution
- `On udpu mode, peer-node's address wouldn't be removed in corosync.conf`
  This is because pass the hostname to `corosync.del_node`, not ip address;
  Add `get_cluster_node_ip` function to make sure we got the right parameter value, that is to say,
  if a hostname configured, pass that hostname, if IP configured, pass that IP
- `Value of expected_votes and two_node changed, but not sync to other left cluster nodes`
  Calling `csync2_update` to sync corosync.conf after all things are done.
## Test
* Functional test
* Unit test