### PR TITLE
Minor change for _get_sbd_device_interactive function

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -215,7 +215,7 @@ Configure SBD:
         Get sbd device on interactive mode
         """
         if _context.yes_to_all:
-            warn("Not configuring SBD (%s left untouched)." % (SYSCONFIG_SBD))
+            warn("Not configuring SBD ({} left untouched).".format(SYSCONFIG_SBD))
             return
 
         status(self.SBD_STATUS_DESCRIPTION)
@@ -226,14 +226,16 @@ Configure SBD:
 
         self._check_environment()
 
-        configured_dev = self._get_sbd_device_from_config()
-        if configured_dev and not confirm("SBD is already configured to use {} - overwrite?".format(';'.join(configured_dev))):
-            return configured_dev
+        configured_dev_list = self._get_sbd_device_from_config()
+        if configured_dev_list and not confirm("SBD is already configured to use {} - overwrite?".format(';'.join(configured_dev_list))):
+            return configured_dev_list
 
         dev_list = []
         dev_looks_sane = False
         while not dev_looks_sane:
             dev = prompt_for_string('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', r'none|\/.*')
+            if not dev:
+                continue
             if dev == "none":
                 self.diskless_sbd = True
                 return
@@ -241,7 +243,7 @@ Configure SBD:
             try:
                 self._verify_sbd_device(dev_list)
             except ValueError as err_msg:
-                print(term.render(clidisplay.error(str(err_msg))))
+                print_error_msg(str(err_msg))
                 continue
             for dev_item in dev_list:
                 warn("All data on {} will be destroyed!".format(dev_item))

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -53,6 +53,116 @@ class TestSBDManager(unittest.TestCase):
         Global tearDown.
         """
 
+    @mock.patch('crmsh.bootstrap.warn')
+    def test_get_sbd_device_interactive_yes_to_all(self, mock_warn):
+        bootstrap._context = mock.Mock(yes_to_all=True)
+        self.sbd_inst._get_sbd_device_interactive()
+        mock_warn.assert_called_once_with("Not configuring SBD ({} left untouched).".format(bootstrap.SYSCONFIG_SBD))
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.warn')
+    def test__get_sbd_device_interactive_not_confirm(self, mock_warn, mock_status, mock_confirm):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.return_value = False
+        self.sbd_inst._get_sbd_device_interactive()
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_warn.assert_called_once_with("Not configuring SBD - STONITH will be disabled.")
+
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    def test__get_sbd_device_interactive_already_configured(self, mock_status, mock_confirm, mock_check, mock_from_config):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.side_effect = [True, False]
+        mock_from_config.return_value = ["/dev/sda1"]
+
+        res = self.sbd_inst._get_sbd_device_interactive()
+        self.assertEqual(res, ["/dev/sda1"])
+
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_confirm.assert_has_calls([
+            mock.call("Do you wish to use SBD?"),
+            mock.call("SBD is already configured to use /dev/sda1 - overwrite?")
+            ])
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_check.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_get_sbd_device_interactive_diskless(self, mock_status, mock_confirm, mock_check, mock_from_config, mock_prompt):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.return_value = True
+        mock_from_config.return_value = None
+        mock_prompt.return_value = "none"
+
+        self.sbd_inst._get_sbd_device_interactive()
+
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_check.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+        mock_prompt.assert_called_once_with('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', 'none|\\/.*')
+
+    @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_get_sbd_device_interactive_null_and_diskless(self, mock_status, mock_confirm, mock_check, mock_from_config, mock_prompt):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.return_value = True
+        mock_from_config.return_value = None
+        mock_prompt.side_effect = [None, "none"]
+
+        self.sbd_inst._get_sbd_device_interactive()
+
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_confirm.assert_called_once_with("Do you wish to use SBD?")
+        mock_check.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+        mock_prompt.assert_has_calls([
+            mock.call('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', 'none|\\/.*') for x in range(2)
+            ])
+
+    @mock.patch('crmsh.bootstrap.warn')
+    @mock.patch('crmsh.bootstrap.print_error_msg')
+    @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
+    @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_get_sbd_device_interactive(self, mock_status, mock_confirm, mock_check, mock_from_config, mock_prompt, mock_verify, mock_error_msg, mock_warn):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.side_effect = [True, False, True]
+        mock_from_config.return_value = None
+        mock_prompt.side_effect = ["/dev/test1", "/dev/sda1", "/dev/sdb1"]
+        mock_verify.side_effect = [ValueError("/dev/test1 error"), None, None]
+
+        res = self.sbd_inst._get_sbd_device_interactive()
+        self.assertEqual(res, ["/dev/sdb1"])
+
+        mock_status.assert_called_once_with(bootstrap.SBDManager.SBD_STATUS_DESCRIPTION)
+        mock_confirm.assert_has_calls([
+            mock.call("Do you wish to use SBD?"),
+            mock.call("Are you sure you wish to use this device?")
+            ])
+        mock_check.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+        mock_error_msg.assert_called_once_with("/dev/test1 error")
+        mock_warn.assert_has_calls([
+            mock.call("All data on /dev/sda1 will be destroyed!"),
+            mock.call("All data on /dev/sdb1 will be destroyed!")
+            ])
+        mock_prompt.assert_has_calls([
+            mock.call('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', 'none|\\/.*') for x in range(3)
+            ])
+
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.check_watchdog')
     def test_check_environment_no_watchdog(self, mock_watchdog, mock_error):


### PR DESCRIPTION
Changes include:

- Using .format instead of %s
- Meaningful variable names
- Using print_error_msg instead of term.render
- Continue if sbd device value is None to avoid crash(bsc#1178333)
- Add unit test codes for _get_sbd_device_interactive function