### PR TITLE
[crmsh-4.1] Dev: unittest: adjust duplicated test function name

### DIFF
--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -879,7 +879,7 @@ def test_node_util_attr():
     assert obj.cli_use_validate()
 
 
-def test_dup_create():
+def test_dup_create_same_name():
     """
     Creating two objects with the same name
     """

--- a/test/unittests/test_report.py
+++ b/test/unittests/test_report.py
@@ -343,7 +343,7 @@ def test_dump_D_process_None(mock_get_stdout_stderr):
 
 
 @mock.patch('crmsh.utils.get_stdout_stderr')
-def test_dump_D_process_None(mock_get_stdout_stderr):
+def test_dump_D_process(mock_get_stdout_stderr):
     mock_get_stdout_stderr.side_effect = [
             (0, "10001\n10002", None),
             (0, "comm_out for 10001", None),


### PR DESCRIPTION
backport #656 