### PR TITLE
Refactor service management codes

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -578,7 +578,7 @@ def is_online(crm_mon_txt):
     if not re.search("Online: .* {} ".format(peer_node), crm_mon_txt):
         shutil.copy(COROSYNC_CONF_ORIG, corosync.conf())
         csync2_update(corosync.conf())
-        stop_service("corosync")
+        utils.stop_service("corosync")
         print()
         error("Cannot see peer node \"{}\", please check the communication IP".format(peer_node))
     return True
@@ -597,24 +597,6 @@ def pick_default_value(default_list, prev_list):
         if value not in prev_list:
             return value
     return ""
-
-
-def start_service(service):
-    """
-    Start and enable systemd service
-    """
-    invoke("systemctl enable " + service)
-    rc, _out, _err = utils.get_stdout_stderr('systemctl -q is-active ' + service)
-    if rc != 0:
-        if not invoke("systemctl start " + service):
-            error("Failed to start " + service)
-
-
-def stop_service(service):
-    """
-    Stops the systemd service
-    """
-    return invoke("systemctl stop " + service)
 
 
 def sleep(t):
@@ -681,19 +663,6 @@ def check_tty():
         error("No pseudo-tty detected! Use -t option to ssh if calling remotely.")
 
 
-def grep_output(cmd, txt):
-    _rc, outp, _err = utils.get_stdout_stderr(cmd)
-    return txt in outp
-
-
-def grep_file(fn, txt):
-    return os.path.exists(fn) and txt in open(fn).read()
-
-
-def service_is_available(svcname):
-    return grep_output("systemctl list-unit-files {}".format(svcname), svcname)
-
-
 def my_hostname_resolves():
     import socket
     hostname = utils.this_node()
@@ -716,7 +685,7 @@ def check_prereqs(stage):
     timekeepers = ('chronyd.service', 'ntp.service', 'ntpd.service')
     timekeeper = None
     for tk in timekeepers:
-        if service_is_available(tk):
+        if utils.service_is_available(tk):
             timekeeper = tk
             break
 
@@ -909,8 +878,8 @@ def init_cluster_local():
     invoke("rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*")
 
     # only try to start hawk if hawk is installed
-    if service_is_available("hawk.service"):
-        start_service("hawk.service")
+    if utils.service_is_available("hawk.service"):
+        utils.start_service("hawk.service", enable=True)
         status("Hawk cluster interface is now running. To see cluster status, open:")
         status("  https://{}:7630/".format(_context.default_ip_list[0]))
         status("Log in with username 'hacluster'{}".format(pass_msg))
@@ -920,7 +889,7 @@ def init_cluster_local():
     if pass_msg:
         warn("You should change the hacluster password to something more secure!")
 
-    start_service("pacemaker.service")
+    utils.start_service("pacemaker.service", enable=True)
     wait_for_cluster()
 
 
@@ -976,7 +945,7 @@ def init_ssh():
     """
     Configure passwordless SSH.
     """
-    start_service("sshd.service")
+    utils.start_service("sshd.service", enable=True)
     configure_local_ssh_key()
 
 
@@ -1056,7 +1025,7 @@ include /etc/pacemaker/authkey;
 }
     """ % (utils.this_node()), CSYNC2_CFG)
 
-    start_service("csync2.socket")
+    utils.start_service("csync2.socket", enable=True)
     status_long("csync2 checking files")
     invoke("csync2", "-cr", "/")
     status_done()
@@ -1727,7 +1696,7 @@ def join_ssh(seed_host):
     if not seed_host:
         error("No existing IP/hostname specified (use -c option)")
 
-    start_service("sshd.service")
+    utils.start_service("sshd.service", enable=True)
     configure_local_ssh_key()
     swap_public_ssh_key(seed_host)
 
@@ -1818,7 +1787,7 @@ def join_csync2(seed_host):
     if not invoke("scp root@%s:'/etc/csync2/{csync2.cfg,key_hagroup}' /etc/csync2" % (seed_host)):
         error("Can't retrieve csync2 config from %s" % (seed_host))
 
-    start_service("csync2.socket")
+    utils.start_service("csync2.socket", enable=True)
 
     # Sync new config out.  This goes to all hosts; csync2.cfg definitely
     # needs to go to all hosts (else hosts other than the seed and the
@@ -2158,7 +2127,7 @@ def start_qdevice_on_join_node(seed_host):
         qnetd_addr = corosync.get_value("quorum.device.net.host")
         qdevice_inst = corosync.QDevice(qnetd_addr, cluster_node=seed_host)
         qdevice_inst.certificate_process_on_join()
-    start_service("corosync-qdevice.service")
+    utils.start_service("corosync-qdevice.service", enable=True)
     status_done()
 
 
@@ -2191,8 +2160,7 @@ def remove_node_from_cluster():
     set_cluster_node_ip()
 
     status("Stopping the corosync service")
-    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "systemctl stop corosync"'.format(node)):
-        error("Stopping corosync on {} failed".format(node))
+    utils.stop_service("corosync.service", disable=True, remote_addr=node)
 
     # delete configuration files from the node to be removed
     if not invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {}\\\""'.format(node, " ".join(_context.rm_list))):
@@ -2455,9 +2423,8 @@ def remove_self():
         if rc != 0:
             error("Failed to remove this node from {}".format(othernode))
     else:
-        # stop cluster
-        if not stop_service("corosync"):
-            error("Stopping corosync failed")
+        # disable and stop cluster
+        utils.stop_service("corosync", disable=True)
         # remove all trace of cluster from this node
         # delete configuration files from the node to be removed
         if not invoke('bash -c "rm -f {}"'.format(" ".join(_context.rm_list))):
@@ -2615,6 +2582,6 @@ def bootstrap_arbitrator(context):
         error("Failed to copy {} from {}".format(BOOTH_CFG, node))
     # TODO: verify that the arbitrator IP in the configuration is us?
     status("Enabling and starting the booth arbitrator service")
-    start_service("booth@booth")
+    utils.start_service("booth@booth", enable=True)
 
 # EOF

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -49,44 +49,6 @@ def test_run_cmd_on_remote(mock_check_ssh_pw, mock_parallax_call, mock_to_ascii)
 
 
 @mock.patch("crmsh.utils.get_stdout")
-def test_service_is_enabled_local(mock_run):
-    mock_run.return_value = (0, None)
-    res = utils.service_is_enabled("pacemaker")
-    assert res is True
-    mock_run.assert_called_once_with("systemctl is-enabled pacemaker")
-
-
-@mock.patch("crmsh.utils.run_cmd_on_remote")
-def test_service_is_enabled_remote(mock_run_remote):
-    mock_run_remote.return_value = (0, None, None)
-    res = utils.service_is_enabled("pacemaker", "other_node")
-    assert res is True
-    mock_run_remote.assert_called_once_with(
-            "systemctl is-enabled pacemaker",
-            "other_node",
-            "Check whether pacemaker is enabled on other_node")
-
-
-@mock.patch("crmsh.utils.get_stdout")
-def test_service_is_active_local(mock_run):
-    mock_run.return_value = (0, None)
-    res = utils.service_is_active("pacemaker")
-    assert res is True
-    mock_run.assert_called_once_with("systemctl -q is-active pacemaker")
-
-
-@mock.patch("crmsh.utils.run_cmd_on_remote")
-def test_service_is_active_remote(mock_run_remote):
-    mock_run_remote.return_value = (0, None, None)
-    res = utils.service_is_active("pacemaker", "other_node")
-    assert res is True
-    mock_run_remote.assert_called_once_with(
-            "systemctl -q is-active pacemaker",
-            "other_node",
-            "Check whether pacemaker is active on other_node")
-
-
-@mock.patch("crmsh.utils.get_stdout")
 def test_package_is_installed_local(mock_run):
     mock_run.return_value = (0, None)
     res = utils.package_is_installed("crmsh")
@@ -1100,6 +1062,146 @@ class TestInterfacesInfo(unittest.TestCase):
         mock_interface_list.assert_called_once_with()
         mock_interface_inst_1.ip_in_network.assert_called_once_with("10.10.10.1")
         mock_interface_inst_2.ip_in_network.assert_called_once_with("10.10.10.1")
+
+
+class TestServiceManager(unittest.TestCase):
+    """
+    Unitary tests for class utils.ServiceManager
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.service_local = utils.ServiceManager("service1")
+        self.service_remote = utils.ServiceManager("service1", "node1")
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    def test_do_action_wrong_type(self):
+        with self.assertRaises(ValueError) as err:
+            self.service_local._do_action("test")
+        self.assertEqual("status_type should be enable/disable/start/stop/is-enabled/is-active/list-unit-files", str(err.exception))
+
+    @mock.patch("crmsh.utils.get_stdout_stderr")
+    def test_do_action_except_run_error(self, mock_run):
+        mock_run.return_value = (1, None, "this command failed")
+        with self.assertRaises(ValueError) as err:
+            self.service_local._do_action("start")
+        self.assertEqual("Run \"systemctl start service1\" error: this command failed", str(err.exception))
+        mock_run.assert_called_once_with("systemctl start service1")
+
+    @mock.patch("crmsh.utils.run_cmd_on_remote")
+    def test_do_action_remote(self, mock_run_remote):
+        mock_run_remote.return_value = (0, "data", None)
+        rc, out = self.service_remote._do_action("start")
+        assert rc == True
+        assert out == "data"
+        mock_run_remote.assert_called_once_with("systemctl start service1",
+                "node1",
+                "Run \"systemctl start service1\" on node1")
+
+    def test_is_available(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, "service1 service2")
+        assert self.service_local.is_available() == True
+        self.service_local._do_action.assert_called_once_with("list-unit-files")
+
+    def test_is_enabled(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        assert self.service_local.is_enabled() == True
+        self.service_local._do_action.assert_called_once_with("is-enabled")
+
+    def test_is_active(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        assert self.service_local.is_active() == True
+        self.service_local._do_action.assert_called_once_with("is-active")
+
+    def test_start(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        self.service_local.start()
+        self.service_local._do_action.assert_called_once_with("start")
+
+    def test_stop(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        self.service_local.stop()
+        self.service_local._do_action.assert_called_once_with("stop")
+
+    def test_enable(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        self.service_local.enable()
+        self.service_local._do_action.assert_called_once_with("enable")
+
+    def test_disable(self):
+        self.service_local._do_action = mock.Mock()
+        self.service_local._do_action.return_value = (True, None)
+        self.service_local.disable()
+        self.service_local._do_action.assert_called_once_with("disable")
+
+    @mock.patch("crmsh.utils.ServiceManager.is_available")
+    def test_service_is_available(self, mock_available):
+        mock_available.return_value = True
+        res = utils.ServiceManager.service_is_available("service1")
+        self.assertEqual(res, True)
+        mock_available.assert_called_once_with()
+
+    @mock.patch("crmsh.utils.ServiceManager.is_enabled")
+    def test_service_is_enabled(self, mock_enabled):
+        mock_enabled.return_value = True
+        res = utils.ServiceManager.service_is_enabled("service1")
+        self.assertEqual(res, True)
+        mock_enabled.assert_called_once_with()
+
+    @mock.patch("crmsh.utils.ServiceManager.is_active")
+    def test_service_is_active(self, mock_active):
+        mock_active.return_value = True
+        res = utils.ServiceManager.service_is_active("service1")
+        self.assertEqual(res, True)
+        mock_active.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.ServiceManager.start')
+    @mock.patch('crmsh.utils.ServiceManager.enable')
+    def test_start_service(self, mock_enable, mock_start):
+        utils.ServiceManager.start_service("service1", enable=True)
+        mock_enable.assert_called_once_with()
+        mock_start.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.ServiceManager.stop')
+    @mock.patch('crmsh.utils.ServiceManager.disable')
+    def test_stop_service(self, mock_disable, mock_stop):
+        utils.ServiceManager.stop_service("service1", disable=True)
+        mock_disable.assert_called_once_with()
+        mock_stop.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.ServiceManager.enable')
+    def test_enable_service(self, mock_enable):
+        utils.ServiceManager.enable_service("service1")
+        mock_enable.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.ServiceManager.disable')
+    def test_disable_service(self, mock_disable):
+        utils.ServiceManager.disable_service("service1")
+        mock_disable.assert_called_once_with()
 
 
 @mock.patch("crmsh.utils.get_nodeid_from_name")


### PR DESCRIPTION
## Problem
1. Some service management related functions were here and there, and some of them were redundant
2. It will more convenient to make all of these functions running remotely or locally
## Solution
1. Create class `ServerManager` which has a set of service management functions
2. Create shortcuts for the classmethod to make sure the API wouldn't change

This PR would be small enough to backport to other branches