### PR TITLE
[crmsh-4.1] Low: cibconfig: Avoid adding the ID attribute to select_* nodes

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -687,7 +687,11 @@ def fix_node_ids(node, oldnode):
         'alerts': 'alert',
         }
 
-    idless = set(['operations', 'fencing-topology', 'network', 'docker', 'rkt', 'storage', 'select', 'select_attributes'])
+    idless = set([
+        'operations', 'fencing-topology', 'network', 'docker', 'rkt',
+        'storage', 'select', 'select_attributes', 'select_fencing',
+        'select_nodes', 'select_resources'
+    ])
     isref = set(['resource_ref', 'obj_ref', 'crmsh-ref'])
 
     def needs_id(node):

--- a/test/testcases/newfeatures
+++ b/test/testcases/newfeatures
@@ -32,6 +32,9 @@ alert notify_10 /usr/share/pacemaker/alerts/alert_snmp.sh \
         trap_add_hires_timestamp_oid="false" \
         select attributes { master-prmStateful test1 } \
         to 192.168.28.188
+alert notify_11 /usr/share/pacemaker/alerts/alert_snmp.sh \
+        select fencing nodes resources \
+        to 192.168.28.188
 show tag:ones and type:location
 show tag:ones and p1
 show

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -20,6 +20,7 @@
 .INP: tag ones l1 p1
 .INP: alert notify_9 /usr/share/pacemaker/alerts/alert_snmp.sh         attributes         trap_add_hires_timestamp_oid="false"         trap_node_states="non-trap"         trap_resource_tasks="start,stop,monitor,promote,demote"         to "192.168.40.9"
 .INP: alert notify_10 /usr/share/pacemaker/alerts/alert_snmp.sh         attributes         trap_add_hires_timestamp_oid="false"         select attributes { master-prmStateful test1 }         to 192.168.28.188
+.INP: alert notify_11 /usr/share/pacemaker/alerts/alert_snmp.sh         select fencing nodes resources         to 192.168.28.188
 .INP: show tag:ones and type:location
 location l1 { p0 p1 p2 } inf: node1
 .INP: show tag:ones and p1
@@ -49,6 +50,9 @@ property cib-bootstrap-options: \
 alert notify_10 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
 	attributes trap_add_hires_timestamp_oid=false \
         select attributes { master-prmStateful test1 } \
+	to 192.168.28.188
+alert notify_11 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
+	select fencing nodes resources \
 	to 192.168.28.188
 alert notify_9 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
 	attributes trap_add_hires_timestamp_oid=false trap_node_states=non-trap trap_resource_tasks="start,stop,monitor,promote,demote" \


### PR DESCRIPTION
Backport of #595.