### PR TITLE
Qdevice configure process improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,12 @@ jobs:
         - $FUNCTIONAL_TEST qdevice before_install
       script:
         - $FUNCTIONAL_TEST qdevice run validate
+    
+    - name: "functional test for qdevice - user case"
+      before_install:
+        - $FUNCTIONAL_TEST qdevice before_install
+      script:
+        - $FUNCTIONAL_TEST qdevice run usercase
 
     - name: "functional test for resource subcommand"
       before_install:

--- a/data-manifest
+++ b/data-manifest
@@ -71,6 +71,7 @@ test/features/bootstrap_options.feature
 test/features/environment.py
 test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature
+test/features/qdevice_usercase.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
 test/features/resource_set.feature

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -9,7 +9,7 @@ before() {
 
   # deploy first node hanode1
   docker run -d --name=hanode1 --hostname hanode1 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Docker_image}
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
   docker network connect --ip=10.10.10.2 second_net hanode1
   docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
@@ -21,7 +21,7 @@ before() {
 
   # deploy second node hanode2
   docker run -d --name=hanode2 --hostname hanode2 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" ${Docker_image}
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
   docker network connect --ip=10.10.10.3 second_net hanode2
   docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
@@ -34,7 +34,7 @@ before() {
   if [ x"$1" == x"qdevice" ];then
     # deploy node qnetd-node for qnetd service
     docker run -d --name=qnetd-node --hostname qnetd-node \
-	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Docker_image}
+	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --shm-size="1g" ${Docker_image}
     docker network connect --ip=10.10.10.9 second_net qnetd-node
     docker exec -t qnetd-node /bin/sh -c "zypper ref;zypper -n in corosync-qnetd"
     docker exec -t qnetd-node /bin/sh -c "systemctl start sshd.service"

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -1,0 +1,63 @@
+@qdevice
+Feature: Verify usercase master survive when split-brain
+
+  Steps to setup a two-nodes cluster with heuristics qdevice,
+  started with a promotable clone resource, and make sure master side always with quorum:
+  1. Setup a two-nodes cluster
+  2. Generate script to check whether this node is master
+  3. Add a promotable clone resource
+  4. Setup qdevice with heuristics
+  5. Use iptables command to simulate split-brain
+  6. Check whether hanode1 has quorum, while hanode2 doesn't
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  Background: Cluster and qdevice service are stopped
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Service "corosync-qdevice" is "stopped" on "hanode1"
+    And     Service "corosync-qdevice" is "stopped" on "hanode2"
+
+  @clean
+  Scenario: Master survive when split-brain
+    # Setup a two-nodes cluster
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+
+    # Generate script to check whether this node is master
+    When    Write multi lines to file "/etc/corosync/qdevice/check_master.sh"
+      """
+      #!/usr/bin/sh
+      crm_resource --locate -r promotable-1 2>&1 | grep Master | grep `crm_node -n` >/dev/null 2>&1
+      """
+    And     Run "chmod +x /etc/corosync/qdevice/check_master.sh" on "hanode1"
+    And     Run "scp -p /etc/corosync/qdevice/check_master.sh root@hanode2:/etc/corosync/qdevice" on "hanode1"
+    # Add a promotable clone resource and make sure hanode1 is master
+    And     Run "crm configure primitive stateful-1 ocf:pacemaker:Stateful op monitor_Slave interval=10s op monitor_Master interval=5s" on "hanode1"
+    And     Run "crm configure clone promotable-1 stateful-1 meta promotable=true" on "hanode1"
+    And     Run "sleep 5" on "hanode1"
+    Then    Show cluster status on "hanode1"
+
+    # Setup qdevice with heuristics
+    When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node --qdevice-heuristics=/etc/corosync/qdevice/check_master.sh -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    When    Run "sleep 5" on "hanode1"
+    Then    Show status from qnetd
+    When    Run "corosync-quorumtool -s" on "hanode1"
+    Then    Expected "Quorate:          Yes" in stdout
+    When    Run "ssh root@hanode2 corosync-quorumtool -s" on "hanode1"
+    Then    Expected "Quorate:          Yes" in stdout
+    # Use iptables command to simulate split-brain
+    When    Run "iptables -I INPUT -s 172.17.0.3 -j DROP; iptables -I OUTPUT -d 172.17.0.3 -j DROP" on "hanode1"
+    And     Run "iptables -I INPUT -s 172.17.0.2 -j DROP; iptables -I OUTPUT -d 172.17.0.2 -j DROP" on "hanode2"
+    # Check whether hanode1 has quorum, while hanode2 doesn't
+    And     Run "sleep 20" on "hanode1"
+    When    Run "corosync-quorumtool -s" on "hanode1"
+    Then    Expected "Quorate:          Yes" in stdout
+    When    Run "ssh root@hanode2 corosync-quorumtool -s" on "hanode1"
+    Then    Expected "Quorate:          No" in stdout
+    And     Show cluster status on "hanode1"
+    And     Show cluster status on "hanode2"

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -29,26 +29,34 @@ Feature: corosync qdevice/qnetd options validate
     Then    Except "ERROR: cluster.init: invalid qdevice port range(1024 - 65535)"
 
   @clean
-  Scenario: Option "--qdevice-algo" set wrong value
-    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-algo=wrongalgo"
-    Then    Except "ERROR: cluster.init: invalid qdevice algorithm(ffsplit/lms)"
-
-  @clean
   Scenario: Option "--qdevice-tie-breaker" set wrong value
     When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tie-breaker=wrongtiebreaker"
     Then    Except "ERROR: cluster.init: invalid qdevice tie_breaker(lowest/highest/valid_node_id)"
 
   @clean
-  Scenario: Option "--qdevice-tls" set wrong value
-    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=wrong"
-    Then    Except "ERROR: cluster.init: invalid qdevice tls(on/off/required)"
-
-  @clean
   Scenario: Option "--qdevice-heuristics" set wrong value
     When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='ls /opt'"
     Then    Except "ERROR: cluster.init: commands for heuristics should be absolute path"
-    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/bin/not_exists_cmd /opt'"
-    Then    Except "ERROR: cluster.init: command /bin/not_exists_cmd not exists"
+    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/bin/not_exist_cmd /opt'"
+    Then    Except "ERROR: cluster.init: command /bin/not_exist_cmd not exist"
+
+  @clean
+  Scenario: Option "--qnetd-hostname" is required by other qdevice options
+    When    Try "crm cluster init --qdevice-port=1234"
+    Then    Except multiple lines
+      """
+      usage: init [options] [STAGE]
+      crm: error: Option --qnetd-hostname is required if want to configure qdevice
+      """
+
+  @clean
+  Scenario: Option --qdevice-heuristics is required if want to configure heuristics mode
+    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics-mode="on""
+    Then    Except multiple lines
+      """
+      usage: init [options] [STAGE]
+      crm: error: Option --qdevice-heuristics is required if want to configure heuristics mode
+      """
 
   @clean
   Scenario: Node for qnetd is a cluster node
@@ -56,7 +64,30 @@ Feature: corosync qdevice/qnetd options validate
     When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
-    Then    Except "ERROR: cluster.init: host for qnetd must be a non-cluster node"
+    Then    Except multiple lines
+      """"
+      ERROR: cluster.init: host for qnetd must be a non-cluster node
+      Cluster service already successfully started on this node
+      If you still want to use qdevice, change to another host or stop cluster service on hanode2
+      Then run command "crm cluster init qdevice --qnetd-hostname=hanode2"
+      This command will setup qdevice separately
+      """
+    And     Cluster service is "started" on "hanode1"
+    When    Run "crm cluster stop" on "hanode2"
+
+  @clean
+  Scenario: Node for qnetd not installed corosync-qnetd
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
+    Then    Except multiple lines
+      """"
+      ERROR: cluster.init: Package "corosync-qnetd" not installed on hanode2
+      Cluster service already successfully started on this node
+      If you still want to use qdevice, install "corosync-qnetd" on hanode2
+      Then run command "crm cluster init qdevice --qnetd-hostname=hanode2"
+      This command will setup qdevice separately
+      """
+    And     Cluster service is "started" on "hanode1"
 
   @clean
   Scenario: Run qdevice stage on inactive cluster node

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -91,6 +91,10 @@ Network configuration:
   -M, --multi-heartbeats
                         Configure corosync with second heartbeat line
   -I, --ipv6            Configure corosync use IPv6
+
+QDevice configuration:
+  Options for configuring QDevice and QNetd.
+
   --qnetd-hostname HOST
                         HOST or IP of the QNetd server to be used
   --qdevice-port PORT   TCP PORT of QNetd server(default:5403)
@@ -105,6 +109,9 @@ Network configuration:
                         COMMAND to run with absolute path. For multiple
                         commands, use ";" to separate(details about heuristics
                         can see man 8 corosync-qdevice)
+  --qdevice-heuristics-mode MODE
+                        MODE of operation of heuristics(on/sync/off,
+                        default:sync)
 
 Storage configuration:
   Options for configuring shared storage.

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -6,6 +6,10 @@ from utils import check_cluster_state, check_service_state, online, run_command,
                   run_command_local_or_remote
 import const
 
+@when('Write multi lines to file "{f}"')
+def step_impl(context, f):
+    with open(f, 'w') as fd:
+        fd.write(context.text)
 
 @given('Cluster service is "{state}" on "{addr}"')
 def step_impl(context, state, addr):

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -74,6 +74,12 @@ def step_impl(context, msg):
     context.command_error_output = None
 
 
+@then('Except multiple lines')
+def step_impl(context):
+    assert context.command_error_output.split('\n') == context.text.split('\n')
+    context.command_error_output = None
+
+
 @then('Except "{msg}" in stderr')
 def step_impl(context, msg):
     assert msg in context.command_error_output


### PR DESCRIPTION
## Overview

The work of this pull request was based on #464 
Changes include:

- Check whether corosync-qdevice installed
- Check whether corosync-qnetd installed
- All qdevice related options require --qnetd-hostname
- Add --qdevice-heuristics-mode option to configure heuristics mode
- Make qdevice related options as a separate argparse group
- Test master survive scenarios using behave
- Complete unit test and functional test

## Details
- **Check whether corosync-qdevice installed**
```
# when corosync-qdevice not installed
crm cluster init -y --qnetd-hostname=10.10.10.53
ERROR: cluster.init: Package "corosync-qdevice" not installed on this node
```
- **Check whether corosync-qnetd installed**
  When valid qnetd raise ValueError, give specific suggestion
```
# when corosync-qnetd not installed on remote node
crm cluster init -y --qnetd-hostname=10.10.10.53
WARNING: chronyd.service is not configured to start at system boot.
  Generating SSH key
  Configuring csync2
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
  Configuring corosync
WARNING: Not configuring SBD (/etc/sysconfig/sbd left untouched).
  Hawk cluster interface is now running. To see cluster status, open:
    https://192.168.122.120:7630/
  Log in with username 'hacluster'
  Waiting for cluster..............done
  Loading initial cluster configuration
  
Configure Qdevice/Qnetd
  Copy ssh key to qnetd node(10.10.10.53)
Password: 
ERROR: cluster.init: Package "corosync-qnetd" not installed on 10.10.10.53
Cluster service already successfully started on this node
If you still want to use qdevice, install "corosync-qnetd" on 10.10.10.53
Then run command "crm cluster init qdevice --qnetd-hostname=10.10.10.53"
This command will setup qdevice separately
```
- **All qdevice related options require --qnetd-hostname**
```
crm cluster init -y --qdevice-port=1234
usage: init [options] [STAGE]
crm: error: Option --qnetd-hostname is required if want to configure qdevice
```
- **Add --qdevice-heuristics-mode option to configure heuristics mode**
- **Make qdevice related options as a separate argparse group**
```
QDevice configuration:
  Options for configuring QDevice and QNetd.

  --qnetd-hostname HOST
                        HOST or IP of the QNetd server to be used
  --qdevice-port PORT   TCP PORT of QNetd server(default:5403)
  --qdevice-algo ALGORITHM
                        QNetd decision ALGORITHM(ffsplit/lms, default:ffsplit)
  --qdevice-tie-breaker TIE_BREAKER
                        QNetd TIE_BREAKER(lowest/highest/valid_node_id,
                        default:lowest)
  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd(on/off/required,
                        default:on)
  --qdevice-heuristics COMMAND
                        COMMAND to run with absolute path. For multiple
                        commands, use ";" to separate(details about heuristics
                        can see man 8 corosync-qdevice)
  --qdevice-heuristics-mode MODE
                        MODE of operation of heuristics(on/sync/off,
                        default:sync)
```

- **Test master survive scenarios using behave**
```
@qdevice
Feature: Verify usercase master survive when split-brain

  Steps to setup a two-nodes cluster with heuristics qdevice,
  started with a promotable clone resource, and make sure master side always with quorum:
  1. Setup a two-nodes cluster
  2. Generate script to check whether this node is master
  3. Add a promotable clone resource
  4. Setup qdevice with heuristics
  5. Use iptables command to simulate split-brain
  6. Check whether hanode1 has quorum, while hanode2 doesn't

  Tag @clean means need to stop cluster service if the service is available

  Background: Cluster and qdevice service are stopped
    Given   Cluster service is "stopped" on "hanode1"
    And     Cluster service is "stopped" on "hanode2"
    And     Service "corosync-qdevice" is "stopped" on "hanode1"
    And     Service "corosync-qdevice" is "stopped" on "hanode2"

  @clean
  Scenario: Master survive when split-brain
    # Setup a two-nodes cluster
    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
    Then    Cluster service is "started" on "hanode1"
    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
    Then    Cluster service is "started" on "hanode2"

    # Generate script to check whether this node is master
    When    Write multi lines to file "/etc/corosync/qdevice/check_master.sh"
      """
      #!/usr/bin/sh
      crm_resource --locate -r promotable-1 2>&1 | grep Master | grep `crm_node -n` >/dev/null 2>&1
      """
    And     Run "chmod +x /etc/corosync/qdevice/check_master.sh" on "hanode1"
    And     Run "scp -p /etc/corosync/qdevice/check_master.sh root@hanode2:/etc/corosync/qdevice" on "hanode1"
    # Add a promotable clone resource and make sure hanode1 is master
    And     Run "crm configure primitive stateful-1 ocf:pacemaker:Stateful op monitor_Slave interval=10s op monitor_Master interval=5s" on "hanode1"
    And     Run "crm configure clone promotable-1 stateful-1 meta promotable=true" on "hanode1"
    And     Run "sleep 5" on "hanode1"
    Then    Show cluster status on "hanode1"

    # Setup qdevice with heuristics
    When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node --qdevice-heuristics=/etc/corosync/qdevice/check_master.sh -y" on "hanode1"
    Then    Service "corosync-qdevice" is "started" on "hanode1"
    And     Service "corosync-qdevice" is "started" on "hanode2"
    When    Run "sleep 5" on "hanode1"
    Then    Show status from qnetd
    When    Run "corosync-quorumtool -s" on "hanode1"
    Then    Expected "Quorate:          Yes" in stdout
    When    Run "ssh root@hanode2 corosync-quorumtool -s" on "hanode1"
    Then    Expected "Quorate:          Yes" in stdout
    # Use iptables command to simulate split-brain
    When    Run "iptables -I INPUT -s 172.17.0.3 -j DROP; iptables -I OUTPUT -d 172.17.0.3 -j DROP" on "hanode1"
    And     Run "iptables -I INPUT -s 172.17.0.2 -j DROP; iptables -I OUTPUT -d 172.17.0.2 -j DROP" on "hanode2"
    # Check whether hanode1 has quorum, while hanode2 doesn't
    And     Run "sleep 20" on "hanode1"
    When    Run "corosync-quorumtool -s" on "hanode1"
    Then    Expected "Quorate:          Yes" in stdout
    When    Run "ssh root@hanode2 corosync-quorumtool -s" on "hanode1"
    Then    Expected "Quorate:          No" in stdout
    And     Show cluster status on "hanode1"
    And     Show cluster status on "hanode2"
```