### PR TITLE
Low: hb_report: Fix collecting of binary data

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -725,7 +725,7 @@ def pipe_cmd_nosudo(cmd):
     return rc
 
 
-def get_stdout(cmd, input_s=None, stderr_on=True, shell=True):
+def get_stdout(cmd, input_s=None, stderr_on=True, shell=True, raw=False):
     '''
     Run a cmd, return stdout output.
     Optional input string "input_s".
@@ -743,10 +743,12 @@ def get_stdout(cmd, input_s=None, stderr_on=True, shell=True):
                             stdout=subprocess.PIPE,
                             stderr=stderr)
     stdout_data, stderr_data = proc.communicate(input_s)
+    if raw:
+        return proc.returncode, stdout_data
     return proc.returncode, to_ascii(stdout_data).strip()
 
 
-def get_stdout_stderr(cmd, input_s=None, shell=True):
+def get_stdout_stderr(cmd, input_s=None, shell=True, raw=False):
     '''
     Run a cmd, return (rc, stdout, stderr)
     '''
@@ -758,6 +760,8 @@ def get_stdout_stderr(cmd, input_s=None, shell=True):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     stdout_data, stderr_data = proc.communicate(input_s)
+    if raw:
+        return proc.returncode, stdout_data, stderr_data
     return proc.returncode, to_ascii(stdout_data).strip(), to_ascii(stderr_data).strip()
 
 

--- a/hb_report/constants.py
+++ b/hb_report/constants.py
@@ -8,6 +8,7 @@ ARGOPTS_VALUE = "f:t:l:u:X:p:L:e:E:n:MSDZVsvhdQ"
 B_CONF = None
 CIB_DIR = None
 COMPRESS = config.report.compress
+COMPRESS_DATA_FLAG = "COMPRESS HB_REPORT DATA:::"
 COMPRESS_PROG = ""
 COMPRESS_EXT = ""
 CORES_DIRS = None

--- a/hb_report/hb_report.in
+++ b/hb_report/hb_report.in
@@ -280,13 +280,10 @@ def run():
     #     problem description template, and prints final notes
     #
     if is_collector():
-        import io
-        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
-
         utillib.collect_info()
         cmd = r"cd %s/.. && tar -h -cf - %s" % (constants.WORKDIR, constants.WE)
-        code, out, err = crmutils.get_stdout_stderr(cmd)
-        print(out)
+        code, out, err = crmutils.get_stdout_stderr(cmd, raw=True)
+        print("{}{}".format(constants.COMPRESS_DATA_FLAG, out))
     else:
         p_list = []
         p_list.append(multiprocessing.Process(target=utillib.analyze))

--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -1548,14 +1548,17 @@ def start_slave_collector(node, arg_str):
                     log_warning(err)
                 break
 
+    compress_data = ""
+    for data in out.split('\n'):
+        if data.startswith(constants.COMPRESS_DATA_FLAG):
+            # hb_report data from collector
+            compress_data = data.lstrip(constants.COMPRESS_DATA_FLAG)
+        else:
+            # log data from collector
+            print(data)
+
     cmd = r"(cd {} && tar xf -)".format(constants.WORKDIR)
-    # typeof out here will always "str"
-    # input_s of get_stdout will always need bytes
-    # different situation depend on whether found pe file
-    if out.startswith("b'"):
-        crmutils.get_stdout(cmd, input_s=eval(out))
-    else:
-        crmutils.get_stdout(cmd, input_s=out.encode('utf-8'))
+    crmutils.get_stdout(cmd, input_s=eval(compress_data))
 
 
 def str_to_bool(v):


### PR DESCRIPTION
When creating a resulting archive in a slave collector ('hb_report
__slave'), the code tried to decode output produced by the tar utility
as a UTF-8 string (crmutils.get_stdout_stderr() -> to_ascii()). This
corrupted any binary files in the archive, such as gzipped pengine
files.

The patch fixes the problem by obtaining the output from the tar utility
as a bytes object and writing it in the repr() form on stdout of the
slave collector. Similarly, the receiving side is updated to accept this
format.