### PR TITLE
Low: corosync: handle the return code of corosync-quorumtool correctly

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -66,12 +66,15 @@ def query_ring_status():
 def query_quorum_status():
     """
     Query corosync quorum status
+
     """
     utils.print_cluster_nodes()
     rc, out, err = utils.get_stdout_stderr("corosync-quorumtool -s")
     if rc != 0 and err:
         raise ValueError(err)
-    if rc == 0 and out:
+    # If the return code of corosync-quorumtool is 2,
+    # that means no problem appeared but node is not quorate
+    if rc in [0, 2] and out:
         print(out)
 
 

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -55,9 +55,9 @@ Feature: Verify usercase master survive when split-brain
     And     Run "iptables -I INPUT -s 172.17.0.2 -j DROP; iptables -I OUTPUT -d 172.17.0.2 -j DROP" on "hanode2"
     # Check whether hanode1 has quorum, while hanode2 doesn't
     And     Run "sleep 20" on "hanode1"
-    When    Run "corosync-quorumtool -s" on "hanode1"
+    When    Run "crm corosync status quorum" on "hanode1"
     Then    Expected "Quorate:          Yes" in stdout
-    When    Run "ssh root@hanode2 corosync-quorumtool -s" on "hanode1"
+    When    Run "crm corosync status quorum" on "hanode2"
     Then    Expected "Quorate:          No" in stdout
     And     Show cluster status on "hanode1"
     And     Show cluster status on "hanode2"

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -101,6 +101,15 @@ def test_query_quorum_status(mock_run, mock_print_nodes):
     mock_print_nodes.assert_called_once_with()
 
 
+@mock.patch("crmsh.utils.print_cluster_nodes")
+@mock.patch("crmsh.utils.get_stdout_stderr")
+def test_query_quorum_status_no_quorum(mock_run, mock_print_nodes):
+    mock_run.return_value = (2, "no quorum", None)
+    corosync.query_quorum_status()
+    mock_run.assert_called_once_with("corosync-quorumtool -s")
+    mock_print_nodes.assert_called_once_with()
+
+
 @mock.patch("crmsh.utils.is_qdevice_configured")
 def test_query_qnetd_status_no_qdevice(mock_qdevice_configured):
     mock_qdevice_configured.return_value = False


### PR DESCRIPTION
Since the return code 2 of command `corosync-quorumtool -s` means no problem appeared but node is not quorate, we should adopt to handle that return code when quorum lost.
Additionally, behave test in `qdevice_usercase.feature` has changed to use command `crm corosync status quorum` to make sure this scenarios been tested while quorum lost