### PR TITLE
Test: bootstrap_bugs: don't overwrite the ssh key when init-ing

### DIFF
--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -7,7 +7,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Set placement-strategy value as "default"(bsc#1129462)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Show cluster status on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"


### PR DESCRIPTION
By specifying only the -y key in the "crm cluster init -y" the
ssh key may be overwritten and this will make the test fail.
The --no-overwrite-sshkey flag will prevent it from this.