### PR TITLE
Fix: utils: skip if no netmask in the result of ip -o addr show

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2330,6 +2330,9 @@ class InterfacesInfo(object):
         # 2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0\       valid_lft forever preferred_lft forever
         for line in out.splitlines():
             _, nic, _, ip_with_mask, *_ = line.split()
+            # maybe from tun interface
+            if not '/' in ip_with_mask:
+                continue
             #TODO change this condition when corosync support link-local address
             interface_inst = Interface(ip_with_mask)
             if interface_inst.is_loopback or interface_inst.is_link_local:

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -855,7 +855,8 @@ class TestInterfacesInfo(unittest.TestCase):
     """
 
     network_output_error = """1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
-2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0"""
+2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0
+61: tun0    inet 10.163.45.46 peer 10.163.45.45/32 scope global tun0"""
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Problem
When tun interface(like when using openvpn) was available, the format of output `ip -4 -o addr show` might not consistent as:
```
4: br1    inet 10.10.10.10/24 brd 10.10.10.255 scope global noprefixroute br1\       valid_lft forever preferred_lft forever
5: br2    inet 20.20.20.20/24 brd 20.20.20.255 scope global noprefixroute br2\       valid_lft forever preferred_lft forever
6: virbr0    inet 192.168.122.1/24 brd 192.168.122.255 scope global virbr0\       valid_lft forever preferred_lft forever
61: tun0    inet 10.163.45.46 peer 10.163.45.45/32 scope global tun0\       valid_lft forever preferred_lft forever
```
Will cause init process failed with error `ERROR: cluster.init: not enough values to unpack (expected 2, got 1)`
## Solution
Drop the interface item when detecting without netmask
