### PR TITLE
Dev: bootstrap: improve invoke to print error to give specific hints

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -278,8 +278,9 @@ Configure SBD:
         if self.diskless_sbd:
             return
         for dev in self._sbd_devices:
-            if not invoke("sbd -d {} create".format(dev)):
-                error("Failed to initialize SBD device {}".format(dev))
+            rc, _, err = invoke("sbd -d {} create".format(dev))
+            if not rc:
+                error("Failed to initialize SBD device {}: {}".format(dev, err))
 
     def _update_configuration(self):
         """
@@ -336,12 +337,12 @@ Configure SBD:
             return
         if utils.service_is_enabled("sbd.service"):
             if self._get_sbd_device_from_config():
-                if not invoke("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
+                if not invokerc("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
                     error("Can't create stonith-sbd primitive")
-                if not invoke("crm configure property stonith-enabled=true"):
+                if not invokerc("crm configure property stonith-enabled=true"):
                     error("Can't enable STONITH for SBD")
             else:
-                if not invoke("crm configure property stonith-enabled=true stonith-watchdog-timeout=5s"):
+                if not invokerc("crm configure property stonith-enabled=true stonith-watchdog-timeout=5s"):
                     error("Can't enable STONITH for diskless SBD")
 
     def join_sbd(self, peer_host):
@@ -353,7 +354,7 @@ Configure SBD:
         if not utils.package_is_installed("sbd"):
             return
         cmd_detect_enabled = "ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(peer_host)
-        if not os.path.exists(SYSCONFIG_SBD) or not invoke(cmd_detect_enabled):
+        if not os.path.exists(SYSCONFIG_SBD) or not invokerc(cmd_detect_enabled):
             invoke("systemctl disable sbd.service")
             return
         self._check_environment()
@@ -483,7 +484,7 @@ def invoke(*args):
     """
     Log command execution to log file.
     Log output from command to log file.
-    Return returncode == 0
+    Return (boolean, stdout, stderr)
     """
     log("+ " + " ".join(args))
     rc, stdout, stderr = utils.get_stdout_stderr(" ".join(args))
@@ -491,17 +492,14 @@ def invoke(*args):
         log(stdout)
     if stderr:
         log(stderr)
-    return rc == 0
+    return rc == 0, stdout, stderr
 
 
 def invokerc(*args):
-    "Like invoke, but returns the returncode, not True/False"
-    log("+ " + " ".join(args))
-    rc, stdout, stderr = utils.get_stdout_stderr(" ".join(args))
-    if stdout:
-        log(stdout)
-    if stderr:
-        log(stderr)
+    """
+    Calling invoke, return True/False
+    """
+    rc, _, _ = invoke(*args)
     return rc
 
 
@@ -789,7 +787,7 @@ def configure_firewall(tcp=None, udp=None):
 
         # Firewall is active, either restart or complain if we couldn't tweak it
         status("Restarting firewall (tcp={}, udp={})".format(" ".join(tcp), " ".join(udp)))
-        if not invoke("rcSuSEfirewall2 restart"):
+        if not invokerc("rcSuSEfirewall2 restart"):
             error("Failed to restart firewall (SuSEfirewall2)")
 
     def init_firewall_firewalld(tcp, udp):
@@ -797,7 +795,7 @@ def configure_firewall(tcp=None, udp=None):
         cmdbase = 'firewall-cmd --zone=public --permanent ' if has_firewalld else 'firewall-offline-cmd --zone=public '
 
         def cmd(args):
-            if not invoke(cmdbase + args):
+            if not invokerc(cmdbase + args):
                 error("Failed to configure firewall.")
 
         for p in tcp:
@@ -807,7 +805,7 @@ def configure_firewall(tcp=None, udp=None):
             cmd("--add-port={}/udp".format(p))
 
         if has_firewalld:
-            if not invoke("firewall-cmd --reload"):
+            if not invokerc("firewall-cmd --reload"):
                 error("Failed to reload firewall configuration.")
 
     def init_firewall_ufw(tcp, udp):
@@ -815,10 +813,10 @@ def configure_firewall(tcp=None, udp=None):
         try configuring firewall with ufw
         """
         for p in tcp:
-            if not invoke("ufw allow {}/tcp".format(p)):
+            if not invokerc("ufw allow {}/tcp".format(p)):
                 error("Failed to configure firewall (ufw)")
         for p in udp:
-            if not invoke("ufw allow {}/udp".format(p)):
+            if not invokerc("ufw allow {}/udp".format(p)):
                 error("Failed to configure firewall (ufw)")
 
     if utils.package_is_installed("firewalld"):
@@ -989,9 +987,15 @@ def append_to_remote_file(fromfile, remote_node, tofile):
     """
     Append content of fromfile to tofile on remote_node
     """
+    err_details_string = """
+    crmsh has no way to help you to setup up passwordless ssh among nodes at this time. 
+    As the hint, likely, `PasswordAuthentication` is 'no' in /etc/ssh/sshd_config. 
+    Given in this case, users must setup passwordless ssh beforehand, or change it to 'yes' and manage passwords properly
+    """
     cmd = "cat {} | ssh -oStrictHostKeyChecking=no root@{} 'cat >> {}'".format(fromfile, remote_node, tofile)
-    if not invoke(cmd):
-        error("Failed to run \"{}\"".format(cmd))
+    rc, _, err = invoke(cmd)
+    if not rc:
+        error("Failed to append contents of {} to {}:\n\"{}\"\n{}".format(fromfile, remote_node, err, err_details_string))
 
 
 def init_csync2():
@@ -1002,7 +1006,7 @@ def init_csync2():
 
     invoke("rm", "-f", CSYNC2_KEY)
     status_long("Generating csync2 shared key (this may take a while)")
-    if not invoke("csync2", "-k", CSYNC2_KEY):
+    if not invokerc("csync2", "-k", CSYNC2_KEY):
         error("Can't create csync2 key {}".format(CSYNC2_KEY))
     status_done()
 
@@ -1042,10 +1046,10 @@ def csync2_update(path):
     If there was a conflict, use '-f' to force this side to win
     '''
     invoke("csync2 -rm {}".format(path))
-    if invoke("csync2 -rxv {}".format(path)):
+    if invokerc("csync2 -rxv {}".format(path)):
         return
     invoke("csync2 -rf {}".format(path))
-    if not invoke("csync2 -rxv {}".format(path)):
+    if not invokerc("csync2 -rxv {}".format(path)):
         warn("{} was not synced".format(path))
 
 
@@ -1103,7 +1107,7 @@ def init_remote_auth():
 
     pcmk_remote_dir = os.path.dirname(PCMK_REMOTE_AUTH)
     mkdirs_owned(pcmk_remote_dir, mode=0o750, gid="haclient")
-    if not invoke("dd if=/dev/urandom of={} bs=4096 count=1".format(PCMK_REMOTE_AUTH)):
+    if not invokerc("dd if=/dev/urandom of={} bs=4096 count=1".format(PCMK_REMOTE_AUTH)):
         warn("Failed to create pacemaker authkey: {}".format(PCMK_REMOTE_AUTH))
     utils.chown(PCMK_REMOTE_AUTH, "hacluster", "haclient")
     os.chmod(PCMK_REMOTE_AUTH, 0o640)
@@ -1187,7 +1191,7 @@ class Validation(object):
 
         # Check whether this IP already configured in cluster
         ping_cmd = "ping6" if ipv6 else "ping"
-        if invoke("{} -c 1 {}".format(ping_cmd, addr)):
+        if invokerc("{} -c 1 {}".format(ping_cmd, addr)):
             raise ValueError("Address already in use: {}".format(addr))
 
 
@@ -1440,12 +1444,12 @@ Configure Shared Storage:
             return
         status_long("Erasing existing partitions...")
         for part in partitions:
-            if not invoke("parted -s %s rm %s" % (dev, part)):
+            if not invokerc("parted -s %s rm %s" % (dev, part)):
                 error("Failed to remove partition %s from %s" % (part, dev))
         status_done()
 
     status_long("Creating partitions...")
-    if not invoke("parted", "-s", dev, "mklabel", "msdos"):
+    if not invokerc("parted", "-s", dev, "mklabel", "msdos"):
         error("Failed to create partition table")
 
     # This is a bit rough, and probably won't result in great performance,
@@ -1453,9 +1457,9 @@ Configure Shared Storage:
     # we have to specify the size of the first partition in this in bytes
     # rather than MB, or parted's rounding gives us a ~30Kb partition
     # (see rhbz#623268).
-    if not invoke("parted -s %s mkpart primary 0 1048576B" % (dev)):
+    if not invokerc("parted -s %s mkpart primary 0 1048576B" % (dev)):
         error("Failed to create first partition on %s" % (dev))
-    if not invoke("parted -s %s mkpart primary 1M 100%%" % (dev)):
+    if not invokerc("parted -s %s mkpart primary 1M 100%%" % (dev)):
         error("Failed to create second partition")
 
     status_done()
@@ -1577,14 +1581,14 @@ colocation clusterfs-with-base inf: c-clusterfs base-clone
     # existing partition.  For the commit that introduced this, see:
     # http://oss.oracle.com/git/?p=ocfs2-tools.git;a=commit;h=8345a068479196172190f4fa287052800fa2b66f
     # TODO: if make the cluster name configurable, we need to update it here too
-    if not invoke("mkfs.ocfs2 --cluster-stack pcmk --cluster-name %s -N 8 -x %s" % (_context.cluster_name, dev)):
+    if not invokerc("mkfs.ocfs2 --cluster-stack pcmk --cluster-name %s -N 8 -x %s" % (_context.cluster_name, dev)):
         error("Failed to create OCFS2 filesystem on %s" % (dev))
     status_done()
 
     # TODO: refactor, maybe
-    if not invoke("mkdir -p %s" % (mntpoint)):
+    if not invokerc("mkdir -p %s" % (mntpoint)):
         error("Can't create mountpoint %s" % (mntpoint))
-    if not invoke("crm resource meta clusterfs delete target-role"):
+    if not invokerc("crm resource meta clusterfs delete target-role"):
         error("Can't start cluster filesystem clone")
     wait_for_resource("Waiting for %s to be mounted" % (mntpoint), "clusterfs:0")
 
@@ -1632,8 +1636,9 @@ Configure Qdevice/Qnetd:""")
     # Configure ssh passwordless to qnetd if detect password is needed
     if utils.check_ssh_passwd_need(qnetd_addr):
         status("Copy ssh key to qnetd node({})".format(qnetd_addr))
-        if not invoke("ssh-copy-id -i /root/.ssh/id_rsa.pub root@{}".format(qnetd_addr)):
-            error("Failed to copy ssh key")
+        rc, _, err = invoke("ssh-copy-id -i /root/.ssh/id_rsa.pub root@{}".format(qnetd_addr))
+        if not rc:
+            error("Failed to copy ssh key: {}".format(err))
     # Start qdevice service if qdevice already configured
     if utils.is_qdevice_configured() and not confirm("Qdevice is already configured - overwrite?"):
         start_qdevice_service()
@@ -1709,8 +1714,9 @@ def join_ssh(seed_host):
     # authorized_keys file (again, to help with the case where the
     # user has done manual initial setup without the assistance of
     # ha-cluster-init).
-    if not invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.default_nic_list[0])):
-        error("Can't invoke crm cluster init -i {} ssh_remote on {}".format(_context.default_nic_list[0], seed_host))
+    rc, _, err = invoke("ssh root@{} crm cluster init -i {} ssh_remote".format(seed_host, _context.default_nic_list[0]))
+    if not rc:
+        error("Can't invoke crm cluster init -i {} ssh_remote on {}: {}".format(_context.default_nic_list[0], seed_host, err))
 
 
 def swap_public_ssh_key(remote_node):
@@ -1748,12 +1754,13 @@ def fetch_public_key_from_remote_node(node):
     for key in ("id_rsa", "id_ecdsa", "id_ed25519", "id_dsa"):
         public_key_file = "/root/.ssh/{}.pub".format(key)
         cmd = "ssh -oStrictHostKeyChecking=no root@{} 'test -f {}'".format(node, public_key_file)
-        if not invoke(cmd):
+        if not invokerc(cmd):
             continue
         _, temp_public_key_file = tmpfiles.create()
         cmd = "scp -oStrictHostKeyChecking=no root@{}:{} {}".format(node, public_key_file, temp_public_key_file)
-        if not invoke(cmd):
-            error("Failed to run \"{}\"".format(cmd))
+        rc, _, err = invoke(cmd)
+        if not rc:
+            error("Failed to run \"{}\": {}".format(cmd, err))
         return temp_public_key_file
     raise ValueError("No ssh key exist on {}".format(node))
 
@@ -1777,8 +1784,9 @@ def join_csync2(seed_host):
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
     cmd = "crm cluster init -i {} csync2_remote {}".format(_context.default_nic_list[0], utils.this_node())
-    if not invoke("ssh -o StrictHostKeyChecking=no root@{} {}".format(seed_host, cmd)):
-        error("Can't invoke \"{}\" on {}".format(cmd, seed_host))
+    rc, _, err = invoke("ssh -o StrictHostKeyChecking=no root@{} {}".format(seed_host, cmd))
+    if not rc:
+        error("Can't invoke \"{}\" on {}: {}".format(cmd, seed_host, err))
 
     # This is necessary if syncing /etc/hosts (to ensure everyone's got the
     # same list of hosts)
@@ -1786,9 +1794,9 @@ def join_csync2(seed_host):
     # invoke scp root@seed_host:/etc/hosts $tmp_conf \
     #   || error "Can't retrieve /etc/hosts from seed_host"
     # install_tmp $tmp_conf /etc/hosts
-
-    if not invoke("scp root@%s:'/etc/csync2/{csync2.cfg,key_hagroup}' /etc/csync2" % (seed_host)):
-        error("Can't retrieve csync2 config from %s" % (seed_host))
+    rc, _, err = invoke("scp root@%s:'/etc/csync2/{csync2.cfg,key_hagroup}' /etc/csync2" % (seed_host))
+    if not rc:
+        error("Can't retrieve csync2 config from {}: {}".format(seed_host, err))
 
     utils.start_service("csync2.socket", enable=True)
 
@@ -1801,7 +1809,7 @@ def join_csync2(seed_host):
     # they haven't gone to all nodes in the cluster, which means a
     # subseqent join of another node can fail its sync of corosync.conf
     # when it updates expected_votes.  Grrr...
-    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "csync2 -rm /; csync2 -rxv || csync2 -rf / && csync2 -rxv"'.format(seed_host)):
+    if not invokerc('ssh -o StrictHostKeyChecking=no root@{} "csync2 -rm /; csync2 -rxv || csync2 -rf / && csync2 -rxv"'.format(seed_host)):
         print("")
         warn("csync2 run failed - some files may not be sync'd")
 
@@ -2171,15 +2179,16 @@ def remove_node_from_cluster():
     stop_services(SERVICES_STOP_LIST, remote_addr=node)
 
     # delete configuration files from the node to be removed
-    if not invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {}\\\""'.format(node, " ".join(_context.rm_list))):
-        error("Deleting the configuration files failed")
+    rc, _, err = invoke('ssh -o StrictHostKeyChecking=no root@{} "bash -c \\\"rm -f {}\\\""'.format(node, " ".join(_context.rm_list)))
+    if not rc:
+        error("Deleting the configuration files failed: {}".format(err))
 
     # execute the command : crm node delete $HOSTNAME
     status("Removing the node {}".format(node))
-    if not invoke("crm node delete {}".format(node)):
+    if not invokerc("crm node delete {}".format(node)):
         error("Failed to remove {}".format(node))
 
-    if not invoke("sed -i /{}/d {}".format(node, CSYNC2_CFG)):
+    if not invokerc("sed -i /{}/d {}".format(node, CSYNC2_CFG)):
         error("Removing the node {} from {} failed".format(node, CSYNC2_CFG))
 
     # Remove node from nodelist
@@ -2453,7 +2462,7 @@ def remove_self():
         stop_services(SERVICES_STOP_LIST)
         # remove all trace of cluster from this node
         # delete configuration files from the node to be removed
-        if not invoke('bash -c "rm -f {}"'.format(" ".join(_context.rm_list))):
+        if not invokerc('bash -c "rm -f {}"'.format(" ".join(_context.rm_list))):
             error("Deleting the configuration files failed")
 
 
@@ -2482,8 +2491,9 @@ def create_booth_authkey():
     status("Create authentication key for booth")
     if os.path.exists(BOOTH_AUTH):
         rmfile(BOOTH_AUTH)
-    if not invoke("booth-keygen {}".format(BOOTH_AUTH)):
-        error("Failed to generate booth authkey")
+    rc, _, err = invoke("booth-keygen {}".format(BOOTH_AUTH))
+    if not rc:
+        error("Failed to generate booth authkey: {}".format(err))
 
 
 def create_booth_config(arbitrator, clusters, tickets):
@@ -2546,8 +2556,9 @@ def geo_fetch_config(node):
     # TODO: clean this up
     status("Retrieving configuration - This may prompt for root@%s:" % (node))
     tmpdir = tmpfiles.create_dir()
-    if not invoke("scp -oStrictHostKeyChecking=no root@%s:'/etc/booth/*' %s/" % (node, tmpdir)):
-        error("Failed to retrieve configuration")
+    rc, _, err = invoke("scp -oStrictHostKeyChecking=no root@%s:'/etc/booth/*' %s/" % (node, tmpdir))
+    if not rc:
+        error("Failed to retrieve configuration: {}".format(err))
     try:
         if os.path.isfile("%s/authkey" % (tmpdir)):
             invoke("mv %s/authkey %s" % (tmpdir, BOOTH_AUTH))

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -238,7 +238,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     def test_initialize_sbd(self, mock_invoke, mock_error):
         self.sbd_inst._sbd_devices = ["/dev/sdb1", "/dev/sdc1"]
-        mock_invoke.side_effect = [True, False]
+        mock_invoke.side_effect = [(True, None, None), (False, None, "error")]
         mock_error.side_effect = ValueError
 
         with self.assertRaises(ValueError):
@@ -248,7 +248,7 @@ class TestSBDManager(unittest.TestCase):
             mock.call("sbd -d /dev/sdb1 create"),
             mock.call("sbd -d /dev/sdc1 create")
             ])
-        mock_error.assert_called_once_with("Failed to initialize SBD device /dev/sdc1")
+        mock_error.assert_called_once_with("Failed to initialize SBD device /dev/sdc1: error")
 
     @mock.patch('crmsh.bootstrap.csync2_update')
     @mock.patch('crmsh.utils.sysconfig_set')
@@ -339,7 +339,7 @@ class TestSBDManager(unittest.TestCase):
         mock_package.assert_called_once_with("sbd")
 
     @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
@@ -360,7 +360,7 @@ class TestSBDManager(unittest.TestCase):
         mock_error.assert_called_once_with("Can't create stonith-sbd primitive")
 
     @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
@@ -384,7 +384,7 @@ class TestSBDManager(unittest.TestCase):
         mock_error.assert_called_once_with("Can't enable STONITH for SBD")
 
     @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
@@ -423,21 +423,20 @@ class TestSBDManager(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
     @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_join_sbd_config_disabled(self, mock_package, mock_exists, mock_invoke, mock_check):
+    def test_join_sbd_config_disabled(self, mock_package, mock_exists, mock_invokerc, mock_invoke, mock_check):
         mock_package.return_value = True
         mock_exists.return_value = True
-        mock_invoke.side_effect = [False, True]
+        mock_invokerc.return_value = False
 
         self.sbd_inst.join_sbd("node1")
 
         mock_package.assert_called_once_with("sbd")
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invoke.assert_has_calls([
-                mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service"),
-                mock.call("systemctl disable sbd.service")
-            ])
+        mock_invokerc.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_invoke.assert_called_once_with("systemctl disable sbd.service")
         mock_check.assert_not_called()
 
     @mock.patch('crmsh.bootstrap.status')
@@ -445,22 +444,21 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
     @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_join_sbd(self, mock_package, mock_exists, mock_invoke, mock_check, mock_get_device, mock_verify, mock_status):
+    def test_join_sbd(self, mock_package, mock_exists, mock_invokerc, mock_invoke, mock_check, mock_get_device, mock_verify, mock_status):
         mock_package.return_value = True
         mock_exists.return_value = True
-        mock_invoke.side_effect = [True, True]
+        mock_invokerc.return_value = True
         mock_get_device.return_value = ["/dev/sdb1"]
 
         self.sbd_inst.join_sbd("node1")
 
         mock_package.assert_called_once_with("sbd")
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invoke.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service"),
-            mock.call("systemctl enable sbd.service")
-            ])
+        mock_invokerc.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
+        mock_invoke.assert_called_once_with("systemctl enable sbd.service")
         mock_check.assert_called_once_with()
         mock_get_device.assert_called_once_with()
         mock_verify.assert_called_once_with(["/dev/sdb1"])
@@ -536,13 +534,14 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     def test_append_to_remote_file(self, mock_invoke, mock_error):
-        mock_invoke.return_value = False
+        mock_invoke.return_value = (False, None, "error")
+        error_string = 'Failed to append contents of fromfile to node1:\n"error"\n\n    crmsh has no way to help you to setup up passwordless ssh among nodes at this time. \n    As the hint, likely, `PasswordAuthentication` is \'no\' in /etc/ssh/sshd_config. \n    Given in this case, users must setup passwordless ssh beforehand, or change it to \'yes\' and manage passwords properly\n    '
         bootstrap.append_to_remote_file("fromfile", "node1", "tofile")
         cmd = "cat fromfile | ssh -oStrictHostKeyChecking=no root@node1 'cat >> tofile'"
         mock_invoke.assert_called_once_with(cmd)
-        mock_error.assert_called_once_with("Failed to run \"{}\"".format(cmd))
+        mock_error.assert_called_once_with(error_string)
 
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     def test_fetch_public_key_from_remote_node_exception(self, mock_invoke):
         mock_invoke.side_effect = [False, False, False, False]
 
@@ -558,18 +557,18 @@ class TestBootstrap(unittest.TestCase):
             ])
 
     @mock.patch('crmsh.tmpfiles.create')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
-    def test_fetch_public_key_from_remote_node(self, mock_invoke, mock_tmpfile):
-        mock_invoke.side_effect = [True, True]
+    def test_fetch_public_key_from_remote_node(self, mock_invoke, mock_invokerc, mock_tmpfile):
+        mock_invokerc.return_value = True
+        mock_invoke.return_value = (True, None, None)
         mock_tmpfile.return_value = (0, "temp_file_name")
 
         res = bootstrap.fetch_public_key_from_remote_node("node1")
         self.assertEqual(res, "temp_file_name")
 
-        mock_invoke.assert_has_calls([
-            mock.call("ssh -oStrictHostKeyChecking=no root@node1 'test -f /root/.ssh/id_rsa.pub'"),
-            mock.call("scp -oStrictHostKeyChecking=no root@node1:/root/.ssh/id_rsa.pub temp_file_name")
-            ])
+        mock_invokerc.assert_called_once_with("ssh -oStrictHostKeyChecking=no root@node1 'test -f /root/.ssh/id_rsa.pub'")
+        mock_invoke.assert_called_once_with("scp -oStrictHostKeyChecking=no root@node1:/root/.ssh/id_rsa.pub temp_file_name")
         mock_tmpfile.assert_called_once_with()
 
     @mock.patch('crmsh.bootstrap.error')
@@ -586,7 +585,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.utils.start_service')
     def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_swap, mock_invoke, mock_error):
         bootstrap._context = mock.Mock(default_nic_list=["eth1"])
-        mock_invoke.return_value = False
+        mock_invoke.return_value = (False, None, "error")
 
         bootstrap.join_ssh("node1")
 
@@ -594,7 +593,7 @@ class TestBootstrap(unittest.TestCase):
         mock_config_ssh.assert_called_once_with()
         mock_swap.assert_called_once_with("node1")
         mock_invoke.assert_called_once_with("ssh root@node1 crm cluster init -i eth1 ssh_remote")
-        mock_error.assert_called_once_with("Can't invoke crm cluster init -i eth1 ssh_remote on node1")
+        mock_error.assert_called_once_with("Can't invoke crm cluster init -i eth1 ssh_remote on node1: error")
 
     @mock.patch('crmsh.bootstrap.warn')
     @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')
@@ -833,24 +832,26 @@ class TestBootstrap(unittest.TestCase):
         mock_stop_service.assert_not_called()
         mock_error.assert_not_called()
 
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
-    def test_csync2_update_no_conflicts(self, mock_invoke):
-        mock_invoke.side_effect = [True, True]
+    def test_csync2_update_no_conflicts(self, mock_invoke, mock_invokerc):
+        mock_invokerc.return_value = True
         bootstrap.csync2_update("/etc/corosync.conf")
-        mock_invoke.assert_has_calls([
-            mock.call("csync2 -rm /etc/corosync.conf"),
-            mock.call("csync2 -rxv /etc/corosync.conf")
-            ])
+        mock_invoke.assert_called_once_with("csync2 -rm /etc/corosync.conf")
+        mock_invokerc.assert_called_once_with("csync2 -rxv /etc/corosync.conf")
 
     @mock.patch('crmsh.bootstrap.warn')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
-    def test_csync2_update(self, mock_invoke, mock_warn):
-        mock_invoke.side_effect = [True, False, True, False]
+    def test_csync2_update(self, mock_invoke, mock_invokerc, mock_warn):
+        mock_invokerc.side_effect = [False, False]
         bootstrap.csync2_update("/etc/corosync.conf")
         mock_invoke.assert_has_calls([
             mock.call("csync2 -rm /etc/corosync.conf"),
+            mock.call("csync2 -rf /etc/corosync.conf")
+            ])
+        mock_invokerc.assert_has_calls([
             mock.call("csync2 -rxv /etc/corosync.conf"),
-            mock.call("csync2 -rf /etc/corosync.conf"),
             mock.call("csync2 -rxv /etc/corosync.conf")
             ])
         mock_warn.assert_called_once_with("/etc/corosync.conf was not synced")
@@ -884,7 +885,7 @@ class TestBootstrap(unittest.TestCase):
     def test_init_qdevice_copy_ssh_key_failed(self, mock_status, mock_ssh, mock_invoke, mock_error):
         bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
         mock_ssh.return_value = True
-        mock_invoke.return_value = False
+        mock_invoke.return_value = (False, None, "error")
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
@@ -896,7 +897,7 @@ class TestBootstrap(unittest.TestCase):
             ])
         mock_ssh.assert_called_once_with("10.10.10.123")
         mock_invoke.assert_called_once_with("ssh-copy-id -i /root/.ssh/id_rsa.pub root@10.10.10.123")
-        mock_error.assert_called_once_with("Failed to copy ssh key")
+        mock_error.assert_called_once_with("Failed to copy ssh key: error")
 
     @mock.patch('crmsh.bootstrap.start_qdevice_service')
     @mock.patch('crmsh.bootstrap.confirm')
@@ -1093,6 +1094,25 @@ class TestBootstrap(unittest.TestCase):
         mock_start_service.assert_called_once_with("corosync-qdevice.service", enable=True)
         mock_status_done.assert_called_once_with()
 
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.bootstrap.log')
+    def test_invoke(self, mock_log, mock_run):
+        mock_run.return_value = (0, "output", "error")
+        res = bootstrap.invoke("cmd --option")
+        self.assertEqual(res, (True, "output", "error"))
+        mock_log.assert_has_calls([
+            mock.call('+ cmd --option'),
+            mock.call('output'),
+            mock.call('error')
+            ])
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    def test_invokerc(self, mock_invoke):
+        mock_invoke.return_value = (True, None, None)
+        res = bootstrap.invokerc("cmd")
+        self.assertEqual(res, True)
+        mock_invoke.assert_called_once_with("cmd")
+
 
 class TestValidation(unittest.TestCase):
     """
@@ -1169,7 +1189,7 @@ class TestValidation(unittest.TestCase):
         bootstrap.Validation.valid_port("10.10.10.1")
         mock_port.assert_called_once_with()
 
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.utils.IP.is_ipv6')
     def test_valid_admin_ip_in_use(self, mock_ipv6, mock_invoke):
         mock_ipv6.return_value = False
@@ -1480,7 +1500,7 @@ class TestValidation(unittest.TestCase):
         mock_error.assert_called_once_with("Failed to remove this node from node2")
 
     @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.stop_services')
     @mock.patch('crmsh.xmlutil.listnodes')
     def test_remove_self_rm_failed(self, mock_list, mock_stop_service, mock_invoke, mock_error):
@@ -1543,7 +1563,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.stop_services')
     @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
     def test_remove_node_from_cluster_rm_failed(self, mock_get_ip, mock_stop, mock_invoke, mock_error):
-        mock_invoke.return_value = False
+        mock_invoke.return_value = (False, None, "error")
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
@@ -1553,15 +1573,17 @@ class TestValidation(unittest.TestCase):
         mock_get_ip.assert_called_once_with()
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
         mock_invoke.assert_called_once_with('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""')
-        mock_error.assert_called_once_with("Deleting the configuration files failed")
+        mock_error.assert_called_once_with("Deleting the configuration files failed: error")
 
     @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.stop_services')
     @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
-    def test_remove_node_from_cluster_rm_node_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_error):
-        mock_invoke.side_effect = [True, False]
+    def test_remove_node_from_cluster_rm_node_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_invokerc, mock_error):
+        mock_invoke.return_value = (True, None, None)
+        mock_invokerc.return_value = False
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
@@ -1571,19 +1593,19 @@ class TestValidation(unittest.TestCase):
         mock_get_ip.assert_called_once_with()
         mock_status.assert_called_once_with("Removing the node node1")
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
-        mock_invoke.assert_has_calls([
-            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
-            mock.call('crm node delete node1')
-            ])
+        mock_invoke.assert_called_once_with('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""')
+        mock_invokerc.assert_called_once_with("crm node delete node1")
         mock_error.assert_called_once_with("Failed to remove node1")
 
     @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.stop_services')
     @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
-    def test_remove_node_from_cluster_rm_csync_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_error):
-        mock_invoke.side_effect = [True, True, False]
+    def test_remove_node_from_cluster_rm_csync_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_invokerc, mock_error):
+        mock_invoke.return_value = (True, None, None)
+        mock_invokerc.side_effect = [True, False]
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
@@ -1593,8 +1615,8 @@ class TestValidation(unittest.TestCase):
         mock_get_ip.assert_called_once_with()
         mock_status.assert_called_once_with("Removing the node node1")
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
-        mock_invoke.assert_has_calls([
-            mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
+        mock_invoke.assert_called_once_with('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""')
+        mock_invokerc.assert_has_calls([
             mock.call('crm node delete node1'),
             mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
             ])
@@ -1605,13 +1627,15 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.corosync.del_node')
     @mock.patch('crmsh.corosync.get_values')
     @mock.patch('crmsh.bootstrap.error')
+    @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.stop_services')
     @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
     def test_remove_node_from_cluster_hostname(self, mock_get_ip, mock_stop, mock_status,
-            mock_invoke, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2):
-        mock_invoke.side_effect = [True, True, True, True]
+            mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2):
+        mock_invoke.side_effect = [(True, None, None), (True, None, None)]
+        mock_invokerc.side_effect = [True, True]
         mock_get_values.return_value = ["10.10.10.1"]
 
         bootstrap._context = mock.Mock(cluster_node="node1", cluster_node_ip=None, rm_list=["file1", "file2"])
@@ -1625,9 +1649,11 @@ class TestValidation(unittest.TestCase):
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
         mock_invoke.assert_has_calls([
             mock.call('ssh -o StrictHostKeyChecking=no root@node1 "bash -c \\"rm -f file1 file2\\""'),
-            mock.call('crm node delete node1'),
-            mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG)),
             mock.call("corosync-cfgtool -R")
+            ])
+        mock_invokerc.assert_has_calls([
+            mock.call('crm node delete node1'),
+            mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
             ])
         mock_error.assert_not_called()
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")


### PR DESCRIPTION
## Problem
When meeting error on bootstrap process, error message might make user confused like:
```Shell
# crm cluster join -c crmsh15sp2-1
WARNING: No watchdog device found. If SBD is used, the cluster will be unable to start without a watchdog.
Do you want to continue anyway (y/n)? y
WARNING: Failed to detect firewall: Could not open ports tcp=30865|5560|7630|21064, udp=
  Generating SSH key
  Configuring SSH passwordless with root@crmsh15sp2-1
ERROR: cluster.join: Failed to run "cat /root/.ssh/id_rsa.pub | ssh -oStrictHostKeyChecking=no root@crmsh15sp2-1 'cat >> /root/.ssh/authorized_keys'"
```
User cannot find reason why this command failed

## Solution
In bootstrap.py, `invoke` was commonly used, it record log about what has executed, the stdout and the stderr after running command.

I change the return code of `invoke` function, return `(boolean, stdout, stderr)` tuple, print `stderr` when necessary.

Also for the important place like first ssh command in join process when swapping ssh key with init node, ssh might failed in **Azure** environment, so here I give more details, like:
```Shell
# crm cluster join -c crmsh15sp2-1 -y
WARNING: No watchdog device found. If SBD is used, the cluster will be unable to start without a watchdog.
WARNING: Failed to detect firewall: Could not open ports tcp=30865|5560|7630|21064, udp=
  Configuring SSH passwordless with root@crmsh15sp2-1
ERROR: cluster.join: Failed to append contents of /root/.ssh/id_rsa.pub to crmsh15sp2-1: root@crmsh15sp2-1: Permission denied (publickey).

    crmsh has no way to help you to setup up passwordless ssh among nodes at this time. 
    As the hint, likely, `PasswordAuthentication` is 'no' in /etc/ssh/sshd_config. 
    Given in this case, users must setup passwordless ssh beforehand, or change it to 'yes' and manage passwords properly
```

Besides that, for those place might only need return code of invoke, I changed the function `invokerc`, wrapped `invoke`, just return True/False