### PR TITLE
Fix: bootstrap: no overwrite ssh key if detect passwordless(bsc#1169581)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ jobs:
       script:
         - $FUNCTIONAL_TEST bootstrap run bugs
 
+    - name: "regression test for bootstrap bugs (second set)"
+      before_install:
+        - $FUNCTIONAL_TEST bootstrap before_install
+      script:
+        - $FUNCTIONAL_TEST bootstrap run bugs2
+
     - name: "functional test for bootstrap - init, join and remove"
       before_install:
         - $FUNCTIONAL_TEST bootstrap before_install

--- a/data-manifest
+++ b/data-manifest
@@ -65,6 +65,7 @@ test/defaults
 test/descriptions
 test/docker_scripts.sh
 test/evaltest.sh
+test/features/bootstrap_bugs2.feature
 test/features/bootstrap_bugs.feature
 test/features/bootstrap_init_join_remove.feature
 test/features/bootstrap_options.feature

--- a/test/features/bootstrap_bugs2.feature
+++ b/test/features/bootstrap_bugs2.feature
@@ -1,0 +1,15 @@
+@bootstrap
+Feature: Regression test for bootstrap bugs
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Setup cluster on nodes with unique ssh key(bsc#1169581)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -u -i eth0 -y --no-overwrite-sshkey" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    And     Show cluster status on "hanode1"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -90,7 +90,10 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
         mock_confirm.assert_called_once_with("/root/.ssh/id_rsa already exists - overwrite?")
-        mock_rmfile.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_rmfile.assert_has_calls([
+            mock.call("/root/.ssh/id_rsa"),
+            mock.call("/root/.ssh/authorized_keys")
+            ])
         mock_status.assert_called_once_with("Generating SSH key")
         mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
@@ -113,28 +116,20 @@ class TestBootstrap(unittest.TestCase):
         mock_rmfile.assert_not_called()
 
     @mock.patch('builtins.open')
-    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('crmsh.bootstrap.append_to_file')
     @mock.patch('os.path.join')
     @mock.patch('os.path.exists')
-    def test_init_ssh_remote_no_sshkey(self, mock_exists, mock_join, mock_append, mock_open_file):
+    def test_init_ssh_remote(self, mock_exists, mock_join, mock_append, mock_open_file):
         mock_exists.side_effect = [False, True, False, False, False]
         mock_join.side_effect = ["/root/.ssh/id_rsa",
                                  "/root/.ssh/id_dsa",
                                  "/root/.ssh/id_ecdsa",
                                  "/root/.ssh/id_ed25519"]
-        mock_open_file.side_effect = [
-            mock.mock_open().return_value,
-            mock.mock_open(read_data="data1 data2").return_value,
-            mock.mock_open(read_data="data1111").return_value
-        ]
+        mock_open_file.return_value = mock.mock_open().return_value
 
         bootstrap.init_ssh_remote()
 
-        mock_open_file.assert_has_calls([
-            mock.call("/root/.ssh/authorized_keys", 'w'),
-            mock.call("/root/.ssh/authorized_keys", "r+"),
-            mock.call("/root/.ssh/id_rsa.pub")
-        ])
+        mock_open_file.assert_called_once_with("/root/.ssh/authorized_keys", 'w')
         mock_exists.assert_has_calls([
             mock.call("/root/.ssh/authorized_keys"),
             mock.call("/root/.ssh/id_rsa"),
@@ -304,3 +299,24 @@ class TestBootstrap(unittest.TestCase):
             mock.call("csync2 -rxv /etc/corosync.conf")
             ])
         mock_warn.assert_called_once_with("/etc/corosync.conf was not synced")
+
+    @mock.patch('os.path.exists')
+    def test_append_to_file_no_exist(self, mock_exists):
+        mock_exists.return_value = False
+        bootstrap.append_to_file("file1", "file2")
+        mock_exists.assert_called_once_with("file1")
+
+    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('crmsh.bootstrap.grep_file')
+    @mock.patch('builtins.open', new_callable=mock.mock_open, read_data='data')
+    @mock.patch('os.path.exists')
+    def test_append_to_file(self, mock_exists, mock_open_file, mock_grep, mock_append):
+        mock_exists.return_value = True
+        mock_grep.return_value = False
+
+        bootstrap.append_to_file("file1", "file2")
+
+        mock_exists.assert_called_once_with("file1")
+        mock_open_file.assert_called_once_with("file1")
+        mock_grep.assert_called_once_with("file2", "data")
+        mock_append.assert_called_once_with("file1", "file2")


### PR DESCRIPTION
Steps to reproduce,
I have two nodes(node1 and node2)
1. each node generate its ssh key
2. on node1, run cat .ssh/id_rsa.pub | ssh root@node2 'cat >> .ssh/authorized_keys'
3. on node2, run cat .ssh/id_rsa.pub | ssh root@node1 'cat >> .ssh/authorized_keys'
4. now node1 and node2 can login each other without password
5. on node1, run crm cluster init -y --no-overwrite-sshkey
6. on node2, run crm cluster join -c node1 -y, since now on node2, all the key were overwrite by crmsh, join process still require password input

--no-overwrite-sshkey can just avoid overwrite existing keys on init node

#### Reason
The unique ssh key and authorized_keys will be overwritten since `-y` option was specified while joining.
#### Solution
Before overwrite join node's keys with init node's keys, test whether join node can login to init node without password, if yes, even `-y` option specified, join node's key will not be overwritten