### PR TITLE
[crmsh-3.0] Low: bootstrap: check cluster was running on init node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1698,12 +1698,6 @@ def setup_passwordless_with_other_nodes(init_node):
 
     Should fetch the node list from init node, then swap the key
     """
-    # Check whether pacemaker.service is active on init node
-    cmd = "ssh -o StrictHostKeyChecking=no root@{} systemctl -q is-active {}".format(init_node, "pacemaker.service")
-    rc, _, _ = utils.get_stdout_stderr(cmd)
-    if rc != 0:
-        error("Cluster is inactive on {}".format(init_node))
-
     # Fetch cluster nodes list
     cmd = "ssh -o StrictHostKeyChecking=no root@{} crm_node -l".format(init_node)
     rc, out, err = utils.get_stdout_stderr(cmd)
@@ -2083,6 +2077,9 @@ def bootstrap_join(context):
             _context.cluster_node = cluster_node
 
         join_ssh(cluster_node)
+
+        if not utils.service_is_active("pacemaker.service", cluster_node):
+            error("Cluster is inactive on {}".format(cluster_node))
 
         lock_inst = join_lock.JoinLock(cluster_node)
         with lock_inst.lock():

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -609,29 +609,14 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_setup_passwordless_with_other_nodes_cluster_inactive(self, mock_run, mock_error):
+    def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
         mock_run.return_value = (1, None, None)
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
-        mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service")
-        mock_error.assert_called_once_with("Cluster is inactive on node1")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
-        mock_run.side_effect = [(0, None, None), (1, None, None)]
-        mock_error.side_effect = SystemExit
-
-        with self.assertRaises(SystemExit):
-            bootstrap.setup_passwordless_with_other_nodes("node1")
-
-        mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l")
-            ])
+        mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l")
         mock_error.assert_called_once_with("Can't fetch cluster nodes list from node1: None")
 
     @mock.patch('crmsh.bootstrap.error')
@@ -640,7 +625,6 @@ class TestBootstrap(unittest.TestCase):
         out_node_list = """1 node1 member
         2 node2 member"""
         mock_run.side_effect = [
-                (0, None, None),
                 (0, out_node_list, None),
                 (1, None, None)
                 ]
@@ -650,7 +634,6 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 hostname")
             ])
@@ -662,7 +645,6 @@ class TestBootstrap(unittest.TestCase):
         out_node_list = """1 node1 member
         2 node2 member"""
         mock_run.side_effect = [
-                (0, None, None),
                 (0, out_node_list, None),
                 (0, "node1", None)
                 ]
@@ -670,7 +652,6 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call("ssh -o StrictHostKeyChecking=no root@node1 systemctl -q is-active pacemaker.service"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 hostname")
             ])


### PR DESCRIPTION
backport #688 