### PR TITLE
Convert score to kind for rsc_order configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,12 @@ jobs:
         - $FUNCTIONAL_TEST configure before_install
       script:
         - $FUNCTIONAL_TEST configure run bugs
+    
+    - name: "functional test for constraints bugs"
+      before_install:
+        - $FUNCTIONAL_TEST constraints before_install
+      script:
+        - $FUNCTIONAL_TEST constraints run bugs
 
     - name: "functional test for geo cluster"
       before_install:

--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -22,7 +22,10 @@ def verify(cib):
     rc, _, stderr = utils.get_stdout_stderr(cib_verify, cib.encode('utf-8'))
     for i, line in enumerate(line for line in stderr.split('\n') if line):
         if i == 0:
-            err_buf.error(_prettify(line, 0))
+            if "warning:" in line:
+                err_buf.warning(_prettify(line, 0))
+            else:
+                err_buf.error(_prettify(line, 0))
         else:
             err_buf.writemsg(_prettify(line, 7))
     return rc

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1071,7 +1071,7 @@ class CibConfig(command.UI):
                                   compl.call(schema.rng_attr_values, 'rsc_order', 'kind'),
                                   top_rsc_tmpl_id_list)
     def do_order(self, context, *args):
-        """usage: order <id> {kind|<score>}: <rsc>[:<action>] <rsc>[:<action>] ...
+        """usage: order <id> [kind]: <rsc>[:<action>] <rsc>[:<action>] ...
         [symmetrical=<bool>]"""
         return self.__conf_object(context.get_command_name(), *args)
 

--- a/data-manifest
+++ b/data-manifest
@@ -70,6 +70,7 @@ test/features/bootstrap_init_join_remove.feature
 test/features/bootstrap_options.feature
 test/features/bootstrap_sbd.feature
 test/features/configure_bugs.feature
+test/features/constraints_bugs.feature
 test/features/environment.py
 test/features/geo_setup.feature
 test/features/hb_report_bugs.feature

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3719,9 +3719,9 @@ For more details on how to configure resource sets, see
 
 Usage:
 ...............
-order <id> [{kind|<score>}:] first then [symmetrical=<bool>]
+order <id> [kind:] first then [symmetrical=<bool>]
 
-order <id> [{kind|<score>}:] resource_sets [symmetrical=<bool>]
+order <id> [kind:] resource_sets [symmetrical=<bool>]
 
 kind :: Mandatory | Optional | Serialize
 
@@ -3741,7 +3741,6 @@ Example:
 ...............
 order o-1 Mandatory: apache:start ip_1
 order o-2 Serialize: A ( B C )
-order o-3 inf: [ A B ] C
 order o-4 first-resource then-resource
 ...............
 

--- a/test/features/constraints_bugs.feature
+++ b/test/features/constraints_bugs.feature
@@ -1,0 +1,23 @@
+@constraints
+Feature: Verify constraints(order/colocation/location) bug
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  Background: Setup a two nodes cluster
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Show cluster status on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    And     Show cluster status on "hanode1"
+
+  @clean
+  Scenario: Convert score to kind for rsc_order(bsc#1122391)
+    When    Run "crm configure primitive d1 Dummy op monitor interval=10s" on "hanode1"
+    And     Run "crm configure primitive d2 Dummy op monitor interval=10s" on "hanode1"
+    And     Run "crm configure order o1 100: d1 d2" on "hanode1"
+    When    Run "crm configure show" on "hanode1"
+    Then    Expected "order o1 Mandatory: d1 d2" in stdout

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -27,7 +27,7 @@ case "$1" in
 		configure
 		make_install
 		exit $?;;
-	bootstrap|qdevice|hb_report|resource|geo|configure)
+	bootstrap|qdevice|hb_report|resource|geo|configure|constraints)
 		functional_tests $1 $2
 		exit $?;;
 	*)

--- a/test/testcases/common.excl
+++ b/test/testcases/common.excl
@@ -22,4 +22,4 @@ Error performing operation: Transport endpoint is not connected
 ^\.EXT sed ["][^"]+
 ^\.EXT [a-zA-Z]+ validate-all
 ^[ ]+File ["][^"]+
-^ERROR\: ([0-9]+\: )?\(cluster\_status\) 	warning\: Fencing and resource management disabled due to lack of quorum
+^WARNING\: ([0-9]+\: )?\(cluster\_status\) 	warning\: Fencing and resource management disabled due to lack of quorum

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -14,6 +14,12 @@ from crmsh.xmlutil import xml_tostring
 from lxml import etree
 
 
+def test_score_to_kind():
+    assert parse.score_to_kind("0") == "Optional"
+    assert parse.score_to_kind("INFINITY") == "Mandatory"
+    assert parse.score_to_kind("200") == "Mandatory"
+
+
 class MockValidation(parse.Validation):
     def resource_roles(self):
         return ['Master', 'Slave', 'Started']
@@ -709,7 +715,7 @@ class TestCliParser(unittest.TestCase):
             '<rsc_order id="o1" kind="Mandatory" first="m5" then="m6"/>',
             '<rsc_order id="o2" kind="Optional" first="d1" first-action="start" then="m5" then-action="promote"/>',
             '<rsc_order id="o3" kind="Serialize" first="m5" then="m6"/>',
-            '<rsc_order id="o4" score="INFINITY" first="m5" then="m6"/>',
+            '<rsc_order id="o4" kind="Mandatory" first="m5" then="m6"/>',
             '<rsc_ticket id="ticket-A_m6" ticket="ticket-A" rsc="m6"/>',
             '<rsc_ticket id="ticket-B_m6_m5" ticket="ticket-B" loss-policy="fence"><resource_set><resource_ref id="m6"/><resource_ref id="m5"/></resource_set></rsc_ticket>',
             '<rsc_ticket id="ticket-C_master" ticket="ticket-C" loss-policy="fence"><resource_set><resource_ref id="m6"/></resource_set><resource_set role="Master"><resource_ref id="m5"/></resource_set></rsc_ticket>',


### PR DESCRIPTION
## Problem

1. In pacemaker 2.x, `score` syntax in rsc_order configure was deprecated
2. crmsh give error while the return message of crm_verify was a warning

## Solution
For problem 1, convert score to `kind`, that is, convert `INFINITY` and score greater than "0" to `Mandatory`, else, convert as `Optional`
For problem 2, give a warning if return message of crm_verify was a warning

## Test
For problem 1:
```Shell
When    Run "crm configure primitive d1 Dummy op monitor interval=10s" on "hanode1"
And     Run "crm configure primitive d2 Dummy op monitor interval=10s" on "hanode1"
And     Run "crm configure order o1 100: d1 d2" on "hanode1"
When    Run "crm configure show" on "hanode1"
Then    Expected "order o1 Mandatory: d1 d2" in stdout
```