### PR TITLE
Fix: bootstrap: disable corosync-qdevice if not configured

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1621,6 +1621,8 @@ def init_qdevice():
     """
     # If don't want to config qdevice, return
     if not _context.qdevice_inst:
+        if utils.service_is_enabled("corosync-qdevice.service"):
+            utils.disable_service("corosync-qdevice.service")
         return
 
     status("""
@@ -2115,6 +2117,9 @@ def join_cluster(seed_host):
 
     if is_qdevice_configured:
         start_qdevice_on_join_node(seed_host)
+    else:
+        if utils.service_is_enabled("corosync-qdevice.service"):
+            utils.disable_service("corosync-qdevice.service")
 
 
 def start_qdevice_on_join_node(seed_host):

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -890,11 +890,16 @@ class TestBootstrap(unittest.TestCase):
         mock_interfaces_inst.get_default_nic_list_from_route.assert_called_once_with()
         mock_interfaces_inst.get_default_ip_list.assert_called_once_with()
 
+    @mock.patch('crmsh.utils.disable_service')
+    @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.bootstrap.status')
-    def test_init_qdevice_no_config(self, mock_status):
+    def test_init_qdevice_no_config(self, mock_status, mock_enabled, mock_disable):
         bootstrap._context = mock.Mock(qdevice_inst=None)
+        mock_enabled.return_value = True
         bootstrap.init_qdevice()
         mock_status.assert_not_called()
+        mock_enabled.assert_called_once_with("corosync-qdevice.service")
+        mock_disable.assert_called_once_with("corosync-qdevice.service")
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')


### PR DESCRIPTION
cluster init without qdevice should "systemctl disable corosync-qdevice" if it is enabled, and the similarly for cluster join