### PR TITLE
Integrate preflight_check into crmsh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,11 @@ install-data-hook:
 hanoarchdir = $(datadir)/@PACKAGE@/hb_report
 hanoarch_DATA = hb_report/constants.py hb_report/utillib.py
 hanoarch_SCRIPTS = hb_report/hb_report
-EXTRA_DIST = $(hanoarch_DATA)
+preflightnoarchdir = $(datadir)/@PACKAGE@/preflight_check
+preflightnoarch_DATA = preflight_check/check.py preflight_check/explain.py preflight_check/__init__.py \
+		       preflight_check/config.py preflight_check/main.py preflight_check/utils.py preflight_check/task.py
+preflightnoarch_SCRIPTS = preflight_check/ha-cluster-preflight-check
+EXTRA_DIST = $(hanoarch_DATA) $(preflightnoarch_DATA)
 
 # Python module installation
 all-local:

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -49,22 +49,21 @@ def resources(args=None):
     if cib_el is None:
         return []
     nodes = xmlutil.get_interesting_nodes(cib_el, [])
-    res = [x.get("id") for x in nodes if xmlutil.is_resource(x)]
+    rsc_id_list = [x.get("id") for x in nodes if xmlutil.is_resource(x)]
     if args and args[0] in ['promote', 'demote']:
-        return list(filter(xmlutil.RscState().is_ms, res))
+        return [item for item in rsc_id_list if xmlutil.RscState().is_ms(item)]
     if args and args[0] == "started":
-        return list(filter(xmlutil.RscState().is_running, res))
+        return [item for item in rsc_id_list if xmlutil.RscState().is_running(item)]
     if args and args[0] == "stopped":
-        for item in filter(xmlutil.RscState().is_running, res):
-            res.remove(item)
-    return res
+        return [item for item in rsc_id_list if not xmlutil.RscState().is_running(item)]
+    return rsc_id_list
 
 
-def resources_started(args):
+def resources_started(args=None):
     return resources(["started"])
 
 
-def resources_stopped(args):
+def resources_stopped(args=None):
     return resources(["stopped"])
 
 

--- a/preflight_check/check.py
+++ b/preflight_check/check.py
@@ -1,0 +1,236 @@
+import re
+from . import utils
+from . import task
+from crmsh import utils as crmshutils
+from crmsh import bootstrap as crmshboot
+from crmsh import completers
+
+
+def check(context):
+    """
+    Check environment and cluster state if related options are enabled
+    """
+    if context.env_check:
+        check_environment()
+    if context.cluster_check:
+        check_cluster()
+    print()
+
+
+def check_environment():
+    """
+    A set of functions to check environment
+    """
+    print("\n============ Checking environment ============")
+    check_my_hostname_resolves()
+    check_time_service()
+    check_firewall()
+
+
+def check_my_hostname_resolves():
+    """
+    check if the hostname is resolvable
+    """
+    task_inst = task.TaskCheck("Checking hostname resolvable")
+    with task_inst.run():
+        if not crmshboot.my_hostname_resolves():
+            task_inst.error('''Hostname "{}" is unresolvable.
+  Please add an entry to /etc/hosts or configure DNS.'''.format(utils.this_node()))
+
+
+def check_time_service():
+    """
+    Check time service
+    """
+    task_inst = task.TaskCheck("Checking time service")
+    with task_inst.run():
+        timekeepers = ('chronyd.service', 'ntp.service', 'ntpd.service')
+        timekeeper = None
+        for tk in timekeepers:
+            if crmshutils.service_is_available(tk):
+                timekeeper = tk
+                break
+        else:
+            task_inst.warn("No NTP service found.")
+            return
+
+        task_inst.info("{} is available".format(timekeeper))
+        if crmshutils.service_is_enabled(timekeeper):
+            task_inst.info("{} is enabled".format(timekeeper))
+        else:
+            task_inst.warn("{} is disabled".format(timekeeper))
+        if crmshutils.service_is_active(timekeeper):
+            task_inst.info("{} is active".format(timekeeper))
+        else:
+            task_inst.warn("{} is not active".format(timekeeper))
+
+
+def check_port_open(task, firewall_type):
+    """
+    Check whether corosync port is blocked by iptables
+    """
+    ports = utils.corosync_port_list()
+    if not ports:
+        task.error("Can not get corosync's port")
+        return
+
+    if firewall_type == "firewalld":
+        rc, out, err = crmshutils.get_stdout_stderr('firewall-cmd --list-port')
+        if rc != 0:
+            task.error(err)
+            return
+        for p in ports:
+            if re.search(' {}/udp'.format(p), out):
+                task.info("UDP port {} is opened in firewalld".format(p))
+            else:
+                task.error("UDP port {} should open in firewalld".format(p))
+    elif firewall_type == "SuSEfirewall2":
+        #TODO
+        pass
+
+
+def check_firewall():
+    """
+    Check the firewall status
+    """
+    task_inst = task.TaskCheck("Checking firewall")
+    with task_inst.run():
+        for item in ("firewalld", "SuSEfirewall2"):
+            if crmshutils.package_is_installed(item):
+                task_inst.info("{}.service is available".format(item))
+                if crmshutils.service_is_active(item):
+                    task_inst.info("{}.service is active".format(item))
+                    check_port_open(task_inst, item)
+                else:
+                    task_inst.warn("{}.service is not active".format(item))
+                break
+        else:
+           task_inst.warn("Failed to detect firewall")
+
+
+def check_cluster():
+    """
+    A set of functions to check cluster state
+    """
+    print("\n============ Checking cluster state ============")
+    if not check_cluster_service():
+        return
+    check_fencing()
+    check_nodes()
+    check_resources()
+
+
+def check_cluster_service(quiet=False):
+    """
+    Check service status of pacemaker/corosync
+    """
+    task_inst = task.TaskCheck("Checking cluster service", quiet=quiet)
+    with task_inst.run():
+        if crmshutils.service_is_enabled("pacemaker"):
+            task_inst.info("pacemaker.service is enabled")
+        else:
+            task_inst.warn("pacemaker.service is disabled")
+
+        if crmshutils.service_is_enabled("corosync"):
+            task_inst.warn("corosync.service is enabled")
+
+        for s in ("corosync", "pacemaker"):
+            if crmshutils.service_is_active(s):
+                task_inst.info("{}.service is running".format(s))
+            else:
+                task_inst.error("{}.service is not running!".format(s))
+        return task_inst.passed
+
+
+def check_fencing():
+    """
+    Check STONITH/Fence:
+      Whether stonith is enabled
+      Whether stonith resource is configured and running
+    """
+    task_inst = task.TaskCheck("Checking STONITH/Fence")
+    with task_inst.run():
+        if not utils.FenceInfo().fence_enabled:
+            task_inst.warn("stonith is disabled")
+            return
+
+        task_inst.info("stonith is enabled")
+        rc, outp, _ = crmshutils.get_stdout_stderr("crm_mon -r1 | grep '(stonith:.*):'")
+        if rc != 0:
+            task_inst.warn("No stonith resource configured!")
+            return
+
+        res = re.search(r'([^\s]+)\s+\(stonith:(.*)\):\s+(\w+)', outp)
+        res_name, res_agent, res_state = res.groups()
+        common_msg = "stonith resource {}({})".format(res_name, res_agent)
+        state_msg = "{} is {}".format(common_msg, res_state)
+
+        task_inst.info("{} is configured".format(common_msg))
+        if res_state == "Started":
+            task_inst.info(state_msg)
+        else:
+            task_inst.warn(state_msg)
+
+        if re.search(r'sbd$', res_agent):
+            if crmshutils.service_is_active("sbd"):
+                task_inst.info("sbd service is running")
+            else:
+                task_inst.warn("sbd service is not running!")
+
+
+def check_nodes():
+    """
+    Check nodes info:
+      Current DC
+      Quorum status
+      Online/OFFLINE/UNCLEAN nodes
+    """
+    task_inst = task.TaskCheck("Checking nodes")
+    with task_inst.run():
+        rc, outp, errp = crmshutils.get_stdout_stderr("crm_mon -1")
+        if rc != 0:
+            task_inst.error("run \"crm_mon -1\" error: {}".format(errp))
+            return
+        # check DC
+        res = re.search(r'Current DC: (.*) \(', outp)
+        if res:
+            task_inst.info("DC node: {}".format(res.group(1)))
+
+        # check quorum
+        if re.search(r'partition with quorum', outp):
+            task_inst.info("Cluster have quorum")
+        else:
+            task_inst.warn("Cluster lost quorum!")
+
+        # check Online nodes
+        res = re.search(r'Online:\s+(\[.*\])', outp)
+        if res:
+            task_inst.info("Online nodes: {}".format(res.group(1)))
+
+        # check OFFLINE nodes
+        res = re.search(r'OFFLINE:\s+(\[.*\])', outp)
+        if res:
+            task_inst.warn("OFFLINE nodes: {}".format(res.group(1)))
+
+        # check UNCLEAN nodes
+        res = re.findall(r'Node (.*): UNCLEAN', outp)
+        for item in res:
+            task_inst.warn('Node {} is UNCLEAN!'.format(item))
+
+
+def check_resources():
+    """
+    Check items of Started/Stopped/FAILED resources
+    """
+    task_inst = task.TaskCheck("Checking resources")
+    with task_inst.run():
+        started_list = completers.resources_started()
+        stopped_list = completers.resources_stopped()
+        # TODO need suitable method to get failed resources list
+        failed_list = []
+        if started_list:
+            task_inst.info("Started resources: {}".format(','.join(started_list)))
+        if stopped_list:
+            task_inst.info("Stopped resources: {}".format(','.join(stopped_list)))
+        if failed_list:
+            task_inst.warn("Failed resources: {}".format(','.join(failed_list)))

--- a/preflight_check/config.py
+++ b/preflight_check/config.py
@@ -1,0 +1,7 @@
+FENCE_TIMEOUT = 60
+FENCE_NODE = "crm_attribute -t status -N '{}' -n terminate -v true"
+BLOCK_IP = '''iptables -{action} INPUT -s {peer_ip} -j DROP;
+              iptables -{action} OUTPUT -d {peer_ip} -j DROP'''
+REMOVE_PORT = "firewall-cmd --zone=public --remove-port={port}/udp"
+ADD_PORT = "firewall-cmd --zone=public --add-port={port}/udp"
+FENCE_HISTORY = "stonith_admin -h {node}"

--- a/preflight_check/explain.py
+++ b/preflight_check/explain.py
@@ -1,0 +1,31 @@
+contents = {}
+
+contents["sbd"]= '''On {nodeA}, once the sbd process get killed, there are two situations:
+  a) sbd process restarted
+     Systemd will restart sbd service immediately.
+     Restarting sbd service will also lead to restart corosync and pacemaker services because of the pre-defined dependencies among the systemd unit files.
+
+  b) {nodeA} experience the watchdog fencing
+     There is the race condition with the watchdog timer. Watchdog might reset {nodeA}, just before the sbd service get restarted and not tickle the watchdog timer in time.'''
+
+contents["sbd-l"] = '''On {nodeA}, the sbd service is killed consistantly all the time. 
+Very quickly, systemd will hit the start limit to restart sbd service. 
+Basically, in the end, systemd stops restarting anymore, marks the sbd service as failure.
+{nodeB} sbd cluster health check marks it as "UNHEALTHY".
+{nodeB} treats {nodeA} as a node lost, and fences it in the end.'''
+
+contents["corosync"] = '''On {nodeA}, once the corosync process get killed, systemd will restart corosync service immediately. There are two situations:
+  a) corosync process restarts
+     {nodeA} corosync process get restarted and rejoins to the existent membership quickly enough.
+     Basically, it happens before {nodeB} treats it as a node lost.
+     In the end, the cluster looks like nothing happened to the user. RA stays safe and sound.
+
+  b) {nodeA} gets fenced
+     {nodeA} gets fenced since {nodeB} corosync just ran out of timeout and treat it as a node lost and forms a new membership.
+     The decision making process of {nodeB}, pengine(aka. schedulerd in Pacemaker 2), will initiate fence action against {nodeA}. '''
+
+contents["corosync-l"] = '''The corosync service is killed consistantly all the time.
+Very quickly, systemd will hit the start limit to restart corosync service.
+Basically, in the end, systemd stops restarting anymore, marks the corosync service as failure. {nodeB} treats {nodeA} as a node lost, marks it as "unclean", and fence it in the end.'''
+
+contents["pacemakerd"] = '''The pacemakerd process gets restarted by systemd. All RAs must stay intact.'''

--- a/preflight_check/ha-cluster-preflight-check
+++ b/preflight_check/ha-cluster-preflight-check
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from preflight_check import main
+
+
+if __name__ == "__main__":
+    main.ctx.process_name = os.path.basename(sys.argv[0])
+    main.run(main.ctx)

--- a/preflight_check/main.py
+++ b/preflight_check/main.py
@@ -1,0 +1,250 @@
+import os
+import sys
+import argparse
+import logging
+import logging.config
+from argparse import RawTextHelpFormatter
+
+from . import check
+from . import config
+from . import utils
+from . import task
+from crmsh import utils as crmshutils
+
+
+logger = logging.getLogger('cpc')
+
+
+class Context(object):
+    """
+    Class to store context attributes
+    """
+    def __init__(self):
+        """
+        Initialize attributes
+        """
+        self.process_name = None
+        self.var_dir = None
+        self.task_list = []
+        self.report_path = None
+        self.jsonfile = None
+        self.logfile = None
+        self.current_case = None
+
+        # set by argparse
+        self.env_check = None
+        self.cluster_check = None
+        self.sbd = None
+        self.corosync = None
+        self.pacemakerd = None
+        self.fence_node = None
+        self.sp_iptables = None
+        self.loop = None
+        self.yes = None
+        self.help = None
+
+    def __setattr__(self, name, value):
+        super(Context, self).__setattr__(name, value)
+
+
+ctx = Context()
+
+
+LOGGING_CFG = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'file_formatter': {
+                'format': '%(asctime)s %(name)s %(levelname)s: %(message)s',
+                'datefmt': '%Y/%m/%d %H:%M:%S'
+                },
+            'stream_formatter': {
+                '()': 'preflight_check.utils.MyLoggingFormatter'
+                }
+            },
+        'handlers': {
+            'null': {
+                'class': 'logging.NullHandler'
+                },
+            'file': {
+                'class': 'logging.FileHandler',
+                'formatter': 'file_formatter'
+                },
+            'stream': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'stream_formatter'
+                }
+            },
+        'loggers': {
+            'cpc': {
+                'handlers': ['null', 'file', 'stream'],
+                'propagate': False,
+                'level': 'DEBUG'
+                }
+            }
+        }
+
+
+def kill_process(context):
+    """
+    Testcase: kill cluster related processes
+    --kill-sbd            restarted or fenced
+    --kill-sbd -l         fenced
+    --kill-corosync       restarted or fenced
+    --kill-corosync -l    fenced
+    --kill-pacemakerd     restarted
+    --kill-pacemakerd -l  blocked by bsc#1111692
+    """
+    for case in ('sbd', 'corosync', 'pacemakerd'):
+        if getattr(context, case):
+            if case == 'pacemakerd' and context.loop:
+                return #blocked by bsc#1111692
+            context.current_case = case
+            break
+    else:
+        return
+
+    task_inst = task.TaskKill(context)
+    try:
+        task_inst.pre_check()
+        task_inst.print_header()
+        task_inst.enable_report()
+        task_inst.run()
+        task_inst.wait()
+    except task.TaskError as err:
+        task_inst.error(str(err))
+        sys.exit(1)
+
+
+def split_brain(context):
+    """
+    Testcase: make split brain by blocking corosync ports
+    """
+    if not context.sp_iptables:
+        return
+
+    task_inst = task.TaskSplitBrain()
+    try:
+        task_inst.pre_check()
+        task_inst.print_header()
+        with task_inst.do_block():
+            task_inst.run()
+            task_inst.wait()
+    except task.TaskError as err:
+        task_inst.error(str(err))
+        sys.exit(1)
+
+
+def fence_node(context):
+    """
+    Testcase: fence specific node
+    """
+    if not context.fence_node:
+        return
+
+    task_inst = task.TaskFence(context.fence_node)
+    try:
+        task_inst.pre_check()
+        task_inst.print_header()
+        task_inst.run()
+        task_inst.wait()
+    except task.TaskError as err:
+        task_inst.error(str(err))
+        sys.exit(1)
+
+
+class MyArgParseFormatter(RawTextHelpFormatter):
+    def __init__(self,prog):
+        super(MyArgParseFormatter,self).__init__(prog, max_help_position=50)
+
+
+def parse_argument(context):
+    """
+    Parse argument using argparse
+    """
+    parser = argparse.ArgumentParser(prog=context.process_name,
+                                     description='Cluster preflight check tool set',
+                                     add_help=False,
+                                     formatter_class=MyArgParseFormatter,
+                                     epilog='''
+Log: {}
+Json results: {}
+For each --kill-* testcase, report directory: {}'''.format(context.logfile,
+                                                           context.jsonfile,
+                                                           context.report_path))
+
+    parser.add_argument('-e', '--env-check', dest='env_check', action='store_true',
+                        help='Check environment')
+    parser.add_argument('-c', '--cluster-check', dest='cluster_check', action='store_true',
+                        help='Check cluster state')
+
+    group_mutual = parser.add_mutually_exclusive_group()
+    group_mutual.add_argument('--kill-sbd', dest='sbd', action='store_true',
+                              help='Kill sbd daemon')
+    group_mutual.add_argument('--kill-corosync', dest='corosync', action='store_true',
+                              help='Kill corosync daemon')
+    group_mutual.add_argument('--kill-pacemakerd', dest='pacemakerd', action='store_true',
+                              help='Kill pacemakerd daemon')
+    group_mutual.add_argument('--fence-node', dest='fence_node', metavar='NODE',
+                              help='Fence specific node')
+    group_mutual.add_argument('--split-brain-iptables', dest='sp_iptables', action='store_true',
+                              help='Make split brain by blocking corosync ports')
+    parser.add_argument('-l', '--kill-loop', dest='loop', action='store_true',
+                        help='Kill process in loop')
+
+    other_options = parser.add_argument_group('other options')
+    other_options.add_argument('-y', '--yes', dest='yes', action='store_true',
+                               help='Answer "yes" if asked to run the test')
+    other_options.add_argument('-h', '--help', dest='help', action='store_true',
+                               help='Show this help message and exit')
+
+    args = parser.parse_args()
+    if args.help:
+        parser.print_help()
+        sys.exit(0)
+    for arg in vars(args):
+        setattr(context, arg, getattr(args, arg))
+
+
+def setup_logging(context):
+    """
+    Setupt logging
+    """
+    LOGGING_CFG['handlers']['file']['filename'] = context.logfile
+    logging.config.dictConfig(LOGGING_CFG)
+
+
+def setup_basic_context(context):
+    """
+    Setup basic context
+    """
+    var_dir = "/var/lib/{}".format(context.process_name)
+    context.var_dir = var_dir
+    context.report_path = var_dir
+    context.jsonfile = "{}/{}.json".format(var_dir, context.process_name)
+    context.logfile = "/var/log/{}.log".format(context.process_name)
+
+
+def run(context):
+    """
+    Major work flow
+    """
+    setup_basic_context(context)
+    parse_argument(context)
+    if not utils.is_root():
+        logging.fatal("{} can only be executed as user root!".format(context.process_name))
+        sys.exit(1)
+    if not os.path.exists(context.var_dir):
+        os.makedirs(context.var_dir, exist_ok=True)
+    setup_logging(context)
+
+    try:
+        check.check(context)
+        kill_process(context)
+        fence_node(context)
+        split_brain(context)
+
+    except KeyboardInterrupt:
+        utils.json_dumps()
+        print("\nCtrl-C, leaving")
+        sys.exit(1)

--- a/preflight_check/task.py
+++ b/preflight_check/task.py
@@ -1,0 +1,560 @@
+import os
+import sys
+import re
+import time
+import threading
+import logging
+from contextlib import contextmanager
+
+from . import utils
+from . import config
+from crmsh import utils as crmshutils
+
+
+logger = logging.getLogger('cpc')
+
+
+class TaskError(Exception):
+    pass
+
+
+class Task(object):
+    """
+    Task is a base class
+    Use for record the information of each test case
+    """
+    def __init__(self, description, flush=False, quiet=False):
+        """
+        Init function
+        flush, to print the message immediately
+        """
+        self.passed = True
+        self.quiet = quiet
+        self.messages = []
+        self.timestamp = utils.now()
+        self.description = description
+        utils.msg_info(self.description, to_stdout=False)
+        self.flush = flush
+        self.fence_start_event = threading.Event()
+        self.fence_finish_event = threading.Event()
+        self.thread_stop_event = threading.Event()
+        from . import main
+        self.prev_task_list = main.ctx.task_list
+
+    def info(self, msg):
+        self.msg_append("info", msg)
+        utils.msg_info(msg, to_stdout=self.flush)
+
+    def warn(self, msg):
+        self.msg_append("warn", msg)
+        utils.msg_warn(msg, to_stdout=self.flush)
+
+    def error(self, msg):
+        self.msg_append("error", msg)
+        utils.msg_error(msg, to_stdout=self.flush)
+
+    def msg_append(self, msg_type, msg):
+        if msg_type == "error":
+            self.passed = False
+        self.messages.append((msg_type, msg, utils.now()))
+        if self.flush:
+            self.to_json()
+            self.to_report()
+
+    def header(self):
+        pass
+
+    def to_report(self):
+        pass
+
+    def to_json(self):
+        pass
+
+    def build_base_result(self):
+        """
+        Build base results
+        """
+        self.result = {
+            "Timestamp": self.timestamp,
+            "Description": self.description,
+            "Messages": ["{} {}:{}".format(m[2], m[0].upper(), m[1])
+                         for m in self.messages]
+        }
+
+    def print_header(self):
+        """
+        Print testcase header
+        """
+        print(self.header())
+        if not crmshutils.ask("Run?"):
+            self.info("Testcase cancelled")
+            sys.exit()
+
+    def task_pre_check(self, need_fence=True):
+        """
+        Prerequisite check
+          * pacemaker.service is active
+          * stonith is enabled
+        """
+        if not crmshutils.service_is_active("pacemaker.service"):
+            raise TaskError("Cluster not running!")
+        if need_fence:
+            self.get_fence_info()
+            if not self.fence_enabled:
+                raise TaskError("Require stonith enabled")
+
+    def get_fence_info(self):
+        """
+        Get fence info
+        """
+        fence_info_inst = utils.FenceInfo()
+        self.fence_enabled = fence_info_inst.fence_enabled
+        self.fence_action = fence_info_inst.fence_action
+        self.fence_timeout = fence_info_inst.fence_timeout
+
+    def fence_action_monitor(self):
+        """
+        Monitor fencing process, running in thread, exit on two cases:
+        1. There is one latest fence action successfully done
+        2. No fence action during fence timeout, thread_stop_event triggered by main thread
+        """
+        target_node = None
+        from_node = None
+        fence_timestamp = None
+
+        # Try to find out which node fire the fence action
+        while not self.thread_stop_event.is_set():
+            rc, out, _ = crmshutils.get_stdout_stderr("crm_mon -1|grep -A1 \"Fencing Actions:\"")
+            if rc == 0 and out:
+                match = re.search(r"of (.*) pending: .*origin=(.*)$", out)
+                if match:
+                    target_node, from_node = match.groups()
+                    self.info("Node \"{}\" will be fenced by \"{}\"!".format(target_node, from_node))
+                    self.fence_start_event.set()
+                    break
+            time.sleep(1)
+
+        # Try to find out proof that fence happened
+        while not self.thread_stop_event.is_set():
+            rc, out, _ = crmshutils.get_stdout_stderr(config.FENCE_HISTORY.format(node=target_node))
+            if rc == 0 and out:
+                match = re.search(r"Node {} last fenced at: (.*)".format(target_node), out)
+                if match:
+                    fence_timestamp = match.group(1)
+                    task_timestamp_dt = utils.str_to_datetime(self.timestamp, '%Y/%m/%d %H:%M:%S')
+                    fence_timestamp_dt = utils.str_to_datetime(fence_timestamp, '%a %b %d %H:%M:%S %Y')
+                    # If the fence action timestamp larger than this task's timestamp
+                    # That is the proof
+                    if task_timestamp_dt < fence_timestamp_dt:
+                        self.info("Node \"{}\" was successfully fenced by \"{}\"".format(target_node, from_node))
+                        # Tell main thread fence happened
+                        self.fence_finish_event.set()
+                        break
+            time.sleep(1)
+
+
+class TaskFence(Task):
+    """
+    Class to fence node
+    """
+    def  __init__(self, target):
+        """
+        Init function
+        """
+        self.target_node = target
+        description = "Fence node {}".format(self.target_node)
+        super(self.__class__, self).__init__(description, flush=True)
+
+    def header(self):
+        """
+        Header content for this task
+        """
+        h = '''==============================================
+Testcase:          {}
+Fence action:      {}
+Fence timeout:     {}
+'''.format(self.description, self.fence_action, self.fence_timeout)
+        return h
+
+    def to_json(self):
+        """
+        Dump join result
+        """
+        self.build_base_result()
+        self.result['Fence action'] = self.fence_action
+        self.result['Fence timeout'] = self.fence_timeout
+        from . import main
+        main.ctx.task_list = self.prev_task_list + [self.result]
+        utils.json_dumps()
+
+    def pre_check(self):
+        """
+        Check the prerequisite for fence node
+        """
+        self.task_pre_check()
+
+        for cmd in ['crm_node', 'stonith_admin', 'crm_attribute']:
+            rc, _, err = crmshutils.get_stdout_stderr("which {}".format(cmd))
+            if rc != 0 and err:
+                raise TaskError(err)
+
+        if not utils.check_node_status(self.target_node, 'member'):
+            raise TaskError("Node \"{}\" not in cluster!".format(self.target_node))
+
+    def run(self):
+        """
+        Fence node and start a thread to monitor the result
+        """
+        self.info("Trying to fence node \"{}\"".format(self.target_node))
+        crmshutils.get_stdout_stderr(config.FENCE_NODE.format(self.target_node))
+        th = threading.Thread(target=self.fence_action_monitor)
+        th.start()
+
+    def wait(self):
+        """
+        Wait until fence happened
+        """
+        if self.target_node == utils.this_node():
+            self.info("Waiting {}s for self {}...".format(self.fence_timeout, self.fence_action))
+        else:
+            self.info("Waiting {}s for node \"{}\" {}...".format(self.fence_timeout,
+                self.target_node, self.fence_action))
+
+        result = self.fence_finish_event.wait(int(self.fence_timeout))
+        if not result:
+            self.thread_stop_event.set()
+            raise TaskError("Target fence node \"{}\" still alive".format(self.target_node))
+
+
+class TaskCheck(Task):
+    """
+    Class to define the format of output for checking item results and how to dump json
+    """
+
+    def __init__(self, description, quiet=False):
+        """
+        Init function
+        """
+        super(self.__class__, self).__init__(description, quiet=quiet)
+
+    def to_stdout(self):
+        """
+        Define the format of results to stdout
+        """
+        with utils.manage_handler("file", keep=False):
+            utils.get_handler(logger, "stream").setFormatter(utils.MyLoggingFormatter(flush=False))
+
+            if self.passed:
+                message = "{} [{}]".format(self.description, utils.CGREEN + "Pass" + utils.CEND)
+            else:
+                message = "{} [{}]".format(self.description, utils.CRED + "Fail" + utils.CEND)
+            logger.info(message, extra={'timestamp': '[{}]'.format(self.timestamp)})
+
+            for msg in self.messages:
+                logger.log(utils.LEVEL[msg[0]], msg[1], extra={'timestamp': '  '})
+
+            utils.get_handler(logger, "stream").setFormatter(utils.MyLoggingFormatter())
+
+    def to_json(self):
+        """
+        Json results
+        """
+        self.build_base_result()
+        self.result['Result'] = self.passed
+        from . import main
+        main.ctx.task_list.append(self.result)
+        utils.json_dumps()
+
+    def print_result(self):
+        """
+        Print results to stdout and json
+        """
+        if self.quiet:
+            return
+        self.to_stdout()
+        self.to_json()
+
+    @contextmanager
+    def run(self):
+        """
+        Context manager to do things and print results finally
+        """
+        try:
+            yield
+        finally:
+            self.print_result()
+
+
+class TaskKill(Task):
+    """
+    Class to define how to run kill testcases
+    """
+
+    EXPECTED = {
+        # process_name: (expected_results, expected_results_with_loop)
+        'sbd':        ('''a) sbd process restarted
+                   b) Or, this node fenced.''', 'This node fenced'),
+        'corosync':   ('''a) corosync process restarted
+                   b) Or, this node fenced.''', 'This node fenced'),
+        'pacemakerd': ('pacemakerd process restarted', None),
+    }
+    WAIT_TIMEOUT = 10
+
+    def  __init__(self, context):
+        """
+        Init function
+        """
+        self.target_kill = context.current_case
+        self.description = "Force kill {}".format(self.target_kill)
+        super(self.__class__, self).__init__(self.description, flush=True)
+        self.cmd = "killall -9 {}".format(self.target_kill)
+        self.looping = context.loop
+        if not self.looping:
+            self.expected = self.EXPECTED[self.target_kill][0]
+        else:
+            self.expected = self.EXPECTED[self.target_kill][1]
+        self.report = False
+        self.restart_happen_event = threading.Event()
+
+    def enable_report(self):
+        """
+        Enable report
+        """
+        self.report = True
+        from . import main
+        if not os.path.isdir(main.ctx.report_path):
+            utils.msg_error("{} is not a directory".format(main.ctx.report_path))
+
+        report_path = main.ctx.report_path
+        report_name = "{}-{}.report".format(main.ctx.process_name, utils.now("%Y%m%d-%s"))
+        self.report_file = os.path.join(report_path, report_name)
+        print("(Report: {})".format(self.report_file))
+
+        if self.looping:
+            content_key = "{}-l".format(self.target_kill)
+        else:
+            content_key = self.target_kill
+
+        from . import explain
+        self.explain = explain.contents[content_key].format(nodeA=utils.this_node(), nodeB="other node")
+
+    def header(self):
+        """
+        Define descriptions
+        """
+        h = '''==============================================
+Testcase:          {}
+Looping Kill:      {}
+Expected State:    {}
+'''.format(self.description, self.looping, self.expected)
+        return h
+
+    def to_json(self):
+        """
+        Json results
+        """
+        self.build_base_result()
+        self.result['Looping Kill'] = self.looping
+        self.result['Expected State'] = self.expected
+        from . import main
+        main.ctx.task_list = self.prev_task_list + [self.result]
+        utils.json_dumps()
+
+    def to_report(self):
+        """
+        Generate report
+        """
+        if not self.report:
+            return
+        with open(self.report_file, 'w') as f:
+            f.write(self.header())
+            f.write("\nLog:\n")
+            for m in self.messages:
+                f.write("{} {}:{}\n".format(m[2], m[0].upper(), m[1]))
+            f.write("\nTestcase Explained:\n")
+            f.write("{}\n".format(self.explain))
+            f.flush()
+            os.fsync(f)
+
+    def pre_check(self):
+        """
+        Check the prerequisite
+        """
+        self.task_pre_check()
+        rc, pid = utils.get_process_status(self.target_kill)
+        if not rc:
+            raise TaskError("Process {} is not running!".format(self.target_kill))
+
+    def run(self):
+        """
+        Execute specific kill command and monitor the results
+        """
+        while True:
+            rc, pid = utils.get_process_status(self.target_kill)
+            if rc:
+                self.info("Process {}({}) is running...".format(self.target_kill, pid))
+            else:
+                continue
+            self.info("Trying to run \"{}\"".format(self.cmd))
+            crmshutils.get_stdout_stderr(self.cmd)
+            # endless loop will lead to fence
+            if not self.looping:
+                break
+
+        fence_check_th = threading.Thread(target=self.fence_action_monitor)
+        fence_check_th.start()
+        restart_check_th = threading.Thread(target=self.process_monitor)
+        restart_check_th.start()
+
+    def wait(self):
+        """
+        Wait process to restart
+        """
+        if self.fence_start_event.wait(self.WAIT_TIMEOUT) and not self.restart_happen_event.is_set():
+            raise TaskError("Process {} is not restarted!".format(self.target_kill))
+        self.thread_stop_event.set()
+
+    def process_monitor(self):
+        """
+        Monitor process status
+        """
+        while not self.thread_stop_event.is_set():
+            rc, pid = utils.get_process_status(self.target_kill)
+            if rc:
+                self.info("Process {}({}) is restarted!".format(self.target_kill, pid))
+                self.restart_happen_event.set()
+                break
+            time.sleep(1)
+
+
+class TaskSplitBrain(Task):
+    """
+    Class to define how to simulate split brain by blocking corosync ports
+    """
+
+    def  __init__(self):
+        """
+        Init function
+        """
+        self.description = "Simulate split brain by blocking corosync ports"
+        self.expected = "One of nodes get fenced"
+        self.ports = []
+        self.peer_nodelist = []
+        super(self.__class__, self).__init__(self.description, flush=True)
+
+    def header(self):
+        """
+        Define descriptions
+        """
+        h = '''==============================================
+Testcase:          {}
+Expected Result:   {}
+Fence action:      {}
+Fence timeout:     {}
+'''.format(self.description, self.expected, self.fence_action, self.fence_timeout)
+        return h
+
+    def to_json(self):
+        """
+        Json results
+        """
+        self.build_base_result()
+        self.result['Fence action'] = self.fence_action
+        self.result['Fence timeout'] = self.fence_timeout
+        from . import main
+        main.ctx.task_list = self.prev_task_list + [self.result]
+        utils.json_dumps()
+
+    def pre_check(self):
+        """
+        Check the prerequisite
+        """
+        self.task_pre_check()
+
+        for cmd in ["iptables"]:
+            rc, _, err = crmshutils.get_stdout_stderr("which {}".format(cmd))
+            if rc != 0 and err:
+                raise TaskError(err)
+
+        if len(utils.online_nodes()) < 2:
+            raise TaskError("At least two nodes online!")
+
+    @contextmanager
+    def do_block(self):
+        """
+        Context manager to block and unblock ip/ports
+        """
+        self.firewalld_enabled = crmshutils.service_is_active("firewalld.service")
+        if self.firewalld_enabled:
+            self.do_block_firewalld()
+        else:
+            self.do_block_iptables()
+        try:
+            yield
+        finally:
+            self.un_block()
+
+    def do_block_firewalld(self):
+        """
+        Block corosync ports
+        """
+        self.ports = utils.corosync_port_list()
+        if not self.ports:
+            raise TaskError("Can not get corosync's port")
+        self.info("Trying to temporarily block port {}".format(','.join(self.ports)))
+        for p in self.ports:
+            crmshutils.get_stdout_stderr(config.REMOVE_PORT.format(port=p))
+
+    def do_block_iptables(self):
+        """
+        Block corosync communication ip
+        """
+        self.peer_nodelist = utils.peer_node_list()
+        for node in self.peer_nodelist:
+            self.info("Trying to temporarily block {} communication ip".format(node))
+            for ip in crmshutils.get_iplist_from_name(node):
+                crmshutils.get_stdout_stderr(config.BLOCK_IP.format(action='I', peer_ip=ip))
+
+    def un_block(self):
+        """
+        Unblock corosync ip/ports
+        """
+        if self.firewalld_enabled:
+            self.un_block_firewalld()
+        else:
+            self.un_block_iptables()
+
+    def un_block_firewalld(self):
+        """
+        Unblock corosync ports
+        """
+        self.info("Trying to add port {}".format(','.join(self.ports)))
+        for p in self.ports:
+            crmshutils.get_stdout_stderr(config.ADD_PORT.format(port=p))
+
+    def un_block_iptables(self):
+        """
+        Unblock corosync communication ip
+        """
+        for node in self.peer_nodelist:
+            self.info("Trying to recover {} communication ip".format(node))
+            for ip in crmshutils.get_iplist_from_name(node):
+                crmshutils.get_stdout_stderr(config.BLOCK_IP.format(action='D', peer_ip=ip))
+
+    def run(self):
+        """
+        Fence node and start a thread to monitor the result
+        """
+        #self.info("Trying to fence node \"{}\"".format(self.target_node))
+        #crmshutils.get_stdout_stderr(config.FENCE_NODE.format(self.target_node), wait=False)
+        th = threading.Thread(target=self.fence_action_monitor)
+        th.start()
+
+    def wait(self):
+        """
+        Wait until fence happened
+        """
+        result = self.fence_finish_event.wait(int(self.fence_timeout))
+        if not result:
+            self.thread_stop_event.set()
+            # should be an error here

--- a/preflight_check/utils.py
+++ b/preflight_check/utils.py
@@ -1,0 +1,234 @@
+import os
+import re
+import json
+import logging
+from datetime import datetime
+from contextlib import contextmanager
+from crmsh import utils as crmshutils
+from . import config
+
+
+logger = logging.getLogger('cpc')
+
+CRED = '\033[31m'
+CYELLOW = '\033[33m'
+CGREEN = '\033[32m'
+CEND = '\033[0m'
+
+LEVEL = {
+    "info": logging.INFO,
+    "warn": logging.WARNING,
+    "error": logging.ERROR
+}
+
+
+class MyLoggingFormatter(logging.Formatter):
+    """
+    Class to change logging formatter
+    """
+
+    FORMAT_FLUSH = "[%(asctime)s]%(levelname)s: %(message)s"
+    FORMAT_NOFLUSH = "%(timestamp)s%(levelname)s: %(message)s"
+
+    COLORS = {
+        'WARNING': CYELLOW,
+        'INFO': CGREEN,
+        'ERROR': CRED
+    }
+
+    def __init__(self, flush=True):
+        fmt = self.FORMAT_FLUSH if flush else self.FORMAT_NOFLUSH
+        logging.Formatter.__init__(self, fmt=fmt, datefmt='%Y/%m/%d %H:%M:%S')
+
+    def format(self, record):
+        levelname = record.levelname
+        if levelname in self.COLORS:
+            levelname_color = self.COLORS[levelname] + levelname + CEND
+            record.levelname = levelname_color
+        return logging.Formatter.format(self, record)
+
+
+def now(form="%Y/%m/%d %H:%M:%S"):
+    return datetime.now().strftime(form)
+
+
+@contextmanager
+def manage_handler(_type, keep=True):
+    """
+    Define a contextmanager to remove specific logging handler temporarily
+    """
+    try:
+        handler = get_handler(logger, _type)
+        if not keep:
+            logger.removeHandler(handler)
+        yield
+    finally:
+        if not keep:
+            logger.addHandler(handler)
+
+
+def msg_raw(level, msg, to_stdout=True):
+    with manage_handler("stream", to_stdout):
+        logger.log(level, msg)
+
+
+def msg_info(msg, to_stdout=True):
+    msg_raw(logging.INFO, msg, to_stdout)
+
+
+def msg_warn(msg, to_stdout=True):
+    msg_raw(logging.WARNING, msg, to_stdout)
+
+
+def msg_error(msg, to_stdout=True):
+    msg_raw(logging.ERROR, msg, to_stdout)
+
+
+def json_dumps():
+    """
+    Dump the json results to file
+    """
+    from . import main
+    with open(main.ctx.jsonfile, 'w') as f:
+        f.write(json.dumps(main.ctx.task_list, indent=2))
+        f.flush()
+        os.fsync(f)
+
+
+def get_property(name):
+    """
+    Get cluster properties
+    """
+    cmd = "crm configure get_property " + name
+    rc, stdout, _ = crmshutils.get_stdout_stderr(cmd)
+    if rc != 0:
+        return None
+    else:
+        return stdout
+
+
+class FenceInfo(object):
+    """
+    Class to collect fence info
+    """
+    @property
+    def fence_enabled(self):
+        enable_result = get_property("stonith-enabled")
+        if not enable_result or enable_result.lower() != "true":
+            return False
+        return True
+
+    @property
+    def fence_action(self):
+        action_result = get_property("stonith-action")
+        if action_result is None or action_result not in ["off", "poweroff", "reboot"]:
+            msg_error("Cluster property \"stonith-action\" should be reboot|off|poweroff")
+            return None
+        return action_result
+
+    @property
+    def fence_timeout(self):
+        timeout_result = get_property("stonith-timeout")
+        if timeout_result and re.match(r'[1-9][0-9]*(s|)$', timeout_result):
+            return timeout_result.strip("s")
+        return config.FENCE_TIMEOUT
+
+
+def check_node_status(node, state):
+    """
+    Check whether the node has expected state
+    """
+    rc, stdout, stderr = crmshutils.get_stdout_stderr('crm_node -l')
+    if rc != 0:
+        msg_error(stderr)
+        return False
+    pattern = re.compile(r'^.* {} {}'.format(node, state), re.MULTILINE)
+    if not pattern.search(stdout):
+        return False
+    return True
+
+
+def online_nodes():
+    """
+    Get online node list
+    """
+    rc, stdout, stderr = crmshutils.get_stdout_stderr('crm_mon -1')
+    if rc == 0 and stdout:
+        res = re.search(r'Online:\s+\[\s(.*)\s\]', stdout)
+        if res:
+            return res.group(1).split()
+    return []
+
+
+def peer_node_list():
+    """
+    Get online node list except self
+    """
+    online_nodelist = online_nodes()
+    if online_nodelist:
+        online_nodelist.remove(this_node())
+        return online_nodelist
+    return []
+
+
+def this_node():
+    """
+    Try to get the node name from crm_node command
+    If failed, use its hostname
+    """
+    rc, stdout, stderr = crmshutils.get_stdout_stderr("crm_node --name")
+    if rc != 0:
+        msg_error(stderr)
+        return crmshutils.this_node()
+    return stdout
+
+
+def str_to_datetime(str_time, fmt):
+    return datetime.strptime(str_time, fmt)
+
+
+def corosync_port_list():
+    """
+    Get corosync ports using corosync-cmapctl
+    """
+    ports = []
+    rc, out, _ = crmshutils.get_stdout_stderr("corosync-cmapctl totem.interface")
+    if rc == 0 and out:
+        ports = re.findall(r'(?:mcastport.*) ([0-9]+)', out)
+    return ports
+
+
+def get_handler(logger, _type):
+    """
+    Get logger specific handler
+    """
+    for h in logger.handlers:
+        if getattr(h, '_name') == _type:
+            return h
+
+
+def is_root():
+    return os.getuid() == 0
+
+
+def get_process_status(s):
+    """
+    Returns true if argument is the name of a running process.
+
+    s: process name
+    returns Boolean and pid
+    """
+    # find pids of running processes
+    pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+    for pid in pids:
+        try:
+            pid_file = os.path.join('/proc', pid, 'cmdline')
+            with open(pid_file, 'rb') as f:
+                data = f.read()
+                procname = os.path.basename(crmshutils.to_ascii(data).replace('\x00', ' ').split(' ')[0])
+                if procname == s or procname == s + ':':
+                    return True, int(pid)
+        except EnvironmentError:
+            # a process may have died since we got the list of pids
+            pass
+    return False, -1


### PR DESCRIPTION
## Background
This PR was for integrating [cluster_preflight_check](https://github.com/liangxin1300/cluster_preflight_check) into crmsh

## Benefits:

- Consistency
- Easier to memorize for our customers
- Integrated under one root ("crm cluster")
- Less maintain job for  python-cluster-preflight-check package
- Easy to make tests under the existing crmsh test framework 

## Scope in this PR

- [ ] Integrate into crmsh (where and which sub command name)
- [x] No functionalities change
- [x] Reasonable refactors (reuse crmsh functions; using meaningful classes instead of functions)
- [ ] Good unit test coverage

## Code structure
#### Major flow
```
main.run
    setup_basic_context
    parse_argument
    setup_logging

    check.check  (-e/--env-check and -c/--cluster-check option, task.TaskCheck)
    kill_process (--kill-sbd/--kill-corosync/--kill-pacemakerd, task.TaskKill)
    fence_node   (--fence-node, task.TaskFence)
    split_brain  (--split-brain-iptables, task.TaskSplitBrain)
``` 
#### Task* class
- Prerequisite checking
- Logging
- Results/report dumping
- Run command
- Wait/Monitor result in thread

## RPM
[only for Tumbleweed and 15sp2](https://build.opensuse.org/package/show/home:XinLiang:integrate_preflight_check_into_crmsh/crmsh)

## How to run

`/usr/share/crmsh/preflight_check/ha-cluster-preflight-check -h`

## Next steps

- Back port to other branches
- More checking items for `-e`(env checking) and `-c`(cluster related checking) options

> check nic's mtu used by corosync, should large than totem.netmtu
> check rrp mode is passive or active
> check whether using non-exist IP

- Unify logging system with crmsh(#614 ) and hb_report
- More preflight scenarios