### PR TITLE
Stop service which is active, not which is available

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2157,7 +2157,7 @@ def stop_services(stop_list, remote_addr=None):
     Stop cluster related service
     """
     for service in stop_list:
-        if utils.service_is_available(service, remote_addr=remote_addr):
+        if utils.service_is_active(service, remote_addr=remote_addr):
             status("Stopping the {}".format(service))
             utils.stop_service(service, disable=True, remote_addr=remote_addr)
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1427,11 +1427,11 @@ class TestValidation(unittest.TestCase):
 
     @mock.patch('crmsh.utils.stop_service')
     @mock.patch('crmsh.bootstrap.status')
-    @mock.patch('crmsh.utils.service_is_available')
-    def test_stop_services(self, mock_available, mock_status, mock_stop):
-        mock_available.side_effect = [True, True, True]
+    @mock.patch('crmsh.utils.service_is_active')
+    def test_stop_services(self, mock_active, mock_status, mock_stop):
+        mock_active.side_effect = [True, True, True]
         bootstrap.stop_services(bootstrap.SERVICES_STOP_LIST)
-        mock_available.assert_has_calls([
+        mock_active.assert_has_calls([
             mock.call("corosync-qdevice.service", remote_addr=None),
             mock.call("corosync.service", remote_addr=None),
             mock.call("hawk.service", remote_addr=None)


### PR DESCRIPTION
Missed in #648, already synced with #652 and #653 