### PR TITLE
Low: config: Try to handle configparser.MissingSectionHeaderError while reading

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -303,6 +303,17 @@ class _Configuration(object):
         self._systemwide = None
         self._user = None
 
+    def _safe_read(self, config_parser_inst, file_list):
+        """
+        Try to handle configparser.MissingSectionHeaderError while reading
+        """
+        from . import utils
+        try:
+            config_parser_inst.read(file_list)
+        except configparser.MissingSectionHeaderError:
+            with utils.disable_exception_traceback():
+                raise
+
     def load(self):
         self._defaults = configparser.ConfigParser()
         for section, keys in DEFAULTS.items():
@@ -312,14 +323,14 @@ class _Configuration(object):
 
         if os.path.isfile(_SYSTEMWIDE):
             self._systemwide = configparser.ConfigParser()
-            self._systemwide.read([_SYSTEMWIDE])
+            self._safe_read(self._systemwide, [_SYSTEMWIDE])
         # for backwards compatibility with <=2.1.1 due to ridiculous bug
         elif os.path.isfile("/etc/crm/crmsh.conf"):
             self._systemwide = configparser.ConfigParser()
-            self._systemwide.read(["/etc/crm/crmsh.conf"])
+            self._safe_read(self._systemwide, ["/etc/crm/crmsh.conf"])
         if os.path.isfile(_PERUSER):
             self._user = configparser.ConfigParser()
-            self._user.read([_PERUSER])
+            self._safe_read(self._user, [_PERUSER])
 
     def save(self):
         if self._user:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2540,4 +2540,15 @@ def package_is_installed(pkg, remote_addr=None):
         # check on local
         rc, _ = get_stdout(cmd)
     return rc == 0
+
+
+@contextmanager
+def disable_exception_traceback():
+    """
+    All traceback information is suppressed and only the exception type and value are printed
+    """
+    default_value = getattr(sys, "tracebacklimit", 1000)  # `1000` is a Python's default value
+    sys.tracebacklimit = 0
+    yield
+    sys.tracebacklimit = default_value  # revert changes
 # vim:ts=4:sw=4:et:


### PR DESCRIPTION
## Problem
When un-commented options in `/etc/crm/crm.conf` and missing un-commented section headers,
configparser.MissingSectionHeaderError will raise and print traceback
```
Traceback (most recent call last):
  File "/usr/sbin/crm", line 29, in <module>
    from crmsh import main
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 9, in <module>
    from . import config
  File "/usr/lib/python3.6/site-packages/crmsh/config.py", line 454, in <module>
    load()
  File "/usr/lib/python3.6/site-packages/crmsh/config.py", line 394, in load
    _configuration.load()
  File "/usr/lib/python3.6/site-packages/crmsh/config.py", line 315, in load
    self._systemwide.read([_SYSTEMWIDE])
  File "/usr/lib64/python3.6/configparser.py", line 697, in read
    self._read(fp, filename)
  File "/usr/lib64/python3.6/configparser.py", line 1080, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
configparser.MissingSectionHeaderError: File contains no section headers.
file: '/etc/crm/crm.conf', line: 15
'force = no\n'
```
It's not user friendly.

## Solution
Try to suppressed the traceback information by setting `sys.tracebacklimit = 0`

## Result
```
# crm
configparser.MissingSectionHeaderError: File contains no section headers.
file: '/etc/crm/crm.conf', line: 15
'force = no\n'
```