### PR TITLE
hb report include archived log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ jobs:
       script:
         - docker run -t -v "$(pwd):/app" $IMAGE /bin/sh -c "cd /app; TOXENV=py38-codeclimate; tox"
 
+    - name: "functional test for hb_report"
+      before_install:
+        - $FUNCTIONAL_TEST hb_report before_install
+      script:
+        - $FUNCTIONAL_TEST hb_report run bugs 
+
     - name: "regression test for bootstrap bugs"
       before_install:
         - $FUNCTIONAL_TEST bootstrap before_install

--- a/data-manifest
+++ b/data-manifest
@@ -71,6 +71,7 @@ test/features/bootstrap_options.feature
 test/features/bootstrap_sbd.feature
 test/features/environment.py
 test/features/geo_setup.feature
+test/features/hb_report_bugs.feature
 test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature
 test/features/qdevice_usercase.feature

--- a/test/features/hb_report_bugs.feature
+++ b/test/features/hb_report_bugs.feature
@@ -1,0 +1,46 @@
+@hb_report
+Feature: hb_report functional test
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Verify hb_report options
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+
+    When    Run "hb_report" on "hanode1"
+    Then    Default hb_report tar file created
+    When    Remove default hb_report tar file
+
+    @clean
+    Scenario: Include archived logs(bsc#1148873)
+    When    Write multi lines to file "/var/log/log1"
+      """
+      Sep 08 08:36:34 node1 log message line1
+      Sep 08 08:37:01 node1 log message line2
+      Sep 08 08:37:02 node1 log message line3
+      """
+    And     Run "xz /var/log/log1" on "hanode1"
+    When    Write multi lines to file "/var/log/log1"
+      """
+      Sep 08 09:37:02 node1 log message line4
+      Sep 08 09:37:12 node1 log message line5
+      """
+    And     Run "hb_report -f 20200901 -E /var/log/log1 report1" on "hanode1"
+    Then    File "log1" in "report1.tar.bz2"
+    When    Run "tar jxf report1.tar.bz2" on "hanode1"
+    And     Run "cat report1/hanode1/log1" on "hanode1"
+    Then    Expected multiple lines in output
+      """
+      Sep 08 08:36:34 node1 log message line1
+      Sep 08 08:37:01 node1 log message line2
+      Sep 08 08:37:02 node1 log message line3
+      Sep 08 09:37:02 node1 log message line4
+      Sep 08 09:37:12 node1 log message line5
+      """
+    When    Run "rm -rf report1.tar.gz report1" on "hanode1"

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -1,5 +1,33 @@
+import tarfile
+import glob
+import re
 import socket
 from crmsh import utils, bootstrap, parallax
+
+
+def get_file_type(file_path):
+    rc, out, _ = utils.get_stdout_stderr("file {}".format(file_path))
+    if re.search(r'{}: bzip2'.format(file_path), out):
+        return "bzip2"
+    if re.search(r'{}: directory'.format(file_path), out):
+        return "directory"
+
+
+def get_all_files(archive_path):
+    archive_type = get_file_type(archive_path)
+    if archive_type == "bzip2":
+        with tarfile.open(archive_path) as tar:
+            return tar.getnames()
+    if archive_type == "directory":
+        all_files = glob.glob("{}/*".format(archive_path)) + glob.glob("{}/*/*".format(archive_path))
+        return all_files
+
+
+def file_in_archive(f, archive_path):
+    for item in get_all_files(archive_path):
+        if re.search(r'/{}$'.format(f), item):
+            return True
+    return False
 
 
 def me():
@@ -11,17 +39,17 @@ def run_command(context, cmd, err_record=False):
     if rc != 0 and err:
         if err_record:
             context.command_error_output = err
-            return
+            return rc, out
         if out:
             context.logger.info("\n{}\n".format(out))
         context.logger.error("\n{}\n".format(err))
         context.failed = True
-    return out
+    return rc, out
 
 
 def run_command_local_or_remote(context, cmd, addr, err_record=False):
     if addr == me():
-        out = run_command(context, cmd, err_record)
+        _, out = run_command(context, cmd, err_record)
         return out
     else:
         try:


### PR DESCRIPTION
## Problem
hb_report would not collect any archived logs like `/var/log/messages-20200819.xz`
## Root cause
* In `arch_logs` function, miss appending archived logs
* Should use `lzma.open` to open `.xz` files instead of using `open`
* Part of codes in this PR are borrowed from #557, in which this issue has been fixed
 ## Prove the result
```
    @clean
    Scenario: Include archived logs(bsc#1148873)
    When    Write multi lines to file "/var/log/log1"
      """
      Sep 08 08:36:34 node1 log message line1
      Sep 08 08:37:01 node1 log message line2
      Sep 08 08:37:02 node1 log message line3
      """
    And     Run "xz /var/log/log1" on "hanode1"
    When    Write multi lines to file "/var/log/log1"
      """
      Sep 08 09:37:02 node1 log message line4
      Sep 08 09:37:12 node1 log message line5
      """
    And     Run "hb_report -f 20200901 -E /var/log/log1 report1" on "hanode1"
    Then    File "log1" in "report1.tar.bz2"
    When    Run "tar jxf report1.tar.bz2" on "hanode1"
    And     Run "cat report1/hanode1/log1" on "hanode1"
    Then    Expected multiple lines in output
      """
      Sep 08 08:36:34 node1 log message line1
      Sep 08 08:37:01 node1 log message line2
      Sep 08 08:37:02 node1 log message line3
      Sep 08 09:37:02 node1 log message line4
      Sep 08 09:37:12 node1 log message line5
      """
    When    Run "rm -rf report1.tar.gz report1" on "hanode1"
```