### PR TITLE
Resolve csync2 conflicts(bsc#1166684)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -784,9 +784,17 @@ include /etc/pacemaker/authkey;
 
 
 def csync2_update(path):
-    invoke("csync2 -rm %s" % (path))
-    invoke("csync2 -rf %s" % (path))
-    invoke("csync2 -rxv %s" % (path))
+    '''
+    Sync path to all peers
+
+    If there was a conflict, use '-f' to force this side to win
+    '''
+    invoke("csync2 -rm {}".format(path))
+    if invoke("csync2 -rxv {}".format(path)):
+        return
+    invoke("csync2 -rf {}".format(path))
+    if not invoke("csync2 -rxv {}".format(path)):
+        warn("{} was not synced".format(path))
 
 
 def init_csync2_remote():
@@ -1740,7 +1748,7 @@ def join_csync2(seed_host):
     # they haven't gone to all nodes in the cluster, which means a
     # subseqent join of another node can fail its sync of corosync.conf
     # when it updates expected_votes.  Grrr...
-    if not invoke('ssh -o StrictHostKeyChecking=no root@%s "csync2 -mr / ; csync2 -fr / ; csync2 -xv"' % (seed_host)):
+    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "csync2 -rm /; csync2 -rxv || csync2 -rf / && csync2 -rxv"'.format(seed_host)):
         print("")
         warn("csync2 run failed - some files may not be sync'd")
 

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -36,7 +36,7 @@ before() {
     docker run -d --name=qnetd-node --hostname qnetd-node \
 	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Docker_image}
     docker network connect --ip=10.10.10.9 second_net qnetd-node
-    docker exec -t qnetd-node /bin/sh -c "zypper -n in corosync-qnetd"
+    docker exec -t qnetd-node /bin/sh -c "zypper ref;zypper -n in corosync-qnetd"
     docker exec -t qnetd-node /bin/sh -c "systemctl start sshd.service"
 
     # deploy node without ssh.service running for validation

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -32,6 +32,8 @@ Feature: corosync qdevice/qnetd setup/remove process
     Then    Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
     And     Service "corosync-qdevice" is "stopped" on "hanode2"
+    When    Run "echo "# This is a test for bsc#1166684" >> /etc/corosync/corosync.conf" on "hanode1"
+    When    Run "scp /etc/corosync/corosync.conf root@hanode2:/etc/corosync" on "hanode1"
     When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode1"
     Then    Service "corosync-qdevice" is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode2"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -282,3 +282,25 @@ class TestBootstrap(unittest.TestCase):
         mock_csync2.assert_not_called()
         mock_stop_service.assert_not_called()
         mock_error.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_csync2_update_no_conflicts(self, mock_invoke):
+        mock_invoke.side_effect = [True, True]
+        bootstrap.csync2_update("/etc/corosync.conf")
+        mock_invoke.assert_has_calls([
+            mock.call("csync2 -rm /etc/corosync.conf"),
+            mock.call("csync2 -rxv /etc/corosync.conf")
+            ])
+
+    @mock.patch('crmsh.bootstrap.warn')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_csync2_update(self, mock_invoke, mock_warn):
+        mock_invoke.side_effect = [True, False, True, False]
+        bootstrap.csync2_update("/etc/corosync.conf")
+        mock_invoke.assert_has_calls([
+            mock.call("csync2 -rm /etc/corosync.conf"),
+            mock.call("csync2 -rxv /etc/corosync.conf"),
+            mock.call("csync2 -rf /etc/corosync.conf"),
+            mock.call("csync2 -rxv /etc/corosync.conf")
+            ])
+        mock_warn.assert_called_once_with("/etc/corosync.conf was not synced")


### PR DESCRIPTION
Based on https://github.com/LINBIT/csync2/blob/master/doc/csync2.adoc#resolving-a-conflict
Csync2 option -f should be used **after** conflicts happen, not **before**

This PR based on the truth that:
We trust each steps change to configure file **on the bootstrap side**, so we use -f option to win all possible conficts

#### Functional test
```
When    Run "echo "# This is test for bsc#1166684" >> /etc/corosync/corosync.conf" on "hanode1"
When    Run "scp /etc/corosync/corosync.conf root@hanode2:/etc/corosync" on "hanode1"
```
These two lines added after two-nodes cluster started.
Means change the corosync.conf manually, so csync2 db not aware the change.
Then next functional test try to setup qdevice on the running cluster.
Command `csync -rxv /etc/corosync/corosync.conf` will failed.
Now use '-f' option to force to win for the conflicts.