### PR TITLE
Low: bootstrap: check cluster was running on init node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1935,12 +1935,6 @@ def setup_passwordless_with_other_nodes(init_node):
 
     Should fetch the node list from init node, then swap the key
     """
-    # Check whether pacemaker.service is active on init node
-    cmd = "ssh -o StrictHostKeyChecking=no root@{} systemctl -q is-active {}".format(init_node, "pacemaker.service")
-    rc, _, _ = utils.get_stdout_stderr(cmd)
-    if rc != 0:
-        error("Cluster is inactive on {}".format(init_node))
-
     # Fetch cluster nodes list
     cmd = "ssh -o StrictHostKeyChecking=no root@{} crm_node -l".format(init_node)
     rc, out, err = utils.get_stdout_stderr(cmd)
@@ -2337,6 +2331,9 @@ def bootstrap_join(context):
             _context.cluster_node = cluster_node
 
         join_ssh(cluster_node)
+
+        if not utils.service_is_active("pacemaker.service", cluster_node):
+            error("Cluster is inactive on {}".format(cluster_node))
 
         lock_inst = join_lock.JoinLock(cluster_node)
         with lock_inst.lock():

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -628,29 +628,14 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_setup_passwordless_with_other_nodes_cluster_inactive(self, mock_run, mock_error):
+    def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
         mock_run.return_value = (1, None, None)
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
-        mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service")
-        mock_error.assert_called_once_with("Cluster is inactive on node1")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
-        mock_run.side_effect = [(0, None, None), (1, None, None)]
-        mock_error.side_effect = SystemExit
-
-        with self.assertRaises(SystemExit):
-            bootstrap.setup_passwordless_with_other_nodes("node1")
-
-        mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l")
-            ])
+        mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l")
         mock_error.assert_called_once_with("Can't fetch cluster nodes list from node1: None")
 
     @mock.patch('crmsh.bootstrap.error')
@@ -659,7 +644,6 @@ class TestBootstrap(unittest.TestCase):
         out_node_list = """1 node1 member
         2 node2 member"""
         mock_run.side_effect = [
-                (0, None, None),
                 (0, out_node_list, None),
                 (1, None, None)
                 ]
@@ -669,7 +653,6 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 hostname")
             ])
@@ -681,7 +664,6 @@ class TestBootstrap(unittest.TestCase):
         out_node_list = """1 node1 member
         2 node2 member"""
         mock_run.side_effect = [
-                (0, None, None),
                 (0, out_node_list, None),
                 (0, "node1", None)
                 ]
@@ -689,7 +671,6 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 hostname")
             ])


### PR DESCRIPTION
I make this PR based on these thinking:
- Detecting whether init node has cluster service running, on logical side, shouldn't be the task inside `setup_passwordless_with_other_nodes` function
- Instead, we should do this detecting job just after finishing `join_ssh`, that is, detect after finishing swapping the ssh key with the init node
- Considering the `init lock` I mentioned yesterday, if on init process we create `/tmp/.crmsh_join_lock_directory`, join node will wait. But I don't want to use this `init lock` to protect unready init node, instead, just to protect extra qdevice setup process. 

@arbulu89 , what do you think?