### PR TITLE
[crmsh-3.0] Fix: utils: skip if no netmask in the result of ip -o addr show

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2143,6 +2143,9 @@ class InterfacesInfo(object):
         for line in out.splitlines():
             data = line.split()
             nic, ip_with_mask = data[1], data[3]
+            # maybe from tun interface
+            if not '/' in ip_with_mask:
+                continue
             #TODO change this condition when corosync support link-local address
             interface_inst = Interface(ip_with_mask)
             if interface_inst.is_loopback or interface_inst.is_link_local:

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -558,7 +558,8 @@ class TestInterfacesInfo(unittest.TestCase):
     """
 
     network_output_error = """1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
-2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0"""
+2: enp1s0    inet 192.168.122.241/24 brd 192.168.122.255 scope global enp1s0
+61: tun0    inet 10.163.45.46 peer 10.163.45.45/32 scope global tun0"""
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
backport #715 