### PR TITLE
SBD management improve

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -251,7 +251,7 @@ Note:
         storage_group = parser.add_argument_group("Storage configuration", "Options for configuring shared storage.")
         storage_group.add_argument("-p", "--partition-device", dest="shared_device", metavar="DEVICE",
                                    help='Partition this shared storage device (only used in "storage" stage)')
-        storage_group.add_argument("-s", "--sbd-device", dest="sbd_device", metavar="DEVICE", action="append",
+        storage_group.add_argument("-s", "--sbd-device", dest="sbd_devices", metavar="DEVICE", action="append",
                                    help="Block device to use for SBD fencing, use \";\" as separator or -s multiple times for multi path (up to 3 devices)")
         storage_group.add_argument("-o", "--ocfs2-device", dest="ocfs2_device", metavar="DEVICE",
                                    help='Block device to use for OCFS2 (only used in "vgfs" stage)')
@@ -272,6 +272,9 @@ Note:
             options.qdevice_heuristics_mode = options.qdevice_heuristics_mode or "sync"
         elif re.search("--qdevice-.*", ' '.join(sys.argv)):
             parser.error("Option --qnetd-hostname is required if want to configure qdevice")
+
+        if options.sbd_devices and options.diskless_sbd:
+            parser.error("Can't use -s and -S options together")
 
         # if options.geo and options.name == "hacluster":
         #    parser.error("For a geo cluster, each cluster must have a unique name (use --name to set)")

--- a/data-manifest
+++ b/data-manifest
@@ -68,6 +68,7 @@ test/evaltest.sh
 test/features/bootstrap_bugs.feature
 test/features/bootstrap_init_join_remove.feature
 test/features/bootstrap_options.feature
+test/features/bootstrap_sbd.feature
 test/features/environment.py
 test/features/geo_setup.feature
 test/features/qdevice_options.feature

--- a/test/features/bootstrap_sbd.feature
+++ b/test/features/bootstrap_sbd.feature
@@ -1,0 +1,79 @@
+@bootstrap
+Feature: crmsh bootstrap sbd management
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Check prerequisites for SBD
+    Given   Has disk "/dev/sda1" on "hanode1"
+
+    When    Run "mv /usr/sbin/sbd /tmp" on "hanode1"
+    And     Try "crm cluster init -s /dev/sda1 -y"
+    Then    Except "ERROR: cluster.init: sbd executable not found! Cannot configure SBD"
+    When    Run "mv /tmp/sbd /usr/sbin" on "hanode1"
+
+    When    Run "mv /dev/watchdog /tmp" on "hanode1"
+    And     Try "crm cluster init -s /dev/sda1 -y"
+    Then    Except "ERROR: cluster.init: Watchdog device must be configured in order to use SBD"
+    When    Run "mv /tmp/watchdog /dev" on "hanode1"
+
+  @clean
+  Scenario: Verify sbd device
+    When    Try "crm cluster init -s "/dev/sda1;/dev/sda2;/dev/sda3;/dev/sda4" -y"
+    Then    Except "ERROR: cluster.init: Maximum number of SBD device is 3"
+    When    Try "crm cluster init -s "/dev/sda1;/dev/sdaxxxx" -y"
+    Then    Except "ERROR: cluster.init: /dev/sdaxxxx doesn't look like a block device"
+
+  @clean
+  Scenario: Setup sbd with init and join process(bsc#1170999)
+    Given   Has disk "/dev/sda1" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Has disk "/dev/sda1" on "hanode2"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -s /dev/sda1 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "sbd" is "started" on "hanode1"
+    And     Resource "stonith-sbd" type "external/sbd" is "Started"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "sbd" is "started" on "hanode2"
+
+  @clean
+  Scenario: Re-setup cluster without sbd(bsc#1166967)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "sbd" is "stopped" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "sbd" is "stopped" on "hanode2"
+    And     Resource "stonith:external/sbd" not configured
+
+  @clean
+  Scenario: Configure diskless sbd
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -S -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "sbd" is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "sbd" is "started" on "hanode2"
+    And     Resource "stonith:external/sbd" not configured
+
+  @clean
+  Scenario: Configure multi disks sbd
+    Given   Has disk "/dev/sda1" on "hanode1"
+    Given   Has disk "/dev/sda2" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Has disk "/dev/sda1" on "hanode2"
+    Given   Has disk "/dev/sda2" on "hanode2"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -s /dev/sda1 -s /dev/sda2 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "sbd" is "started" on "hanode1"
+    And     Resource "stonith-sbd" type "external/sbd" is "Started"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "sbd" is "started" on "hanode2"

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -21,6 +21,12 @@ def step_impl(context, name, state, addr):
     assert check_service_state(context, name, state, addr) is True
 
 
+@given('Has disk "{disk}" on "{addr}"')
+def step_impl(context, disk, addr):
+    out = run_command_local_or_remote(context, "fdisk -l", addr)
+    assert re.search(r'{} '.format(disk), out) is not None
+
+
 @given('Online nodes are "{nodelist}"')
 def step_impl(context, nodelist):
     assert online(context, nodelist) is True
@@ -181,6 +187,13 @@ def step_impl(context, res, node, number):
     if out:
         result = re.search(r'name=fail-count-{} value={}'.format(res, number), out)
         assert result is not None
+
+
+@then('Resource "{res_type}" not configured')
+def step_impl(context, res_type):
+    out = run_command(context, "crm configure show")
+    result = re.search(r' {} '.format(res_type), out)
+    assert result is None
 
 
 @then('Output is the same with expected "{cmd}" help output')

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -22,6 +22,298 @@ from crmsh import bootstrap
 from crmsh.constants import SSH_KEY_CRMSH, SSH_WITH_KEY, SCP_WITH_KEY, SSH_KEY_CRMSH_TAG
 
 
+class TestSBDManager(unittest.TestCase):
+    """
+    Unitary tests for crmsh.bootstrap.SBDManager
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.sbd_inst = bootstrap.SBDManager(sbd_devices=["/dev/sdb1", "/dev/sdc1"])
+        self.sbd_inst_devices_gt_3 = bootstrap.SBDManager(sbd_devices=["/dev/sdb1", "/dev/sdc1", "/dev/sdd1", "/dev/sde1"])
+        self.sbd_inst_interactive = bootstrap.SBDManager()
+        self.sbd_inst_diskless = bootstrap.SBDManager(diskless_sbd=True)
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.check_watchdog')
+    def test_check_environment_no_watchdog(self, mock_watchdog, mock_error):
+        mock_watchdog.return_value = False
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst._check_environment()
+
+        mock_error.assert_called_once_with("Watchdog device must be configured in order to use SBD")
+        mock_watchdog.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.is_program')
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.check_watchdog')
+    def test_check_environment_no_sbd(self, mock_watchdog, mock_error, mock_is_program):
+        mock_watchdog.return_value = True
+        mock_is_program.return_value = False
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst._check_environment()
+
+        mock_error.assert_called_once_with("sbd executable not found! Cannot configure SBD")
+        mock_watchdog.assert_called_once_with()
+        mock_is_program.assert_called_once_with("sbd")
+
+    def test_parse_sbd_device(self):
+        res = self.sbd_inst._parse_sbd_device()
+        assert res == ["/dev/sdb1", "/dev/sdc1"]
+
+    def test_verify_sbd_device_gt_3(self):
+        assert self.sbd_inst_devices_gt_3.sbd_devices_input == ["/dev/sdb1", "/dev/sdc1", "/dev/sdd1", "/dev/sde1"]
+        dev_list = self.sbd_inst_devices_gt_3.sbd_devices_input
+        with self.assertRaises(ValueError) as err:
+            self.sbd_inst_devices_gt_3._verify_sbd_device(dev_list)
+        self.assertEqual("Maximum number of SBD device is 3", str(err.exception))
+
+    @mock.patch('crmsh.bootstrap.is_block_device')
+    def test_verify_sbd_device_not_block(self, mock_block_device):
+        assert self.sbd_inst.sbd_devices_input == ["/dev/sdb1", "/dev/sdc1"]
+        dev_list = self.sbd_inst.sbd_devices_input
+        mock_block_device.side_effect = [True, False]
+
+        with self.assertRaises(ValueError) as err:
+            self.sbd_inst._verify_sbd_device(dev_list)
+        self.assertEqual("/dev/sdc1 doesn't look like a block device", str(err.exception))
+
+        mock_block_device.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdc1")])
+
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
+    @mock.patch('crmsh.bootstrap.SBDManager._parse_sbd_device')
+    def test_get_sbd_device_from_option(self, mock_parse, mock_verify, mock_check):
+        mock_parse.return_value = ["/dev/sdb1", "/dev/sdc1"]
+        self.sbd_inst._get_sbd_device()
+        mock_parse.assert_called_once_with()
+        mock_verify.assert_called_once_with(mock_parse.return_value)
+        mock_check.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_interactive')
+    def test_get_sbd_device_from_interactive(self, mock_interactive):
+        mock_interactive.return_value = ["/dev/sdb1", "/dev/sdc1"]
+        self.sbd_inst_interactive._get_sbd_device()
+        mock_interactive.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    def test_get_sbd_device_diskless(self, mock_check):
+        self.sbd_inst_diskless._get_sbd_device()
+        mock_check.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_initialize_sbd(self, mock_invoke, mock_error):
+        self.sbd_inst._sbd_devices = ["/dev/sdb1", "/dev/sdc1"]
+        mock_invoke.side_effect = [True, False]
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst._initialize_sbd()
+
+        mock_invoke.assert_has_calls([
+            mock.call("sbd -d /dev/sdb1 create"),
+            mock.call("sbd -d /dev/sdc1 create")
+            ])
+        mock_error.assert_called_once_with("Failed to initialize SBD device /dev/sdc1")
+
+    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.utils.sysconfig_set')
+    @mock.patch('crmsh.bootstrap.detect_watchdog_device')
+    @mock.patch('shutil.copyfile')
+    def test_update_configuration(self, mock_copy, mock_detect, mock_sysconfig, mock_update):
+        self.sbd_inst._sbd_devices = ["/dev/sdb1", "/dev/sdc1"]
+        mock_detect.return_value = "/dev/watchdog"
+
+        self.sbd_inst._update_configuration()
+
+        mock_copy.assert_called_once_with("/usr/share/fillup-templates/sysconfig.sbd", "/etc/sysconfig/sbd")
+        mock_detect.assert_called_once_with()
+        mock_sysconfig.assert_called_once_with("/etc/sysconfig/sbd", SBD_PACEMAKER='yes', SBD_STARTMODE='always', SBD_DELAY_START='no', SBD_WATCHDOG_DEV='/dev/watchdog', SBD_DEVICE='/dev/sdb1;/dev/sdc1')
+        mock_update.assert_called_once_with("/etc/sysconfig/sbd")
+
+    @mock.patch('crmsh.bootstrap.utils.parse_sysconfig')
+    def test_get_sbd_device_from_config_none(self, mock_parse):
+        mock_parse_inst = mock.Mock()
+        mock_parse.return_value = mock_parse_inst
+        mock_parse_inst.get.return_value = None
+
+        res = self.sbd_inst._get_sbd_device_from_config()
+        assert res is None
+
+        mock_parse.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_parse_inst.get.assert_called_once_with("SBD_DEVICE")
+
+    @mock.patch('crmsh.bootstrap.utils.parse_sysconfig')
+    def test_get_sbd_device_from_config(self, mock_parse):
+        mock_parse_inst = mock.Mock()
+        mock_parse.return_value = mock_parse_inst
+        mock_parse_inst.get.return_value = "/dev/sdb1;/dev/sdc1"
+
+        res = self.sbd_inst._get_sbd_device_from_config()
+        assert res == ["/dev/sdb1", "/dev/sdc1"]
+
+        mock_parse.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_parse_inst.get.assert_called_once_with("SBD_DEVICE")
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.bootstrap.SBDManager._update_configuration')
+    @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
+    def test_sbd_init_return(self, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done):
+        self.sbd_inst._sbd_devices = None
+        self.sbd_inst.diskless_sbd = False
+
+        self.sbd_inst.sbd_init()
+
+        mock_get_device.assert_called_once_with()
+        mock_status.assert_not_called()
+        mock_initialize.assert_not_called()
+        mock_update.assert_not_called()
+        mock_status_done.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.bootstrap.SBDManager._update_configuration')
+    @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
+    def test_sbd_init_return(self, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done):
+        self.sbd_inst_diskless.sbd_init()
+
+        mock_get_device.assert_called_once_with()
+        mock_status.assert_called_once_with("Initializing diskless SBD...")
+        mock_initialize.assert_called_once_with()
+        mock_update.assert_called_once_with()
+        mock_status_done.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_manage_sbd_service_enable(self, mock_invoke):
+        self.sbd_inst._sbd_service_flag = True
+        self.sbd_inst.manage_sbd_service()
+        mock_invoke.assert_called_once_with("systemctl enable sbd.service")
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_manage_sbd_service_disable(self, mock_invoke):
+        self.sbd_inst._sbd_service_flag = False
+        self.sbd_inst.manage_sbd_service()
+        mock_invoke.assert_called_once_with("systemctl disable sbd.service")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    def test_configure_sbd_resource_error_primitive(self, mock_get_device, mock_invoke, mock_error):
+        self.sbd_inst._sbd_devices = ["/dev/sdb1"]
+        mock_get_device.return_value = ["/dev/sdb1"]
+        mock_invoke.return_value = False
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst.configure_sbd_resource()
+
+        mock_get_device.assert_called_once_with()
+        mock_invoke.assert_called_once_with("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s")
+        mock_error.assert_called_once_with("Can't create stonith-sbd primitive")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    def test_configure_sbd_resource_error_property(self, mock_get_device, mock_invoke, mock_error):
+        self.sbd_inst._sbd_devices = ["/dev/sdb1"]
+        mock_get_device.return_value = ["/dev/sdb1"]
+        mock_invoke.side_effect = [True, False]
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst.configure_sbd_resource()
+
+        mock_get_device.assert_called_once_with()
+        mock_invoke.assert_has_calls([
+            mock.call("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"),
+            mock.call("crm configure property stonith-enabled=true")
+            ])
+        mock_error.assert_called_once_with("Can't enable STONITH for SBD")
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    def test_configure_sbd_resource_diskless(self, mock_get_device, mock_invoke, mock_error):
+        self.sbd_inst_diskless._sbd_devices = None
+        mock_invoke.return_value = False
+        mock_error.side_effect = ValueError
+
+        with self.assertRaises(ValueError):
+            self.sbd_inst_diskless.configure_sbd_resource()
+
+        mock_get_device.assert_not_called()
+        mock_invoke.assert_called_once_with("crm configure property stonith-enabled=true stonith-watchdog-timeout=5s")
+        mock_error.assert_called_once_with("Can't enable STONITH for diskless SBD")
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('os.path.exists')
+    def test_join_sbd_config_not_exist(self, mock_exists, mock_invoke):
+        mock_exists.return_value = False
+        self.sbd_inst.join_sbd("node1")
+        mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_invoke.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('os.path.exists')
+    def test_join_sbd_config_disabled(self, mock_exists, mock_invoke, mock_check):
+        mock_exists.return_value = True
+        mock_invoke.return_value = False
+
+        self.sbd_inst.join_sbd("node1")
+
+        mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_invoke.assert_called_once_with("ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_check.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('os.path.exists')
+    def test_join_sbd(self, mock_exists, mock_invoke, mock_check, mock_get_device, mock_verify, mock_status):
+        mock_exists.return_value = True
+        mock_invoke.return_value = True
+        mock_get_device.return_value = ["/dev/sdb1"]
+
+        self.sbd_inst.join_sbd("node1")
+
+        mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_invoke.assert_called_once_with("ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_check.assert_called_once_with()
+        mock_get_device.assert_called_once_with()
+        mock_verify.assert_called_once_with(["/dev/sdb1"])
+        mock_status.assert_called_once_with("Got SBD configuration")
+
+
 class TestBootstrap(unittest.TestCase):
     """
     Unitary tests for crmsh/bootstrap.py


### PR DESCRIPTION
#### Motivation
We are facing several issues about sbd in crmsh lately.
It's might not a good way to add more codes without structure, and might cause more issues with small piece of code here and there.
It's better to manage sbd as a whole part.
#### Solution
Create a class `SBDManager`, and a set of methods to manage sbd configuration and services
#### Advantages
Treats sbd as a whole part
Specific methods are easy to find, understand and test
#### Changes

- Create class `SBDManager`
- `SBDManager.sbd_init` to get sbd device, initialize and write configure file
- `SBDManager.manage_sbd_service` to enable or disable sbd service
- `SBDManager.configure_sbd_resource` to configure stonith-sbd resource and stonith-enabled property
- `SBDManager.join_sbd` to check and verify sbd device on join process
- Make `-s`(for sbd device) option and `-S`(for diskless sbd) option mutual
- Unit test for `SBDManager`
- Functional test `bootstrap_sbd.feature` which can only running on local environment(since it seems impossible to configure watchdog inside container)