### PR TITLE
Fix: hb_report: collect corosync.log if it defined in config file(bsc#1148874)

### DIFF
--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -27,6 +27,7 @@ import constants
 import crmsh.config
 from crmsh import msg as crmmsg
 from crmsh import utils as crmutils
+from crmsh import corosync
 
 
 class Tempfile(object):
@@ -312,7 +313,13 @@ def collect_info():
     for p in process_list:
         p.join()
 
-    for l in constants.EXTRA_LOGS.split():
+    logfile_list = []
+    corosync_log = corosync.get_value('logging.logfile')
+    if corosync_log:
+        logfile_list.append(corosync_log)
+    logfile_list += constants.EXTRA_LOGS.split()
+
+    for l in logfile_list:
         if not os.path.isfile(l):
             continue
         if l == constants.HA_LOG and l != constants.HALOG_F:

--- a/test/features/hb_report_bugs.feature
+++ b/test/features/hb_report_bugs.feature
@@ -43,6 +43,22 @@ Feature: hb_report functional test for verifying bugs
     When    Run "rm -rf report1.tar.gz report1" on "hanode1"
 
   @clean
+  Scenario: Collect corosync.log(bsc#1148874)
+    When    Run "sed -i 's/\(\s*logfile:\s*\).*/\1\/var\/log\/cluster\/corosync.log/' /etc/corosync/corosync.conf" on "hanode1"
+    And     Run "hb_report report" on "hanode1"
+    And     Run "tar jxf report.tar.bz2" on "hanode1"
+    Then    File "corosync.log" not in "report.tar.bz2"
+    When    Run "rm -rf report.tar.gz report" on "hanode1"
+
+    When    Run "sed -i 's/\(\s*to_logfile:\s*\).*/\1yes/' /etc/corosync/corosync.conf" on "hanode1"
+    And     Run "crm cluster stop" on "hanode1"
+    And     Run "crm cluster start" on "hanode1"
+    And     Run "hb_report report" on "hanode1"
+    And     Run "tar jxf report.tar.bz2" on "hanode1"
+    Then    File "corosync.log" in "report.tar.bz2"
+    When    Run "rm -rf report.tar.gz report" on "hanode1"
+
+  @clean
   Scenario: Replace sensitive data(bsc#1163581)
     # Set sensitive data TEL and password
     When    Run "crm node utilization hanode1 set TEL 13356789876" on "hanode1"


### PR DESCRIPTION
## Problem
The hb_report result didn't include corosync.log

## Solution
Collect corosync log if it was defined in **logging.logfile** in corosync.conf and in the time span

## Functional test
``` Shell
  @clean
  Scenario: Collect corosync.log(bsc#1148874)
    When    Run "sed -i 's/\(\s*logfile:\s*\).*/\1\/var\/log\/cluster\/corosync.log/' /etc/corosync/corosync.conf" on "hanode1"
    And     Run "hb_report report" on "hanode1"
    And     Run "tar jxf report.tar.bz2" on "hanode1"
    Then    File "corosync.log" not in "report.tar.bz2"
    When    Run "rm -rf report.tar.gz report" on "hanode1"

    When    Run "sed -i 's/\(\s*to_logfile:\s*\).*/\1yes/' /etc/corosync/corosync.conf" on "hanode1"
    And     Run "crm cluster stop" on "hanode1"
    And     Run "crm cluster start" on "hanode1"
    And     Run "hb_report report" on "hanode1"
    And     Run "tar jxf report.tar.bz2" on "hanode1"
    Then    File "corosync.log" in "report.tar.bz2"
    When    Run "rm -rf report.tar.gz report" on "hanode1"
```