### PR TITLE
Dev: bootstrap: check watchdog while already in use

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1497,6 +1497,11 @@ def check_watchdog():
     Verify watchdog device. Fall back to /dev/watchdog.
     """
     watchdog_dev = detect_watchdog_device()
+    # In case this watchdog already in use
+    _, out, _ = utils.get_stdout_stderr("lsof")
+    if re.search(" {}\n".format(watchdog_dev), out):
+        return True
+    # not in use
     rc, _out, _err = utils.get_stdout_stderr("wdctl %s" % (watchdog_dev))
     return rc == 0
 


### PR DESCRIPTION
## Problem
`bootstrap.check_watchdog` will return False when cluster was running with sbd.
That will cause confused result while using preflight check to check watchdog.

Or, I was wondering whether this case possible: some other process which was not related with HA stack was using /dev/watchdog, while using bootstrap to configure sbd will failed because `bootstrap.check_watchdog` return False.(@zzhou1 @gao-yan )

## Reason
`wdctl` will return these when this watchdog was using
```
wdctl: /dev/watchdog: watchdog already in use, terminating.
wdctl: cannot open /dev/watchdog: Device or resource busy
```

## Solution
1. Using `lsof` and then grep this watchdog device whether being used, if yes, return True
2. Use `wdctl` to verify