### PR TITLE
[crmsh-3.0] Low: config: Try to handle configparser.MissingSectionHeaderError while reading

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -4,6 +4,7 @@
 Holds user-configurable options.
 '''
 
+import sys
 import os
 import re
 try:
@@ -299,6 +300,16 @@ class _Configuration(object):
         self._systemwide = None
         self._user = None
 
+    def _safe_read(self, config_parser_inst, file_list):
+        """
+        Try to handle configparser.MissingSectionHeaderError while reading
+        """
+        try:
+            config_parser_inst.read(file_list)
+        except ConfigParser.MissingSectionHeaderError as e:
+            print("{}: {}".format(type(e).__name__, e))
+            sys.exit(1)
+
     def load(self):
         self._defaults = ConfigParser.SafeConfigParser()
         for section, keys in DEFAULTS.iteritems():
@@ -308,14 +319,14 @@ class _Configuration(object):
 
         if os.path.isfile(_SYSTEMWIDE):
             self._systemwide = ConfigParser.SafeConfigParser()
-            self._systemwide.read([_SYSTEMWIDE])
+            self._safe_read(self._systemwide, [_SYSTEMWIDE])
         # for backwards compatibility with <=2.1.1 due to ridiculous bug
         elif os.path.isfile("/etc/crm/crmsh.conf"):
             self._systemwide = ConfigParser.SafeConfigParser()
-            self._systemwide.read(["/etc/crm/crmsh.conf"])
+            self._safe_read(self._systemwide, ["/etc/crm/crmsh.conf"])
         if os.path.isfile(_PERUSER):
             self._user = ConfigParser.SafeConfigParser()
-            self._user.read([_PERUSER])
+            self._safe_read(self._user, [_PERUSER])
 
     def save(self):
         if self._user:


### PR DESCRIPTION
backport from #633 