### PR TITLE
Fix: bootstrap: make sure sbd device UUID was the same between nodes

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -201,7 +201,36 @@ Configure SBD:
         return result_list
 
     @staticmethod
-    def _verify_sbd_device(dev_list):
+    def _get_device_uuid(dev, node=None):
+        """
+        Get UUID for specific device and node
+        """
+        cmd = "sbd -d {} dump".format(dev)
+        if node:
+            cmd = "ssh -o StrictHostKeyChecking=no root@{} '{}'".format(node, cmd)
+
+        rc, out, err = utils.get_stdout_stderr(cmd)
+        if rc != 0 and err:
+            raise ValueError("Cannot dump sbd meta-data: {}".format(err))
+        if rc == 0 and out:
+            res = re.search("UUID\s*:\s*(.*)\n", out)
+            if not res:
+                raise ValueError("Cannot find sbd device UUID for {}".format(dev))
+            return res.group(1)
+
+    def _compare_device_uuid(self, dev, node_list):
+        """
+        Compare local sbd device UUID with other node's sbd device UUID
+        """
+        if not node_list:
+            return
+        local_uuid = self._get_device_uuid(dev)
+        for node in node_list:
+            remote_uuid = self._get_device_uuid(dev, node)
+            if local_uuid != remote_uuid:
+                raise ValueError("Device {} doesn't have the same UUID with {}".format(dev, node))
+
+    def _verify_sbd_device(self, dev_list, compare_node_list=[]):
         """
         Verify sbd device
         """
@@ -210,6 +239,7 @@ Configure SBD:
         for dev in dev_list:
             if not is_block_device(dev):
                 raise ValueError("{} doesn't look like a block device".format(dev))
+            self._compare_device_uuid(dev, compare_node_list)
 
     def _get_sbd_device_interactive(self):
         """
@@ -353,16 +383,27 @@ Configure SBD:
         """
         if not utils.package_is_installed("sbd"):
             return
-        cmd_detect_enabled = "ssh -o StrictHostKeyChecking=no root@{} systemctl is-enabled sbd.service".format(peer_host)
-        if not os.path.exists(SYSCONFIG_SBD) or not invokerc(cmd_detect_enabled):
+        if not os.path.exists(SYSCONFIG_SBD) or not utils.service_is_enabled("sbd.service", peer_host):
             invoke("systemctl disable sbd.service")
             return
         self._check_environment()
         dev_list = self._get_sbd_device_from_config()
         if dev_list:
-            self._verify_sbd_device(dev_list)
+            self._verify_sbd_device(dev_list, [peer_host])
         status("Got {}SBD configuration".format("" if dev_list else "diskless "))
         invoke("systemctl enable sbd.service")
+
+    @classmethod
+    def verify_sbd_device(cls):
+        """
+        This classmethod is for verifying sbd device on a running cluster
+        Raise ValueError for exceptions
+        """
+        inst = cls()
+        dev_list = inst._get_sbd_device_from_config()
+        if not dev_list:
+            raise ValueError("No sbd device configured")
+        inst._verify_sbd_device(dev_list, utils.list_cluster_nodes_except_me())
 
 
 _context = None

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -201,8 +201,9 @@ class TestSBDManager(unittest.TestCase):
             self.sbd_inst_devices_gt_3._verify_sbd_device(dev_list)
         self.assertEqual("Maximum number of SBD device is 3", str(err.exception))
 
+    @mock.patch('crmsh.bootstrap.SBDManager._compare_device_uuid')
     @mock.patch('crmsh.bootstrap.is_block_device')
-    def test_verify_sbd_device_not_block(self, mock_block_device):
+    def test_verify_sbd_device_not_block(self, mock_block_device, mock_compare):
         assert self.sbd_inst.sbd_devices_input == ["/dev/sdb1", "/dev/sdc1"]
         dev_list = self.sbd_inst.sbd_devices_input
         mock_block_device.side_effect = [True, False]
@@ -212,6 +213,7 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("/dev/sdc1 doesn't look like a block device", str(err.exception))
 
         mock_block_device.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdc1")])
+        mock_compare.assert_called_once_with("/dev/sdb1", [])
 
     @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
     @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
@@ -423,20 +425,20 @@ class TestSBDManager(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
     @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.bootstrap.invokerc')
+    @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_join_sbd_config_disabled(self, mock_package, mock_exists, mock_invokerc, mock_invoke, mock_check):
+    def test_join_sbd_config_disabled(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_check):
         mock_package.return_value = True
         mock_exists.return_value = True
-        mock_invokerc.return_value = False
+        mock_enabled.return_value = False
 
         self.sbd_inst.join_sbd("node1")
 
         mock_package.assert_called_once_with("sbd")
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invokerc.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
         mock_invoke.assert_called_once_with("systemctl disable sbd.service")
+        mock_enabled.assert_called_once_with("sbd.service", "node1")
         mock_check.assert_not_called()
 
     @mock.patch('crmsh.bootstrap.status')
@@ -444,25 +446,91 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.bootstrap.SBDManager._check_environment')
     @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.bootstrap.invokerc')
+    @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_join_sbd(self, mock_package, mock_exists, mock_invokerc, mock_invoke, mock_check, mock_get_device, mock_verify, mock_status):
+    def test_join_sbd(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_check, mock_get_device, mock_verify, mock_status):
         mock_package.return_value = True
         mock_exists.return_value = True
-        mock_invokerc.return_value = True
+        mock_enabled.return_value = True
         mock_get_device.return_value = ["/dev/sdb1"]
 
         self.sbd_inst.join_sbd("node1")
 
         mock_package.assert_called_once_with("sbd")
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
-        mock_invokerc.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl is-enabled sbd.service")
         mock_invoke.assert_called_once_with("systemctl enable sbd.service")
         mock_check.assert_called_once_with()
         mock_get_device.assert_called_once_with()
-        mock_verify.assert_called_once_with(["/dev/sdb1"])
+        mock_verify.assert_called_once_with(["/dev/sdb1"], ["node1"])
+        mock_enabled.assert_called_once_with("sbd.service", "node1")
         mock_status.assert_called_once_with("Got SBD configuration")
+
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    def test_verify_sbd_device_classmethod_exception(self, mock_get_config):
+        mock_get_config.return_value = []
+        with self.assertRaises(ValueError) as err:
+            bootstrap.SBDManager.verify_sbd_device()
+        self.assertEqual("No sbd device configured", str(err.exception))
+        mock_get_config.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
+    @mock.patch('crmsh.utils.list_cluster_nodes_except_me')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    def test_verify_sbd_device_classmethod(self, mock_get_config, mock_list_nodes, mock_verify):
+        mock_get_config.return_value = ["/dev/sda1"]
+        mock_list_nodes.return_value = ["node1"]
+        bootstrap.SBDManager.verify_sbd_device()
+        mock_get_config.assert_called_once_with()
+        mock_verify.assert_called_once_with(["/dev/sda1"], ["node1"])
+
+    @mock.patch('crmsh.bootstrap.SBDManager._get_device_uuid')
+    def test_compare_device_uuid_return(self, mock_get_uuid):
+        self.sbd_inst._compare_device_uuid("/dev/sdb1", None)
+        mock_get_uuid.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.SBDManager._get_device_uuid')
+    def test_compare_device_uuid(self, mock_get_uuid):
+        mock_get_uuid.side_effect = ["1234", "5678"]
+        with self.assertRaises(ValueError) as err:
+            self.sbd_inst._compare_device_uuid("/dev/sdb1", ["node1"])
+        self.assertEqual("Device /dev/sdb1 doesn't have the same UUID with node1", str(err.exception))
+        mock_get_uuid.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdb1", "node1")])
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_device_uuid_error_dump(self, mock_run):
+        mock_run.return_value = (1, None, "error data")
+        with self.assertRaises(ValueError) as err:
+            self.sbd_inst._get_device_uuid("/dev/sdb1")
+        self.assertEqual("Cannot dump sbd meta-data: error data", str(err.exception))
+        mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump")
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_device_uuid_not_match(self, mock_run):
+        mock_run.return_value = (0, "output data", None)
+        with self.assertRaises(ValueError) as err:
+            self.sbd_inst._get_device_uuid("/dev/sdb1")
+        self.assertEqual("Cannot find sbd device UUID for /dev/sdb1", str(err.exception))
+        mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump")
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_device_uuid(self, mock_run):
+        output = """
+        ==Dumping header on disk /dev/sda1
+        Header version     : 2.1
+        UUID               : a2e9a92c-cc72-4ef9-ac55-ccc342f3546b
+        Number of slots    : 255
+        Sector size        : 512
+        Timeout (watchdog) : 5
+        Timeout (allocate) : 2
+        Timeout (loop)     : 1
+        Timeout (msgwait)  : 10
+        ==Header on disk /dev/sda1 is dumped
+        """
+        mock_run.return_value = (0, output, None)
+        res = self.sbd_inst._get_device_uuid("/dev/sda1")
+        self.assertEqual(res, "a2e9a92c-cc72-4ef9-ac55-ccc342f3546b")
+        mock_run.assert_called_once_with("sbd -d /dev/sda1 dump")
 
 
 class TestBootstrap(unittest.TestCase):


### PR DESCRIPTION
## Problem
SBD devices might have the same name but different UUID between cluster nodes, that might lead to stonith action failed

## Solution

- During join process, for each configured sbd device, compare local UUID with UUID on init node
- For outer tools (like preflight check) want to verify sbd device on an existing cluster, calling `bootstrap.SBDManager.verify_sbd_device`, will raise `ValueError` when having this problem

@arbulu89 @gao-yan @zzhou1 Any suggestions?
Thanks!