### PR TITLE
Qdevice config process improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,20 +24,6 @@ jobs:
       script:
         - docker run -t -v "$(pwd):/app" $IMAGE /bin/sh -c "cd /app; TOXENV=py38-codeclimate; tox"
 
-    - name: "original regression test"
-      before_script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - ./cc-test-reporter before-build
-      before_install:
-        - docker pull $IMAGE
-      script:
-        - docker run -t -v "$(pwd):/app" $IMAGE /bin/sh -c "cd /app; ./test/run-in-travis.sh"
-      after_failure:
-        - sudo cat $TRAVIS_BUILD_DIR/crmtestout/regression.out $TRAVIS_BUILD_DIR/crmtestout/crm.*
-      after_script:
-        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-
     - name: "regression test for bootstrap bugs"
       before_install:
         - $FUNCTIONAL_TEST bootstrap before_install
@@ -55,12 +41,6 @@ jobs:
         - $FUNCTIONAL_TEST bootstrap before_install
       script:
         - $FUNCTIONAL_TEST bootstrap run options
-
-    - name: "functional test for geo cluster"
-      before_install:
-        - $FUNCTIONAL_TEST geo before_install
-      script:
-        - $FUNCTIONAL_TEST geo run setup
 
     - name: "functional test for qdevice - setup and remove"
       before_install:
@@ -91,6 +71,26 @@ jobs:
         - $FUNCTIONAL_TEST resource before_install
       script:
         - $FUNCTIONAL_TEST resource run
+
+    - name: "functional test for geo cluster"
+      before_install:
+        - $FUNCTIONAL_TEST geo before_install
+      script:
+        - $FUNCTIONAL_TEST geo run setup
+
+    - name: "original regression test"
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+      before_install:
+        - docker pull $IMAGE
+      script:
+        - docker run -t -v "$(pwd):/app" $IMAGE /bin/sh -c "cd /app; ./test/run-in-travis.sh"
+      after_failure:
+        - sudo cat $TRAVIS_BUILD_DIR/crmtestout/regression.out $TRAVIS_BUILD_DIR/crmtestout/crm.*
+      after_script:
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
     - stage: delivery
       if: type != pull_request AND branch = master

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -310,6 +310,8 @@ Configure SBD:
         2. Initialize sbd device
         3. Write config file /etc/sysconfig/sbd
         """
+        if not utils.package_is_installed("sbd"):
+            return
         self._get_sbd_device()
         if not self._sbd_devices and not self.diskless_sbd:
             invoke("systemctl disable sbd.service")
@@ -324,6 +326,8 @@ Configure SBD:
         """
         Configure stonith-sbd resource and stonith-enabled property
         """
+        if not utils.package_is_installed("sbd"):
+            return
         if utils.service_is_enabled("sbd.service"):
             if self._get_sbd_device_from_config():
                 if not invoke("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
@@ -340,6 +344,8 @@ Configure SBD:
         On joining process, check whether peer node has enabled sbd.service
         If so, check prerequisites of SBD and verify sbd device on join node
         """
+        if not utils.package_is_installed("sbd"):
+            return
         cmd_detect_enabled = "ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(peer_host)
         if not os.path.exists(SYSCONFIG_SBD) or not invoke(cmd_detect_enabled):
             invoke("systemctl disable sbd.service")

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -106,6 +106,18 @@ def query_qnetd_status():
         print(utils.to_ascii(qnetd_result_stdout))
 
 
+def add_nodelist_from_cmaptool():
+    for nodeid, iplist in utils.get_nodeinfo_from_cmaptool().items():
+        try:
+            add_node_ucast(iplist, nodeid)
+        except IPAlreadyConfiguredError:
+            continue
+
+
+def is_unicast():
+    return get_value("totem.transport") == "udpu"
+
+
 _tCOMMENT = 0
 _tBEGIN = 1
 _tEND = 2
@@ -130,7 +142,9 @@ class Token(object):
 
 
 class QDevice(object):
-    '''
+    """
+    Class to manage qdevice configuration and services
+
     Whole certification process:
     For init
     Step 1:  init_db_on_qnetd
@@ -150,7 +164,7 @@ class QDevice(object):
     Step 2:  init_db_on_local
     Step 3:  fetch_p12_from_cluster
     Step 4:  import_p12_on_local
-    '''
+    """
     qnetd_service = "corosync-qnetd.service"
     qnetd_cacert_filename = "qnetd-cacert.crt"
     qdevice_crq_filename = "qdevice-net-node.crq"
@@ -159,9 +173,12 @@ class QDevice(object):
     qdevice_path = "/etc/corosync/qdevice/net"
     qdevice_db_path = "/etc/corosync/qdevice/net/nssdb"
 
-    def __init__(self, ip, port=5403, algo="ffsplit", tie_breaker="lowest",
+    def __init__(self, qnetd_addr, port=5403, algo="ffsplit", tie_breaker="lowest",
             tls="on", cluster_node=None, cmds=None, mode=None):
-        self.ip = ip
+        """
+        Init function
+        """
+        self.qnetd_addr = qnetd_addr
         self.port = port
         self.algo = algo
         self.tie_breaker = tie_breaker
@@ -173,53 +190,103 @@ class QDevice(object):
 
     @property
     def qnetd_cacert_on_qnetd(self):
+        """
+        Return path of qnetd-cacert.crt on qnetd node
+        """
         return "{}/nssdb/{}".format(self.qnetd_path, self.qnetd_cacert_filename)
 
     @property
     def qnetd_cacert_on_local(self):
-        return "{}/{}/{}".format(self.qdevice_path, self.ip, self.qnetd_cacert_filename)
+        """
+        Return path of qnetd-cacert.crt on local node
+        """
+        return "{}/{}/{}".format(self.qdevice_path, self.qnetd_addr, self.qnetd_cacert_filename)
 
     @property
     def qnetd_cacert_on_cluster(self):
+        """
+        Return path of qnetd-cacert.crt on cluster node
+        """
         return "{}/{}/{}".format(self.qdevice_path, self.cluster_node, self.qnetd_cacert_filename)
 
     @property
     def qdevice_crq_on_qnetd(self):
+        """
+        Return path of qdevice-net-node.crq on qnetd node
+        """
         return "{}/nssdb/{}".format(self.qnetd_path, self.qdevice_crq_filename)
     
     @property
     def qdevice_crq_on_local(self):
+        """
+        Return path of qdevice-net-node.crq on local node
+        """
         return "{}/nssdb/{}".format(self.qdevice_path, self.qdevice_crq_filename)
 
     @property
     def qnetd_cluster_crt_on_qnetd(self):
+        """
+        Return path of cluster-cluster_name.crt on qnetd node
+        """
         return "{}/nssdb/cluster-{}.crt".format(self.qnetd_path, self.cluster_name)
 
     @property
     def qnetd_cluster_crt_on_local(self):
-        return "{}/{}/{}".format(self.qdevice_path, self.ip, os.path.basename(self.qnetd_cluster_crt_on_qnetd))
+        """
+        Return path of cluster-cluster_name.crt on local node
+        """
+        return "{}/{}/{}".format(self.qdevice_path, self.qnetd_addr, os.path.basename(self.qnetd_cluster_crt_on_qnetd))
 
     @property
     def qdevice_p12_on_local(self):
+        """
+        Return path of qdevice-net-node.p12 on local node
+        """
         return "{}/nssdb/{}".format(self.qdevice_path, self.qdevice_p12_filename)
 
     @property
     def qdevice_p12_on_cluster(self):
+        """
+        Return path of qdevice-net-node.p12 on cluster node
+        """
         return "{}/{}/{}".format(self.qdevice_path, self.cluster_node, self.qdevice_p12_filename)
 
-    def valid_attr(self, interfaces_inst):
-        if not bootstrap.package_is_installed("corosync-qdevice"):
+    def valid_attr(self):
+        """
+        Validate qdevice related options
+        """
+        qnetd_ip = None
+
+        if not utils.package_is_installed("corosync-qdevice"):
             raise ValueError("Package \"corosync-qdevice\" not installed on this node")
-        if self.ip == utils.this_node() or self.ip in interfaces_inst.ip_list:
+
+        try:
+            # socket.getaddrinfo works for both ipv4 and ipv6 address
+            # The function returns a list of 5-tuples with the following structure:
+            # (family, type, proto, canonname, sockaddr)
+            # sockaddr is a tuple describing a socket address, whose format depends on the returned family
+            # (a (address, port) 2-tuple for AF_INET, a (address, port, flow info, scope id) 4-tuple for AF_INET6)
+            res = socket.getaddrinfo(self.qnetd_addr, None)
+            qnetd_ip = res[0][-1][0]
+        except socket.error:
+            raise ValueError("host \"{}\" is unreachable".format(self.qnetd_addr))
+
+        rc, _ = utils.get_stdout("ping -c 1 {}".format(self.qnetd_addr))
+        if rc != 0:
+            raise ValueError("host \"{}\" is unreachable".format(self.qnetd_addr))
+
+        if utils.InterfacesInfo.ip_in_local(qnetd_ip):
             raise ValueError("host for qnetd must be a remote one")
-        if not utils.resolve_hostnames([self.ip])[0]:
-            raise ValueError("host \"{}\" is unreachable".format(self.ip))
-        if not utils.check_port_open(self.ip, 22):
-            raise ValueError("ssh service on \"{}\" not available".format(self.ip))
+
+        if not utils.check_port_open(qnetd_ip, 22):
+            raise ValueError("ssh service on \"{}\" not available".format(self.qnetd_addr))
+
         if not utils.valid_port(self.port):
             raise ValueError("invalid qdevice port range(1024 - 65535)")
+
         if self.tie_breaker not in ["lowest", "highest"] and not utils.valid_nodeid(self.tie_breaker):
             raise ValueError("invalid qdevice tie_breaker(lowest/highest/valid_node_id)")
+
         if self.cmds:
             for cmd in self.cmds.strip(';').split(';'):
                 if not cmd.startswith('/'):
@@ -228,52 +295,30 @@ class QDevice(object):
                     raise ValueError("command {} not exist".format(cmd.split()[0]))
 
     def valid_qnetd(self):
-        if self.check_ssh_passwd_need():
+        """
+        Validate on qnetd node
+        """
+        if utils.check_ssh_passwd_need(self.qnetd_addr):
             self.askpass = True
 
         exception_msg = ""
         suggest = ""
-        if self.remote_running_cluster():
+        if utils.service_is_active("pacemaker", self.qnetd_addr):
             exception_msg = "host for qnetd must be a non-cluster node"
-            suggest = "change to another host or stop cluster service on {}".format(self.ip)
-        elif not self.qnetd_installed():
-            exception_msg = "Package \"corosync-qnetd\" not installed on {}".format(self.ip)
-            suggest = "install \"corosync-qnetd\" on {}".format(self.ip)
+            suggest = "change to another host or stop cluster service on {}".format(self.qnetd_addr)
+        elif not utils.package_is_installed("corosync-qnetd", self.qnetd_addr):
+            exception_msg = "Package \"corosync-qnetd\" not installed on {}".format(self.qnetd_addr)
+            suggest = "install \"corosync-qnetd\" on {}".format(self.qnetd_addr)
 
         if exception_msg:
-            exception_msg += "\nCluster service already successfully started on this node\nIf you still want to use qdevice, {}\nThen run command \"crm cluster init qdevice --qnetd-hostname={}\"\nThis command will setup qdevice separately".format(suggest, self.ip)
+            exception_msg += "\nCluster service already successfully started on this node except qdevice service\nIf you still want to use qdevice, {}\nThen run command \"crm cluster init\" with \"qdevice\" stage, like:\n  crm cluster init qdevice qdevice_related_options\nThat command will setup qdevice separately".format(suggest)
             raise ValueError(exception_msg)
-
-    def check_ssh_passwd_need(self):
-        return utils.check_ssh_passwd_need(self.ip)
-
-    def remote_running_cluster(self):
-        cmd = "systemctl -q is-active pacemaker"
-        if self.askpass:
-            print("Checking on QNetd node({})".format(self.ip))
-        try:
-            parallax.parallax_call([self.ip], cmd, self.askpass)
-        except ValueError:
-            return False
-        else:
-            return True
-
-    def qnetd_installed(self):
-        cmd = "rpm -q --quiet corosync-qnetd"
-        if self.askpass:
-            print("Checking whether corosync-qnetd installed on node({})".format(self.ip))
-        try:
-            parallax.parallax_call([self.ip], cmd, self.askpass)
-        except ValueError:
-            return False
-        else:
-            return True
 
     def manage_qnetd(self, action):
         cmd = "systemctl {} {}".format(action, self.qnetd_service)
         if self.askpass:
-            print("{} {} on {}".format(action.capitalize(), self.qnetd_service, self.ip))
-        parallax.parallax_call([self.ip], cmd, self.askpass)
+            print("{} {} on {}".format(action.capitalize(), self.qnetd_service, self.qnetd_addr))
+        parallax.parallax_call([self.qnetd_addr], cmd, self.askpass)
 
     def enable_qnetd(self):
         self.manage_qnetd("enable")
@@ -292,71 +337,71 @@ class QDevice(object):
         bootstrap.log("# " + msg)
 
     def init_db_on_qnetd(self):
-        '''
+        """
         Certificate process for init
         Step 1
         Initialize database on QNetd server by running corosync-qnetd-certutil -i
-        '''
+        """
         cmd = "test -f {}".format(self.qnetd_cacert_on_qnetd)
         if self.askpass:
-            print("Test whether QNetd server({}) has database".format(self.ip))
+            print("Test whether {} exists on QNetd server({})".format(self.qnetd_cacert_on_qnetd, self.qnetd_addr))
         try:
-            parallax.parallax_call([self.ip], cmd, self.askpass)
+            parallax.parallax_call([self.qnetd_addr], cmd, self.askpass)
         except ValueError:
+            # target file not exist
             pass
         else:
             return
 
         cmd = "corosync-qnetd-certutil -i"
-        desc = "Step 1: Initialize database on {}".format(self.ip)
+        desc = "Step 1: Initialize database on {}".format(self.qnetd_addr)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_call([self.ip], cmd, self.askpass)
+        parallax.parallax_call([self.qnetd_addr], cmd, self.askpass)
 
     def fetch_qnetd_crt_from_qnetd(self):
-        '''
+        """
         Certificate process for init
         Step 2
         Fetch QNetd CA certificate(qnetd-cacert.crt) from QNetd server
-        '''
+        """
         if os.path.exists(self.qnetd_cacert_on_local):
             return
 
-        desc = "Step 2: Fetch {} from {}".format(self.qnetd_cacert_filename, self.ip)
+        desc = "Step 2: Fetch {} from {}".format(self.qnetd_cacert_filename, self.qnetd_addr)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_slurp([self.ip], self.qdevice_path,
-                             self.qnetd_cacert_on_qnetd, self.askpass)
+        parallax.parallax_slurp([self.qnetd_addr], self.qdevice_path, self.qnetd_cacert_on_qnetd, self.askpass)
 
     def copy_qnetd_crt_to_cluster(self):
-        '''
+        """
         Certificate process for init
         Step 3
         Copy exported QNetd CA certificate (qnetd-cacert.crt) to every node
-        '''
-        node_list = utils.list_cluster_nodes()
-        me = utils.this_node()
-        if len(node_list) == 1 and me in node_list:
+        """
+        node_list = utils.list_cluster_nodes_except_me()
+        if not node_list:
             return
 
-        if me in node_list:
-            node_list.remove(me)
         desc = "Step 3: Copy exported {} to {}".format(self.qnetd_cacert_filename, node_list)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_copy(node_list, os.path.dirname(self.qnetd_cacert_on_local),
-                            self.qdevice_path, self.askpass)
+        parallax.parallax_copy(
+                node_list,
+                os.path.dirname(self.qnetd_cacert_on_local),
+                self.qdevice_path,
+                self.askpass)
 
     def init_db_on_cluster(self):
-        '''
+        """
         Certificate process for init
         Step 4
         On one of cluster node initialize database by running
         /usr/sbin/corosync-qdevice-net-certutil -i -c qnetd-cacert.crt
-        '''
+        """
         node_list = utils.list_cluster_nodes()
         cmd = "corosync-qdevice-net-certutil -i -c {}".format(self.qnetd_cacert_on_local)
         desc = "Step 4: Initialize database on {}".format(node_list)
@@ -366,13 +411,13 @@ class QDevice(object):
         parallax.parallax_call(node_list, cmd, self.askpass)
 
     def create_ca_request(self):
-        '''
+        """
         Certificate process for init
         Step 5
         Generate certificate request:
         /usr/sbin/corosync-qdevice-net-certutil -r -n Cluster
         (Cluster name must match cluster_name key in the corosync.conf)
-        '''
+        """
         self.debug_and_log_to_bootstrap("Step 5: Generate certificate request {}".format(self.qdevice_crq_filename))
         self.cluster_name = get_value('totem.cluster_name')
         if not self.cluster_name:
@@ -383,53 +428,59 @@ class QDevice(object):
             raise ValueError(err)
 
     def copy_crq_to_qnetd(self):
-        '''
+        """
         Certificate process for init
         Step 6
         Copy exported CRQ to QNetd server
-        '''
-        desc = "Step 6: Copy {} to {}".format(self.qdevice_crq_filename, self.ip)
+        """
+        desc = "Step 6: Copy {} to {}".format(self.qdevice_crq_filename, self.qnetd_addr)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_copy([self.ip], self.qdevice_crq_on_local,
-                            os.path.dirname(self.qdevice_crq_on_qnetd), self.askpass)
+        parallax.parallax_copy(
+                [self.qnetd_addr],
+                self.qdevice_crq_on_local,
+                os.path.dirname(self.qdevice_crq_on_qnetd),
+                self.askpass)
 
     def sign_crq_on_qnetd(self):
-        '''
+        """
         Certificate process for init
         Step 7
         On QNetd server sign and export cluster certificate by running
         corosync-qnetd-certutil -s -c qdevice-net-node.crq -n Cluster
-        '''
-        desc = "Step 7: Sign and export cluster certificate on {}".format(self.ip)
+        """
+        desc = "Step 7: Sign and export cluster certificate on {}".format(self.qnetd_addr)
         self.debug_and_log_to_bootstrap(desc)
         cmd = "corosync-qnetd-certutil -s -c {} -n {}".\
                 format(self.qdevice_crq_on_qnetd, self.cluster_name)
         if self.askpass:
             print(desc)
-        parallax.parallax_call([self.ip], cmd, self.askpass)
+        parallax.parallax_call([self.qnetd_addr], cmd, self.askpass)
 
     def fetch_cluster_crt_from_qnetd(self):
-        '''
+        """
         Certificate process for init
         Step 8
         Copy exported CRT to node where certificate request was created
-        '''
-        desc = "Step 8: Fetch {} from {}".format(os.path.basename(self.qnetd_cluster_crt_on_qnetd), self.ip)
+        """
+        desc = "Step 8: Fetch {} from {}".format(os.path.basename(self.qnetd_cluster_crt_on_qnetd), self.qnetd_addr)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_slurp([self.ip], self.qdevice_path,
-                             self.qnetd_cluster_crt_on_qnetd, self.askpass)
+        parallax.parallax_slurp(
+                [self.qnetd_addr],
+                self.qdevice_path,
+                self.qnetd_cluster_crt_on_qnetd,
+                self.askpass)
 
     def import_cluster_crt(self):
-        '''
+        """
         Certificate process for init
         Step 9
         Import certificate on node where certificate request was created by
         running /usr/sbin/corosync-qdevice-net-certutil -M -c cluster-Cluster.crt
-        '''
+        """
         self.debug_and_log_to_bootstrap("Step 9: Import certificate file {} on local".format(os.path.basename(self.qnetd_cluster_crt_on_local)))
         cmd = "corosync-qdevice-net-certutil -M -c {}".format(self.qnetd_cluster_crt_on_local)
         rc, _, err = utils.get_stdout_stderr(cmd)
@@ -437,34 +488,34 @@ class QDevice(object):
             raise ValueError(err)
 
     def copy_p12_to_cluster(self):
-        '''
+        """
         Certificate process for init
         Step 10
         Copy output qdevice-net-node.p12 to all other cluster nodes
-        '''
-        node_list = utils.list_cluster_nodes()
-        me = utils.this_node()
-        if len(node_list) == 1 and me in node_list:
+        """
+        node_list = utils.list_cluster_nodes_except_me()
+        if not node_list:
             return
 
-        if me in node_list:
-            node_list.remove(me)
         desc = "Step 10: Copy {} to {}".format(self.qdevice_p12_filename, node_list)
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_copy(node_list, self.qdevice_p12_on_local,
-                            os.path.dirname(self.qdevice_p12_on_local), self.askpass)
+        parallax.parallax_copy(
+                node_list,
+                self.qdevice_p12_on_local,
+                os.path.dirname(self.qdevice_p12_on_local),
+                self.askpass)
 
     def import_p12_on_cluster(self):
-        '''
+        """
         Certificate process for init
         Step 11
         Import cluster certificate and key on all other cluster nodes:
         /usr/sbin/corosync-qdevice-net-certutil -m -c qdevice-net-node.p12
-        '''
-        node_list = utils.list_cluster_nodes()
-        if len(node_list) == 1 and node_list[0] == utils.this_node():
+        """
+        node_list = utils.list_cluster_nodes_except_me()
+        if not node_list:
             return
 
         desc = "Step 11: Import {} on {}".format(self.qdevice_p12_filename, node_list)
@@ -474,12 +525,28 @@ class QDevice(object):
         cmd = "corosync-qdevice-net-certutil -m -c {}".format(self.qdevice_p12_on_local)
         parallax.parallax_call(node_list, cmd, self.askpass)
 
+    def certificate_process_on_init(self):
+        """
+        The qdevice certificate process on init node
+        """
+        self.init_db_on_qnetd()
+        self.fetch_qnetd_crt_from_qnetd()
+        self.copy_qnetd_crt_to_cluster()
+        self.init_db_on_cluster()
+        self.create_ca_request()
+        self.copy_crq_to_qnetd()
+        self.sign_crq_on_qnetd()
+        self.fetch_cluster_crt_from_qnetd()
+        self.import_cluster_crt()
+        self.copy_p12_to_cluster()
+        self.import_p12_on_cluster()
+
     def fetch_qnetd_crt_from_cluster(self):
-        '''
+        """
         Certificate process for join
         Step 1
         Fetch QNetd CA certificate(qnetd-cacert.crt) from init node
-        '''
+        """
         if os.path.exists(self.qnetd_cacert_on_cluster):
             return
 
@@ -487,16 +554,19 @@ class QDevice(object):
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_slurp([self.cluster_node], self.qdevice_path,
-                             self.qnetd_cacert_on_local, self.askpass)
+        parallax.parallax_slurp(
+                [self.cluster_node],
+                self.qdevice_path,
+                self.qnetd_cacert_on_local,
+                self.askpass)
 
     def init_db_on_local(self):
-        '''
+        """
         Certificate process for join
         Step 2
         Initialize database by running
         /usr/sbin/corosync-qdevice-net-certutil -i -c qnetd-cacert.crt
-        '''
+        """
         if os.path.exists(self.qdevice_db_path):
             utils.rmdir_r(self.qdevice_db_path)
 
@@ -507,11 +577,11 @@ class QDevice(object):
             raise ValueError(err)
 
     def fetch_p12_from_cluster(self):
-        '''
+        """
         Certificate process for join
         Step 3
         Fetch p12 key file from init node
-        '''
+        """
         if os.path.exists(self.qdevice_p12_on_cluster):
             return
 
@@ -519,33 +589,47 @@ class QDevice(object):
         self.debug_and_log_to_bootstrap(desc)
         if self.askpass:
             print(desc)
-        parallax.parallax_slurp([self.cluster_node], self.qdevice_path,
-                             self.qdevice_p12_on_local, self.askpass)
+        parallax.parallax_slurp(
+                [self.cluster_node],
+                self.qdevice_path,
+                self.qdevice_p12_on_local,
+                self.askpass)
 
     def import_p12_on_local(self):
-        '''
+        """
         Certificate process for join
         Step 4
         Import cluster certificate and key
-        '''
+        """
         self.debug_and_log_to_bootstrap("Step 4: Import cluster certificate and key")
         cmd = "corosync-qdevice-net-certutil -m -c {}".format(self.qdevice_p12_on_cluster)
         rc, _, err = utils.get_stdout_stderr(cmd)
         if rc != 0:
             raise ValueError(err)
 
-    def config(self):
-        f = open(conf()).read()
-        p = Parser(f)
+    def certificate_process_on_join(self):
+        """
+        The qdevice certificate process on join node
+        """
+        self.fetch_qnetd_crt_from_cluster()
+        self.init_db_on_local()
+        self.fetch_p12_from_cluster()
+        self.import_p12_on_local()
+
+    def write_qdevice_config(self):
+        """
+        Write qdevice attributes to config file
+        """
+        with open(conf()) as f:
+            p = Parser(f.read())
 
         p.remove("quorum.device")
-
         p.add('quorum', make_section('quorum.device', []))
         p.set('quorum.device.votes', '1')
         p.set('quorum.device.model', 'net')
         p.add('quorum.device', make_section('quorum.device.net', []))
         p.set('quorum.device.net.tls', self.tls)
-        p.set('quorum.device.net.host', self.ip)
+        p.set('quorum.device.net.host', self.qnetd_addr)
         p.set('quorum.device.net.port', self.port)
         p.set('quorum.device.net.algorithm', self.algo)
         p.set('quorum.device.net.tie_breaker', self.tie_breaker)
@@ -557,23 +641,27 @@ class QDevice(object):
                 exec_name = "exec_{}{}".format(cmd_name, i)
                 p.set('quorum.device.heuristics.{}'.format(exec_name), cmd)
 
-        f = open(conf(), 'w')
-        f.write(p.to_string())
-        f.flush()
-        os.fsync(f)
-        f.close()
+        with open(conf(), 'w') as f:
+            f.write(p.to_string())
+            f.flush()
+            os.fsync(f)
 
-    def remove_config(self):
-        f = open(conf()).read()
-        p = Parser(f)
-        p.remove("quorum.device")
-        f = open(conf(), 'w')
-        f.write(p.to_string())
-        f.flush()
-        os.fsync(f)
-        f.close()
+    def remove_qdevice_config(self):
+        """
+        Remove configuration of qdevice
+        """
+        with open(conf()) as f:
+            p = Parser(f.read())
+            p.remove("quorum.device")
+        with open(conf(), 'w') as f:
+            f.write(p.to_string())
+            f.flush()
+            os.fsync(f)
 
     def remove_qdevice_db(self):
+        """
+        Remove qdevice database
+        """
         if not os.path.exists(self.qdevice_db_path):
             return
         node_list = utils.list_cluster_nodes()

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -63,7 +63,7 @@ class Corosync(command.UI):
         '''
         Quick cluster health status. Corosync status or QNetd status
         '''
-        if not bootstrap.service_is_active("corosync.service"):
+        if not utils.service_is_active("corosync.service"):
             err_buf.error("corosync.service is not running!")
             return False
 

--- a/test/docker_scripts.sh
+++ b/test/docker_scripts.sh
@@ -3,63 +3,50 @@ Docker_image='liangxin1300/hatbw'
 HA_packages='pacemaker corosync corosync-qdevice'
 TEST_TYPE='bootstrap qdevice hb_report geo'
 
+etc_hosts_content=`cat <<EOF
+10.10.10.2 hanode1
+10.10.10.3 hanode2
+10.10.10.4 hanode3
+10.10.10.5 hanode4
+10.10.10.6 hanode5
+20.20.20.7 qnetd-node
+10.10.10.8 node-without-ssh
+EOF`
+
+deploy_node() {
+  node_name=$1
+  echo "##### Deploy $node_name start"
+
+  docker run -d --name=$node_name --hostname $node_name \
+             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
+  docker network connect second_net $node_name
+  docker network connect third_net $node_name
+  docker exec -t $node_name /bin/sh -c "echo \"$etc_hosts_content\" | grep -v $node_name >> /etc/hosts"
+
+  if [ "$node_name" == "qnetd-node" ];then
+    docker exec -t $node_name /bin/sh -c "zypper ref;zypper -n in corosync-qnetd"
+  elif [ "$node_name" == "node-without-ssh" ];then
+    docker exec -t $node_name /bin/sh -c "systemctl stop sshd.service"
+  else
+    docker exec -t $node_name /bin/sh -c "cd /app; ./test/run-in-travis.sh build"
+  fi
+  echo "##### Deploy $node_name finished"
+  echo
+}
+
 before() {
   docker pull ${Docker_image}
   docker network create --subnet 10.10.10.0/24 --ipv6 --subnet 2001:db8:10::/64 second_net
+  docker network create --subnet 20.20.20.0/24 --ipv6 --subnet 2001:db8:20::/64 third_net
 
-  # deploy first node hanode1
-  docker run -d --name=hanode1 --hostname hanode1 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
-  docker network connect --ip=10.10.10.2 second_net hanode1
-  docker network connect --ip=2001:db8:10::2 second_net hanode1
-  docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
-  if [ x"$1" == x"qdevice" ];then
-    docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.9 qnetd-node\" >> /etc/hosts"
-    docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.10 node-without-ssh\" >> /etc/hosts"
-  fi
-  if [ x"$1" == x"geo" ];then
-    docker exec -t hanode1 /bin/sh -c "echo \"10.10.10.4 hanode3\" >> /etc/hosts"
-  fi
-  docker exec -t hanode1 /bin/sh -c "cd /app; ./test/run-in-travis.sh build"
-
-  # deploy second node hanode2
-  docker run -d --name=hanode2 --hostname hanode2 \
-             --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
-  docker network connect --ip=10.10.10.3 second_net hanode2
-  docker network connect --ip=2001:db8:10::3 second_net hanode2
-  docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
-  if [ x"$1" == x"qdevice" ];then
-    docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.9 qnetd-node\" >> /etc/hosts"
-  fi
-  if [ x"$1" == x"geo" ];then
-    docker exec -t hanode2 /bin/sh -c "echo \"10.10.10.4 hanode3\" >> /etc/hosts"
-  fi
-  docker exec -t hanode2 /bin/sh -c "systemctl start sshd.service"
-  docker exec -t hanode2 /bin/sh -c "cd /app; ./test/run-in-travis.sh build"
-
-  if [ x"$1" == x"qdevice" ];then
-    # deploy node qnetd-node for qnetd service
-    docker run -d --name=qnetd-node --hostname qnetd-node \
-	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --shm-size="1g" ${Docker_image}
-    docker network connect --ip=10.10.10.9 second_net qnetd-node
-    docker exec -t qnetd-node /bin/sh -c "zypper ref;zypper -n in corosync-qnetd"
-    docker exec -t qnetd-node /bin/sh -c "systemctl start sshd.service"
-
-    # deploy node without ssh.service running for validation
-    docker run -d --name=node-without-ssh --hostname node-without-ssh \
-	       --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ${Docker_image}
-    docker network connect --ip=10.10.10.10 second_net node-without-ssh
-    docker exec -t node-without-ssh /bin/sh -c "systemctl stop sshd.service"
-  fi
-
-  if [ x"$1" == x"geo" ];then
-    docker run -d --name=hanode3 --hostname hanode3 \
-	    --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v "$(pwd):/app" --shm-size="1g" ${Docker_image}
-    docker network connect --ip=10.10.10.4 second_net hanode3
-    docker exec -t hanode3 /bin/sh -c "echo \"10.10.10.2 hanode1\" >> /etc/hosts"
-    docker exec -t hanode3 /bin/sh -c "echo \"10.10.10.3 hanode2\" >> /etc/hosts"
-    docker exec -t hanode3 /bin/sh -c "systemctl start sshd.service"
-    docker exec -t hanode3 /bin/sh -c "cd /app; ./test/run-in-travis.sh build"
+  deploy_node hanode1
+  deploy_node hanode2
+  deploy_node hanode3
+  deploy_node hanode4
+  deploy_node hanode5
+  if [ "$1" == "qdevice" ];then
+    deploy_node qnetd-node
+    deploy_node node-without-ssh
   fi
 }
 

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -77,8 +77,6 @@ Feature: crmsh bootstrap process - options
     Then    Except "ERROR: cluster.init: 'xxx' does not appear to be an IPv4 or IPv6 address"
     When    Try "crm cluster init -A 10.10.10.2 -y"
     Then    Except "ERROR: cluster.init: Address already in use: 10.10.10.2"
-    When    Try "crm cluster init -A 10.20.10.2 -y"
-    Then    Except "ERROR: cluster.init: Address '10.20.10.2' not in any local network"
     When    Run "crm cluster init -n hatest -A 10.10.10.123 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster name is "hatest"

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -65,12 +65,13 @@ Feature: corosync qdevice/qnetd options validate
     Then    Cluster service is "started" on "hanode2"
     When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
     Then    Except multiple lines
-      """"
+      """
       ERROR: cluster.init: host for qnetd must be a non-cluster node
-      Cluster service already successfully started on this node
+      Cluster service already successfully started on this node except qdevice service
       If you still want to use qdevice, change to another host or stop cluster service on hanode2
-      Then run command "crm cluster init qdevice --qnetd-hostname=hanode2"
-      This command will setup qdevice separately
+      Then run command "crm cluster init" with "qdevice" stage, like:
+        crm cluster init qdevice qdevice_related_options
+      That command will setup qdevice separately
       """
     And     Cluster service is "started" on "hanode1"
     When    Run "crm cluster stop" on "hanode2"
@@ -80,12 +81,13 @@ Feature: corosync qdevice/qnetd options validate
     Given   Cluster service is "stopped" on "hanode2"
     When    Try "crm cluster init --qnetd-hostname=hanode2 -y"
     Then    Except multiple lines
-      """"
+      """
       ERROR: cluster.init: Package "corosync-qnetd" not installed on hanode2
-      Cluster service already successfully started on this node
+      Cluster service already successfully started on this node except qdevice service
       If you still want to use qdevice, install "corosync-qnetd" on hanode2
-      Then run command "crm cluster init qdevice --qnetd-hostname=hanode2"
-      This command will setup qdevice separately
+      Then run command "crm cluster init" with "qdevice" stage, like:
+        crm cluster init qdevice qdevice_related_options
+      That command will setup qdevice separately
       """
     And     Cluster service is "started" on "hanode1"
 
@@ -101,4 +103,8 @@ Feature: corosync qdevice/qnetd options validate
     When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster init qdevice"
-    Then    Except "ERROR: cluster.init: qdevice related options are missing (--qnetd-hostname option is mandatory, find for more information using --help)"
+    Then    Except multiple lines
+      """
+      usage: init [options] [STAGE]
+      crm: error: Option --qnetd-hostname is required if want to configure qdevice
+      """

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -78,6 +78,13 @@ def step_impl(context, msg):
     context.stdout = None
 
 
+@then('Expected regrex "{reg_str}" in stdout')
+def step_impl(context, reg_str):
+    res = re.search(reg_str, context.stdout)
+    assert res is not None
+    context.stdout = None
+
+
 @then('Except "{msg}"')
 def step_impl(context, msg):
     assert context.command_error_output == msg
@@ -217,3 +224,8 @@ def step_impl(context, transport_type):
         assert corosync.get_value("totem.transport") != "udpu"
     if transport_type == "unicast":
         assert corosync.get_value("totem.transport") == "udpu"
+
+
+@then('Expected votes will be "{votes}"')
+def step_impl(context, votes):
+    assert int(corosync.get_value("quorum.expected_votes")) == int(votes)

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -44,7 +44,7 @@ def check_service_state(context, service_name, state, addr):
     state_dict = {"started": True, "stopped": False}
 
     if addr == me():
-        return bootstrap.service_is_active(service_name) is state_dict[state]
+        return utils.service_is_active(service_name) is state_dict[state]
     else:
         test_active = "systemctl -q is-active {}".format(service_name)
         try:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -19,6 +19,7 @@ except ImportError:
     import mock
 
 from crmsh import bootstrap
+from crmsh import corosync
 
 
 class TestSBDManager(unittest.TestCase):
@@ -212,7 +213,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.bootstrap.service_is_enabled')
+    @mock.patch('crmsh.utils.service_is_enabled')
     def test_configure_sbd_resource_error_primitive(self, mock_enabled, mock_get_device, mock_invoke, mock_error):
         mock_enabled.return_value = True
         mock_get_device.return_value = ["/dev/sdb1"]
@@ -230,7 +231,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.bootstrap.service_is_enabled')
+    @mock.patch('crmsh.utils.service_is_enabled')
     def test_configure_sbd_resource_error_property(self, mock_enabled, mock_get_device, mock_invoke, mock_error):
         mock_enabled.return_value = True
         mock_get_device.return_value = ["/dev/sdb1"]
@@ -251,7 +252,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.bootstrap.service_is_enabled')
+    @mock.patch('crmsh.utils.service_is_enabled')
     def test_configure_sbd_resource_diskless(self, mock_enabled, mock_get_device, mock_invoke, mock_error):
         mock_enabled.return_value = True
         mock_get_device.return_value = None
@@ -329,6 +330,7 @@ class TestBootstrap(unittest.TestCase):
         """
         Test setUp.
         """
+        self.qdevice_with_ip = corosync.QDevice("10.10.10.123")
 
     def tearDown(self):
         """
@@ -575,20 +577,6 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
-    @mock.patch('crmsh.utils.get_nodeinfo_from_cmaptool')
-    @mock.patch('crmsh.corosync.add_node_ucast')
-    def test_add_nodelist_from_cmaptool(self, mock_add_ucast, mock_nodeinfo):
-        mock_nodeinfo.return_value = {'1': ['10.10.10.1', '20.20.20.1'],
-                                      '2': ['10.10.10.2', '20.20.20.2']}
-
-        bootstrap.add_nodelist_from_cmaptool()
-
-        mock_nodeinfo.assert_called_once_with()
-        mock_add_ucast.assert_has_calls([
-            mock.call(['10.10.10.1', '20.20.20.1'], '1'),
-            mock.call(['10.10.10.2', '20.20.20.2'], '2')
-        ])
-
     @mock.patch('crmsh.utils.IP.is_valid_ip')
     @mock.patch('crmsh.utils.get_stdout_stderr')
     def test_get_cluster_node_hostname_None(self, mock_stdout_stderr, mock_valid_ip):
@@ -750,6 +738,228 @@ class TestBootstrap(unittest.TestCase):
         mock_interfaces_inst.get_default_nic_list_from_route.assert_called_once_with()
         mock_interfaces_inst.get_default_ip_list.assert_called_once_with()
 
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_qdevice_no_config(self, mock_status):
+        bootstrap._context = mock.Mock(qdevice_inst=None)
+        bootstrap.init_qdevice()
+        mock_status.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.utils.check_ssh_passwd_need')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_qdevice_copy_ssh_key_failed(self, mock_status, mock_ssh, mock_invoke, mock_error):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        mock_ssh.return_value = True
+        mock_invoke.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.init_qdevice()
+
+        mock_status.assert_has_calls([
+            mock.call("\nConfigure Qdevice/Qnetd:"),
+            mock.call("Copy ssh key to qnetd node(10.10.10.123)")
+            ])
+        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_invoke.assert_called_once_with("ssh-copy-id -i /root/.ssh/id_rsa.pub root@10.10.10.123")
+        mock_error.assert_called_once_with("Failed to copy ssh key")
+
+    @mock.patch('crmsh.bootstrap.start_qdevice_service')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    @mock.patch('crmsh.utils.check_ssh_passwd_need')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_qdevice_already_configured(self, mock_status, mock_ssh, mock_qdevice_configured, mock_confirm, mock_qdevice_start):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        mock_ssh.return_value = False
+        mock_qdevice_configured.return_value = True
+        mock_confirm.return_value = False
+
+        bootstrap.init_qdevice()
+
+        mock_status.assert_called_once_with("\nConfigure Qdevice/Qnetd:")
+        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_qdevice_configured.assert_called_once_with()
+        mock_confirm.assert_called_once_with("Qdevice is already configured - overwrite?")
+        mock_qdevice_start.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.start_qdevice_service')
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.corosync.QDevice.certificate_process_on_init')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.utils.is_qdevice_tls_on')
+    @mock.patch('crmsh.bootstrap.config_qdevice')
+    @mock.patch('crmsh.corosync.QDevice.valid_qnetd')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    @mock.patch('crmsh.utils.check_ssh_passwd_need')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_qdevice(self, mock_status, mock_ssh, mock_qdevice_configured, mock_valid_qnetd, mock_config_qdevice,
+            mock_tls, mock_status_long, mock_certificate, mock_status_done, mock_start_qdevice):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        mock_ssh.return_value = False
+        mock_qdevice_configured.return_value = False
+        mock_tls.return_value = True
+
+        bootstrap.init_qdevice()
+
+        mock_status.assert_called_once_with("\nConfigure Qdevice/Qnetd:")
+        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_valid_qnetd.assert_called_once_with()
+        mock_qdevice_configured.assert_called_once_with()
+        mock_config_qdevice.assert_called_once_with()
+        mock_tls.assert_called_once_with()
+        mock_status_long.assert_called_once_with("Qdevice certification process")
+        mock_certificate.assert_called_once_with()
+        mock_status_done.assert_called_once_with()
+        mock_start_qdevice.assert_called_once_with()
+
+    @mock.patch('crmsh.corosync.QDevice.start_qnetd')
+    @mock.patch('crmsh.corosync.QDevice.enable_qnetd')
+    @mock.patch('crmsh.utils.cluster_run_cmd')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_start_qdevice_service(self, mock_status, mock_cluster_run, mock_enable_qnetd, mock_start_qnetd):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+
+        bootstrap.start_qdevice_service()
+
+        mock_status.assert_has_calls([
+            mock.call("Enable corosync-qdevice.service in cluster"),
+            mock.call("Starting corosync-qdevice.service in cluster"),
+            mock.call("Enable corosync-qnetd.service on 10.10.10.123"),
+            mock.call("Starting corosync-qnetd.service on 10.10.10.123")
+            ])
+        mock_cluster_run.assert_has_calls([
+            mock.call("systemctl enable corosync-qdevice"),
+            mock.call("systemctl start corosync-qdevice")
+            ])
+        mock_enable_qnetd.assert_called_once_with()
+        mock_start_qnetd.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.utils.cluster_run_cmd')
+    @mock.patch('crmsh.bootstrap.update_expected_votes')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.corosync.add_nodelist_from_cmaptool')
+    @mock.patch('crmsh.corosync.is_unicast')
+    @mock.patch('crmsh.corosync.QDevice.write_qdevice_config')
+    @mock.patch('crmsh.corosync.QDevice.remove_qdevice_db')
+    def test_config_qdevice(self, mock_remove_qdevice_db, mock_write_qdevice_config, mock_is_unicast,
+            mock_add_nodelist, mock_status_long, mock_update_votes, mock_cluster_run, mock_status_done):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        mock_is_unicast.return_value = False
+
+        bootstrap.config_qdevice()
+
+        mock_remove_qdevice_db.assert_called_once_with()
+        mock_write_qdevice_config.assert_called_once_with()
+        mock_is_unicast.assert_called_once_with()
+        mock_add_nodelist.assert_called_once_with()
+        mock_status_long.assert_called_once_with("Update configuration")
+        mock_update_votes.assert_called_once_with()
+        mock_cluster_run.assert_called_once_with("crm corosync reload")
+        mock_status_done.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice_no_configured(self, mock_qdevice_configured, mock_error):
+        mock_qdevice_configured.return_value = False
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.remove_qdevice()
+
+        mock_qdevice_configured.assert_called_once_with()
+        mock_error.assert_called_once_with("No QDevice configuration in this cluster")
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice_not_confirmed(self, mock_qdevice_configured, mock_confirm):
+        mock_qdevice_configured.return_value = True
+        mock_confirm.return_value = False
+
+        bootstrap.remove_qdevice()
+
+        mock_qdevice_configured.assert_called_once_with()
+        mock_confirm.assert_called_once_with("Removing QDevice service and configuration from cluster: Are you sure?")
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.bootstrap.update_expected_votes')
+    @mock.patch('crmsh.corosync.QDevice')
+    @mock.patch('crmsh.corosync.get_value')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.is_qdevice_configured')
+    def test_remove_qdevice(self, mock_qdevice_configured, mock_confirm, mock_status, mock_invoke,
+            mock_status_long, mock_get_value, mock_qdevice, mock_update_votes, mock_status_done):
+        mock_qdevice_configured.return_value = True
+        mock_confirm.return_value = True
+        mock_get_value.return_value = "10.10.10.123"
+        mock_qdevice_inst = mock.Mock()
+        mock_qdevice.return_value = mock_qdevice_inst
+        mock_qdevice_inst.remove_qdevice_config = mock.Mock()
+        mock_qdevice_inst.remove_qdevice_db = mock.Mock()
+
+        bootstrap.remove_qdevice()
+
+        mock_qdevice_configured.assert_called_once_with()
+        mock_confirm.assert_called_once_with("Removing QDevice service and configuration from cluster: Are you sure?")
+        mock_status.assert_has_calls([
+            mock.call("Disable corosync-qdevice.service"),
+            mock.call("Stopping corosync-qdevice.service")
+            ])
+        mock_invoke.assert_has_calls([
+            mock.call("crm cluster run 'systemctl disable corosync-qdevice'"),
+            mock.call("crm cluster run 'systemctl stop corosync-qdevice'"),
+            mock.call("crm cluster run 'crm corosync reload'")
+            ] )
+        mock_status_long.assert_called_once_with("Removing QDevice configuration from cluster")
+        mock_get_value.assert_called_once_with("quorum.device.net.host")
+        mock_qdevice.assert_called_once_with("10.10.10.123")
+        mock_qdevice_inst.remove_qdevice_config.assert_called_once_with()
+        mock_qdevice_inst.remove_qdevice_db.assert_called_once_with()
+        mock_update_votes.assert_called_once_with()
+        mock_status_done.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.status_done')
+    @mock.patch('crmsh.bootstrap.start_service')
+    @mock.patch('crmsh.corosync.QDevice')
+    @mock.patch('crmsh.corosync.get_value')
+    @mock.patch('crmsh.utils.is_qdevice_tls_on')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.corosync.conf')
+    @mock.patch('crmsh.corosync.add_nodelist_from_cmaptool')
+    @mock.patch('crmsh.corosync.is_unicast')
+    @mock.patch('crmsh.bootstrap.status_long')
+    def test_start_qdevice_on_join_node(self, mock_status_long, mock_is_unicast, mock_add_nodelist,
+            mock_conf, mock_csync2_update, mock_invoke, mock_qdevice_tls,
+            mock_get_value, mock_qdevice, mock_start_service, mock_status_done):
+        mock_is_unicast.return_value = False
+        mock_qdevice_tls.return_value = True
+        mock_conf.return_value = "corosync.conf"
+        mock_get_value.return_value = "10.10.10.123"
+        mock_qdevice_inst = mock.Mock()
+        mock_qdevice.return_value = mock_qdevice_inst
+        mock_qdevice_inst.certificate_process_on_join = mock.Mock()
+
+        bootstrap.start_qdevice_on_join_node("node2")
+
+        mock_status_long.assert_called_once_with("Starting corosync-qdevice.service")
+        mock_is_unicast.assert_called_once_with()
+        mock_add_nodelist.assert_called_once_with()
+        mock_conf.assert_called_once_with()
+        mock_csync2_update.assert_called_once_with("corosync.conf")
+        mock_invoke.assert_called_once_with("crm corosync reload")
+        mock_qdevice_tls.assert_called_once_with()
+        mock_get_value.assert_called_once_with("quorum.device.net.host")
+        mock_qdevice.assert_called_once_with("10.10.10.123", cluster_node="node2")
+        mock_qdevice_inst.certificate_process_on_join.assert_called_once_with()
+        mock_start_service.assert_called_once_with("corosync-qdevice.service")
+        mock_status_done.assert_called_once_with()
+
 
 class TestValidation(unittest.TestCase):
     """
@@ -838,19 +1048,3 @@ class TestValidation(unittest.TestCase):
 
         mock_ipv6.assert_called_once_with("10.10.10.1")
         mock_invoke.assert_called_once_with("ping -c 1 10.10.10.1")
-
-    @mock.patch('crmsh.utils.InterfacesInfo.ip_in_network')
-    @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.utils.IP.is_ipv6')
-    def test_valid_admin_ip_not_in_network(self, mock_ipv6, mock_invoke, mock_ip_in_network):
-        mock_ipv6.return_value = False
-        mock_invoke.return_value = False
-        mock_ip_in_network.return_value = False
-
-        with self.assertRaises(ValueError) as err:
-            self.validate_inst.valid_admin_ip("10.10.10.1")
-        self.assertEqual("Address '10.10.10.1' not in any local network", str(err.exception))
-
-        mock_ipv6.assert_called_once_with("10.10.10.1")
-        mock_invoke.assert_called_once_with("ping -c 1 10.10.10.1")
-        mock_ip_in_network.assert_called_once_with("10.10.10.1")


### PR DESCRIPTION
The work of this pull request was based on #540 and #464
Changes include:
- More reasonable naming for variables
- More function docstrings
- Move function to more reasonable location, like:
  * change `bootstrap.add_nodelist_from_cmaptool` to `corosync.add_nodelist_from_cmaptool`
- Create functions to integrate similar functions inside one, like:
  * create `QDevice.certificate_process_on_init` and `QDevice.certificate_process_on_join` methods to integrate certification related fuctions
- Change big function to small one, more easier for unit test, like:
  * `bootstrap.init_qdevice`
- Refactor functions:
  * Make `utils.service_is_enabled`, `utils.service_is_active` and `utils.package_is_installed` can be executed on remote node
- Create `utils.cluster_run_cmd` function to avoid using `crm cluster run` directly in code
- Simplify container deploy bash script `docker_scripts.sh` for functional test
- Complete unit test and functional test
- Append functional test for qdevice running on multi node and running on ipv6