### PR TITLE
Obscure sesitive data by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,12 @@ jobs:
       script:
         - $FUNCTIONAL_TEST resource run
 
+    - name: "functional test for configure sublevel bugs"
+      before_install:
+        - $FUNCTIONAL_TEST configure before_install
+      script:
+        - $FUNCTIONAL_TEST configure run bugs
+
     - name: "functional test for geo cluster"
       before_install:
         - $FUNCTIONAL_TEST geo before_install

--- a/crm.conf.in
+++ b/crm.conf.in
@@ -20,6 +20,22 @@
 ; ignore_missing_metadata = no
 ; report_tool_options =
 
+; obscure_pattern option is the persisent configuration of CLI.
+; Example, for the high security concern, obscure_pattern = passw* | ip
+; which makes `crm configure show` is equal to
+;
+; node-1:~ # crm configure show obscure:passw* obscure:ip
+; node 1084783297: node1
+; primitive fence_device stonith:fence_ilo5 \
+;         params password="******"
+; primitive ip IPaddr2 \
+;         params ip="******"
+;
+; The default option is passw*
+; If you don't want to obscure, change the value to blank.
+;
+; obscure_pattern = passw*
+
 [path]
 ; sharedir = <detected>
 ; cache = <detected>

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -238,7 +238,8 @@ DEFAULTS = {
         'dotty': opt_program('', ('dotty',)),
         'dot': opt_program('', ('dot',)),
         'ignore_missing_metadata': opt_boolean('no'),
-        'report_tool_options': opt_string('')
+        'report_tool_options': opt_string(''),
+        'obscure_pattern': opt_string('passw*')
     },
     'path': {
         'sharedir': opt_dir('%(datadir)s/crmsh'),

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
+import re
 import time
 from . import command
 from . import completers as compl
@@ -550,6 +551,12 @@ class CibConfig(command.UI):
         "usage: show [xml] [<id>...]"
         from .utils import obscure
         osargs = [arg[8:] for arg in args if arg.startswith('obscure:')]
+        if not osargs and config.core.obscure_pattern:
+            # obscure_pattern could be
+            #   1. "pattern1 pattern2 pattern3"
+            #   2. "pattern1|pattern2|pattern3"
+            # regrex here also filter out possible spaces
+            osargs = re.split('\s*\|\s*|\s+', config.core.obscure_pattern.strip('|'))
         args = [arg for arg in args if not arg.startswith('obscure:')]
         with obscure(osargs):
             set_obj = mkset_obj(*args)

--- a/data-manifest
+++ b/data-manifest
@@ -69,6 +69,7 @@ test/features/bootstrap_bugs.feature
 test/features/bootstrap_init_join_remove.feature
 test/features/bootstrap_options.feature
 test/features/bootstrap_sbd.feature
+test/features/configure_bugs.feature
 test/features/environment.py
 test/features/geo_setup.feature
 test/features/hb_report_bugs.feature

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -4208,6 +4208,24 @@ configuration over a public channel, to avoid exposing potentially
 sensitive information. The +<glob>+ argument is a bash-style pattern
 matching attribute keys.
 
+In +/etc/crm/crm.conf+, +obscure_pattern+ option is the persisent configuration of CLI.
+Example, for the high security concern,
+...............
+[core]
+obscure_pattern = passw* | ip
+...............
+Which makes +crm configure show+ is equal to
+...............
+node-1:~ # crm configure show obscure:passw* obscure:ip
+node 1084783297: node1
+primitive fence_device stonith:fence_ilo5 \
+        params password="******"
+primitive ip IPaddr2 \
+        params ip="******"
+...............
+The default suggestion is +passw*+
+If you don't want to obscure, change the value to blank.
+
 Usage:
 ...............
 show [xml] [<id>

--- a/test/features/configure_bugs.feature
+++ b/test/features/configure_bugs.feature
@@ -1,0 +1,34 @@
+@configure
+Feature: Functional test for configure sub level
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Replace sensitive data by default(bsc#1163581)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+
+    # mask password by default
+    When    Run "crm node utilization hanode1 set password qwertyui" on "hanode1"
+    When    Try "crm configure show|grep password|grep qwertyui"
+    Then    Expected return code is "1"
+    And     Show crm configure
+
+    # mask password and ip address
+    When    Run "crm configure primitive ip2 IPaddr2 params ip=10.10.10.124" on "hanode1"
+    And     Run "sed -i 's/; \[core\]/[core]/' /etc/crm/crm.conf" on "hanode1"
+    And     Run "sed -i 's/; obscure_pattern = .*$/obscure_pattern = passw*|ip/g' /etc/crm/crm.conf" on "hanode1"
+    And     Try "crm configure show|grep -E "10.10.10.124|qwertyui""
+    Then    Expected return code is "1"
+    And     Show crm configure
+
+    # mask password and ip address with another pattern
+    When    Run "sed -i 's/obscure_pattern = .*$/obscure_pattern = passw* ip/g' /etc/crm/crm.conf" on "hanode1"
+    And     Try "crm configure show|grep -E "10.10.10.124|qwertyui""
+    Then    Expected return code is "1"
+    And     Show crm configure

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -171,6 +171,13 @@ def step_impl(context):
         context.logger.info("\n{}".format(out))
 
 
+@then('Show crm configure')
+def step_impl(context):
+    _, out = run_command(context, 'crm configure show')
+    if out:
+        context.logger.info("\n{}".format(out))
+
+
 @then('Show status from qnetd')
 def step_impl(context):
     _, out = run_command(context, 'crm corosync status qnetd')

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -8,6 +8,7 @@ configure() {
 make_install() {
 	echo "** Make / Install"
 	make install
+	make install-crmconfDATA prefix=
 }
 
 regression_tests() {
@@ -26,7 +27,7 @@ case "$1" in
 		configure
 		make_install
 		exit $?;;
-	bootstrap|qdevice|hb_report|resource|geo)
+	bootstrap|qdevice|hb_report|resource|geo|configure)
 		functional_tests $1 $2
 		exit $?;;
 	*)


### PR DESCRIPTION
## Issue
`crm configure show` will display sensitive data like `password` in clear text
## Solution
By adding default value to `/etc/crm/crm.conf`:
```
; [core]
; obscure_pattern = passw*
```
The sensitive data will be replaced by `*` by default.
If you don't want to obscure, change the `obscure_pattern` to blank.
If you want to replace more sensitive data, you could append more patterns
to `obscure_pattern` with format `pattern1 pattern2 pattern3` or `pattern1|pattern2|pattern3`.
## Prove the result
```
    When    Run "crm node utilization hanode1 set password qwertyui" on "hanode1"
    When    Try "crm configure show|grep password|grep qwertyui"
    Then    Expected return code is "1"
```