### PR TITLE
Bootstrap network improvement

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -41,8 +41,6 @@ SYSCONFIG_FW = "/etc/sysconfig/SuSEfirewall2"
 SYSCONFIG_FW_CLUSTER = "/etc/sysconfig/SuSEfirewall2.d/services/cluster"
 PCMK_REMOTE_AUTH = "/etc/pacemaker/authkey"
 COROSYNC_CONF_ORIG = tmpfiles.create()[1]
-
-
 INIT_STAGES = ("ssh", "ssh_remote", "csync2", "csync2_remote", "corosync", "storage", "sbd", "cluster", "vgfs", "admin", "qdevice")
 
 
@@ -61,10 +59,10 @@ class Context(object):
         self.cluster_name = None
         self.watchdog = None
         self.no_overwrite_sshkey = None
-        self.nic = None
+        self.nic_list = None
         self.unicast = None
         self.admin_ip = None
-        self.second_hb = None
+        self.second_heartbeat = None
         self.ipv6 = None
         self.qdevice = None
         self.qdevice_host = None
@@ -81,11 +79,17 @@ class Context(object):
         self.arbitrator = None
         self.clusters = None
         self.tickets = None
-        self.ip_address = None
-        self.ip_network = None
         self.sbd_manager = None
         self.sbd_devices = None
         self.diskless_sbd = None
+        self.stage = None
+        self.args = None
+        self.ui_context = None
+        self.interfaces_inst = None
+        self.default_nic_list = []
+        self.default_ip_list = []
+        self.local_ip_list = []
+        self.local_network_list = []
 
     @classmethod
     def set_context(cls, options):
@@ -105,6 +109,26 @@ class Context(object):
                 tls=self.qdevice_tls,
                 cmds=self.qdevice_heuristics,
                 mode=self.qdevice_heuristics_mode)
+
+    def validate_option(self):
+        """
+        Validate options
+        """
+        if self.admin_ip:
+            try:
+                Validation.valid_admin_ip(self.admin_ip)
+            except ValueError as err:
+                error(err)
+        if self.qdevice:
+            try:
+                self.qdevice.valid_attr(self.interfaces_inst)
+            except ValueError as err:
+                error(err)
+        if self.nic_list:
+            if len(self.nic_list) > 2:
+                error("Maximum number of interface is 2")
+            if len(self.nic_list) != len(set(self.nic_list)):
+                error("Duplicated input")
 
     def init_sbd_manager(self):
         self.sbd_manager = SBDManager(self.sbd_devices, self.diskless_sbd)
@@ -346,6 +370,13 @@ def error(*args):
     die(*args)
 
 
+def print_error_msg(msg):
+    """
+    Just print error message
+    """
+    print(term.render(clidisplay.error("ERROR:")) + " {}".format(msg))
+
+
 def warn(*args):
     """
     Log and display a warning message.
@@ -384,9 +415,10 @@ def drop_last_history():
         readline.remove_history_item(hlen - 1)
 
 
-def prompt_for_string(msg, match=None, default='', valid_func=None, prev_value=None):
+def prompt_for_string(msg, match=None, default='', valid_func=None, prev_value=[]):
     if _context.yes_to_all:
         return default
+
     while True:
         disable_completion()
         val = utils.multi_input('  %s [%s]' % (msg, default))
@@ -395,12 +427,22 @@ def prompt_for_string(msg, match=None, default='', valid_func=None, prev_value=N
             val = default
         else:
             drop_last_history()
-        if match is None:
+
+        if not val:
+            return None
+        if not match and not valid_func:
             return val
-        if val and re.match(match, val) is not None:
-            if not valid_func or valid_func(val, prev_value):
-                return val
-        print(term.render(clidisplay.error("    Invalid value entered")))
+        if match and not re.match(match, val):
+            print_error_msg("Invalid value entered")
+            continue
+        if valid_func:
+            try:
+                valid_func(val, prev_value)
+            except ValueError as err:
+                print_error_msg(err)
+                continue
+
+        return val
 
 
 def confirm(msg):
@@ -497,7 +539,7 @@ def get_cluster_node_hostname():
     """
     peer_node = None
     if _context.cluster_node:
-        if utils.valid_ip_addr(_context.cluster_node):
+        if utils.IP.is_valid_ip(_context.cluster_node):
             rc, out, err = utils.get_stdout_stderr("ssh {} crm_node --name".format(_context.cluster_node))
             if rc != 0:
                 error(err)
@@ -743,30 +785,20 @@ def log_start():
 
 def init_network():
     """
-    Auto-detection of IP address and netmask only works if $NET_IF is
-    up. If $IP_ADDRESS is overridden, network detect shouldn't work,
-    because "ip route" won't be able to help us.
+    Get all needed network information through utils.InterfacesInfo
     """
-    if not _context.ipv6:
-        nic, ipaddr, ipnetwork, _prefix = utils.network_defaults(_context.nic)
-    else:
-        all_ = utils.network_v6_all()
-        if not all_:
-            error("Unable to configure network: No usable IPv6 addresses found.")
-        nic = sorted(all_.keys())[0]
-        ipaddr = all_[nic][0].split('/')[0]
-        ipnetwork = utils.get_ipv6_network(all_[nic][0])
+    interfaces_inst = utils.InterfacesInfo(_context.ipv6, _context.second_heartbeat, _context.nic_list)
+    interfaces_inst.get_interfaces_info()
+    _context.default_nic_list = interfaces_inst.get_default_nic_list_from_route()
+    _context.default_ip_list = interfaces_inst.get_default_ip_list()
 
-    if _context.nic is None:
-        _context.nic = nic
-    if _context.ip_address is None:
-        _context.ip_address = ipaddr
-    if _context.ip_network is None:
-        _context.ip_network = ipnetwork
-    if _context.ip_address is None:
-        warn("Could not detect IP address for {}".format(nic))
-    if _context.ip_network is None:
-        warn("Could not detect IP network address for {}".format(nic))
+    # local_ip_list and local_network_list are for validation
+    _context.local_ip_list = interfaces_inst.ip_list
+    _context.local_network_list = interfaces_inst.network_list
+    _context.interfaces_inst = interfaces_inst
+    # use two "-i" options equal to use "-M" option
+    if len(_context.default_nic_list) == 2 and not _context.second_heartbeat:
+        _context.second_heartbeat = True
 
 
 def configure_firewall(tcp=None, udp=None):
@@ -896,8 +928,8 @@ def init_cluster_local():
     if service_is_available("hawk.service"):
         start_service("hawk.service")
         status("Hawk cluster interface is now running. To see cluster status, open:")
-        status("  https://%s:7630/" % (_context.ip_address))
-        status("Log in with username 'hacluster'%s" % (pass_msg))
+        status("  https://{}:7630/".format(_context.default_ip_list[0]))
+        status("Log in with username 'hacluster'{}".format(pass_msg))
     else:
         warn("Hawk not installed - not configuring web management interface.")
 
@@ -1098,108 +1130,90 @@ def init_remote_auth():
     os.chmod(PCMK_REMOTE_AUTH, 0o640)
 
 
-def valid_network(addr, prev_value=None):
+class Validation(object):
     """
-    bindnetaddr(IPv4) must one of the local networks or local IP addresses
+    Class to validate values from interactive inputs
     """
-    if prev_value and addr == prev_value[0]:
-        warn("  Network address '{}' is already in use!".format(addr))
-        return False
 
-    all_networks = utils.network_all()
-    all_ips = utils.ip_in_local()
-    if addr in all_networks or \
-       addr in all_ips:
-        return True
-    warn("  Address '{}' invalid, expected one of {}".format(addr, all_networks + all_ips))
-    return False
+    def __init__(self, value, prev_value_list=[]):
+        """
+        Init function
+        """
+        self.value = value
+        self.prev_value_list = prev_value_list
+        if self.value in self.prev_value_list:
+            raise ValueError("Already in use: {}".format(self.value))
 
+    def _is_mcast_addr(self):
+        """
+        Check whether the address is multicast address
+        """
+        if not utils.IP.is_mcast(self.value):
+            raise ValueError("{} is not multicast address".format(self.value))
 
-def valid_v6_network(addr, prev_value=None):
-    """
-    bindnetaddr(IPv6) must be one of the local networks
-    """
-    if prev_value and addr == prev_value[0]:
-        warn("  Network address '{}' is already in use!".format(addr))
-        return False
-    network_list = []
-    all_ = utils.network_v6_all()
-    # the format of return example:
-    # {'eth2': ['2002:db8::3/64'], 'eth1': ['2001:db8::3/64']}
-    if not all_:
-        return False
-    for item in list(all_.values()):
-        network_list.extend(item)
-    network_list = [utils.get_ipv6_network(x) for x in network_list]
-    if addr in network_list:
-        return True
-    warn("  Address '{}' invalid, expected one of {}".format(addr, network_list))
-    return False
+    def _is_local_addr(self, local_addr_list):
+        """
+        Check whether the address is in local
+        """
+        if self.value not in local_addr_list:
+            raise ValueError("Address must be a local address (one of {})".format(local_addr_list))
 
+    def _is_valid_port(self):
+        """
+        Check whether the port is valid
+        """
+        if self.prev_value_list and abs(int(self.value) - int(self.prev_value_list[0])) <= 1:
+            raise ValueError("Port {} is already in use by corosync. Leave a gap between multiple rings.".format(self.value))
+        if int(self.value) <= 1024 or int(self.value) > 65535:
+            raise ValueError("Valid port range should be 1025-65535")
 
-def valid_ucastIP(addr, prev_value=None):
-    if prev_value and addr == prev_value[0]:
-        print(term.render(clidisplay.error("    IP {} is already in use".format(addr))))
-        return False
-    ip_local = utils.ip_in_local(_context.ipv6)
-    if addr not in ip_local:
-        print(term.render(clidisplay.error("    IP must be a local address (one of {})".format(ip_local))))
-        return False
-    return True
+    @classmethod
+    def valid_mcast_address(cls, addr, prev_value_list=[]):
+        """
+        Check whether the address is already in use and whether the address is for multicast
+        """
+        cls_inst = cls(addr, prev_value_list)
+        cls_inst._is_mcast_addr()
 
+    @classmethod
+    def valid_ucast_ip(cls, addr, prev_value_list=[]):
+        """
+        Check whether the address is already in use and whether the address exists on local
+        """
+        cls_inst = cls(addr, prev_value_list)
+        cls_inst._is_local_addr(_context.local_ip_list)
 
-def valid_adminIP(addr, prev_value=None):
-    """
-    valid adminIP for IPv4/IPv6
-    """
-    try:
-        ip = utils.IP(addr)
-    except ValueError as err:
-        print(term.render(clidisplay.error("    {}".format(err))))
-        return False
-    else:
-        all_ = []
-        if ip.version() == 4:
-            ping = "ping"
-            all_ = utils.network_all(with_mask=True)
-        else:
-            # for IPv6
-            ping = "ping6"
-            network_list = utils.network_v6_all()
-            for item in list(network_list.values()):
-                all_.extend(item)
-        if invoke("{} -c 1 {}".format(ping, addr)):
-            warn("  Address already in use: {}".format(addr))
-            return False
-        for net in all_:
-            if utils.ip_in_network(addr, net):
-                return True
-        warn("  Address '{}' invalid, expected one of {}".format(addr, all_))
-        return False
+    @classmethod
+    def valid_mcast_ip(cls, addr, prev_value_list=[]):
+        """
+        Check whether the address is already in use and whether the address exists on local address and network
+        """
+        cls_inst = cls(addr, prev_value_list)
+        cls_inst._is_local_addr(_context.local_ip_list + _context.local_network_list)
 
+    @classmethod
+    def valid_port(cls, port, prev_value_list=[]):
+        """
+        Check whether the port is valid
+        """
+        cls_inst = cls(port, prev_value_list)
+        cls_inst._is_valid_port()
 
-def valid_ipv4_addr(addr, prev_value=None):
-    if prev_value and addr == prev_value[0]:
-        warn("  Address already in use: {}".format(addr))
-        return False
-    return utils.valid_ip_addr(addr)
+    @staticmethod
+    def valid_admin_ip(addr, prev_value_list=[]):
+        """
+        Validate admin IP address
+        """
+        ipv6 = utils.IP.is_ipv6(addr)
 
+        # Check whether this IP already configured in cluster
+        ping_cmd = "ping6" if ipv6 else "ping"
+        if invoke("{} -c 1 {}".format(ping_cmd, addr)):
+            raise ValueError("Address already in use: {}".format(addr))
 
-def valid_ipv6_addr(addr, prev_value=None):
-    if prev_value and addr == prev_value[0]:
-        warn("  Address already in use: {}".format(addr))
-        return False
-    return utils.valid_ip_addr(addr, 6)
-
-
-def valid_port(port, prev_value=None):
-    if prev_value:
-        if abs(int(port) - int(prev_value[0])) <= 1:
-            warn("  Port {} is already in use by corosync. Leave a gap between multiple rings.".format(port))
-            return False
-    if int(port) >= 1024 and int(port) <= 65535:
-        return True
-    return False
+        # Check whether this IP belong to one of local network
+        if not utils.InterfacesInfo.ip_in_network(addr):
+            raise ValueError("Address '{}' not in any local network".format(addr))
 
 
 def add_nodelist_from_cmaptool():
@@ -1219,59 +1233,48 @@ def init_corosync_unicast():
 Configure Corosync (unicast):
   This will configure the cluster messaging layer.  You will need
   to specify a network address over which to communicate (default
-  is %s's network, but you can use the network address of any
+  is {}'s network, but you can use the network address of any
   active interface).
-""" % (_context.nic))
-
-    if os.path.exists(corosync.conf()):
-        if not confirm("%s already exists - overwrite?" % (corosync.conf())):
-            return
+""".format(_context.default_nic_list[0]))
 
     ringXaddr_res = []
     mcastport_res = []
     default_ports = ["5405", "5407"]
     two_rings = False
 
-    local_iplist = utils.ip_in_local(_context.ipv6)
-    len_iplist = len(local_iplist)
-    if len_iplist == 0:
-        error("No network configured at {}!".format(utils.this_node()))
-
-    default_ip = [_context.ip_address] + [ip for ip in local_iplist if ip != _context.ip_address]
-
-    for i in 0, 1:
-        ringXaddr = prompt_for_string('Address for ring{}'.format(i),
-                                      r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                      pick_default_value(default_ip, ringXaddr_res),
-                                      valid_ucastIP,
-                                      ringXaddr_res)
+    for i in range(2):
+        ringXaddr = prompt_for_string(
+                'Address for ring{}'.format(i),
+                default=pick_default_value(_context.default_ip_list, ringXaddr_res),
+                valid_func=Validation.valid_ucast_ip,
+                prev_value=ringXaddr_res)
         if not ringXaddr:
             error("No value for ring{}".format(i))
         ringXaddr_res.append(ringXaddr)
 
-        mcastport = prompt_for_string('Port for ring{}'.format(i),
-                                      '[0-9]+',
-                                      pick_default_value(default_ports, mcastport_res),
-                                      valid_port,
-                                      mcastport_res)
+        mcastport = prompt_for_string(
+                'Port for ring{}'.format(i),
+                match='[0-9]+',
+                default=pick_default_value(default_ports, mcastport_res),
+                valid_func=Validation.valid_port,
+                prev_value=mcastport_res)
         if not mcastport:
             error("Expected a multicast port for ring{}".format(i))
         mcastport_res.append(mcastport)
 
         if i == 1 or \
-           len_iplist == 1 or \
-           not _context.second_hb or \
+           not _context.second_heartbeat or \
            not confirm("\nAdd another heartbeat line?"):
             break
         two_rings = True
 
     corosync.create_configuration(
-        clustername=_context.cluster_name,
-        ringXaddr=ringXaddr_res,
-        mcastport=mcastport_res,
-        transport="udpu",
-        ipv6=_context.ipv6,
-        two_rings=two_rings)
+            clustername=_context.cluster_name,
+            ringXaddr=ringXaddr_res,
+            mcastport=mcastport_res,
+            transport="udpu",
+            ipv6=_context.ipv6,
+            two_rings=two_rings)
     csync2_update(corosync.conf())
 
 
@@ -1293,95 +1296,54 @@ def init_corosync_multicast():
 Configure Corosync:
   This will configure the cluster messaging layer.  You will need
   to specify a network address over which to communicate (default
-  is %s's network, but you can use the network address of any
+  is {}'s network, but you can use the network address of any
   active interface).
-""" % (_context.nic))
-
-    if os.path.exists(corosync.conf()):
-        if not confirm("%s already exists - overwrite?" % (corosync.conf())):
-            return
+""".format(_context.default_nic_list[0]))
 
     bindnetaddr_res = []
     mcastaddr_res = []
     mcastport_res = []
     default_ports = ["5405", "5407"]
     two_rings = False
-    default_networks = []
 
-    if _context.ipv6:
-        network_list = []
-        all_ = utils.network_v6_all()
-        for item in list(all_.values()):
-            network_list.extend(item)
-        default_networks = [utils.get_ipv6_network(x) for x in network_list]
-    else:
-        network_list = utils.network_all()
-        if len(network_list) > 1:
-            network_list.remove(_context.ip_network)
-            default_networks = [_context.ip_network, network_list[0]]
-        else:
-            default_networks = [_context.ip_network]
-    if not default_networks:
-        error("No network configured at {}!".format(utils.this_node()))
+    for i in range(2):
+        bindnetaddr = prompt_for_string(
+                'IP or network address to bind to',
+                default=pick_default_value(_context.default_ip_list, bindnetaddr_res),
+                valid_func=Validation.valid_mcast_ip,
+                prev_value=bindnetaddr_res)
+        if not bindnetaddr:
+            error("No value for bindnetaddr")
+        bindnetaddr_res.append(bindnetaddr)
 
-    for i in 0, 1:
-        if _context.ipv6:
-            bindnetaddr = prompt_for_string('Network address to bind to',
-                                            r'.*(::|0)$',
-                                            pick_default_value(default_networks, bindnetaddr_res),
-                                            valid_v6_network,
-                                            bindnetaddr_res)
-            if not bindnetaddr:
-                error("No value for bindnetaddr")
-            bindnetaddr_res.append(bindnetaddr)
+        mcastaddr = prompt_for_string(
+                'Multicast address',
+                default=gen_mcastaddr(),
+                valid_func=Validation.valid_mcast_address,
+                prev_value=mcastaddr_res)
+        if not mcastaddr:
+            error("No value for mcastaddr")
+        mcastaddr_res.append(mcastaddr)
 
-            mcastaddr = prompt_for_string('Multicast address',
-                                          r'^[Ff][Ff].*',
-                                          gen_mcastaddr(),
-                                          valid_ipv6_addr,
-                                          mcastaddr_res)
-            if not mcastaddr:
-                error("No value for mcastaddr")
-            mcastaddr_res.append(mcastaddr)
-
-        else:
-            bindnetaddr = prompt_for_string('Network address to bind to (e.g.: 192.168.1.0)',
-                                            r'([0-9]+\.){3}[0-9]+',
-                                            pick_default_value(default_networks, bindnetaddr_res),
-                                            valid_network,
-                                            bindnetaddr_res)
-            if not bindnetaddr:
-                error("No value for bindnetaddr")
-            bindnetaddr_res.append(bindnetaddr)
-
-            mcastaddr = prompt_for_string('Multicast address (e.g.: 239.x.x.x)',
-                                          utils.mcast_regrex,
-                                          gen_mcastaddr(),
-                                          valid_ipv4_addr,
-                                          mcastaddr_res)
-            if not mcastaddr:
-                error("No value for mcastaddr")
-            mcastaddr_res.append(mcastaddr)
-
-        mcastport = prompt_for_string('Multicast port',
-                                      '[0-9]+',
-                                      pick_default_value(default_ports, mcastport_res),
-                                      valid_port,
-                                      mcastport_res)
+        mcastport = prompt_for_string(
+                'Multicast port',
+                match='[0-9]+',
+                default=pick_default_value(default_ports, mcastport_res),
+                valid_func=Validation.valid_port,
+                prev_value=mcastport_res)
         if not mcastport:
             error("No value for mcastport")
         mcastport_res.append(mcastport)
 
         if i == 1 or \
-           len(default_networks) == 1 or \
-           not _context.second_hb or \
+           not _context.second_heartbeat or \
            not confirm("\nConfigure a second multicast ring?"):
             break
         two_rings = True
 
     nodeid = None
     if _context.ipv6:
-        nodeid = utils.gen_nodeid_from_ipv6(_context.ip_address)
+        nodeid = utils.gen_nodeid_from_ipv6(_context.default_ip_list[0])
 
     corosync.create_configuration(
         clustername=_context.cluster_name,
@@ -1405,6 +1367,11 @@ def init_corosync():
         return host is not None
 
     init_corosync_auth()
+
+    if os.path.exists(corosync.conf()):
+        if not confirm("%s already exists - overwrite?" % (corosync.conf())):
+            return
+
     if _context.unicast or requires_unicast():
         init_corosync_unicast()
     else:
@@ -1674,7 +1641,7 @@ Configure Administration IP Address:
         if not confirm("Do you wish to configure a virtual IP address?"):
             return
 
-        adminaddr = prompt_for_string('Virtual IP', r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:', "", valid_adminIP)
+        adminaddr = prompt_for_string('Virtual IP', valid_func=Validation.valid_admin_ip)
         if not adminaddr:
             error("Expected an IP address")
 
@@ -1806,8 +1773,8 @@ def join_ssh(seed_host):
     # authorized_keys file (again, to help with the case where the
     # user has done manual initial setup without the assistance of
     # ha-cluster-init).
-    if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.nic)):
-        error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.nic, seed_host))
+    if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.default_nic_list[0])):
+        error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.default_nic_list[0], seed_host))
 
 
 def join_csync2(seed_host):
@@ -1828,7 +1795,7 @@ def join_csync2(seed_host):
 
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
-    cmd = "crm cluster init -i {} csync2_remote {}".format(_context.nic, utils.this_node())
+    cmd = "crm cluster init -i {} csync2_remote {}".format(_context.default_nic_list[0], utils.this_node())
     if not invoke("ssh -o StrictHostKeyChecking=no root@{} {}".format(seed_host, cmd)):
         error("Can't invoke \"{}\" on {}".format(cmd, seed_host))
 
@@ -1986,12 +1953,7 @@ def join_cluster(seed_host):
     """
     def get_local_nodeid():
         # for IPv6
-        all_ = utils.network_v6_all()
-        if not all_:
-            error("Doesn't have any usable IPv6 addresses!")
-        nic = sorted(all_.keys())[0]
-        ipaddr = all_[nic][0].split('/')[0]
-        return utils.gen_nodeid_from_ipv6(ipaddr)
+        return utils.gen_nodeid_from_ipv6(_context.local_ip_list[0])
 
     def update_nodeid(nodeid, node=None):
         # for IPv6
@@ -2009,6 +1971,8 @@ def join_cluster(seed_host):
     if ipv6 and ipv6 == "ipv6":
         ipv6_flag = True
     _context.ipv6 = ipv6_flag
+
+    init_network()
 
     # check whether have two rings
     rrp_flag = False
@@ -2049,21 +2013,14 @@ def join_cluster(seed_host):
     # if unicast, we need to add our node to $corosync.conf()
     is_unicast = utils.is_unicast()
     if is_unicast:
-        local_iplist = utils.ip_in_local(_context.ipv6)
-        len_iplist = len(local_iplist)
-        if len_iplist == 0:
-            error("No network configured at {}!".format(utils.this_node()))
-
-        default_ip = [_context.ip_address] + [ip for ip in local_iplist if ip != _context.ip_address]
-
         ringXaddr_res = []
         for i in 0, 1:
             while True:
-                ringXaddr = prompt_for_string('Address for ring{}'.format(i),
-                                              r'([0-9]+\.){3}[0-9]+|[0-9a-fA-F]{1,4}:',
-                                              pick_default_value(default_ip, ringXaddr_res),
-                                              valid_ucastIP,
-                                              ringXaddr_res)
+                ringXaddr = prompt_for_string(
+                        'Address for ring{}'.format(i),
+                        default=pick_default_value(_context.default_ip_list, ringXaddr_res),
+                        valid_func=Validation.valid_ucast_ip,
+                        prev_value=ringXaddr_res)
                 if not ringXaddr:
                     error("No value for ring{}".format(i))
                 ringXaddr_res.append(ringXaddr)
@@ -2321,18 +2278,12 @@ def bootstrap_init(context):
     """
     Init cluster process
     """
-    def check_option():
-        if _context.admin_ip and not valid_adminIP(_context.admin_ip):
-            error("Invalid option: admin_ip")
-        if _context.qdevice:
-            try:
-                _context.qdevice.valid_attr()
-            except ValueError as err:
-                error(err)
-
     global _context
     _context = context
+
+    init()
     _context.init_qdevice()
+    _context.validate_option()
     _context.init_sbd_manager()
 
     stage = _context.stage
@@ -2353,8 +2304,6 @@ def bootstrap_init(context):
         if corosync_active:
             error("Cluster is currently active - can't run %s stage" % (stage))
 
-    check_option()
-
     # Need hostname resolution to work, want NTP (but don't block ssh_remote or csync2_remote)
     if stage not in ('ssh_remote', 'csync2_remote'):
         check_tty()
@@ -2366,8 +2315,6 @@ def bootstrap_init(context):
         if len(args) != 2:
             error("Expected NODE argument to csync2_remote")
         _context.cluster_node = args[1]
-
-    init()
 
     if stage != "":
         globals()["init_" + stage]()
@@ -2397,7 +2344,10 @@ def bootstrap_join(context):
     """
     global _context
     _context = context
+
+    init()
     _context.init_sbd_manager()
+    _context.validate_option()
 
     check_tty()
 
@@ -2407,8 +2357,6 @@ def bootstrap_join(context):
 
     if not check_prereqs("join"):
         return
-
-    init()
 
     cluster_node = _context.cluster_node
     if _context.stage != "":

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -137,10 +137,10 @@ class QDevice(object):
     def qdevice_p12_on_cluster(self):
         return "{}/{}/{}".format(self.qdevice_path, self.cluster_node, self.qdevice_p12_filename)
 
-    def valid_attr(self):
+    def valid_attr(self, interfaces_inst):
         if not bootstrap.package_is_installed("corosync-qdevice"):
             raise ValueError("Package \"corosync-qdevice\" not installed on this node")
-        if self.ip == utils.this_node() or self.ip in utils.ip_in_local():
+        if self.ip == utils.this_node() or self.ip in interfaces_inst.ip_list:
             raise ValueError("host for qnetd must be a remote one")
         if not utils.resolve_hostnames([self.ip])[0]:
             raise ValueError("host \"{}\" is unreachable".format(self.ip))
@@ -850,7 +850,8 @@ def find_configured_ip(ip_list):
     # all_possible_ip is a ip set to check whether one of them already configured
     all_possible_ip = set(ip_list)
     # get local ip list
-    local_ip_list = utils.ip_in_local(utils.is_ipv6(ip_list[0]))
+    is_ipv6 = utils.IP.is_ipv6(ip_list[0])
+    local_ip_list = utils.InterfacesInfo.get_local_ip_list(is_ipv6)
     # extend all_possible_ip if ip_list contain local ip
     # to avoid this scenarios in join node:
     #   eth0's ip already configured in corosync.conf

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -221,14 +221,14 @@ Note:
                             help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
-        network_group.add_argument("-i", "--interface", dest="nic", metavar="IF", choices=utils.interface_choice(),
-                                   help="Bind to IP address on interface IF")
+        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
+                                   help="Bind to IP address on interface IF. Use -i second time for second interface")
         network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
                                    help="Configure corosync to communicate over unicast (UDP), and not multicast. " +
                                    "Default is multicast unless an environment where multicast cannot be used is detected.")
         network_group.add_argument("-A", "--admin-ip", dest="admin_ip", metavar="IP",
                                    help="Configure IP address as an administration virtual IP")
-        network_group.add_argument("-M", "--multi-heartbeats", action="store_true", dest="second_hb",
+        network_group.add_argument("-M", "--multi-heartbeats", action="store_true", dest="second_heartbeat",
                                    help="Configure corosync with second heartbeat line")
         network_group.add_argument("-I", "--ipv6", action="store_true", dest="ipv6",
                                    help="Configure corosync use IPv6")
@@ -323,8 +323,8 @@ If stage is not specified, each stage will be invoked in sequence.
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
-        network_group.add_argument("-i", "--interface", dest="nic", metavar="IF", choices=utils.interface_choice(),
-                help="Bind to IP address on interface IF")
+        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
+                help="Bind to IP address on interface IF. Use -i second time for second interface")
         options, args = parse_options(parser, args)
         if options is None or args is None:
             return

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -25,9 +25,6 @@ from . import term
 from .msg import common_warn, common_info, common_debug, common_err, err_buf
 
 
-mcast_regrex = r'2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}'
-
-
 def to_ascii(input_str):
     """Convert the bytes string to a ASCII string
     Usefull to remove accent (diacritics)"""
@@ -91,94 +88,6 @@ gethomedir = userdir.gethomedir
 def this_node():
     'returns name of this node (hostname)'
     return os.uname()[1]
-
-
-def network_defaults(interface=None):
-    """
-    returns (interface, ip-address, network, prefix-length)
-    """
-    def valfor(l, key):
-        for i in range(0, len(l) - 1):
-            if l[i] == key:
-                return l[i + 1]
-        return None
-    _, outp = get_stdout("/sbin/ip -o route show")
-    info = [None, None, None, None]
-    if interface is not None:
-        info[0] = interface
-    for l in outp.splitlines():
-        sp = l.split()
-        if info[0] is None and len(sp) >= 5 and sp[0] == 'default' and sp[1] == 'via':
-            info[0] = sp[4]
-        if info[0] is not None and valfor(sp, 'dev') == info[0] and sp[0] != 'default':
-            src = valfor(sp, 'src')
-            if sp[0].find('/') >= 0:
-                nw, length = sp[0].split('/')
-                info[1], info[2], info[3] = src, nw, length
-                break
-            # we are reading /32 route entry
-            else:
-                info[1], info[2], info[3] = src, sp[0], 32
-    if info[0] is None:
-        raise ValueError("Failed to determine default network interface")
-    if info[1] is None:
-        ips = ip_in_local()
-        if len(ips) > 0:
-            info[1] = ips[0]
-    return tuple(info)
-
-
-def network_all(with_mask=False):
-    """
-    returns all networks on local node
-    """
-    all_networks = []
-    _, outp = get_stdout("/sbin/ip -o route show")
-    for l in outp.split('\n'):
-        if re.search(r'\.0/[0-9]+ ', l):
-            if with_mask:
-                all_networks.append(l.split()[0])
-            else:
-                all_networks.append(l.split('/')[0])
-    return all_networks
-
-
-def network_v6_all():
-    _, outp = get_stdout("/sbin/ip -6 -o addr show")
-    dict_ = {}
-    for line in outp.split('\n'):
-        if re.search(r' ::1/| [Ff][Ee]80:', line):
-            # skip local address and link-local address
-            continue
-        dict_[line.split()[1]] = []
-    for line in outp.split('\n'):
-        if re.search(r' ::1/| [Ff][Ee]80:', line):
-            # skip local address and link-local address
-            continue
-        dict_[line.split()[1]].append(line.split()[3])
-    return dict_
-
-
-def ip_in_local(IPv6=False):
-    # short-circuit ip list handling for
-    # cloud providers in order to use
-    # metadata service instead
-    ips = iplist_for_cloud()
-    if len(ips) > 0:
-        return ips
-
-    if not IPv6:
-        regex = r' [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]+ '
-    else:
-        regex = r' [0-9a-fA-F]{1,4}:.*:[0-9a-fA-F]{1,4}/[0-9]+ '
-
-    ip_local = []
-    _, outp = get_stdout("/sbin/ip addr show")
-    tmp = re.findall(regex, outp, re.M)
-    if tmp:
-        tmp = map(lambda x: x.split('/')[0].strip(), tmp)
-        ip_local += filter(lambda x: x != "127.0.0.1" and not re.search(r'^[Ff][Ee]80:', x), tmp)
-    return ip_local
 
 
 _cib_shadow = 'CIB_shadow'
@@ -2050,45 +1959,11 @@ def obscure(obscure_list):
         _obscured_nvpairs = prev
 
 
-def valid_ip_addr(addr, version=4):
-    import socket
-    try:
-        if version == 4:
-            socket.inet_pton(socket.AF_INET, addr)
-        elif version == 6:
-            socket.inet_pton(socket.AF_INET6, addr)
-        else:
-            return False
-    except socket.error:
-        return False
-    return True
-
-
-def get_ipv6_network(addr_with_mask):
-    return str(ipaddress.ip_interface(addr_with_mask).network.network_address)
-
-
 def gen_nodeid_from_ipv6(addr):
     return int(ipaddress.ip_address(addr)) % 1000000000
 
 
-def ip_in_network(addr, net):
-    return ipaddress.ip_address(addr) in ipaddress.ip_interface(net).network
-
-
-class IP:
-    def __init__(self, addr):
-        self.addr = ipaddress.ip_address(addr)
-
-    def version(self):
-        return self.addr.version
-
-
-def is_ipv6(addr):
-    return IP(addr).version() == 6
-
-
-# Set by detect_cloud() or iplist_for_cloud()
+# Set by detect_cloud()
 # to avoid multiple requests
 _ip_for_cloud = None
 
@@ -2158,24 +2033,6 @@ def detect_cloud():
             _ip_for_cloud = result
             return "google-cloud-platform"
     return None
-
-
-def iplist_for_cloud():
-    """
-    Return list of viable IPs for the
-    current cloud provider (if any)
-    """
-    global _ip_for_cloud
-    provider = detect_cloud()
-    if _ip_for_cloud is not None:
-        return [_ip_for_cloud]
-    if provider == "amazon-web-services":
-        uri = "http://169.254.169.254/latest/meta-data/local-ipv4"
-        result = _cloud_metadata_request(uri)
-        if result:
-            _ip_for_cloud = result
-            return [_ip_for_cloud]
-    return []
 
 
 def debug_timestamp():
@@ -2287,4 +2144,264 @@ def interface_choice():
     # should consider interface format like "ethx@xxx"
     interface_list = re.findall(r'(?:[0-9]+:) (.*?)(?=: |@.*?: )', out)
     return [nic for nic in interface_list if nic != "lo"]
+
+
+class IP(object):
+    """
+    Class to get some properties of IP address
+    """
+
+    def __init__(self, addr):
+        """
+        Init function
+        """
+        self.addr = addr
+
+    @property
+    def ip_address(self):
+        """
+        Create ipaddress instance
+        """
+        return ipaddress.ip_address(self.addr)
+
+    @property
+    def version(self):
+        """
+        Get IP address version
+        """
+        return self.ip_address.version
+
+    @classmethod
+    def is_mcast(cls, addr):
+        """
+        Check whether the address is multicast address
+        """
+        cls_inst = cls(addr)
+        return cls_inst.ip_address.is_multicast
+
+    @classmethod
+    def is_ipv6(cls, addr):
+        """
+        Check whether the address is IPV6 address
+        """
+        return cls(addr).version == 6
+
+    @classmethod
+    def is_valid_ip(cls, addr):
+        """
+        Check whether the address is valid IP address
+        """
+        cls_inst = cls(addr)
+        try:
+            cls_inst.ip_address
+        except ValueError:
+            return False
+        else:
+            return True
+
+    @property
+    def is_loopback(self):
+        """
+        Check whether the address is loopback address
+        """
+        return self.ip_address.is_loopback
+
+    @property
+    def is_link_local(self):
+        """
+        Check whether the address is link-local address
+        """
+        return self.ip_address.is_link_local
+
+
+class Interface(IP):
+    """
+    Class to get information from one interface
+    """
+
+    def __init__(self, ip_with_mask):
+        """
+        Init function
+        """
+        self.ip, self.mask = ip_with_mask.split('/')
+        super(__class__, self).__init__(self.ip)
+
+    @property
+    def ip_with_mask(self):
+        """
+        Get ip with netmask
+        """
+        return '{}/{}'.format(self.ip, self.mask)
+
+    @property
+    def ip_interface(self):
+        """
+        Create ip_interface instance
+        """
+        return ipaddress.ip_interface(self.ip_with_mask)
+
+    @property
+    def network(self):
+        """
+        Get network address
+        """
+        return str(self.ip_interface.network.network_address)
+
+    def ip_in_network(self, addr):
+        """
+        Check whether the addr in the network
+        """
+        return IP(addr).ip_address in self.ip_interface.network
+
+
+class InterfacesInfo(object):
+    """
+    Class to collect interfaces information on local node
+    """
+
+    def __init__(self, ipv6=False, second_heartbeat=False, custom_nic_list=[]):
+        """
+        Init function
+
+        On init process,
+        "ipv6" is provided by -I option
+        "second_heartbeat" is provided by -M option
+        "custom_nic_list" is provided by -i option
+        """
+        self.ip_version = 6 if ipv6 else 4
+        self.second_heartbeat = second_heartbeat
+        self._default_nic_list = custom_nic_list
+        self._nic_info_dict = {}
+
+    def get_interfaces_info(self):
+        """
+        Try to get interfaces info dictionary via "ip" command
+
+        IMPORTANT: This is the method that populates the data, should always be called after initialize
+        """
+        cmd = "ip -{} -o addr show".format(self.ip_version)
+        rc, out, err = get_stdout_stderr(cmd)
+        if rc != 0:
+            raise ValueError(err)
+
+        # format on each line will like:
+        # 2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0\       valid_lft forever preferred_lft forever
+        for line in out.splitlines():
+            _, nic, _, ip_with_mask, *_ = line.split()
+            #TODO change this condition when corosync support link-local address
+            interface_inst = Interface(ip_with_mask)
+            if interface_inst.is_loopback or interface_inst.is_link_local:
+                continue
+            # one nic might configured multi IP addresses
+            if nic not in self._nic_info_dict:
+                self._nic_info_dict[nic] = []
+            self._nic_info_dict[nic].append(interface_inst)
+
+        if not self._nic_info_dict:
+            raise ValueError("No address configured")
+        if self.second_heartbeat and len(self._nic_info_dict) == 1:
+            raise ValueError("Cannot configure second heartbeat, since only one address is available")
+
+    @property
+    def nic_list(self):
+        """
+        Get interfaces name list
+        """
+        return list(self._nic_info_dict.keys())
+
+    @property
+    def interface_list(self):
+        """
+        Get instance list of class Interface
+        """
+        _interface_list = []
+        for interface in self._nic_info_dict.values():
+            _interface_list.extend(interface)
+        return _interface_list
+
+    @property
+    def ip_list(self):
+        """
+        Get IP address list
+        """
+        return [interface.ip for interface in self.interface_list]
+
+    @classmethod
+    def get_local_ip_list(cls, is_ipv6):
+        """
+        Get IP address list
+        """
+        cls_inst = cls(is_ipv6)
+        cls_inst.get_interfaces_info()
+        return cls_inst.ip_list
+
+    @property
+    def network_list(self):
+        """
+        Get network list
+        """
+        return list(set([interface.network for interface in self.interface_list]))
+
+    def _nic_first_ip(self, nic):
+        """
+        Get the first IP of specific nic
+        """
+        return self._nic_info_dict[nic][0].ip
+
+    def get_default_nic_list_from_route(self):
+        """
+        Get default nic list from route
+        """
+        if self._default_nic_list:
+            return self._default_nic_list
+
+        #TODO what if user only has ipv6 route?
+        cmd = "ip -o route show"
+        rc, out, err = get_stdout_stderr(cmd)
+        if rc != 0:
+            raise ValueError(err)
+        res = re.search(r'^default via .* dev (.*?) ', out)
+        if res:
+            self._default_nic_list = [res.group(1)]
+        else:
+            if not self.nic_list:
+                self.get_interfaces_info()
+            common_warn("No default route configured. Using the first found nic")
+            self._default_nic_list = [self.nic_list[0]]
+        return self._default_nic_list
+
+    def get_default_ip_list(self):
+        """
+        Get default IP list will be used by corosync
+        """
+        if not self._default_nic_list:
+            self.get_default_nic_list_from_route()
+        if not self.nic_list:
+            self.get_interfaces_info()
+
+        _ip_list = []
+        for nic in self._default_nic_list:
+            # in case given interface not exist
+            if nic not in self.nic_list:
+                raise ValueError("Failed to detect IP address for {}".format(nic))
+            _ip_list.append(self._nic_first_ip(nic))
+        # in case -M specified but given one interface via -i
+        if self.second_heartbeat and len(self._default_nic_list) == 1:
+            for nic in self.nic_list:
+                if nic not in self._default_nic_list:
+                    _ip_list.append(self._nic_first_ip(nic))
+                    break
+        return _ip_list
+
+    @classmethod
+    def ip_in_network(cls, addr):
+        """
+        Check whether given address was in one of local networks
+        """
+        cls_inst = cls(IP.is_ipv6(addr))
+        cls_inst.get_interfaces_info()
+        for interface_inst in cls_inst.interface_list:
+            if interface_inst.ip_in_network(addr):
+                return True
+        return False
 # vim:ts=4:sw=4:et:

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -5,12 +5,13 @@ TEST_TYPE='bootstrap qdevice hb_report geo'
 
 before() {
   docker pull ${Docker_image}
-  docker network create --subnet 10.10.10.0/24 second_net
+  docker network create --subnet 10.10.10.0/24 --ipv6 --subnet 2001:db8:10::/64 second_net
 
   # deploy first node hanode1
   docker run -d --name=hanode1 --hostname hanode1 \
              --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
   docker network connect --ip=10.10.10.2 second_net hanode1
+  docker network connect --ip=2001:db8:10::2 second_net hanode1
   docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
     docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.9 qnetd-node\" >> /etc/hosts"
@@ -25,6 +26,7 @@ before() {
   docker run -d --name=hanode2 --hostname hanode2 \
              --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
   docker network connect --ip=10.10.10.3 second_net hanode2
+  docker network connect --ip=2001:db8:10::3 second_net hanode2
   docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
   if [ x"$1" == x"qdevice" ];then
     docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.9 qnetd-node\" >> /etc/hosts"

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -43,9 +43,9 @@ Feature: crmsh bootstrap process - options
   Scenario: Bind specific network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "10.10.10.2" is belong to "eth1"
-    When    Run "crm cluster init -i eth1 -y" on "hanode1"
+    When    Run "crm cluster init -i eth1 -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "10.10.10.2" is used by corosync
+    And     IP "10.10.10.2" is used by corosync on "hanode1"
     And     Show corosync ring status
 
   @clean
@@ -53,16 +53,33 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "172.17.0.2" is belong to "eth0"
     And     IP "10.10.10.2" is belong to "eth1"
-    When    Run "crm cluster init -M -y" on "hanode1"
+    When    Run "crm cluster init -M -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "172.17.0.2" is used by corosync
-    And     IP "10.10.10.2" is used by corosync
+    And     IP "172.17.0.2" is used by corosync on "hanode1"
+    And     IP "10.10.10.2" is used by corosync on "hanode1"
+    And     Show corosync ring status
+
+  @clean
+  Scenario: Using multiple network interface using "-i" option
+    Given   Cluster service is "stopped" on "hanode1"
+    And     IP "172.17.0.2" is belong to "eth0"
+    And     IP "10.10.10.2" is belong to "eth1"
+    When    Run "crm cluster init -i eth0 -i eth1 -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     IP "172.17.0.2" is used by corosync on "hanode1"
+    And     IP "10.10.10.2" is used by corosync on "hanode1"
     And     Show corosync ring status
 
   @clean
   Scenario: Setup cluster name and virtual IP using "-A" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -n hatest -A 10.10.10.123 -y" on "hanode1"
+    When    Try "crm cluster init -A xxx -y"
+    Then    Except "ERROR: cluster.init: 'xxx' does not appear to be an IPv4 or IPv6 address"
+    When    Try "crm cluster init -A 10.10.10.2 -y"
+    Then    Except "ERROR: cluster.init: Address already in use: 10.10.10.2"
+    When    Try "crm cluster init -A 10.20.10.2 -y"
+    Then    Except "ERROR: cluster.init: Address '10.20.10.2' not in any local network"
+    When    Run "crm cluster init -n hatest -A 10.10.10.123 -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster name is "hatest"
     And     Cluster virtual IP is "10.10.10.123"
@@ -71,8 +88,34 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Init cluster service with udpu using "-u" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -u -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -u -y -i eth0 --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster is using udpu transport mode
-    And     IP "172.17.0.2" is used by corosync
+    And     IP "172.17.0.2" is used by corosync on "hanode1"
     And     Show corosync ring status
+    And     Corosync working on "unicast" mode
+
+  @clean
+  Scenario: Init cluster service with ipv6 using "-I" option
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -I -i eth1 -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     IP "2001:db8:10::2" is used by corosync on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     IP "2001:db8:10::3" is used by corosync on "hanode2"
+    And     Corosync working on "multicast" mode
+
+  @clean
+  Scenario: Init cluster service with ipv6 unicast using "-I" and "-u" option
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -I -i eth1 -u -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     IP "2001:db8:10::2" is used by corosync on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     IP "2001:db8:10::3" is used by corosync on "hanode2"
+    And     Show cluster status on "hanode1"
+    And     Corosync working on "unicast" mode

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -21,7 +21,7 @@ Feature: Verify usercase master survive when split-brain
   @clean
   Scenario: Master survive when split-brain
     # Setup a two-nodes cluster
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y -i eth0 --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -82,7 +82,8 @@ Network configuration:
   Options for configuring the network and messaging layer.
 
   -i IF, --interface IF
-                        Bind to IP address on interface IF
+                        Bind to IP address on interface IF. Use -i second time
+                        for second interface
   -u, --unicast         Configure corosync to communicate over unicast (UDP),
                         and not multicast. Default is multicast unless an
                         environment where multicast cannot be used is
@@ -165,7 +166,8 @@ Network configuration:
   -c HOST, --cluster-node HOST
                         IP address or hostname of existing cluster node
   -i IF, --interface IF
-                        Bind to IP address on interface IF
+                        Bind to IP address on interface IF. Use -i second time
+                        for second interface
 
 Stage can be one of:
     ssh         Obtain SSH keys from existing cluster node (requires -c <host>)

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -111,9 +111,9 @@ def step_impl(context, nodelist):
     assert online(context, nodelist) is True
 
 
-@then('IP "{addr}" is used by corosync')
-def step_impl(context, addr):
-    out = run_command(context, 'corosync-cfgtool -s')
+@then('IP "{addr}" is used by corosync on "{node}"')
+def step_impl(context, addr, node):
+    out = run_command_local_or_remote(context, 'corosync-cfgtool -s', node)
     res = re.search(r' {}\n'.format(addr), out)
     assert bool(res) is True
 
@@ -209,3 +209,11 @@ def step_impl(context, cmd):
     cmd_help["crm_cluster_geo-init-arbitrator"] = const.CRM_CLUSTER_GEO_INIT_ARBIT_H_OUTPUT
     key = '_'.join(cmd.split())
     assert context.stdout == cmd_help[key]
+
+
+@then('Corosync working on "{transport_type}" mode')
+def step_impl(context, transport_type):
+    if transport_type == "multicast":
+        assert corosync.get_value("totem.transport") != "udpu"
+    if transport_type == "unicast":
+        assert corosync.get_value("totem.transport") == "udpu"

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -8,6 +8,7 @@ import os
 import socket
 import re
 import imp
+import unittest
 from unittest import mock
 from itertools import chain
 from crmsh import utils
@@ -243,21 +244,6 @@ def test_msec():
     assert utils.crm_msec('1') == 1000
     assert utils.crm_msec('1m') == 60*1000
     assert utils.crm_msec('1h') == 60*60*1000
-
-
-def test_network():
-    ip = utils.IP('192.168.1.2')
-    assert ip.version() == 4
-    ip = utils.IP('2001:db3::1')
-    assert ip.version() == 6
-
-    assert (utils.ip_in_network('192.168.2.0', '192.0.2.0/24') is False)
-    assert (utils.ip_in_network('192.0.2.42', '192.0.2.0/24') is True)
-
-    assert (utils.ip_in_network('2001:db3::1', '2001:db8::2/64') is False)
-    assert (utils.ip_in_network('2001:db8::1', '2001:db8::2/64') is True)
-
-    assert utils.get_ipv6_network("2002:db8::2/64") == "2002:db8::"
 
 
 def test_parse_sysconfig():
@@ -603,3 +589,330 @@ def test_interface_choice(mock_get_stdout):
     mock_get_stdout.return_value = (0, ip_a_output)
     assert utils.interface_choice() == ["enp1s0", "br-933fa0e1438c", "veth3fff6e9"]
     mock_get_stdout.assert_called_once_with("ip a")
+
+
+class TestIP(unittest.TestCase):
+    """
+    Unitary tests for class utils.IP
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.ip_inst = utils.IP("10.10.10.1")
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch('ipaddress.ip_address')
+    def test_ip_address(self, mock_ip_address):
+        mock_ip_address_inst = mock.Mock()
+        mock_ip_address.return_value = mock_ip_address_inst
+        self.ip_inst.ip_address
+        mock_ip_address.assert_called_once_with("10.10.10.1")
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_version(self, mock_ip_address):
+        mock_ip_address_inst = mock.Mock(version=4)
+        mock_ip_address.return_value = mock_ip_address_inst
+        res = self.ip_inst.version
+        self.assertEqual(res, mock_ip_address_inst.version)
+        mock_ip_address.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_is_mcast(self, mock_ip_address):
+        mock_ip_address_inst = mock.Mock(is_multicast=False)
+        mock_ip_address.return_value = mock_ip_address_inst
+        res = utils.IP.is_mcast("10.10.10.1")
+        self.assertEqual(res, False)
+        mock_ip_address.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.version', new_callable=mock.PropertyMock)
+    def test_is_ipv6(self, mock_version):
+        mock_version.return_value = 4
+        res = utils.IP.is_ipv6("10.10.10.1")
+        self.assertEqual(res, False)
+        mock_version.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_is_valid_ip_exception(self, mock_ip_address):
+        mock_ip_address.side_effect = ValueError
+        res = utils.IP.is_valid_ip("xxxx")
+        self.assertEqual(res, False)
+        mock_ip_address.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_is_valid_ip(self, mock_ip_address):
+        res = utils.IP.is_valid_ip("10.10.10.1")
+        self.assertEqual(res, True)
+        mock_ip_address.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_is_loopback(self, mock_ip_address):
+        mock_ip_address_inst = mock.Mock(is_loopback=False)
+        mock_ip_address.return_value = mock_ip_address_inst
+        res = self.ip_inst.is_loopback
+        self.assertEqual(res, mock_ip_address_inst.is_loopback)
+        mock_ip_address.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.IP.ip_address', new_callable=mock.PropertyMock)
+    def test_is_link_local(self, mock_ip_address):
+        mock_ip_address_inst = mock.Mock(is_link_local=False)
+        mock_ip_address.return_value = mock_ip_address_inst
+        res = self.ip_inst.is_link_local
+        self.assertEqual(res, mock_ip_address_inst.is_link_local)
+        mock_ip_address.assert_called_once_with()
+
+
+class TestInterface(unittest.TestCase):
+    """
+    Unitary tests for class utils.Interface
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.interface = utils.Interface("10.10.10.123/24")
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    def test_ip_with_mask(self):
+        assert self.interface.ip_with_mask == "10.10.10.123/24"
+
+    @mock.patch('ipaddress.ip_interface')
+    def test_ip_interface(self, mock_ip_interface):
+        mock_ip_interface_inst = mock.Mock()
+        mock_ip_interface.return_value = mock_ip_interface_inst
+        self.interface.ip_interface
+        mock_ip_interface.assert_called_once_with("10.10.10.123/24")
+
+    @mock.patch('crmsh.utils.Interface.ip_interface', new_callable=mock.PropertyMock)
+    def test_network(self, mock_ip_interface):
+        mock_ip_interface_inst = mock.Mock()
+        mock_ip_interface.return_value = mock_ip_interface_inst
+        mock_ip_interface_inst.network = mock.Mock(network_address="10.10.10.0")
+        assert self.interface.network == "10.10.10.0"
+        mock_ip_interface.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.Interface.ip_interface', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.IP')
+    def test_ip_in_network(self, mock_ip, mock_ip_interface):
+        mock_ip_inst = mock.Mock(ip_address="10.10.10.123")
+        mock_ip.return_value = mock_ip_inst
+        mock_ip_interface_inst = mock.Mock(network=["10.10.10.123"])
+        mock_ip_interface.return_value = mock_ip_interface_inst
+        res = self.interface.ip_in_network("10.10.10.123")
+        assert res is True
+        mock_ip.assert_called_once_with("10.10.10.123")
+        mock_ip_interface.assert_called_once_with()
+
+
+class TestInterfacesInfo(unittest.TestCase):
+    """
+    Unitary tests for class utils.InterfacesInfo
+    """
+
+    network_output_error = """1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0"""
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.interfaces_info = utils.InterfacesInfo()
+        self.interfaces_info_with_second_hb = utils.InterfacesInfo(second_heartbeat=True)
+        self.interfaces_info_with_custom_nic = utils.InterfacesInfo(second_heartbeat=True, custom_nic_list=['eth1'])
+        self.interfaces_info_with_wrong_nic = utils.InterfacesInfo(custom_nic_list=['eth7'])
+        self.interfaces_info_fake = utils.InterfacesInfo()
+        self.interfaces_info_fake._nic_info_dict = {
+                "eth0": [mock.Mock(ip="10.10.10.1", network="10.10.10.0"), mock.Mock(ip="10.10.10.2", network="10.10.10.0")],
+                "eth1": [mock.Mock(ip="20.20.20.1", network="20.20.20.0")]
+                }
+        self.interfaces_info_fake._default_nic_list = ["eth7"]
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_interfaces_info_no_address(self, mock_run):
+        only_lo = "1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever"
+        mock_run.return_value = (0, only_lo, None)
+        with self.assertRaises(ValueError) as err:
+            self.interfaces_info.get_interfaces_info()
+        self.assertEqual("No address configured", str(err.exception))
+        mock_run.assert_called_once_with("ip -4 -o addr show")
+
+    @mock.patch('crmsh.utils.Interface')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_interfaces_info_one_addr(self, mock_run, mock_interface):
+        mock_run.return_value = (0, self.network_output_error, None)
+        mock_interface_inst_1 = mock.Mock(is_loopback=True, is_link_local=False)
+        mock_interface_inst_2 = mock.Mock(is_loopback=False, is_link_local=False)
+        mock_interface.side_effect = [mock_interface_inst_1, mock_interface_inst_2]
+
+        with self.assertRaises(ValueError) as err:
+            self.interfaces_info_with_second_hb.get_interfaces_info()
+        self.assertEqual("Cannot configure second heartbeat, since only one address is available", str(err.exception))
+
+        mock_run.assert_called_once_with("ip -4 -o addr show")
+        mock_interface.assert_has_calls([
+            mock.call("127.0.0.1/8"),
+            mock.call("192.168.122.241/24")
+            ])
+
+    def test_nic_list(self):
+        res = self.interfaces_info_fake.nic_list
+        self.assertEqual(res, ["eth0", "eth1"])
+ 
+    def test_interface_list(self):
+        res = self.interfaces_info_fake.interface_list
+        assert len(res) == 3
+
+    @mock.patch('crmsh.utils.InterfacesInfo.interface_list', new_callable=mock.PropertyMock)
+    def test_ip_list(self, mock_interface_list):
+        mock_interface_list.return_value = [
+                mock.Mock(ip="10.10.10.1"),
+                mock.Mock(ip="10.10.10.2")
+                ]
+        res = self.interfaces_info_fake.ip_list
+        self.assertEqual(res, ["10.10.10.1", "10.10.10.2"])
+        mock_interface_list.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.InterfacesInfo.ip_list', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.InterfacesInfo.get_interfaces_info')
+    def test_get_local_ip_list(self, mock_get_info, mock_ip_list):
+        mock_ip_list.return_value = ["10.10.10.1", "10.10.10.2"]
+        res = utils.InterfacesInfo.get_local_ip_list(False)
+        self.assertEqual(res, mock_ip_list.return_value)
+        mock_get_info.assert_called_once_with()
+        mock_ip_list.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.InterfacesInfo.interface_list', new_callable=mock.PropertyMock)
+    def test_network_list(self, mock_interface_list):
+        mock_interface_list.return_value = [
+                mock.Mock(network="10.10.10.0"),
+                mock.Mock(network="20.20.20.0")
+                ]
+        res = self.interfaces_info.network_list
+        self.assertEqual(res, list(set(["10.10.10.0", "20.20.20.0"])))
+        mock_interface_list.assert_called_once_with()
+
+    def test_nic_first_ip(self):
+        res = self.interfaces_info_fake._nic_first_ip("eth0")
+        self.assertEqual(res, "10.10.10.1")
+
+    @mock.patch('crmsh.utils.InterfacesInfo.nic_list', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.common_warn')
+    @mock.patch('crmsh.utils.InterfacesInfo.get_interfaces_info')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_default_nic_list_from_route_no_default(self, mock_run, mock_get_interfaces_info, mock_warn, mock_nic_list):
+        output = """10.10.10.0/24 dev eth1 proto kernel scope link src 10.10.10.51 
+        20.20.20.0/24 dev eth2 proto kernel scope link src 20.20.20.51"""
+        mock_run.return_value = (0, output, None)
+        mock_nic_list.side_effect = [["eth0", "eth1"], ["eth0", "eth1"]]
+
+        res = self.interfaces_info.get_default_nic_list_from_route()
+        self.assertEqual(res, ["eth0"])
+
+        mock_run.assert_called_once_with("ip -o route show")
+        mock_warn.assert_called_once_with("No default route configured. Using the first found nic")
+        mock_nic_list.assert_has_calls([mock.call(), mock.call()])
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_default_nic_list_from_route(self, mock_run):
+        output = """default via 192.168.122.1 dev eth8 proto dhcp 
+        10.10.10.0/24 dev eth1 proto kernel scope link src 10.10.10.51 
+        20.20.20.0/24 dev eth2 proto kernel scope link src 20.20.20.51 
+        192.168.122.0/24 dev eth8 proto kernel scope link src 192.168.122.120"""
+        mock_run.return_value = (0, output, None)
+
+        res = self.interfaces_info.get_default_nic_list_from_route()
+        self.assertEqual(res, ["eth8"])
+
+        mock_run.assert_called_once_with("ip -o route show")
+
+    @mock.patch('crmsh.utils.InterfacesInfo.nic_list', new_callable=mock.PropertyMock)
+    def test_get_default_ip_list_failed_detect(self, mock_nic_list):
+        mock_nic_list.side_effect = [["eth0", "eth1"], ["eth0", "eth1"]]
+
+        with self.assertRaises(ValueError) as err:
+            self.interfaces_info_with_wrong_nic.get_default_ip_list()
+        self.assertEqual("Failed to detect IP address for eth7", str(err.exception))
+
+        mock_nic_list.assert_has_calls([mock.call(), mock.call()])
+
+    @mock.patch('crmsh.utils.InterfacesInfo._nic_first_ip')
+    @mock.patch('crmsh.utils.InterfacesInfo.nic_list', new_callable=mock.PropertyMock)
+    def test_get_default_ip_list(self, mock_nic_list, mock_first_ip):
+        mock_nic_list.side_effect = [["eth0", "eth1"], ["eth0", "eth1"], ["eth0", "eth1"]]
+        mock_first_ip.side_effect = ["10.10.10.1", "20.20.20.1"]
+
+        res = self.interfaces_info_with_custom_nic.get_default_ip_list()
+        self.assertEqual(res, ["10.10.10.1", "20.20.20.1"])
+
+        mock_nic_list.assert_has_calls([mock.call(), mock.call(), mock.call()])
+        mock_first_ip.assert_has_calls([mock.call("eth1"), mock.call("eth0")])
+
+    @mock.patch('crmsh.utils.Interface')
+    @mock.patch('crmsh.utils.InterfacesInfo.interface_list', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.InterfacesInfo.get_interfaces_info')
+    @mock.patch('crmsh.utils.IP.is_ipv6')
+    def test_ip_in_network(self, mock_is_ipv6, mock_get_interfaces_info, mock_interface_list, mock_interface):
+        mock_is_ipv6.return_value = False
+        mock_interface_inst_1 = mock.Mock()
+        mock_interface_inst_2 = mock.Mock()
+        mock_interface_inst_1.ip_in_network.return_value = False
+        mock_interface_inst_2.ip_in_network.return_value = True
+        mock_interface_list.return_value = [mock_interface_inst_1, mock_interface_inst_2]
+
+        res = utils.InterfacesInfo.ip_in_network("10.10.10.1")
+        assert res is True
+
+        mock_is_ipv6.assert_called_once_with("10.10.10.1")
+        mock_get_interfaces_info.assert_called_once_with()
+        mock_interface_list.assert_called_once_with()
+        mock_interface_inst_1.ip_in_network.assert_called_once_with("10.10.10.1")
+        mock_interface_inst_2.ip_in_network.assert_called_once_with("10.10.10.1")


### PR DESCRIPTION
Changes:
- Enable specify second interface using `-i` option while init and join process
- Add `validate_option` in `Context` class to valid options(reusable by init and join process)
- Add class `utils.IP` to get some properties of IP address
- Add class `utils.Interface` to get information from one interface
- Add class `utils.InterfacesInfo` to collect interfaces information on local node
- Refactor `bootstrap.init_network` function, get all needed network information through `utils.InterfacesInfo`
- Refactor multiple `bootstrap.valid_*` functions, add class `bootstrap.Validation` to validate values from interactive inputs
- Delete redundant codes and functions

TODO:
- [x] More test for interactive mode
- [ ] More test in cloud environment
- [x] UT and functional test, append ipv6 scenarios
- [x] delete more codes which will not be used anymore, like `utils.network_defaults`

RPM:
https://build.opensuse.org/package/show/home:XinLiang:branches:network:ha-clustering:Factory/crmsh