### PR TITLE
Dev: unittest: adjust duplicated test function name

### DIFF
--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -879,7 +879,7 @@ def test_node_util_attr():
     assert obj.cli_use_validate()
 
 
-def test_dup_create():
+def test_dup_create_same_name():
     """
     Creating two objects with the same name
     """

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -134,7 +134,7 @@ def test_query_qnetd_status_no_cluster_name(mock_qdevice_configured, mock_get_va
 
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
-def test_query_qnetd_status_no_cluster_name(mock_qdevice_configured, mock_get_value):
+def test_query_qnetd_status_no_host(mock_qdevice_configured, mock_get_value):
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", None]
     with pytest.raises(ValueError) as err:

--- a/test/unittests/test_report.py
+++ b/test/unittests/test_report.py
@@ -343,7 +343,7 @@ def test_dump_D_process_None(mock_get_stdout_stderr):
 
 
 @mock.patch('crmsh.utils.get_stdout_stderr')
-def test_dump_D_process_None(mock_get_stdout_stderr):
+def test_dump_D_process(mock_get_stdout_stderr):
     mock_get_stdout_stderr.side_effect = [
             (0, "10001\n10002", None),
             (0, "comm_out for 10001", None),

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -234,7 +234,7 @@ def test_list_cluster_nodes_except_me_exception(mock_list_nodes):
 
 @mock.patch('crmsh.utils.this_node')
 @mock.patch('crmsh.utils.list_cluster_nodes')
-def test_list_cluster_nodes_except_me_exception(mock_list_nodes, mock_this_node):
+def test_list_cluster_nodes_except_me(mock_list_nodes, mock_this_node):
     mock_list_nodes.return_value = ["node1", "node2"]
     mock_this_node.return_value = "node1"
     res = utils.list_cluster_nodes_except_me()


### PR DESCRIPTION
by using command `grep -R -E -o "def .*\(" *|uniq -cd`, to print duplicated test function name
That should be changed, otherwise the same named function wouldn't be tested