### PR TITLE
[crmsh-4.1] Low: config: Try to handle configparser.MissingSectionHeaderError while reading

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -4,6 +4,7 @@
 Holds user-configurable options.
 '''
 
+import sys
 import os
 import re
 import configparser
@@ -304,6 +305,16 @@ class _Configuration(object):
         self._systemwide = None
         self._user = None
 
+    def _safe_read(self, config_parser_inst, file_list):
+        """
+        Try to handle configparser.MissingSectionHeaderError while reading
+        """
+        try:
+            config_parser_inst.read(file_list)
+        except configparser.MissingSectionHeaderError as e:
+            print("{}: {}".format(type(e).__name__, e))
+            sys.exit(1)
+
     def load(self):
         self._defaults = configparser.ConfigParser()
         for section, keys in DEFAULTS.items():
@@ -313,14 +324,14 @@ class _Configuration(object):
 
         if os.path.isfile(_SYSTEMWIDE):
             self._systemwide = configparser.ConfigParser()
-            self._systemwide.read([_SYSTEMWIDE])
+            self._safe_read(self._systemwide, [_SYSTEMWIDE])
         # for backwards compatibility with <=2.1.1 due to ridiculous bug
         elif os.path.isfile("/etc/crm/crmsh.conf"):
             self._systemwide = configparser.ConfigParser()
-            self._systemwide.read(["/etc/crm/crmsh.conf"])
+            self._safe_read(self._systemwide, ["/etc/crm/crmsh.conf"])
         if os.path.isfile(_PERUSER):
             self._user = configparser.ConfigParser()
-            self._user.read([_PERUSER])
+            self._safe_read(self._user, [_PERUSER])
 
     def save(self):
         if self._user:


### PR DESCRIPTION
backport from #630 
But change the way as print instead of raise like pr630, since that will cause circular import problem
 ```
    def _safe_read(self, config_parser_inst, file_list):
        """
        Try to handle configparser.MissingSectionHeaderError while reading
        """
        try:
            config_parser_inst.read(file_list)
        except configparser.MissingSectionHeaderError as e:
            print("{}: {}".format(type(e).__name__, e))
            sys.exit(1)
```