### PR TITLE
Low: ui_context: give warning if using alias command

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -76,6 +76,9 @@ class Context(object):
                 self.command_info = self.current_level().get_child(token)
                 if not self.command_info:
                     self.fatal_error("No such command")
+                if self.command_name in self.command_info.aliases:
+                    common_warn("This command '{}' is deprecated, please use '{}'"\
+                            .format(self.command_name, self.command_info.name))
                 self.command_name = self.command_info.name
                 if self.command_info.type == 'level':
                     self.enter_level(self.command_info.level)

--- a/test/crm-interface
+++ b/test/crm-interface
@@ -35,7 +35,7 @@ clone c1 p1
 ms m1 p2
 op_defaults timeout=60s
 commit
-end
+up
 EOF
 }
 crm_show() {

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -27,11 +27,11 @@ Feature: Regression test for bootstrap bugs
     Then    Except "ERROR: cluster.join: Space value not allowed for dest "cluster_node""
     When    Try "crm cluster remove -c ' '"
     Then    Except "ERROR: cluster.remove: Space value not allowed for dest "cluster_node""
-    When    Try "crm cluster geo-init -a ' '"
+    When    Try "crm cluster geo_init -a ' '"
     Then    Except "ERROR: cluster.geo_init: Space value not allowed for dest "arbitrator""
-    When    Try "crm cluster geo-join -c ' '"
+    When    Try "crm cluster geo_join -c ' '"
     Then    Except "ERROR: cluster.geo_join: Space value not allowed for dest "cluster_node""
-    When    Try "crm cluster geo-init-arbitrator -c ' '"
+    When    Try "crm cluster geo_init_arbitrator -c ' '"
     Then    Except "ERROR: cluster.geo_init_arbitrator: Space value not allowed for dest "cluster_node""
 
   @clean

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -1,6 +1,7 @@
 .TRY Configuration bugs
 .INP: options
 .INP: sort_elements false
+WARNING: 2: This command 'sort_elements' is deprecated, please use 'sort-elements'
 .INP: up
 .INP: configure
 .INP: erase
@@ -58,6 +59,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .TRY Unordered load file
 .INP: options
 .INP: sort_elements false
+WARNING: 2: This command 'sort_elements' is deprecated, please use 'sort-elements'
 .INP: up
 .INP: configure
 .INP: load update bugs-test.txt

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -24,6 +24,7 @@
 .INP: ms m d4
 .INP: delete m
 .INP: master m d4
+WARNING: 21: This command 'master' is deprecated, please use 'ms'
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
@@ -41,7 +42,9 @@
 .INP: location l6 m5 	rule $id-ref=l2-rule1
 .INP: location l7 m5 	rule $id-ref=l2
 .INP: collocation c1 inf: m6 m5
+WARNING: 36: This command 'collocation' is deprecated, please use 'colocation'
 .INP: collocation c2 inf: m5:Master d1:Started
+WARNING: 37: This command 'collocation' is deprecated, please use 'colocation'
 .INP: order o1 Mandatory: m5 m6
 .INP: order o2 Optional: d1:start m5:promote
 .INP: order o3 Serialize: m5 m6

--- a/test/testcases/history.exp
+++ b/test/testcases/history.exp
@@ -318,6 +318,7 @@ Dec 14 20:08:43 xen-e lrmd: [24225]: info: rsc:d1 stop[11] (pid 24774)
 Dec 14 20:08:43 xen-e crmd: [24228]: info: process_lrm_event: LRM operation d1_stop_0 (call=11, rc=0, cib-update=125, confirmed=true) ok
 .INP: # reduce report span
 .INP: timeframe "2012-12-14 20:07:30"
+WARNING: 21: This command 'timeframe' is deprecated, please use 'limit'
 .INP: peinputs
 history-test/xen-e/pengine/pe-input-47.bz2
 history-test/xen-e/pengine/pe-input-48.bz2
@@ -373,6 +374,7 @@ Dec 14 20:07:57 xen-e external/libvirt(s-libvirt)[24555]: [24588]: notice: xen+s
 d1
 .INP: # reset timeframe
 .INP: timeframe
+WARNING: 32: This command 'timeframe' is deprecated, please use 'limit'
 .INP: session save _crmsh_regtest
 .EXT mkdir -p /var/cache/crm/history-root/session/_crmsh_regtest
 .INP: session load _crmsh_regtest

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -142,6 +142,7 @@ resource p0 is NOT running
 
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1
+WARNING: This command 'migrate' is deprecated, please use 'move'
 .EXT crm_resource --quiet --move --resource 'p3' --node 'node1'
 INFO: Move constraint created for p3 to node1
 .INP: configure
@@ -161,10 +162,12 @@ INFO: Move constraint created for p3 to node1
 
 .SETENV showobj=
 .TRY resource unmigrate p3
+WARNING: This command 'unmigrate' is deprecated, please use 'clear'
 .EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1 force
+WARNING: This command 'migrate' is deprecated, please use 'move'
 .EXT crm_resource --quiet --move --resource 'p3' --node 'node1' --force
 INFO: Move constraint created for p3 to node1
 .INP: configure
@@ -184,6 +187,7 @@ INFO: Move constraint created for p3 to node1
 
 .SETENV showobj=
 .TRY resource unmigrate p3
+WARNING: This command 'unmigrate' is deprecated, please use 'clear'
 .EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=p0
@@ -911,6 +915,7 @@ INFO: Trace set, restart p0 to trace the stop operation
 .EXT crm_resource --refresh --resource p3 --node node1 --force
 .TRY resource stop p3
 .TRY configure rm cg
+WARNING: This command 'rm' is deprecated, please use 'delete'
 .TRY configure ms msg g
 .TRY resource scores
 .EXT crm_simulate -sUL


### PR DESCRIPTION
When using `alias` command, give warning like 
`This command 'migrate' is deprecated, please use 'move'`