### PR TITLE
Fix: utils: improve disable_service and enable_service function

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1621,8 +1621,7 @@ def init_qdevice():
     """
     # If don't want to config qdevice, return
     if not _context.qdevice_inst:
-        if utils.service_is_enabled("corosync-qdevice.service"):
-            utils.disable_service("corosync-qdevice.service")
+        utils.disable_service("corosync-qdevice.service")
         return
 
     status("""
@@ -2118,8 +2117,7 @@ def join_cluster(seed_host):
     if is_qdevice_configured:
         start_qdevice_on_join_node(seed_host)
     else:
-        if utils.service_is_enabled("corosync-qdevice.service"):
-            utils.disable_service("corosync-qdevice.service")
+        utils.disable_service("corosync-qdevice.service")
 
 
 def start_qdevice_on_join_node(seed_host):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2511,12 +2511,15 @@ class ServiceManager(object):
             raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         return rc == 0, output
 
+    @property
     def is_available(self):
         return self.service_name in self._do_action(self.ACTION_MAP["is_available"])[1]
 
+    @property
     def is_enabled(self):
         return self._do_action(self.ACTION_MAP["is_enabled"])[0]
 
+    @property
     def is_active(self):
         return self._do_action(self.ACTION_MAP["is_active"])[0]
 
@@ -2538,7 +2541,7 @@ class ServiceManager(object):
         Check whether service is available
         """
         inst = cls(name, remote_addr)
-        return inst.is_available()
+        return inst.is_available
 
     @classmethod
     def service_is_enabled(cls, name, remote_addr=None):
@@ -2546,7 +2549,7 @@ class ServiceManager(object):
         Check whether service is enabled
         """
         inst = cls(name, remote_addr)
-        return inst.is_enabled()
+        return inst.is_enabled
 
     @classmethod
     def service_is_active(cls, name, remote_addr=None):
@@ -2554,7 +2557,7 @@ class ServiceManager(object):
         Check whether service is active
         """
         inst = cls(name, remote_addr)
-        return inst.is_active()
+        return inst.is_active
 
     @classmethod
     def start_service(cls, name, enable=False, remote_addr=None):
@@ -2582,7 +2585,8 @@ class ServiceManager(object):
         Enable service
         """
         inst = cls(name, remote_addr)
-        inst.enable()
+        if inst.is_available and not inst.is_enabled:
+            inst.enable()
 
     @classmethod
     def disable_service(cls, name, remote_addr=None):
@@ -2590,7 +2594,8 @@ class ServiceManager(object):
         Disable service
         """
         inst = cls(name, remote_addr)
-        inst.disable()
+        if inst.is_available and inst.is_enabled:
+            inst.disable()
 
 
 service_is_available = ServiceManager.service_is_available

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -891,14 +891,11 @@ class TestBootstrap(unittest.TestCase):
         mock_interfaces_inst.get_default_ip_list.assert_called_once_with()
 
     @mock.patch('crmsh.utils.disable_service')
-    @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.bootstrap.status')
-    def test_init_qdevice_no_config(self, mock_status, mock_enabled, mock_disable):
+    def test_init_qdevice_no_config(self, mock_status, mock_disable):
         bootstrap._context = mock.Mock(qdevice_inst=None)
-        mock_enabled.return_value = True
         bootstrap.init_qdevice()
         mock_status.assert_not_called()
-        mock_enabled.assert_called_once_with("corosync-qdevice.service")
         mock_disable.assert_called_once_with("corosync-qdevice.service")
 
     @mock.patch('crmsh.bootstrap.error')

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1119,19 +1119,19 @@ class TestServiceManager(unittest.TestCase):
     def test_is_available(self):
         self.service_local._do_action = mock.Mock()
         self.service_local._do_action.return_value = (True, "service1 service2")
-        assert self.service_local.is_available() == True
+        assert self.service_local.is_available == True
         self.service_local._do_action.assert_called_once_with("list-unit-files")
 
     def test_is_enabled(self):
         self.service_local._do_action = mock.Mock()
         self.service_local._do_action.return_value = (True, None)
-        assert self.service_local.is_enabled() == True
+        assert self.service_local.is_enabled == True
         self.service_local._do_action.assert_called_once_with("is-enabled")
 
     def test_is_active(self):
         self.service_local._do_action = mock.Mock()
         self.service_local._do_action.return_value = (True, None)
-        assert self.service_local.is_active() == True
+        assert self.service_local.is_active == True
         self.service_local._do_action.assert_called_once_with("is-active")
 
     def test_start(self):
@@ -1158,21 +1158,21 @@ class TestServiceManager(unittest.TestCase):
         self.service_local.disable()
         self.service_local._do_action.assert_called_once_with("disable")
 
-    @mock.patch("crmsh.utils.ServiceManager.is_available")
+    @mock.patch("crmsh.utils.ServiceManager.is_available", new_callable=mock.PropertyMock)
     def test_service_is_available(self, mock_available):
         mock_available.return_value = True
         res = utils.ServiceManager.service_is_available("service1")
         self.assertEqual(res, True)
         mock_available.assert_called_once_with()
 
-    @mock.patch("crmsh.utils.ServiceManager.is_enabled")
+    @mock.patch("crmsh.utils.ServiceManager.is_enabled", new_callable=mock.PropertyMock)
     def test_service_is_enabled(self, mock_enabled):
         mock_enabled.return_value = True
         res = utils.ServiceManager.service_is_enabled("service1")
         self.assertEqual(res, True)
         mock_enabled.assert_called_once_with()
 
-    @mock.patch("crmsh.utils.ServiceManager.is_active")
+    @mock.patch("crmsh.utils.ServiceManager.is_active", new_callable=mock.PropertyMock)
     def test_service_is_active(self, mock_active):
         mock_active.return_value = True
         res = utils.ServiceManager.service_is_active("service1")
@@ -1194,12 +1194,20 @@ class TestServiceManager(unittest.TestCase):
         mock_stop.assert_called_once_with()
 
     @mock.patch('crmsh.utils.ServiceManager.enable')
-    def test_enable_service(self, mock_enable):
+    @mock.patch('crmsh.utils.ServiceManager.is_enabled', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.ServiceManager.is_available', new_callable=mock.PropertyMock)
+    def test_enable_service(self, mock_available, mock_enabled, mock_enable):
+        mock_available.return_value = True
+        mock_enabled.return_value = False
         utils.ServiceManager.enable_service("service1")
         mock_enable.assert_called_once_with()
 
     @mock.patch('crmsh.utils.ServiceManager.disable')
-    def test_disable_service(self, mock_disable):
+    @mock.patch('crmsh.utils.ServiceManager.is_enabled', new_callable=mock.PropertyMock)
+    @mock.patch('crmsh.utils.ServiceManager.is_available', new_callable=mock.PropertyMock)
+    def test_disable_service(self, mock_available, mock_enabled, mock_disable):
+        mock_available.return_value = True
+        mock_enabled.return_value = True
         utils.ServiceManager.disable_service("service1")
         mock_disable.assert_called_once_with()
 


### PR DESCRIPTION
In #680, we should check whether `corosync-qdevice` is available firstly, to avoid error if that package didn't installed

So I've improved `ServiceManager.disable_service` and `ServiceManager.enable_service` to make the action more solid