### PR TITLE
Fix: bootstrap: enable sbd.service while joining(bsc#1170037)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2018,8 +2018,13 @@ def join_cluster(seed_host):
 
     # if no SBD devices are configured,
     # check the existing cluster if the sbd service is enabled
-    if not configured_sbd_device() and invoke("ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(seed_host)):
-        _context.diskless_sbd = True
+    sbd_device = configured_sbd_device()
+    sbd_enabled_on_peer = invoke("ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(seed_host))
+    if sbd_enabled_on_peer:
+        if sbd_device:
+            _context.sbd_device = sbd_device.split(';')
+        else:
+            _context.diskless_sbd = True
 
     if ipv6_flag and not is_unicast:
         # for ipv6 mcast


### PR DESCRIPTION
Related issue: #574 
Since in join process, we already fetched the results of `configured_sbd_device` and whether sbd.service is enabled on init node to assign `_context.diskless_sbd`, we can use those two results to set `_context.sbd_device`, which will decide whether to enable sbd.service