### PR TITLE
[crmsh-3.0] Dev: corosync: change the permission of corosync.conf to 644

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -649,3 +649,4 @@ def create_configuration(clustername="hacluster",
                               _COROSYNC_CONF_TEMPLATE_RING_ALL + \
                               _COROSYNC_CONF_TEMPLATE_TAIL
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config_common, conf())
+    os.chmod(conf(), 0o644)


### PR DESCRIPTION
backport #726 