### PR TITLE
[12sp2] scripts: fix yaml loader warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
 
 install:

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -408,7 +408,7 @@ def _parse_yaml(scriptname, scriptfile):
     try:
         import yaml
         with open(scriptfile) as f:
-            data = yaml.load(f)
+            data = yaml.load(f, Loader=yaml.SafeLoader)
             if isinstance(data, list):
                 data = data[0]
     except ImportError as e:
@@ -1015,7 +1015,7 @@ def load_script_string(script, yml):
     build_script_cache()
     import cStringIO
     import yaml
-    data = yaml.load(cStringIO.StringIO(yml))
+    data = yaml.load(cStringIO.StringIO(yml), Loader=yaml.SafeLoader)
     if isinstance(data, list):
         data = data[0]
     if 'parameters' in data:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27}
+envlist = {py27,}
 skipsdist = True
 
 


### PR DESCRIPTION
unittests.test_scripts.test_load_legacy ... /usr/lib/python3/dist-packages/crmsh/scripts.py:431: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.