### PR TITLE
Validate interface using argparse choices

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -206,7 +206,7 @@ Note:
                             help="Be quiet (don't describe what's happening, just do it)")
         parser.add_argument("-y", "--yes", action="store_true", dest="yes_to_all",
                             help='Answer "yes" to all prompts (use with caution, this is destructive, especially during the "storage" stage. The /root/.ssh/id_rsa key will be overwritten unless the option "--no-overwrite-sshkey" is used)')
-        parser.add_argument("-t", "--template", dest="template",
+        parser.add_argument("-t", "--template", dest="template", metavar="TEMPLATE", choices=['ocfs2'],
                             help='Optionally configure cluster with template "name" (currently only "ocfs2" is valid here)')
         parser.add_argument("-n", "--name", metavar="NAME", dest="cluster_name", default="hacluster",
                             help='Set the name of the configured cluster.')
@@ -221,7 +221,7 @@ Note:
                             help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
-        network_group.add_argument("-i", "--interface", dest="nic", metavar="IF",
+        network_group.add_argument("-i", "--interface", dest="nic", metavar="IF", choices=utils.interface_choice(),
                                    help="Bind to IP address on interface IF")
         network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
                                    help="Configure corosync to communicate over unicast (UDP), and not multicast. " +
@@ -266,9 +266,6 @@ Note:
             stage = args[0]
         if stage not in bootstrap.INIT_STAGES and stage != "":
             parser.error("Invalid stage (%s)" % (stage))
-
-        if options.template and options.template != "ocfs2":
-            parser.error("Invalid template (%s)" % (options.template))
 
         if options.qdevice_host:
             if options.qdevice_heuristics_mode and not options.qdevice_heuristics:
@@ -323,7 +320,8 @@ If stage is not specified, each stage will be invoked in sequence.
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
-        network_group.add_argument("-i", "--interface", dest="nic", help="Bind to IP address on interface IF", metavar="IF")
+        network_group.add_argument("-i", "--interface", dest="nic", metavar="IF", choices=utils.interface_choice(),
+                help="Bind to IP address on interface IF")
         options, args = parse_options(parser, args)
         if options is None or args is None:
             return

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2280,4 +2280,11 @@ def check_space_option_value(options):
         value = getattr(options, opt)
         if isinstance(value, str) and len(value.strip()) == 0:
             raise ValueError("Space value not allowed for dest \"{}\"".format(opt))
+
+
+def interface_choice():
+    _, out = get_stdout("ip a")
+    # should consider interface format like "ethx@xxx"
+    interface_list = re.findall(r'(?:[0-9]+:) (.*?)(?=: |@.*?: )', out)
+    return [nic for nic in interface_list if nic != "lo"]
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_report.py
+++ b/test/unittests/test_report.py
@@ -278,7 +278,7 @@ def test_head():
 def test_is_our_log():
     # empty log
     temp_file = create_tempfile()
-    assert is_our_log(temp_file, time_before, time_between) == 2
+    assert is_our_log(temp_file, time_before, time_between) == 0
 
     # from_time > last_time
     assert is_our_log(pacemaker_log, time_after, time_between) == 2

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -571,3 +571,35 @@ def test_detect_cloud_gcp_rc_error(mock_metadata, mock_get_stdout, mock_is_progr
     ])
     assert mock_metadata.call_count == 0
     assert utils._ip_for_cloud is None
+
+
+@mock.patch("crmsh.utils.get_stdout")
+def test_interface_choice(mock_get_stdout):
+    ip_a_output = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 52:54:00:9e:1b:4f brd ff:ff:ff:ff:ff:ff
+    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::5054:ff:fe9e:1b4f/64 scope link 
+       valid_lft forever preferred_lft forever
+3: br-933fa0e1438c: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
+    link/ether 9e:fe:24:df:59:49 brd ff:ff:ff:ff:ff:ff
+    inet 10.10.10.1/24 brd 10.10.10.255 scope global br-933fa0e1438c
+       valid_lft forever preferred_lft forever
+    inet6 fe80::9cfe:24ff:fedf:5949/64 scope link 
+       valid_lft forever preferred_lft forever
+4: veth3fff6e9@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master docker0 state UP group default 
+    link/ether 1e:2c:b3:73:6b:42 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet6 fe80::1c2c:b3ff:fe73:6b42/64 scope link 
+       valid_lft forever preferred_lft forever
+       valid_lft forever preferred_lft forever
+"""
+    mock_get_stdout.return_value = (0, ip_a_output)
+    assert utils.interface_choice() == ["enp1s0", "br-933fa0e1438c", "veth3fff6e9"]
+    mock_get_stdout.assert_called_once_with("ip a")


### PR DESCRIPTION
To make sure we got the right interface name when init/join

Additionally, use choices to validate -t option