### PR TITLE
Fix: hb_report: run lsof with specific ocfs2 device

### DIFF
--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -1643,12 +1643,30 @@ def dump_D_process():
     return out_string
 
 
+def lsof_ocfs2_device():
+    """
+    List open files for OCFS2 device
+    """
+    out_string = ""
+    _, out, _ = crmutils.get_stdout_stderr("mount")
+    dev_list = re.findall("\n(.*) on .* type ocfs2 ", out)
+    for dev in dev_list:
+        cmd = "lsof {}".format(dev)
+        out_string += "\n\n#=====[ Command ] ==========================#\n"
+        out_string += "# {}\n".format(cmd)
+        _, cmd_out, _ = crmutils.get_stdout_stderr(cmd)
+        if cmd_out:
+            out_string += cmd_out
+    return out_string
+
+
 def dump_ocfs2():
     ocfs2_f = os.path.join(constants.WORKDIR, constants.OCFS2_F)
     with open(ocfs2_f, "w") as f:
         f.write(dump_D_process())
+        f.write(lsof_ocfs2_device())
 
-        cmds = [ "dmesg",  "ps -efL", "lsof",
+        cmds = [ "dmesg",  "ps -efL",
                 "lsblk -o 'NAME,KNAME,MAJ:MIN,FSTYPE,LABEL,RO,RM,MODEL,SIZE,OWNER,GROUP,MODE,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,ROTA,SCHED,MOUNTPOINT'",
                 "mounted.ocfs2 -f", "findmnt", "mount",
                 "cat /sys/fs/ocfs2/cluster_stack"

--- a/test/unittests/test_report.py
+++ b/test/unittests/test_report.py
@@ -357,6 +357,20 @@ def test_dump_D_process(mock_get_stdout_stderr):
         mock.call("cat /proc/10002/stack")
         ])
 
+
+@mock.patch('crmsh.utils.get_stdout_stderr')
+def test_lsof_ocfs2_device(mock_run):
+    output = "\n/dev/sdb1 on /data type ocfs2 (rw,relatime,heartbeat=none)"
+    output_lsof = "lsof data"
+    mock_run.side_effect = [(0, output, None), (0, output_lsof, None)]
+    expected = "\n\n#=====[ Command ] ==========================#\n# lsof /dev/sdb1\nlsof data"
+    assert hb_report.utillib.lsof_ocfs2_device() == expected
+    mock_run.assert_has_calls([
+        mock.call("mount"),
+        mock.call("lsof /dev/sdb1")
+        ])
+
+
 @mock.patch('hb_report.utillib.constants')
 def test_sub_sensitive_string(mock_const):
     data = """


### PR DESCRIPTION
## Problem
During dumping ocfs2 info in hb_report, running `lsof` directly might hanging for a long time,  and the most of output might have no related with ocfs2

## Solution
Run `lsof` with specific ocfs2 device

Test rpm link: https://build.opensuse.org/package/show/home:XinLiang:branches:crmsh_testing3/crmsh