### PR TITLE
Low: bootstrap: swap keys with other nodes when join_ssh

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1769,6 +1769,8 @@ def join_ssh(seed_host):
     if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.default_nic_list[0])):
         error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.default_nic_list[0], seed_host))
 
+    setup_passwordless_with_other_nodes(seed_host)
+
 
 def swap_public_ssh_key(remote_node):
     """
@@ -2037,8 +2039,6 @@ def join_cluster(seed_host):
             invoke("crm cluster run '{}' {}".format(cmd, node))
         else:
             corosync.set_value("totem.nodeid", nodeid)
-
-    setup_passwordless_with_other_nodes(seed_host)
 
     shutil.copy(corosync.conf(), COROSYNC_CONF_ORIG)
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -425,12 +425,13 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.join_ssh(None)
         mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
 
+    @mock.patch('crmsh.bootstrap.setup_passwordless_with_other_nodes')
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.swap_public_ssh_key')
     @mock.patch('crmsh.bootstrap.configure_local_ssh_key')
     @mock.patch('crmsh.bootstrap.start_service')
-    def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_swap, mock_invoke, mock_error):
+    def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_swap, mock_invoke, mock_error, mock_swap_other):
         bootstrap._context = mock.Mock(default_nic_list=["eth1"])
         mock_invoke.return_value = False
 
@@ -441,6 +442,7 @@ class TestBootstrap(unittest.TestCase):
         mock_swap.assert_called_once_with("node1")
         mock_invoke.assert_called_once_with("ssh root@node1 crm cluster init -i eth1 ssh_remote")
         mock_error.assert_called_once_with("Can't invoke crm cluster init -i eth1 ssh_remote on node1")
+        mock_swap_other.assert_called_once_with("node1")
 
     @mock.patch('crmsh.bootstrap.warn')
     @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')


### PR DESCRIPTION
This is a regression issue brought by https://github.com/ClusterLabs/crmsh/pull/617/commits/d4e0b8e57815925f3d625bcfda0d538ca69c1e91
before `join_ssh_merge`, all nodes should finish swapping ssh key, otherwise parallax would have errors like:
```
crm cluster join -c tbw-1 -y
  Generating SSH key
  Configuring SSH passwordless with root@tbw-1
Password: 
  Configuring csync2...done
  Merging known_hosts
WARNING: Failed to get known_hosts from tbw-2: Exited with error code 255, Error output: Warning: Permanently added 'tbw-2,10.10.10.27' (ECDSA) to the list of known hosts.
parallax error: SSH requested a password. Please create SSH keys or
use the -A option to provide a password.
parallax error: SSH requested a password. Please create SSH keys or
use the -A option to provide a password.
root@tbw-2: Permission denied (publickey,password,keyboard-interactive).
```