### PR TITLE
Dev: test: add timeout-minutes to each test job

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   unit_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -38,6 +39,7 @@ jobs:
 
   functional_test_hb_report_bugs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for hb_report
@@ -47,6 +49,7 @@ jobs:
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for bootstrap bugs
@@ -56,6 +59,7 @@ jobs:
 
   functional_test_bootstrap_common:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for bootstrap common
@@ -65,6 +69,7 @@ jobs:
 
   functional_test_bootstrap_options:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for bootstrap options
@@ -74,6 +79,7 @@ jobs:
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for qdevice setup and remove
@@ -83,6 +89,7 @@ jobs:
 
   functional_test_qdevice_options:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for qdevice options
@@ -92,6 +99,7 @@ jobs:
 
   functional_test_qdevice_validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for qdevice validate
@@ -101,6 +109,7 @@ jobs:
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for qdevice user case
@@ -110,6 +119,7 @@ jobs:
 
   functional_test_resource_subcommand:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for resource subcommand
@@ -119,6 +129,7 @@ jobs:
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for configure sublevel bugs
@@ -128,6 +139,7 @@ jobs:
 
   functional_test_constraints_bugs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for constraints bugs
@@ -137,6 +149,7 @@ jobs:
 
   functional_test_geo_cluster:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: functional test for geo cluster
@@ -146,6 +159,7 @@ jobs:
 
   original_regression_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: original regression test
@@ -169,6 +183,7 @@ jobs:
       functional_test_geo_cluster,
       original_regression_test]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - name: delivery process
@@ -187,6 +202,7 @@ jobs:
   submit:
     needs: delivery
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - name: submit process


### PR DESCRIPTION
Default is 360m, see https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes