### PR TITLE
Show help message from command line if that subcommand use argparse

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -187,7 +187,11 @@ class Cluster(command.UI):
         if len(args) > 0:
             if '--dry-run' in args or looks_like_hostnames(args):
                 args = ['--yes', '--nodes'] + [arg for arg in args if arg != '--dry-run']
-        parser = ArgParser(usage="init [options] [STAGE]", epilog="""
+        parser = ArgParser(description="""
+Initialize a cluster from scratch. This command configures
+a complete cluster, and can also add additional cluster
+nodes to the initial one-node cluster using the --nodes
+option.""", usage="init [options] [STAGE]", epilog="""
 
 Stage can be one of:
     ssh         Create SSH keys for passwordless SSH between cluster nodes
@@ -312,7 +316,11 @@ Note:
         '''
         Join this node to an existing cluster
         '''
-        parser = ArgParser(usage="join [options] [STAGE]", epilog="""
+        parser = ArgParser(description="""
+Join the current node to an existing cluster. The
+current node cannot be a member of a cluster already.
+Pass any node in the existing cluster as the argument
+to the -c option.""",usage="join [options] [STAGE]", epilog="""
 
 Stage can be one of:
     ssh         Obtain SSH keys from existing cluster node (requires -c <host>)
@@ -368,7 +376,10 @@ If stage is not specified, each stage will be invoked in sequence.
         Installs packages, sets up corosync and pacemaker, etc.
         Must be executed from a node in the existing cluster.
         '''
-        parser = ArgParser(usage="add [options] [node ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
+        parser = ArgParser(description="""
+Add a new node to the cluster. The new node will be
+configured as a cluster member.""",
+                usage="add [options] [node ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         options, args = parse_options(parser, args)
@@ -386,7 +397,14 @@ If stage is not specified, each stage will be invoked in sequence.
         '''
         Remove the given node(s) from the cluster.
         '''
-        parser = ArgParser(usage="remove [options] [<node> ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
+        parser = ArgParser(description="""
+Remove one or more nodes from the cluster.
+
+This command can remove the last node in the cluster,
+thus effectively removing the whole cluster. To remove
+the last node, pass --force argument to crm or set
+the config.core.force option.""",
+                usage="remove [options] [<node> ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
@@ -465,7 +483,13 @@ If stage is not specified, each stage will be invoked in sequence.
         * arbitrator IP / hostname (optional)
         * list of tickets (can be empty)
         '''
-        parser = ArgParser(usage="geo-init [options]", epilog="""
+        parser = ArgParser(description="""
+Create a new geo cluster with the current cluster as the
+first member. Pass the complete geo cluster topology as
+arguments to this command, and then use geo-join and
+geo-init-arbitrator to add the remaining members to
+the geo cluster.""",
+        usage="geo-init [options]", epilog="""
 
 Cluster Description
 
@@ -522,7 +546,17 @@ Cluster Description
         '''
         Join this cluster to a geo configuration.
         '''
-        parser = ArgParser(usage="geo-join [options]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
+        parser = ArgParser(description="""
+This command should be run from one of the nodes in a cluster
+which is currently not a member of a geo cluster. The geo
+cluster configuration will be fetched from the provided node,
+and the cluster will be added to the geo cluster.
+
+Note that each cluster in a geo cluster needs to have a unique
+name set. The cluster name can be set using the --name argument
+to init, or by configuring corosync with the cluster name in
+an existing cluster.""",
+                usage="geo-join [options]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
@@ -556,7 +590,11 @@ Cluster Description
         '''
         Make this node a geo arbitrator.
         '''
-        parser = ArgParser(usage="geo-init-arbitrator [options]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
+        parser = ArgParser(description="""
+Configure the current node as a geo arbitrator. The command
+requires an existing geo cluster or geo arbitrator from which
+to get the geo cluster configuration.""",
+                usage="geo-init-arbitrator [options]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -76,7 +76,7 @@ class Context(object):
                 self.command_info = self.current_level().get_child(token)
                 if not self.command_info:
                     self.fatal_error("No such command")
-                if self.command_name in self.command_info.aliases:
+                if self.command_name in self.command_info.aliases and self.command_name not in ["-h", "--help"]:
                     common_warn("This command '{}' is deprecated, please use '{}'"\
                             .format(self.command_name, self.command_info.name))
                 self.command_name = self.command_info.name

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -985,21 +985,9 @@ These commands enable easy installation and maintenance of a HA
 cluster, by providing support for package installation, configuration
 of the cluster messaging layer, file system setup and more.
 
-[[cmdhelp_cluster_add,Add a new node to the cluster]]
+[[cmdhelp_cluster_add,Add a new node to the cluster,From Code]]
 ==== `add`
-
-Add a new node to the cluster. The new node will be
-configured as a cluster member.
-
-Options:
-
-*-y, --yes*::
-    Answer "yes" to all prompts (use with caution)
-
-Usage:
-...............
-add [options] [<node> ...]
-...............
+See "crm cluster help add" or "crm cluster add --help"
 
 [[cmdhelp_cluster_copy,Copy file to other cluster nodes]]
 ==== `copy`
@@ -1058,101 +1046,17 @@ Usage:
 enable
 ...............
 
-[[cmdhelp_cluster_geo_init,Configure cluster as geo cluster]]
+[[cmdhelp_cluster_geo_init,Configure cluster as geo cluster,From Code]]
 ==== `geo-init`
+See "crm cluster help geo_init" or "crm cluster geo_init --help"
 
-Create a new geo cluster with the current cluster as the
-first member. Pass the complete geo cluster topology as
-arguments to this command, and then use `geo-join` and
-`geo-init-arbitrator` to add the remaining members to
-the geo cluster.
-
-Options:
-
-*-q, --quiet*::
-    Be quiet (don't describe what's happening, just do it)
-
-*-y, --yes*::
-    Answer "yes" to all prompts (use with caution)
-
-*-s DESC, --clusters=DESC*::
-    Geo cluster description (see details below)
-
-*-a IP, --arbitrator=IP*::
-    IP address of geo cluster arbitrator (optional)
-
-*-t LIST, --tickets=LIST*::
-    Tickets to create (space-separated)
-
-
-Cluster Description:
-
-This is a map of cluster names to IP addresses.
-Each IP address will be configured as a virtual IP
-representing that cluster in the geo cluster
-configuration.
-
-Example with two clusters named paris and amsterdam:
-
-............
-  --clusters "paris=192.168.10.10 amsterdam=192.168.10.11"
-............
-
-Name clusters using the +--name+ parameter to `init`.
-
-Usage:
-...............
-geo-init [options]
-...............
-
-
-[[cmdhelp_cluster_geo_init_arbitrator,Initialize node as geo cluster arbitrator]]
+[[cmdhelp_cluster_geo_init_arbitrator,Initialize node as geo cluster arbitrator,From Code]]
 ==== `geo-init-arbitrator`
+See "crm cluster help geo_init_arbitrator" or "crm cluster geo_init_arbitrator --help"
 
-Configure the current node as a geo arbitrator. The command
-requires an existing geo cluster or geo arbitrator from which
-to get the geo cluster configuration.
-
-Options:
-
-*-c IP, --cluster-node=IP*::
-    IP address of an already-configured geo cluster
-
-Usage:
-...............
-geo-init-arbitrator [options]
-...............
-
-
-[[cmdhelp_cluster_geo_join,Join cluster to existing geo cluster]]
+[[cmdhelp_cluster_geo_join,Join cluster to existing geo cluster,From Code]]
 ==== `geo-join`
-
-This command should be run from one of the nodes in a cluster
-which is currently not a member of a geo cluster. The geo
-cluster configuration will be fetched from the provided node,
-and the cluster will be added to the geo cluster.
-
-Note that each cluster in a geo cluster needs to have a unique
-name set. The cluster name can be set using the `--name` argument
-to `init`, or by configuring corosync with the cluster name in
-an existing cluster.
-
-Options:
-
-*-s DESC, --clusters=DESC*::
-    Geo cluster description (see +geo-init+ for details)
-
-*-c IP, --cluster-node=IP*::
-    IP address of an already-configured geo cluster node
-    or arbitrator. This argument can also be a virtual IP
-    as long as it resolves to a node in an existing geo
-    cluster.
-
-Usage:
-...............
-geo-join --cluster-node <node> --clusters <description>
-...............
-
+See "crm cluster help geo_join" or "crm cluster geo_join --help"
 
 [[cmdhelp_cluster_health,Cluster health check]]
 ==== `health`
@@ -1165,198 +1069,17 @@ Usage:
 health
 ...............
 
-[[cmdhelp_cluster_init,Initializes a new HA cluster]]
+[[cmdhelp_cluster_init,Initializes a new HA cluster,From Code]]
 ==== `init`
+See "crm cluster help init" or "crm cluster init --help"
 
-Initialize a cluster from scratch. This command configures
-a complete cluster, and can also add additional cluster
-nodes to the initial one-node cluster using the `--nodes`
-option.
-
-Options:
-
-*-q, --quiet*::
-    Be quiet (don't describe what's happening, just do it)
-
-*-y, --yes*::
-    Answer "yes" to all prompts (use with caution, this
-    is destructive, especially during the "storage" stage)
-    
-*-t TEMPLATE, --template=TEMPLATE**::
-    Optionally configure cluster with template "name"
-    (currently only "ocfs2" is valid here)
-
-*-n NAME, --name=NAME*::
-    Set the name of the configured cluster.
-
-*-N NODES, --nodes=NODES*::
-    Additional nodes to add to the created cluster. May
-    include the current node, which will always be the
-    initial cluster node.
-
-*-w WATCHDOG, --watchdog=WATCHDOG*::
-    Use the given watchdog device.
-
-*-S, --enable-sbd*::
-    Enable SBD even if no SBD device is configured (diskless mode).
-
-Network configuration:
-
-Options for configuring the network and messaging layer.
-
-*-i IF, --interface=IF*::
-    Bind to IP address on interface IF
-
-*-u, --unicast*::
-    Configure corosync to communicate over unicast (UDP),
-    and not multicast. Default is multicast unless an
-    environment where multicast cannot be used is
-    detected.
-
-*-A IP, --admin-ip=IP*::
-    Configure IP address as an administration virtual IP
-
-Storage configuration:
-
-Options for configuring shared storage.
-
-*-p DEVICE, --partition-device=DEVICE*::
-    Partition this shared storage device (only used in
-    "storage" stage)
-
-*-s DEVICE, --sbd-device=DEVICE*::
-    Block device to use for SBD fencing
-
-*-o DEVICE, --ocfs2-device=DEVICE*::
-    Block device to use for OCFS2 (only used in "vgfs"
-    stage)
-
-
-Stage can be one of:
-
-*ssh*::
-    Create SSH keys for passwordless SSH between cluster nodes
-
-*csync2*::
-    Configure csync2
-
-*corosync*::
-    Configure corosync
-
-*storage*::
-    Partition shared storage (ocfs2 template only)
-
-*sbd*::
-    Configure SBD (requires -s <dev>)
-
-*cluster*::
-    Bring the cluster online
-
-*vgfs*::
-    Create volume group and filesystem (ocfs2 template only, requires `-o <dev>`)
-
-*admin*::
-    Create administration virtual IP (optional)
-
-[NOTE]
-============
-- If stage is not specified, the script will run through each stage
-  in sequence, with prompts for required information.
-- If using the ocfs2 template, the storage stage will partition a block
-  device into two pieces, one for SBD, the remainder for OCFS2.  This is
-  good for testing and demonstration, but not ideal for production.
-  To use storage you have already configured, pass -s and -o to specify
-  the block devices for SBD and OCFS2, and the automatic partitioning
-  will be skipped.
-============
-
-Usage:
-...............
-init [options] [STAGE]
-...............
-
-
-[[cmdhelp_cluster_join,Join existing cluster]]
+[[cmdhelp_cluster_join,Join existing cluster,From Code]]
 ==== `join`
+See "crm cluster help join" or "crm cluster join --help"
 
-Join the current node to an existing cluster. The
-current node cannot be a member of a cluster already.
-Pass any node in the existing cluster as the argument
-to the `-c` option.
-
-Options:
-
-*-q, --quiet*::
-    Be quiet (don't describe what's happening, just do it)
-
-*-y, --yes*::
-    Answer "yes" to all prompts (use with caution)
-
-*-w WATCHDOG, --watchdog=WATCHDOG*::
-    Use the given watchdog device
-
-Network configuration:
-
-Options for configuring the network and messaging layer.
-
-
-*-c HOST, --cluster-node=HOST*::
-    IP address or hostname of existing cluster node
-
-*-i IF, --interface=IF*::
-    Bind to IP address on interface IF
-
-
-Stage can be one of:
-
-*ssh*::
-    Obtain SSH keys from existing cluster node (requires -c <host>)
-
-*csync2*::
-    Configure csync2 (requires -c <host>)
-
-*ssh_merge*::
-    Merge root's SSH known_hosts across all nodes (csync2 must
-    already be configured).
-
-*cluster*::
-    Start the cluster on this node
-
-If stage is not specified, each stage will be invoked in sequence.
-
-Usage:
-...............
-join [options] [STAGE]
-...............
-
-
-[[cmdhelp_cluster_remove,Remove node(s) from the cluster]]
+[[cmdhelp_cluster_remove,Remove node(s) from the cluster,From Code]]
 ==== `remove`
-
-Remove one or more nodes from the cluster.
-
-This command can remove the last node in the cluster,
-thus effectively removing the whole cluster. To remove
-the last node, pass `--force` argument to `crm` or set
-the `config.core.force` option.
-
-Options:
-
-*-q, --quiet*::
-    Be quiet (don't describe what's happening, just do it)
-
-*-y, --yes*::
-    Answer "yes" to all prompts (use with caution)
-
-*-c HOST, --cluster-node=HOST*::
-    IP address or hostname of cluster node which will be
-    removed from the cluster
-
-Usage:
-...............
-remove [options] [<node> ...]
-...............
-
+See "crm cluster help remove" or "crm cluster remove --help"
 
 [[cmdhelp_cluster_restart,Restart cluster services]]
 ==== `restart`

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -55,6 +55,11 @@ optional arguments:
 
 CRM_CLUSTER_INIT_H_OUTPUT = '''usage: init [options] [STAGE]
 
+Initialize a cluster from scratch. This command configures
+a complete cluster, and can also add additional cluster
+nodes to the initial one-node cluster using the --nodes
+option.
+
 optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
@@ -158,6 +163,11 @@ Note:
 
 CRM_CLUSTER_JOIN_H_OUTPUT = '''usage: join [options] [STAGE]
 
+Join the current node to an existing cluster. The
+current node cannot be a member of a cluster already.
+Pass any node in the existing cluster as the argument
+to the -c option.
+
 optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
@@ -186,12 +196,22 @@ If stage is not specified, each stage will be invoked in sequence.'''
 
 CRM_CLUSTER_ADD_H_OUTPUT = '''usage: add [options] [node ...]
 
+Add a new node to the cluster. The new node will be
+configured as a cluster member.
+
 optional arguments:
   -h, --help  Show this help message
   -y, --yes   Answer "yes" to all prompts (use with caution)'''
 
 
 CRM_CLUSTER_REMOVE_H_OUTPUT = '''usage: remove [options] [<node> ...]
+
+Remove one or more nodes from the cluster.
+
+This command can remove the last node in the cluster,
+thus effectively removing the whole cluster. To remove
+the last node, pass --force argument to crm or set
+the config.core.force option.
 
 optional arguments:
   -h, --help            Show this help message
@@ -205,6 +225,12 @@ optional arguments:
 
 
 CRM_CLUSTER_GEO_INIT_H_OUTPUT = '''usage: geo-init [options]
+
+Create a new geo cluster with the current cluster as the
+first member. Pass the complete geo cluster topology as
+arguments to this command, and then use geo-join and
+geo-init-arbitrator to add the remaining members to
+the geo cluster.
 
 optional arguments:
   -h, --help            Show this help message
@@ -234,6 +260,16 @@ Cluster Description
 
 CRM_CLUSTER_GEO_JOIN_H_OUTPUT = '''usage: geo-join [options]
 
+This command should be run from one of the nodes in a cluster
+which is currently not a member of a geo cluster. The geo
+cluster configuration will be fetched from the provided node,
+and the cluster will be added to the geo cluster.
+
+Note that each cluster in a geo cluster needs to have a unique
+name set. The cluster name can be set using the --name argument
+to init, or by configuring corosync with the cluster name in
+an existing cluster.
+
 optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
@@ -246,6 +282,10 @@ optional arguments:
 
 
 CRM_CLUSTER_GEO_INIT_ARBIT_H_OUTPUT = '''usage: geo-init-arbitrator [options]
+
+Configure the current node as a geo arbitrator. The command
+requires an existing geo cluster or geo arbitrator from which
+to get the geo cluster configuration.
 
 optional arguments:
   -h, --help            Show this help message


### PR DESCRIPTION
## Problem

1. For some subcommands which were using argparse, help messages exist both in crm.8.adoc and code, it's easy to cause inconsistent since code in argparse might changed frequently
2. Run `crm cluster --help` will pop a warning: `WARNING: This command '--help' is deprecated, please use 'help'`, this is also inconsistent for the command syntax

## Solution
**For problem 1**: In `crm.8.adoc`, mark those subcommands using argparse as `From Code`, then calling `-h/--help`, display that output, make sure only one place has help messages
**For problem 2**: Add additional condition based on https://github.com/ClusterLabs/crmsh/pull/558, to check whether the command name was -h or --help, don't consider it as alias

## TEST rpm
https://build.opensuse.org/package/show/home:XinLiang:branches:crmsh_testing/crmsh