### PR TITLE
Give suggestions when init node doesn't have crmsh ssh key

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -30,7 +30,7 @@ from . import corosync
 from . import tmpfiles
 from . import clidisplay
 from . import term
-from .constants import SSH_KEY_CRMSH, SSH_WITH_KEY, SCP_WITH_KEY, SSH_KEY_CRMSH_TAG
+from .constants import SSH_KEY_CRMSH, SSH_WITH_KEY, SCP_WITH_KEY, SSH_KEY_CRMSH_TAG, KEY_NOT_EXIST_HINTS
 
 
 LOG_FILE = "/var/log/crmsh/ha-cluster-bootstrap.log"
@@ -1755,8 +1755,13 @@ def join_ssh(seed_host):
     invoke("mkdir -m 700 -p /root/.ssh")
 
     status("Retrieving SSH keys - This may prompt for root@%s:" % (seed_host))
-    if not invoke("scp -oStrictHostKeyChecking=no root@{}:'{}*' /root/.ssh".format(seed_host, SSH_KEY_CRMSH)):
-        error("Failed to retrieve ssh keys")
+    cmd = "scp -oStrictHostKeyChecking=no root@{}:'{}*' /root/.ssh".format(seed_host, SSH_KEY_CRMSH)
+    rc, stdout, stderr = utils.get_stdout_stderr(cmd)
+    if rc != 0 and stderr:
+        if "No such file or directory" in stderr:
+            error(KEY_NOT_EXIST_HINTS.format(key=SSH_KEY_CRMSH, peer=seed_host))
+        else:
+            error(stderr)
 
     invoke("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG))
     append("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -486,4 +486,11 @@ SSH_KEY_CRMSH = "/root/.ssh/id_rsa.crmsh"
 SSH_KEY_CRMSH_TAG = "crmsh-generated"
 SSH_WITH_KEY = "ssh -i {}".format(SSH_KEY_CRMSH)
 SCP_WITH_KEY = "scp -i {}".format(SSH_KEY_CRMSH)
+KEY_NOT_EXIST_HINTS = """{key} couldn't be fetch from {peer}.
+This happens if the cluster was created with an older version of crmsh or the keys have been removed.
+Please, run the next commands on {peer} with admin rights:
+  ssh-keygen -q -f /root/.ssh/id_rsa.crmsh -C 'crmsh-generated' -N ''
+  cat /root/.ssh/id_rsa.crmsh.pub  >> /root/.ssh/authorized_keys
+Then re-run the join process.
+"""
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -383,41 +383,41 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.join_ssh(None)
         mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
 
+    @mock.patch('crmsh.utils.get_stdout_stderr')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.start_service')
     @mock.patch('crmsh.bootstrap.error')
-    def test_join_ssh_error_scp(self, mock_error, mock_start, mock_invoke, mock_status):
+    def test_join_ssh_error_scp(self, mock_error, mock_start, mock_invoke, mock_status, mock_run):
         mock_error.side_effect = ValueError
-        mock_invoke.side_effect = [True, False]
+        mock_run.return_value = (1, None, "Error: No such file or directory")
 
         with self.assertRaises(ValueError):
             bootstrap.join_ssh("node1")
 
         mock_start.assert_called_once_with("sshd.service")
-        mock_invoke.assert_has_calls([
-            mock.call("mkdir -m 700 -p /root/.ssh"),
-            mock.call("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH))
-            ])
-        mock_error.assert_called_once_with("Failed to retrieve ssh keys")
+        mock_invoke.assert_called_once_with("mkdir -m 700 -p /root/.ssh")
+        mock_run.assert_called_once_with("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH))
+        mock_error.assert_called_once_with("/root/.ssh/id_rsa.crmsh couldn't be fetch from node1.\nThis happens if the cluster was created with an older version of crmsh or the keys have been removed.\nPlease, run the next commands on node1 with admin rights:\n  ssh-keygen -q -f /root/.ssh/id_rsa.crmsh -C 'crmsh-generated' -N ''\n  cat /root/.ssh/id_rsa.crmsh.pub  >> /root/.ssh/authorized_keys\nThen re-run the join process.\n")
         mock_status.assert_called_once_with("Retrieving SSH keys - This may prompt for root@node1:")
 
+    @mock.patch('crmsh.utils.get_stdout_stderr')
     @mock.patch('crmsh.bootstrap.append')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.start_service')
     @mock.patch('crmsh.bootstrap.error')
-    def test_join_ssh(self, mock_error, mock_start, mock_invoke, mock_status, mock_append):
-        mock_invoke.side_effect = [True, True, True]
+    def test_join_ssh(self, mock_error, mock_start, mock_invoke, mock_status, mock_append, mock_run):
+        mock_run.return_value = (0, None, None)
 
         bootstrap.join_ssh("node1")
 
         mock_start.assert_called_once_with("sshd.service")
         mock_invoke.assert_has_calls([
             mock.call("mkdir -m 700 -p /root/.ssh"),
-            mock.call("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH)),
             mock.call("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG))
             ])
+        mock_run.assert_called_once_with("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH))
         mock_error.assert_not_called()
         mock_status.assert_called_once_with("Retrieving SSH keys - This may prompt for root@node1:")
         mock_append.assert_called_once_with("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")


### PR DESCRIPTION
When init node doesn't have crmsh ssh key `/root/.ssh/id_rsa.crmsh`(might be from an old version crmsh), join process will fail to fetch that key, on this time, crmsh give suggestions about how to handle this scenarios