### PR TITLE
Revert PR#575 -- Fix: bootstrap: crmsh use its own specific ssh key(bsc#1169581)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -30,7 +30,6 @@ from . import corosync
 from . import tmpfiles
 from . import clidisplay
 from . import term
-from .constants import SSH_KEY_CRMSH, SSH_WITH_KEY, SCP_WITH_KEY, SSH_KEY_CRMSH_TAG
 
 
 LOG_FILE = "/var/log/crmsh/ha-cluster-bootstrap.log"
@@ -44,7 +43,7 @@ PCMK_REMOTE_AUTH = "/etc/pacemaker/authkey"
 COROSYNC_CONF_ORIG = tmpfiles.create()[1]
 
 
-INIT_STAGES = ("ssh", "csync2", "csync2_remote", "corosync", "storage", "sbd", "cluster", "vgfs", "admin", "qdevice")
+INIT_STAGES = ("ssh", "ssh_remote", "csync2", "csync2_remote", "corosync", "storage", "sbd", "cluster", "vgfs", "admin", "qdevice")
 
 
 class Context(object):
@@ -61,6 +60,7 @@ class Context(object):
         self.template = None
         self.cluster_name = None
         self.watchdog = None
+        self.no_overwrite_sshkey = None
         self.nic = None
         self.unicast = None
         self.admin_ip = None
@@ -316,7 +316,7 @@ Configure SBD:
         """
         if not os.path.exists(SYSCONFIG_SBD):
             return
-        if not invoke("{} -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(SSH_WITH_KEY, peer_host)):
+        if not invoke("ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(peer_host)):
             return
         self._check_environment()
         dev_list = self._get_sbd_device_from_config()
@@ -498,7 +498,7 @@ def get_cluster_node_hostname():
     peer_node = None
     if _context.cluster_node:
         if utils.valid_ip_addr(_context.cluster_node):
-            rc, out, err = utils.get_stdout_stderr("{} {} crm_node --name".format(SSH_WITH_KEY, _context.cluster_node))
+            rc, out, err = utils.get_stdout_stderr("ssh {} crm_node --name".format(_context.cluster_node))
             if rc != 0:
                 error(err)
             peer_node = out
@@ -952,16 +952,36 @@ def mkdirs_owned(dirs, mode=0o777, uid=-1, gid=-1):
 
 def init_ssh():
     """
-    Configure passwordless SSH with crmsh specific key.
+    Configure passwordless SSH.
     """
     start_service("sshd.service")
-    if os.path.exists(SSH_KEY_CRMSH):
-        if not confirm("{} already exists - overwrite?".format(SSH_KEY_CRMSH)):
+    invoke("mkdir -m 700 -p /root/.ssh")
+    if os.path.exists("/root/.ssh/id_rsa"):
+        if _context.yes_to_all and _context.no_overwrite_sshkey or \
+                not confirm("/root/.ssh/id_rsa already exists - overwrite?"):
             return
-        rmfile(SSH_KEY_CRMSH)
-        invoke("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG))
-    invoke("ssh-keygen -q -f {} -C '{}' -N ''".format(SSH_KEY_CRMSH, SSH_KEY_CRMSH_TAG))
-    append("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")
+        rmfile("/root/.ssh/id_rsa")
+    status("Generating SSH key")
+    invoke("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
+    append("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+
+
+def init_ssh_remote():
+    """
+    Called by ha-cluster-join
+    """
+    authorized_keys_file = "/root/.ssh/authorized_keys"
+    if not os.path.exists(authorized_keys_file):
+        open(authorized_keys_file, 'w').close()
+    authkeys = open(authorized_keys_file, "r+")
+    authkeys_data = authkeys.read()
+    for key in ("id_rsa", "id_dsa", "id_ecdsa", "id_ed25519"):
+        fn = os.path.join("/root/.ssh", key)
+        if not os.path.exists(fn):
+            continue
+        keydata = open(fn + ".pub").read()
+        if keydata not in authkeys_data:
+            append(fn + ".pub", authorized_keys_file)
 
 
 def init_csync2():
@@ -1665,7 +1685,7 @@ Configure Administration IP Address:
 def init_qdevice():
     def copy_ssh_id_to_qnetd():
         status("Copy ssh key to qnetd node({})".format(qnetd_addr))
-        if not invoke("ssh-copy-id -i {} root@{}".format(SSH_KEY_CRMSH, qnetd_addr)):
+        if not invoke("ssh-copy-id -i /root/.ssh/id_rsa.pub root@{}".format(qnetd_addr)):
             error_msg = "Failed to copy ssh key"
             if not _context.stage:
                 suggest = """
@@ -1754,12 +1774,40 @@ def join_ssh(seed_host):
     start_service("sshd.service")
     invoke("mkdir -m 700 -p /root/.ssh")
 
+    tmpdir = tmpfiles.create_dir()
     status("Retrieving SSH keys - This may prompt for root@%s:" % (seed_host))
-    if not invoke("scp -oStrictHostKeyChecking=no root@{}:'{}*' /root/.ssh".format(seed_host, SSH_KEY_CRMSH)):
+    if not invoke("scp -oStrictHostKeyChecking=no  root@%s:'/root/.ssh/id_*' %s/" % (seed_host, tmpdir)):
         error("Failed to retrieve ssh keys")
 
-    invoke("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG))
-    append("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")
+    # This supports all SSH key types, for the case where ha-cluster-init
+    # wasn't used to set up the seed node, and the user has manually
+    # created, for example, DSA keys (bnc#878080)
+    got_keys = 0
+    for key in ("id_rsa", "id_dsa", "id_ecdsa", "id_ed25519"):
+        if not os.path.exists(os.path.join(tmpdir, key)):
+            continue
+
+        if os.path.exists(os.path.join("/root/.ssh", key)):
+            if not confirm("/root/.ssh/%s already exists - overwrite?" % (key)):
+                continue
+        invoke("mv %s* /root/.ssh/" % (os.path.join(tmpdir, key)))
+        if not grep_file("/root/.ssh/authorized_keys", open("/root/.ssh/%s.pub" % (key)).read()):
+            append("/root/.ssh/%s.pub" % (key), "/root/.ssh/authorized_keys")
+        got_keys += 1
+
+    if got_keys == 0:
+        status("No new SSH keys installed")
+    elif got_keys == 1:
+        status("One new SSH key installed")
+    else:
+        status("%s new SSH keys installed" % (got_keys))
+
+    # This makes sure the seed host has its own SSH keys in its own
+    # authorized_keys file (again, to help with the case where the
+    # user has done manual initial setup without the assistance of
+    # ha-cluster-init).
+    if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.nic)):
+        error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.nic, seed_host))
 
 
 def join_csync2(seed_host):
@@ -1781,7 +1829,7 @@ def join_csync2(seed_host):
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
     cmd = "crm cluster init -i {} csync2_remote {}".format(_context.nic, utils.this_node())
-    if not invoke("{} -o StrictHostKeyChecking=no root@{} {}".format(SSH_WITH_KEY, seed_host, cmd)):
+    if not invoke("ssh -o StrictHostKeyChecking=no root@{} {}".format(seed_host, cmd)):
         error("Can't invoke \"{}\" on {}".format(cmd, seed_host))
 
     # This is necessary if syncing /etc/hosts (to ensure everyone's got the
@@ -1790,8 +1838,9 @@ def join_csync2(seed_host):
     # invoke scp root@seed_host:/etc/hosts $tmp_conf \
     #   || error "Can't retrieve /etc/hosts from seed_host"
     # install_tmp $tmp_conf /etc/hosts
-    if not invoke("{} root@{}:'/etc/csync2/{{csync2.cfg,key_hagroup}}' /etc/csync2".format(SCP_WITH_KEY, seed_host)):
-        error("Can't retrieve csync2 config from {}".format(seed_host))
+
+    if not invoke("scp root@%s:'/etc/csync2/{csync2.cfg,key_hagroup}' /etc/csync2" % (seed_host)):
+        error("Can't retrieve csync2 config from %s" % (seed_host))
 
     start_service("csync2.socket")
 
@@ -1804,12 +1853,53 @@ def join_csync2(seed_host):
     # they haven't gone to all nodes in the cluster, which means a
     # subseqent join of another node can fail its sync of corosync.conf
     # when it updates expected_votes.  Grrr...
-    if not invoke('{} -o StrictHostKeyChecking=no root@{} "csync2 -rm /; csync2 -rxv || csync2 -rf / && csync2 -rxv"'.format(SSH_WITH_KEY, seed_host)):
+    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "csync2 -rm /; csync2 -rxv || csync2 -rf / && csync2 -rxv"'.format(seed_host)):
         print("")
         warn("csync2 run failed - some files may not be sync'd")
 
     status_done()
 
+
+def join_ssh_merge(_cluster_node):
+    status("Merging known_hosts")
+
+    me = utils.this_node()
+    hosts = [m.group(1)
+             for m in re.finditer(r"^\s*host\s*([^ ;]+)\s*;", open(CSYNC2_CFG).read(), re.M)
+             if m.group(1) != me]
+    if not hosts:
+        hosts = [_cluster_node]
+        warn("Unable to extract host list from %s" % (CSYNC2_CFG))
+
+    try:
+        import parallax
+    except ImportError:
+        error("parallax python library is missing")
+
+    opts = parallax.Options()
+    opts.ssh_options = ['StrictHostKeyChecking=no']
+
+    # The act of using pssh to connect to every host (without strict host key
+    # checking) ensures that at least *this* host has every other host in its
+    # known_hosts
+    known_hosts_new = set()
+    cat_cmd = "[ -e /root/.ssh/known_hosts ] && cat /root/.ssh/known_hosts || true"
+    log("parallax.call {} : {}".format(hosts, cat_cmd))
+    results = parallax.call(hosts, cat_cmd, opts)
+    for host, result in results.items():
+        if isinstance(result, parallax.Error):
+            warn("Failed to get known_hosts from {}: {}".format(host, str(result)))
+        else:
+            if result[1]:
+                known_hosts_new.update((utils.to_ascii(result[1]) or "").splitlines())
+    if known_hosts_new:
+        hoststxt = "\n".join(sorted(known_hosts_new))
+        tmpf = utils.str2tmp(hoststxt)
+        log("parallax.copy {} : {}".format(hosts, hoststxt))
+        results = parallax.copy(hosts, tmpf, "/root/.ssh/known_hosts")
+        for host, result in results.items():
+            if isinstance(result, parallax.Error):
+                warn("scp to {} failed ({}), known_hosts update may be incomplete".format(host, str(result)))
 
 def update_expected_votes():
     # get a list of nodes, excluding remote nodes
@@ -1937,7 +2027,7 @@ def join_cluster(seed_host):
     # that yet, so the following crawling horror takes a punt on the seed
     # node being up, then asks it for a list of mountpoints...
     if _context.cluster_node:
-        _rc, outp, _ = utils.get_stdout_stderr("{} -o StrictHostKeyChecking=no root@{} 'cibadmin -Q --xpath \"//primitive\"'".format(SSH_WITH_KEY, seed_host))
+        _rc, outp, _ = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} 'cibadmin -Q --xpath \"//primitive\"'".format(seed_host))
         if outp:
             xml = etree.fromstring(outp)
             mountpoints = xml.xpath(' and '.join(['//primitive[@class="ocf"',
@@ -1987,7 +2077,7 @@ def join_cluster(seed_host):
         except corosync.IPAlreadyConfiguredError as e:
             warn(e)
         csync2_update(corosync.conf())
-        invoke("{} -o StrictHostKeyChecking=no root@{} corosync-cfgtool -R".format(SSH_WITH_KEY, seed_host))
+        invoke("ssh -o StrictHostKeyChecking=no root@{} corosync-cfgtool -R".format(seed_host))
 
     _context.sbd_manager.join_sbd(seed_host)
 
@@ -2095,7 +2185,7 @@ def remove_get_hostname(seed_host):
         _context.host_status = 1
         return
 
-    _rc, outp, _errp = utils.get_stdout_stderr("{} -o StrictHostKeyChecking=no root@{} \"hostname\"".format(SSH_WITH_KEY, seed_host))
+    _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(seed_host))
     if outp:
         _context.connect_name = seed_host
         _context.cluster_node = outp.strip()
@@ -2110,7 +2200,7 @@ def remove_get_hostname(seed_host):
         if nodename not in xmlutil.listnodes():
             error("Specified node {} is not configured in cluster, can not remove".format(nodename))
 
-        _rc, outp, _errp = utils.get_stdout_stderr("{} -o StrictHostKeyChecking=no root@{} \"hostname\"".format(SSH_WITH_KEY, nodename))
+        _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(nodename))
         if outp:
             _context.connect_name = seed_host
             _context.cluster_node = nodename
@@ -2127,7 +2217,7 @@ def remove_get_hostname(seed_host):
             error("Invalid IP address")
 
         # try to use the IP address to connect
-        _rc, outp, _errp = utils.get_stdout_stderr("{} -o StrictHostKeyChecking=no root@{} \"hostname\"".format(SSH_WITH_KEY, nodename))
+        _rc, outp, _errp = utils.get_stdout_stderr("ssh -o StrictHostKeyChecking=no root@{} \"hostname\"".format(nodename))
         if outp:
             ipaddr = nodename
             nodename = outp.strip()
@@ -2151,12 +2241,12 @@ def remove_node_from_cluster():
 
     if _context.host_status != 0:
         status("Stopping the corosync service")
-        if not invoke('{} -o StrictHostKeyChecking=no root@{} "systemctl stop corosync"'.format(SSH_WITH_KEY, _context.connect_name)):
+        if not invoke('ssh -o StrictHostKeyChecking=no root@{} "systemctl stop corosync"'.format(_context.connect_name)):
             error("Stopping corosync on {} failed".format(_context.connect_name))
 
         # delete configuration files from the node to be removed
         toremove = [SYSCONFIG_SBD, CSYNC2_CFG, corosync.conf(), CSYNC2_KEY, COROSYNC_AUTH]
-        if not invoke('{} -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {} && rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*\\\""'.format(SSH_WITH_KEY, node, " ".join(toremove))):
+        if not invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {} && rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*\\\""'.format(node, " ".join(toremove))):
             error("Deleting the configuration files failed")
     else:
         # Check node status
@@ -2259,14 +2349,14 @@ def bootstrap_init(context):
     elif stage == "":
         if corosync_active:
             error("Cluster is currently active - can't run")
-    elif stage not in ("ssh", "csync2", "csync2_remote"):
+    elif stage not in ("ssh", "ssh_remote", "csync2", "csync2_remote"):
         if corosync_active:
             error("Cluster is currently active - can't run %s stage" % (stage))
 
     check_option()
 
-    # Need hostname resolution to work, want NTP (but don't block csync2_remote)
-    if stage not in ('csync2_remote',):
+    # Need hostname resolution to work, want NTP (but don't block ssh_remote or csync2_remote)
+    if stage not in ('ssh_remote', 'csync2_remote'):
         check_tty()
         if not check_prereqs(stage):
             return
@@ -2337,6 +2427,7 @@ def bootstrap_join(context):
         join_ssh(cluster_node)
         join_remote_auth(cluster_node)
         join_csync2(cluster_node)
+        join_ssh_merge(cluster_node)
         join_cluster(cluster_node)
 
     status("Done (log saved to %s)" % (LOG_FILE))
@@ -2406,7 +2497,7 @@ def bootstrap_remove(context):
         if othernode is not None:
             # remove from other node
             cmd = "crm cluster remove{} -c {}".format(" -y" if yes_to_all else "", me)
-            rc = utils.ext_cmd_nosudo("{}{} -o StrictHostKeyChecking=no {} '{}'".format(SSH_WITH_KEY, "" if yes_to_all else " -t", othernode, cmd))
+            rc = utils.ext_cmd_nosudo("ssh{} -o StrictHostKeyChecking=no {} '{}'".format("" if yes_to_all else " -t", othernode, cmd))
             if rc != 0:
                 error("Failed to remove this node from {}".format(othernode))
         else:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -481,9 +481,4 @@ container_helptxt = {
     }
 }
 
-
-SSH_KEY_CRMSH = "/root/.ssh/id_rsa.crmsh"
-SSH_KEY_CRMSH_TAG = "crmsh-generated"
-SSH_WITH_KEY = "ssh -i {}".format(SSH_KEY_CRMSH)
-SCP_WITH_KEY = "scp -i {}".format(SSH_KEY_CRMSH)
 # vim:ts=4:sw=4:et:

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -13,7 +13,6 @@ from . import tmpfiles
 from . import parallax
 from . import bootstrap
 from .msg import err_buf, common_debug
-from .constants import SCP_WITH_KEY
 
 
 def conf():
@@ -746,7 +745,7 @@ def pull_configuration(from_node):
     local_path = conf()
     _, fname = tmpfiles.create()
     print("Retrieving %s:%s..." % (from_node, local_path))
-    cmd = [SCP_WITH_KEY, '-qC',
+    cmd = ['scp', '-qC',
            '-o', 'PasswordAuthentication=no',
            '-o', 'StrictHostKeyChecking=no',
            '%s:%s' % (from_node, local_path),

--- a/crmsh/crm_pssh.py
+++ b/crmsh/crm_pssh.py
@@ -20,7 +20,6 @@ from parallax import Options
 
 from .msg import common_err, common_debug, common_warn
 from . import config
-from .constants import SSH_KEY_CRMSH
 
 
 _DEFAULT_TIMEOUT = 60
@@ -93,8 +92,6 @@ def do_pssh(l, opts):
             cmd += ['-l', user]
         if port:
             cmd += ['-p', port]
-        if os.path.exists(SSH_KEY_CRMSH):
-            cmd += ['-i', SSH_KEY_CRMSH]
         if hasattr(opts, 'extra'):
             cmd.extend(opts.extra)
         if cmdline:

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -4,7 +4,6 @@
 
 import os
 import parallax
-from .constants import SSH_KEY_CRMSH
 
 
 class Parallax(object):
@@ -37,8 +36,6 @@ class Parallax(object):
             self.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
         opts.ssh_options = self.ssh_options
         opts.askpass = self.askpass
-        if hasattr(opts, 'ssh_key'):
-            opts.ssh_key = SSH_KEY_CRMSH
         # warn_message will available from parallax-1.0.5
         if hasattr(opts, 'warn_message'):
             opts.warn_message = False
@@ -88,7 +85,8 @@ def parallax_slurp(nodes, localdir, filename, askpass=False, ssh_options=None):
     ssh_options: Extra options to pass to SSH
     Returns [(host, (rc, stdout, stdin, localpath)), ...] or ValueError exception
     """
-    p = Parallax(nodes, localdir=localdir, filename=filename, askpass=askpass, ssh_options=ssh_options)
+    p = Parallax(nodes, localdir=localdir, filename=filename,
+                 askpass=askpass, ssh_options=ssh_options)
     return p.slurp()
 
 

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -12,7 +12,6 @@ import random
 from copy import deepcopy
 from glob import glob
 from lxml import etree
-from .constants import SSH_KEY_CRMSH, SSH_WITH_KEY
 
 try:
     import json
@@ -421,8 +420,6 @@ def _make_options(params):
         'ControlPersist=no']
     if options.regression_tests:
         opts.ssh_extra += ['-vvv']
-    if hasattr(opts, 'ssh_key'):
-        opts.ssh_key = SSH_KEY_CRMSH
     return opts
 
 
@@ -1085,7 +1082,7 @@ def _check_control_persist():
     Checks if ControlPersist is available. If so,
     we'll use it to make things faster.
     '''
-    cmd = '{} -o ControlPersist'.format(SSH_WITH_KEY).split()
+    cmd = 'ssh -o ControlPersist'.split()
     if options.regression_tests:
         print((".EXT", cmd))
     cmd = subprocess.Popen(cmd,

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -13,7 +13,6 @@ from . import completers as compl
 from . import bootstrap
 from . import corosync
 from .cibconfig import cib_factory
-from .constants import SSH_KEY_CRMSH, SSH_WITH_KEY
 
 
 class ArgParser(ArgumentParser):
@@ -206,7 +205,7 @@ Note:
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet",
                             help="Be quiet (don't describe what's happening, just do it)")
         parser.add_argument("-y", "--yes", action="store_true", dest="yes_to_all",
-                            help='Answer "yes" to all prompts (use with caution, this is destructive, especially during the "storage" stage.)')
+                            help='Answer "yes" to all prompts (use with caution, this is destructive, especially during the "storage" stage. The /root/.ssh/id_rsa key will be overwritten unless the option "--no-overwrite-sshkey" is used)')
         parser.add_argument("-t", "--template", dest="template", metavar="TEMPLATE", choices=['ocfs2'],
                             help='Optionally configure cluster with template "name" (currently only "ocfs2" is valid here)')
         parser.add_argument("-n", "--name", metavar="NAME", dest="cluster_name", default="hacluster",
@@ -218,6 +217,8 @@ Note:
                             help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",
                             help="Use the given watchdog device")
+        parser.add_argument("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
+                            help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-i", "--interface", dest="nic", metavar="IF", choices=utils.interface_choice(),
@@ -309,6 +310,8 @@ Note:
 Stage can be one of:
     ssh         Obtain SSH keys from existing cluster node (requires -c <host>)
     csync2      Configure csync2 (requires -c <host>)
+    ssh_merge   Merge root's SSH known_hosts across all nodes (csync2 must
+                already be configured).
     cluster     Start the cluster on this node
 
 If stage is not specified, each stage will be invoked in sequence.
@@ -329,7 +332,7 @@ If stage is not specified, each stage will be invoked in sequence.
         stage = ""
         if len(args) == 1:
             stage = args[0]
-        if stage not in ("ssh", "csync2", "cluster", ""):
+        if stage not in ("ssh", "csync2", "ssh_merge", "cluster", ""):
             parser.error("Invalid stage (%s)" % (stage))
 
         join_context = bootstrap.Context.set_context(options)
@@ -637,8 +640,6 @@ Cluster Description
         opts = parallax.Options()
         opts.ssh_options = ['StrictHostKeyChecking=no']
         opts.askpass = utils.check_ssh_passwd_need(hosts)
-        if hasattr(opts, 'ssh_key'):
-            opts.ssh_key = SSH_KEY_CRMSH
         for host, result in parallax.call(hosts, cmd, opts).items():
             if isinstance(result, parallax.Error):
                 err_buf.error("[%s]: %s" % (host, result))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1943,8 +1943,6 @@ def remote_diff_slurp(nodes, filename):
     tmpdir = tmpfiles.create_dir()
     opts = parallax.Options()
     opts.localdir = tmpdir
-    if hasattr(opts, 'ssh_key'):
-        opts.ssh_key = constants.SSH_KEY_CRMSH
     dst = os.path.basename(filename)
     return list(parallax.slurp(nodes, filename, dst, opts).items())
 
@@ -2010,13 +2008,10 @@ def cluster_copy_file(local_path, nodes=None):
         import parallax
     except ImportError:
         raise ValueError("parallax is required to copy cluster files")
-
     if not nodes:
         nodes = list_cluster_nodes()
         nodes.remove(this_node())
     opts = parallax.Options()
-    if hasattr(opts, 'ssh_key'):
-        opts.ssh_key = constants.SSH_KEY_CRMSH
     opts.timeout = 60
     opts.ssh_options += ['ControlPersist=no']
     ok = True
@@ -2204,7 +2199,7 @@ def get_member_iplist():
 def check_ssh_passwd_need(hosts):
     ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
     for host in hosts:
-        ssh_cmd = "{} {} -T -o Batchmode=yes {} true".format(constants.SSH_WITH_KEY, ssh_options, host)
+        ssh_cmd = "ssh {} -T -o Batchmode=yes {} true".format(ssh_options, host)
         rc, _, _ = get_stdout_stderr(ssh_cmd)
         if rc != 0:
             return True

--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -26,7 +26,6 @@ import constants
 import crmsh.config
 from crmsh import msg as crmmsg
 from crmsh import utils as crmutils
-from crmsh.constants import SSH_WITH_KEY
 
 
 class Tempfile(object):
@@ -1533,8 +1532,8 @@ def start_slave_collector(node, arg_str):
             cmd += " {}".format(str(item))
         _, out = crmutils.get_stdout(cmd)
     else:
-        cmd = r'{} {} {} "{} hb_report __slave"'.\
-              format(SSH_WITH_KEY, constants.SSH_OPTS, node,
+        cmd = r'ssh {} {} "{} hb_report __slave"'.\
+              format(constants.SSH_OPTS, node,
                      constants.SUDO, os.getcwd())
         for item in arg_str.split():
             cmd += " {}".format(str(item))
@@ -1633,7 +1632,7 @@ def tail(n, indata):
 
 
 def test_ssh_conn(addr):
-    cmd = r"{} {} -T -o Batchmode=yes {} true".format(SSH_WITH_KEY, constants.SSH_OPTS, addr)
+    cmd = r"ssh %s -T -o Batchmode=yes %s true" % (constants.SSH_OPTS, addr)
     code, _ = get_command_info(cmd)
     if code == 0:
         return True

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -7,7 +7,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Set placement-strategy value as "default"(bsc#1129462)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Show cluster status on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -38,7 +38,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Setup cluster with crossed network(udpu only)
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -u -i eth0 -y" on "hanode1"
+    When    Run "crm cluster init -u -i eth0 -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "stopped" on "hanode2"

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -7,7 +7,7 @@ Feature: crmsh bootstrap process - init, join and remove
   Background: Setup a two nodes cluster
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Show cluster status on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -33,7 +33,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Init whole cluster service on node "hanode1" using "--nodes" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --nodes \"hanode1 hanode2\"" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey --nodes \"hanode1 hanode2\"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
@@ -71,7 +71,7 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Init cluster service with udpu using "-u" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -u -y" on "hanode1"
+    When    Run "crm cluster init -u -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster is using udpu transport mode
     And     IP "172.17.0.2" is used by corosync

--- a/test/features/geo_setup.feature
+++ b/test/features/geo_setup.feature
@@ -8,11 +8,11 @@ Feature: geo cluster
   Scenario: GEO cluster setup
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y -n cluster1" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey -n cluster1" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm configure primitive vip IPaddr2 params ip=10.10.10.123" on "hanode1"
 
-    When    Run "crm cluster init -y -n cluster2" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey -n cluster2" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     When    Run "crm configure primitive vip IPaddr2 params ip=10.10.10.124" on "hanode2"
 

--- a/test/features/qdevice_options.feature
+++ b/test/features/qdevice_options.feature
@@ -12,7 +12,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-algo" to change qnetd decision algorithm to "lms"
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-algo=lms -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-algo=lms -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -25,7 +25,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-tie-breaker" to change qnetd tie_breaker to "highest"
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tie-breaker=highest -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tie-breaker=highest -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration
@@ -34,7 +34,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-tls" to turn off TLS certification
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=off -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=off -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration
@@ -43,7 +43,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-heuristics" to configure heuristics
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/usr/bin/test -f /tmp/file_exists;/usr/bin/which pacemaker' -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/usr/bin/test -f /tmp/file_exists;/usr/bin/which pacemaker' -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -12,7 +12,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice/qnetd during init/join process
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -25,7 +25,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice/qnetd on running cluster
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -43,7 +43,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice with heuristics
-    When    Run "crm cluster init -y --qnetd-hostname=qnetd-node --qdevice-heuristics="/usr/bin/test -f /tmp/heuristics.txt" --qdevice-heuristics-mode="on"" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey --qnetd-hostname=qnetd-node --qdevice-heuristics="/usr/bin/test -f /tmp/heuristics.txt" --qdevice-heuristics-mode="on"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -61,7 +61,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Remove qdevice from a two nodes cluster
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -21,7 +21,7 @@ Feature: Verify usercase master survive when split-brain
   @clean
   Scenario: Master survive when split-brain
     # Setup a two-nodes cluster
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -61,9 +61,9 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Node for qnetd is a cluster node
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y" on "hanode2"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
-    When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
+    When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
     Then    Except multiple lines
       """"
       ERROR: cluster.init: host for qnetd must be a non-cluster node
@@ -78,7 +78,7 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Node for qnetd not installed corosync-qnetd
     Given   Cluster service is "stopped" on "hanode2"
-    When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
+    When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
     Then    Except multiple lines
       """"
       ERROR: cluster.init: Package "corosync-qnetd" not installed on hanode2
@@ -98,7 +98,7 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Run qdevice stage but miss "--qnetd-hostname" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster init qdevice"
     Then    Except "ERROR: cluster.init: qdevice related options are missing (--qnetd-hostname option is mandatory, find for more information using --help)"

--- a/test/features/resource_failcount.feature
+++ b/test/features/resource_failcount.feature
@@ -5,7 +5,7 @@ Feature: Use "crm resource failcount" to manage failcounts
 
   Background: Setup one node cluster and configure a Dummy resource
     Given     Cluster service is "stopped" on "hanode1"
-    When      Run "crm cluster init -y" on "hanode1"
+    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then      Cluster service is "started" on "hanode1"
     When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     Then      Resource "d" type "Dummy" is "Started"

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -5,7 +5,7 @@ Feature: Use "crm configure set" to update attributes and operations
 
   Background: Setup one node cluster and configure some resources
     Given     Cluster service is "stopped" on "hanode1"
-    When      Run "crm cluster init -y" on "hanode1"
+    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
     Then      Cluster service is "started" on "hanode1"
     When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     Then      Resource "d" type "Dummy" is "Started"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -59,7 +59,9 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution, this is
-                        destructive, especially during the "storage" stage.)
+                        destructive, especially during the "storage" stage.
+                        The /root/.ssh/id_rsa key will be overwritten unless
+                        the option "--no-overwrite-sshkey" is used)
   -t TEMPLATE, --template TEMPLATE
                         Optionally configure cluster with template "name"
                         (currently only "ocfs2" is valid here)
@@ -72,6 +74,9 @@ optional arguments:
                         (diskless mode)
   -w WATCHDOG, --watchdog WATCHDOG
                         Use the given watchdog device
+  --no-overwrite-sshkey
+                        Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is
+                        used (False by default)
 
 Network configuration:
   Options for configuring the network and messaging layer.
@@ -165,6 +170,8 @@ Network configuration:
 Stage can be one of:
     ssh         Obtain SSH keys from existing cluster node (requires -c <host>)
     csync2      Configure csync2 (requires -c <host>)
+    ssh_merge   Merge root's SSH known_hosts across all nodes (csync2 must
+                already be configured).
     cluster     Start the cluster on this node
 
 If stage is not specified, each stage will be invoked in sequence.'''

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -1,21 +1,5 @@
 import socket
-import parallax
-from crmsh import utils, bootstrap
-
-
-def parallax_call(nodes_list, cmd, askpass=False, ssh_options=None):
-    opts = parallax.Options()
-    if ssh_options is None:
-        opts.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
-    opts.askpass = askpass
-    if hasattr(opts, 'warn_message'):
-        opts.warn_message = False
-
-    results = parallax.call(nodes_list, cmd, opts)
-    for host, result in results.items():
-        if isinstance(result, parallax.Error):
-            raise ValueError("Failed on {}: {}".format(host, result))
-    return list(results.items())
+from crmsh import utils, bootstrap, parallax
 
 
 def me():
@@ -41,7 +25,7 @@ def run_command_local_or_remote(context, cmd, addr, err_record=False):
         return out
     else:
         try:
-            results = parallax_call([addr], cmd)
+            results = parallax.parallax_call([addr], cmd)
         except ValueError as err:
             if err_record:
                 context.command_error_output = str(err)
@@ -64,7 +48,7 @@ def check_service_state(context, service_name, state, addr):
     else:
         test_active = "systemctl -q is-active {}".format(service_name)
         try:
-            parallax_call([addr], test_active)
+            parallax.parallax_call([addr], test_active)
         except ValueError:
             return state_dict[state] is False
         else:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -19,7 +19,6 @@ except ImportError:
     import mock
 
 from crmsh import bootstrap
-from crmsh.constants import SSH_KEY_CRMSH, SSH_WITH_KEY, SCP_WITH_KEY, SSH_KEY_CRMSH_TAG
 
 
 class TestSBDManager(unittest.TestCase):
@@ -290,7 +289,7 @@ class TestSBDManager(unittest.TestCase):
         self.sbd_inst.join_sbd("node1")
 
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invoke.assert_called_once_with("ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_invoke.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
         mock_check.assert_not_called()
 
     @mock.patch('crmsh.bootstrap.status')
@@ -307,7 +306,7 @@ class TestSBDManager(unittest.TestCase):
         self.sbd_inst.join_sbd("node1")
 
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invoke.assert_called_once_with("ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_invoke.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
         mock_check.assert_called_once_with()
         mock_get_device.assert_called_once_with()
         mock_verify.assert_called_once_with(["/dev/sdb1"])
@@ -341,86 +340,101 @@ class TestBootstrap(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.append')
+    @mock.patch('crmsh.bootstrap.status')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.bootstrap.start_service')
-    def test_init_ssh_no_overwrite(self, mock_start, mock_exists, mock_confirm):
-        mock_exists.return_value = True
-        mock_confirm.return_value = False
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_no_exist_keys(self, mock_invoke, mock_start_service,
+                                    mock_exists, mock_status, mock_append):
+        mock_exists.return_value = False
+
         bootstrap.init_ssh()
-        mock_start.assert_called_once_with("sshd.service")
-        mock_exists.assert_called_once_with(SSH_KEY_CRMSH)
-        mock_confirm.assert_called_once_with("{} already exists - overwrite?".format(SSH_KEY_CRMSH))
+
+        mock_start_service.assert_called_once_with("sshd.service")
+        mock_invoke.assert_has_calls([
+            mock.call("mkdir -m 700 -p /root/.ssh"),
+            mock.call("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
+        ])
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_status.assert_called_once_with("Generating SSH key")
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
     @mock.patch('crmsh.bootstrap.append')
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.rmfile')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.bootstrap.start_service')
-    def test_init_ssh_overwrite(self, mock_start, mock_exists, mock_confirm, mock_rmfile,
-            mock_invoke, mock_append):
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_exits_keys_yes_to_all_confirm(self, mock_invoke, mock_start_service,
+                         mock_exists, mock_confirm, mock_rmfile, mock_status, mock_append):
         mock_exists.return_value = True
+        bootstrap._context = mock.Mock(yes_to_all=True, no_overwrite_sshkey=False)
         mock_confirm.return_value = True
 
         bootstrap.init_ssh()
 
-        mock_start.assert_called_once_with("sshd.service")
-        mock_exists.assert_called_once_with(SSH_KEY_CRMSH)
-        mock_confirm.assert_called_once_with("{} already exists - overwrite?".format(SSH_KEY_CRMSH))
-        mock_rmfile.assert_called_once_with(SSH_KEY_CRMSH)
-        mock_invoke.assert_has_calls([
-            mock.call("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG)),
-            mock.call("ssh-keygen -q -f {} -C '{}' -N ''".format(SSH_KEY_CRMSH, SSH_KEY_CRMSH_TAG))
-            ])
-        mock_append.assert_called_once_with("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")
-
-    @mock.patch('crmsh.bootstrap.error')
-    def test_join_ssh_error_no_seed_host(self, mock_error):
-        mock_error.side_effect = ValueError
-
-        with self.assertRaises(ValueError):
-            bootstrap.join_ssh(None)
-        mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
-
-    @mock.patch('crmsh.bootstrap.status')
-    @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.bootstrap.start_service')
-    @mock.patch('crmsh.bootstrap.error')
-    def test_join_ssh_error_scp(self, mock_error, mock_start, mock_invoke, mock_status):
-        mock_error.side_effect = ValueError
-        mock_invoke.side_effect = [True, False]
-
-        with self.assertRaises(ValueError):
-            bootstrap.join_ssh("node1")
-
-        mock_start.assert_called_once_with("sshd.service")
+        mock_start_service.assert_called_once_with("sshd.service")
         mock_invoke.assert_has_calls([
             mock.call("mkdir -m 700 -p /root/.ssh"),
-            mock.call("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH))
-            ])
-        mock_error.assert_called_once_with("Failed to retrieve ssh keys")
-        mock_status.assert_called_once_with("Retrieving SSH keys - This may prompt for root@node1:")
+            mock.call("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal' -N ''")
+        ])
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_confirm.assert_called_once_with("/root/.ssh/id_rsa already exists - overwrite?")
+        mock_rmfile.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_status.assert_called_once_with("Generating SSH key")
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
+    @mock.patch('crmsh.bootstrap.rmfile')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.bootstrap.start_service')
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_init_ssh_exits_keys_no_overwrite(self, mock_invoke, mock_start_service,
+                                              mock_exists, mock_confirm, mock_rmfile):
+        mock_exists.return_value = True
+        bootstrap._context = mock.Mock(yes_to_all=True, no_overwrite_sshkey=True)
+
+        bootstrap.init_ssh()
+
+        mock_start_service.assert_called_once_with("sshd.service")
+        mock_invoke.assert_called_once_with("mkdir -m 700 -p /root/.ssh")
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_confirm.assert_not_called()
+        mock_rmfile.assert_not_called()
+
+    @mock.patch('builtins.open')
     @mock.patch('crmsh.bootstrap.append')
-    @mock.patch('crmsh.bootstrap.status')
-    @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.bootstrap.start_service')
-    @mock.patch('crmsh.bootstrap.error')
-    def test_join_ssh(self, mock_error, mock_start, mock_invoke, mock_status, mock_append):
-        mock_invoke.side_effect = [True, True, True]
+    @mock.patch('os.path.join')
+    @mock.patch('os.path.exists')
+    def test_init_ssh_remote_no_sshkey(self, mock_exists, mock_join, mock_append, mock_open_file):
+        mock_exists.side_effect = [False, True, False, False, False]
+        mock_join.side_effect = ["/root/.ssh/id_rsa",
+                                 "/root/.ssh/id_dsa",
+                                 "/root/.ssh/id_ecdsa",
+                                 "/root/.ssh/id_ed25519"]
+        mock_open_file.side_effect = [
+            mock.mock_open().return_value,
+            mock.mock_open(read_data="data1 data2").return_value,
+            mock.mock_open(read_data="data1111").return_value
+        ]
 
-        bootstrap.join_ssh("node1")
+        bootstrap.init_ssh_remote()
 
-        mock_start.assert_called_once_with("sshd.service")
-        mock_invoke.assert_has_calls([
-            mock.call("mkdir -m 700 -p /root/.ssh"),
-            mock.call("scp -oStrictHostKeyChecking=no root@node1:'{}*' /root/.ssh".format(SSH_KEY_CRMSH)),
-            mock.call("sed -i '/{}/d' /root/.ssh/authorized_keys".format(SSH_KEY_CRMSH_TAG))
-            ])
-        mock_error.assert_not_called()
-        mock_status.assert_called_once_with("Retrieving SSH keys - This may prompt for root@node1:")
-        mock_append.assert_called_once_with("{}.pub".format(SSH_KEY_CRMSH), "/root/.ssh/authorized_keys")
+        mock_open_file.assert_has_calls([
+            mock.call("/root/.ssh/authorized_keys", 'w'),
+            mock.call("/root/.ssh/authorized_keys", "r+"),
+            mock.call("/root/.ssh/id_rsa.pub")
+        ])
+        mock_exists.assert_has_calls([
+            mock.call("/root/.ssh/authorized_keys"),
+            mock.call("/root/.ssh/id_rsa"),
+            mock.call("/root/.ssh/id_dsa"),
+            mock.call("/root/.ssh/id_ecdsa"),
+            mock.call("/root/.ssh/id_ed25519"),
+        ])
+        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
     @mock.patch('crmsh.utils.get_nodeinfo_from_cmaptool')
     @mock.patch('crmsh.corosync.add_node_ucast')
@@ -458,7 +472,7 @@ class TestBootstrap(unittest.TestCase):
         assert peer_node == "node1"
 
         mock_valid_ip.assert_called_once_with("1.1.1.1")
-        mock_stdout_stderr.assert_called_once_with("ssh -i /root/.ssh/id_rsa.crmsh 1.1.1.1 crm_node --name")
+        mock_stdout_stderr.assert_called_once_with("ssh 1.1.1.1 crm_node --name")
 
     @mock.patch('crmsh.utils.valid_ip_addr')
     @mock.patch('crmsh.utils.get_stdout_stderr')

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -63,8 +63,8 @@ def test_check_ssh_passwd_need_True():
         mock_get_stdout_stderr.side_effect = [(0, None, None), (1, None, None)]
         assert utils.check_ssh_passwd_need(["node1", "node2"]) == True
     mock_get_stdout_stderr.assert_has_calls([
-            mock.call('ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
-            mock.call('ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
+            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
+            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
         ])
 
 
@@ -73,8 +73,8 @@ def test_check_ssh_passwd_need_Flase():
         mock_get_stdout_stderr.side_effect = [(0, None, None), (0, None, None)]
         assert utils.check_ssh_passwd_need(["node1", "node2"]) == False
     mock_get_stdout_stderr.assert_has_calls([
-            mock.call('ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
-            mock.call('ssh -i /root/.ssh/id_rsa.crmsh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
+            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
+            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
         ])
 
 


### PR DESCRIPTION
Consider #575 will cause compatibility problem with old version of crmsh, we decided to revert it.