### PR TITLE
Low: ui_corosync: copy ssh key to qnetd while detect need password

### DIFF
--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -8,6 +8,7 @@ from . import utils
 from .msg import err_buf
 from . import corosync
 from . import parallax
+from . import bootstrap
 
 
 def _push_completer(args):
@@ -62,47 +63,15 @@ class Corosync(command.UI):
         '''
         Quick cluster health status. Corosync status or QNetd status
         '''
-        def print_cluster_nodes():
-            rc, out = utils.get_stdout("crm_node -l")
-            if rc == 0 and out:
-                print("{}\n".format(out))
-
-        rc, _ = utils.get_stdout('systemctl -q is-active corosync.service')
-        if rc != 0:
+        if not bootstrap.service_is_active("corosync.service"):
             err_buf.error("corosync.service is not running!")
             return False
 
-        if status_type == "ring":
-            print(corosync.cfgtool('-s')[1])
-            return
-        if status_type == "quorum":
-            print_cluster_nodes()
-            print(corosync.quorumtool('-s')[1])
-            return
-        if status_type == "qnetd":
-            if not utils.is_qdevice_configured():
-                err_buf.error("QDevice/QNetd not configured!")
-                return False
-            cluster_name = corosync.get_value('totem.cluster_name')
-            if not cluster_name:
-                err_buf.error("cluster_name not configured!")
-                return False
-            qnetd_addr = corosync.get_value('quorum.device.net.host')
-            if not qnetd_addr:
-                err_buf.error("host for qnetd not configured!")
-                return False
-
-            cmd = "corosync-qnetd-tool -lv -c {}".format(cluster_name)
-            try:
-                result = parallax.parallax_call([qnetd_addr], cmd)
-            except ValueError as err:
-                err_buf.error(err)
-                return False
-            _, qnetd_result_stdout, _ = result[0][1]
-            if qnetd_result_stdout:
-                print_cluster_nodes()
-                print(utils.to_ascii(qnetd_result_stdout))
-            return
+        try:
+            corosync.query_status(status_type)
+        except ValueError as err:
+            err_buf.error(str(err))
+            return False
 
     @command.skill_level('administrator')
     def do_reload(self, context):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1664,6 +1664,15 @@ def list_corosync_nodes():
         return []
 
 
+def print_cluster_nodes():
+    """
+    Print the output of crm_node -l
+    """
+    rc, out, _ = get_stdout_stderr("crm_node -l")
+    if rc == 0 and out:
+        print("{}\n".format(out))
+
+
 def list_cluster_nodes():
     '''
     Returns a list of nodes in the cluster.

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -22,6 +22,13 @@ def setup_function():
     imp.reload(utils)
 
 
+@mock.patch("crmsh.utils.get_stdout_stderr")
+def test_print_cluster_nodes(mock_run):
+    mock_run.return_value = (0, "data", None)
+    utils.print_cluster_nodes()
+    mock_run.assert_called_once_with("crm_node -l")
+
+
 @mock.patch('os.path.exists')
 def test_check_file_content_included_target_not_exist(mock_exists):
     mock_exists.side_effect = [True, False]


### PR DESCRIPTION
While setup qdevice on init node, init node will copy its ssh key to qnetd node to setup passwordless ssh login with qnetd node.
But after merging PR #603, each cluster node has its own ssh key, so it's possible that query qnetd status using `crm corosync status qnetd` on other cluster nodes will failed.
The solution is to copy the ssh key to qnetd node if detecting need password while the first time querying qnetd status on the other node