### PR TITLE
bootstrap process will not overwrite existing ssh keys

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -175,7 +175,7 @@ class QDevice(object):
             raise ValueError(exception_msg)
 
     def check_ssh_passwd_need(self):
-        return utils.check_ssh_passwd_need([self.ip])
+        return utils.check_ssh_passwd_need(self.ip)
 
     def remote_running_cluster(self):
         cmd = "systemctl -q is-active pacemaker"

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -639,7 +639,11 @@ Cluster Description
 
         opts = parallax.Options()
         opts.ssh_options = ['StrictHostKeyChecking=no']
-        opts.askpass = utils.check_ssh_passwd_need(hosts)
+        for host in hosts:
+            res = utils.check_ssh_passwd_need(host)
+            if res:
+                opts.askpass = True
+                break
         for host, result in parallax.call(hosts, cmd, opts).items():
             if isinstance(result, parallax.Error):
                 err_buf.error("[%s]: %s" % (host, result))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2053,14 +2053,14 @@ def get_member_iplist():
     return ip_list
 
 
-def check_ssh_passwd_need(hosts):
+def check_ssh_passwd_need(host):
+    """
+    Check whether access to host need password
+    """
     ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
-    for host in hosts:
-        ssh_cmd = "ssh {} -T -o Batchmode=yes {} true".format(ssh_options, host)
-        rc, _, _ = get_stdout_stderr(ssh_cmd)
-        if rc != 0:
-            return True
-    return False
+    ssh_cmd = "ssh {} -T -o Batchmode=yes {} true".format(ssh_options, host)
+    rc, _, _ = get_stdout_stderr(ssh_cmd)
+    return rc != 0
 
 
 def check_port_open(host, port):
@@ -2404,4 +2404,20 @@ class InterfacesInfo(object):
             if interface_inst.ip_in_network(addr):
                 return True
         return False
+
+
+def check_file_content_included(source_file, target_file):
+    """
+    Check whether target_file includes contents of source_file
+    """
+    if not os.path.exists(source_file):
+        raise ValueError("File {} not exist".format(source_file))
+    if not os.path.exists(target_file):
+        return False
+
+    with open(target_file, 'r') as target_fd:
+        target_data = target_fd.read()
+    with open(source_file, 'r') as source_fd:
+        source_data = source_fd.read()
+    return source_data in target_data
 # vim:ts=4:sw=4:et:

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -7,7 +7,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Set placement-strategy value as "default"(bsc#1129462)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Show cluster status on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -38,7 +38,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Setup cluster with crossed network(udpu only)
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -u -i eth0 -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -u -i eth0 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "stopped" on "hanode2"

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -7,7 +7,7 @@ Feature: crmsh bootstrap process - init, join and remove
   Background: Setup a two nodes cluster
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Show cluster status on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -33,7 +33,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Init whole cluster service on node "hanode1" using "--nodes" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --no-overwrite-sshkey --nodes \"hanode1 hanode2\"" on "hanode1"
+    When    Run "crm cluster init -y --nodes \"hanode1 hanode2\"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
@@ -43,7 +43,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Bind specific network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "10.10.10.2" is belong to "eth1"
-    When    Run "crm cluster init -i eth1 -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "10.10.10.2" is used by corosync on "hanode1"
     And     Show corosync ring status
@@ -53,7 +53,7 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "172.17.0.2" is belong to "eth0"
     And     IP "10.10.10.2" is belong to "eth1"
-    When    Run "crm cluster init -M -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -M -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "172.17.0.2" is used by corosync on "hanode1"
     And     IP "10.10.10.2" is used by corosync on "hanode1"
@@ -64,7 +64,7 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "172.17.0.2" is belong to "eth0"
     And     IP "10.10.10.2" is belong to "eth1"
-    When    Run "crm cluster init -i eth0 -i eth1 -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -i eth0 -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "172.17.0.2" is used by corosync on "hanode1"
     And     IP "10.10.10.2" is used by corosync on "hanode1"
@@ -79,7 +79,7 @@ Feature: crmsh bootstrap process - options
     Then    Except "ERROR: cluster.init: Address already in use: 10.10.10.2"
     When    Try "crm cluster init -A 10.20.10.2 -y"
     Then    Except "ERROR: cluster.init: Address '10.20.10.2' not in any local network"
-    When    Run "crm cluster init -n hatest -A 10.10.10.123 -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -n hatest -A 10.10.10.123 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster name is "hatest"
     And     Cluster virtual IP is "10.10.10.123"
@@ -88,7 +88,7 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Init cluster service with udpu using "-u" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -u -y -i eth0 --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -u -y -i eth0" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster is using udpu transport mode
     And     IP "172.17.0.2" is used by corosync on "hanode1"
@@ -99,7 +99,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Init cluster service with ipv6 using "-I" option
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -I -i eth1 -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -I -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "2001:db8:10::2" is used by corosync on "hanode1"
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
@@ -111,7 +111,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Init cluster service with ipv6 unicast using "-I" and "-u" option
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -I -i eth1 -u -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -I -i eth1 -u -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "2001:db8:10::2" is used by corosync on "hanode1"
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"

--- a/test/features/geo_setup.feature
+++ b/test/features/geo_setup.feature
@@ -8,11 +8,11 @@ Feature: geo cluster
   Scenario: GEO cluster setup
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --no-overwrite-sshkey -n cluster1" on "hanode1"
+    When    Run "crm cluster init -y -n cluster1" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm configure primitive vip IPaddr2 params ip=10.10.10.123" on "hanode1"
 
-    When    Run "crm cluster init -y --no-overwrite-sshkey -n cluster2" on "hanode2"
+    When    Run "crm cluster init -y -n cluster2" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     When    Run "crm configure primitive vip IPaddr2 params ip=10.10.10.124" on "hanode2"
 

--- a/test/features/qdevice_options.feature
+++ b/test/features/qdevice_options.feature
@@ -12,7 +12,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-algo" to change qnetd decision algorithm to "lms"
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-algo=lms -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-algo=lms -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -25,7 +25,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-tie-breaker" to change qnetd tie_breaker to "highest"
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tie-breaker=highest -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tie-breaker=highest -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration
@@ -34,7 +34,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-tls" to turn off TLS certification
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=off -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=off -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration
@@ -43,7 +43,7 @@ Feature: corosync qdevice/qnetd options
   Scenario: Use "--qdevice-heuristics" to configure heuristics
     Given   Cluster service is "stopped" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/usr/bin/test -f /tmp/file_exists;/usr/bin/which pacemaker' -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics='/usr/bin/test -f /tmp/file_exists;/usr/bin/which pacemaker' -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show corosync qdevice configuration

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -12,7 +12,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice/qnetd during init/join process
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -25,7 +25,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice/qnetd on running cluster
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -43,7 +43,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice with heuristics
-    When    Run "crm cluster init -y --no-overwrite-sshkey --qnetd-hostname=qnetd-node --qdevice-heuristics="/usr/bin/test -f /tmp/heuristics.txt" --qdevice-heuristics-mode="on"" on "hanode1"
+    When    Run "crm cluster init -y --qnetd-hostname=qnetd-node --qdevice-heuristics="/usr/bin/test -f /tmp/heuristics.txt" --qdevice-heuristics-mode="on"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
@@ -61,7 +61,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Remove qdevice from a two nodes cluster
-    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -21,7 +21,7 @@ Feature: Verify usercase master survive when split-brain
   @clean
   Scenario: Master survive when split-brain
     # Setup a two-nodes cluster
-    When    Run "crm cluster init -y -i eth0 --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y -i eth0" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -61,9 +61,9 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Node for qnetd is a cluster node
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
-    When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
+    When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
     Then    Except multiple lines
       """"
       ERROR: cluster.init: host for qnetd must be a non-cluster node
@@ -78,7 +78,7 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Node for qnetd not installed corosync-qnetd
     Given   Cluster service is "stopped" on "hanode2"
-    When    Try "crm cluster init --qnetd-hostname=hanode2 -y --no-overwrite-sshkey"
+    When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
     Then    Except multiple lines
       """"
       ERROR: cluster.init: Package "corosync-qnetd" not installed on hanode2
@@ -98,7 +98,7 @@ Feature: corosync qdevice/qnetd options validate
   @clean
   Scenario: Run qdevice stage but miss "--qnetd-hostname" option
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster init qdevice"
     Then    Except "ERROR: cluster.init: qdevice related options are missing (--qnetd-hostname option is mandatory, find for more information using --help)"

--- a/test/features/resource_failcount.feature
+++ b/test/features/resource_failcount.feature
@@ -5,7 +5,7 @@ Feature: Use "crm resource failcount" to manage failcounts
 
   Background: Setup one node cluster and configure a Dummy resource
     Given     Cluster service is "stopped" on "hanode1"
-    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When      Run "crm cluster init -y" on "hanode1"
     Then      Cluster service is "started" on "hanode1"
     When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     Then      Resource "d" type "Dummy" is "Started"

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -5,7 +5,7 @@ Feature: Use "crm configure set" to update attributes and operations
 
   Background: Setup one node cluster and configure some resources
     Given     Cluster service is "stopped" on "hanode1"
-    When      Run "crm cluster init -y --no-overwrite-sshkey" on "hanode1"
+    When      Run "crm cluster init -y" on "hanode1"
     Then      Cluster service is "started" on "hanode1"
     When      Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     Then      Resource "d" type "Dummy" is "Started"

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -495,7 +495,7 @@ class TestQDevice(unittest.TestCase):
     def test_check_ssh_passwd_need(self, mock_ssh_passwd):
         mock_ssh_passwd.return_value = True
         self.assertTrue(self.qdevice_with_ip.check_ssh_passwd_need())
-        mock_ssh_passwd.assert_called_once_with(["10.10.10.123"])
+        mock_ssh_passwd.assert_called_once_with("10.10.10.123")
 
     @mock.patch("crmsh.parallax.parallax_call")
     def test_remote_running_cluster_false(self, mock_call):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -22,6 +22,30 @@ def setup_function():
     imp.reload(utils)
 
 
+@mock.patch('os.path.exists')
+def test_check_file_content_included_target_not_exist(mock_exists):
+    mock_exists.side_effect = [True, False]
+    res = utils.check_file_content_included("file1", "file2")
+    assert res is False
+    mock_exists.assert_has_calls([mock.call("file1"), mock.call("file2")])
+
+
+@mock.patch("builtins.open")
+@mock.patch('os.path.exists')
+def test_check_file_content_included(mock_exists, mock_open_file):
+    mock_exists.side_effect = [True, True]
+    mock_open_file.side_effect = [
+            mock.mock_open(read_data="data1").return_value,
+            mock.mock_open(read_data="data2").return_value
+        ]
+
+    res = utils.check_file_content_included("file1", "file2")
+    assert res is False
+
+    mock_exists.assert_has_calls([mock.call("file1"), mock.call("file2")])
+    mock_open_file.assert_has_calls([mock.call("file2", 'r'), mock.call("file1", 'r')])
+
+
 @mock.patch('re.search')
 @mock.patch('crmsh.utils.get_stdout')
 def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
@@ -59,24 +83,12 @@ def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
     mock_re_search_inst.group.assert_called_once_with(1)
 
 
-def test_check_ssh_passwd_need_True():
-    with mock.patch('crmsh.utils.get_stdout_stderr') as mock_get_stdout_stderr:
-        mock_get_stdout_stderr.side_effect = [(0, None, None), (1, None, None)]
-        assert utils.check_ssh_passwd_need(["node1", "node2"]) == True
-    mock_get_stdout_stderr.assert_has_calls([
-            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
-            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
-        ])
-
-
-def test_check_ssh_passwd_need_Flase():
-    with mock.patch('crmsh.utils.get_stdout_stderr') as mock_get_stdout_stderr:
-        mock_get_stdout_stderr.side_effect = [(0, None, None), (0, None, None)]
-        assert utils.check_ssh_passwd_need(["node1", "node2"]) == False
-    mock_get_stdout_stderr.assert_has_calls([
-            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true'),
-            mock.call('ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node2 true')
-        ])
+@mock.patch('crmsh.utils.get_stdout_stderr')
+def test_check_ssh_passwd_need(mock_run):
+    mock_run.return_value = (1, None, None)
+    res = utils.check_ssh_passwd_need("node1")
+    assert res is True
+    mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes node1 true")
 
 
 @mock.patch('crmsh.utils.common_debug')


### PR DESCRIPTION
## Motivation
crmsh bootstrap has a very old default of overwriting the root id_rsa ssh key if the customer does not chose the opposite. Also, combined with automation options like -y (that answers yes for all the questions) makes a dangerous combination that can remove SSH access configured previously by the customer, and in extreme cases, could lock the machine depending of the configurations.
## Solution
#### crm cluster init node

- Generate a new rsa key only if /root/.ssh/id_rsa not exist
- Add /root/.ssh/id_rsa.pub to /root/.ssh/authorized_keys, make sure this node itself authorized
#### crm cluster join node
- Generate a new rsa key only if /root/.ssh/id_rsa not exist
- Add /root/.ssh/id_rsa.pub to /root/.ssh/authorized_keys, make sure this node itself authorized
- Detect whether login to init node is passwordless, if not, paste /root/.ssh/id_rsa.pub to init node's /root/.ssh/authorized_keys, then **login from join node to init node is passwordless**
- Fetch the public key from init node, and add it to local /root/.ssh/authorized_keys, then **login from init node to join node is passwordless**
#### For multi nodes scenarios
Above solution should works well for two nodes cluster, but not for multi-nodes, image this scenairos:
```
1. A cluster already has node1 and node2
2. node3 join to node1
3. node3 and node1 are passwordless
4. node3 and node2 still not passwordless
```
To address this issue, create function `setup_passwordless_with_other_nodes`, call it at the beginning of `join_cluster`;
In `setup_passwordless_with_other_nodes`, fetch the node list from init node, then swap the key between join node and the other cluster nodes if detect no passwordless configured before.

## Results
- All cluster nodes are passwordless to access each other
- Each node has its own ssh key(existing key or new created rsa key)
- When using --no-overwrite-sshkey option, give warning: `--no-overwrite-sshkey option is deprecated since crmsh does not overwrite ssh keys by default anymore and will be removed in future versions`