### PR TITLE
Feature asr unit test cases and minor bug fix

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -7,7 +7,19 @@ Holds user-configurable options.
 import os
 import re
 import configparser
+from contextlib import contextmanager
 from . import userdir
+
+
+@contextmanager
+def _disable_exception_traceback():
+    """
+    All traceback information is suppressed and only the exception type and value are printed
+    """
+    default_value = getattr(sys, "tracebacklimit", 1000)  # `1000` is a Python's default value
+    sys.tracebacklimit = 0
+    yield
+    sys.tracebacklimit = default_value  # revert changes
 
 
 def configure_libdir():
@@ -310,11 +322,10 @@ class _Configuration(object):
         """
         Try to handle configparser.MissingSectionHeaderError while reading
         """
-        from . import utils
         try:
             config_parser_inst.read(file_list)
         except configparser.MissingSectionHeaderError:
-            with utils.disable_exception_traceback():
+            with _disable_exception_traceback():
                 raise
 
     def load(self):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2625,17 +2625,6 @@ def package_is_installed(pkg, remote_addr=None):
     return rc == 0
 
 
-@contextmanager
-def disable_exception_traceback():
-    """
-    All traceback information is suppressed and only the exception type and value are printed
-    """
-    default_value = getattr(sys, "tracebacklimit", 1000)  # `1000` is a Python's default value
-    sys.tracebacklimit = 0
-    yield
-    sys.tracebacklimit = default_value  # revert changes
-
-
 def ping_node(node):
     """
     Check if the remote node is reachable

--- a/preflight_check/check.py
+++ b/preflight_check/check.py
@@ -34,14 +34,14 @@ def check_sbd():
     with task_inst.run():
 
         if not os.path.exists(config.SBD_CONF):
-            utils.msg_info("SBD configuration file {} not found.".
+            task_inst.info("SBD configuration file {} not found.".
                            format(config.SBD_CONF))
             return ""
 
         sbd_options = crmshutils.parse_sysconfig(config.SBD_CONF)
 
         if not "SBD_DEVICE" in sbd_options:
-            utils.msg_info("SBD DEVICE not used.")
+            task_inst.info("SBD DEVICE not used.")
             return ""
 
         dev = sbd_options["SBD_DEVICE"]

--- a/preflight_check/task.py
+++ b/preflight_check/task.py
@@ -594,7 +594,7 @@ New SBD device:      {}
 '''.format(self.description, self.old, self.new)
         return h
 
-    def to_json(self): # pragma: no cover
+    def to_json(self):
         """
         Generate json output
         """

--- a/preflight_check/task.py
+++ b/preflight_check/task.py
@@ -576,8 +576,8 @@ class TaskFixSBD(Task):
         self.description = "Replace SBD_DEVICE with candidate {}".format(self.new)
         self.conf = config.SBD_CONF
         super(self.__class__, self).__init__(self.description, flush=True)
-        self.bak = tempfile.mktemp()
-        self.edit = tempfile.mktemp()
+        self.bak = tempfile.mkstemp()[1]
+        self.edit = tempfile.mkstemp()[1]
         self.yes = yes
 
         sbd_options = crmshutils.parse_sysconfig(self.conf)

--- a/test/unittests/test_preflight_check.py
+++ b/test/unittests/test_preflight_check.py
@@ -714,7 +714,7 @@ Active Resources:
     @classmethod
     @mock.patch('builtins.open')
     @mock.patch('preflight_check.task.TaskFixSBD.verify')
-    @mock.patch('tempfile.mktemp')
+    @mock.patch('tempfile.mkstemp')
     @mock.patch('os.remove')
     @mock.patch('shutil.move')
     @mock.patch('shutil.copymode')
@@ -726,7 +726,7 @@ Active Resources:
     def test_correct_sbd(cls, mock_context, mock_os_path_exists,
                          mock_utils_parse_sysconf, mock_msg_info, mock_copyfile,
                          mock_copymode, mock_move, mock_remove,
-                         mock_mktemp, mock_sbd_verify, mock_open):
+                         mock_mkstemp, mock_sbd_verify, mock_open):
         """
         Test correct_sbd
         """
@@ -740,7 +740,7 @@ Active Resources:
             mock.mock_open(read_data="data1").return_value,
             mock.mock_open(read_data="SBD_DEVICE={}".format(dev)).return_value
         ]
-        mock_mktemp.side_effect = [bak, edit]
+        mock_mkstemp.side_effect = [(1, bak), (2, edit)]
 
         check.correct_sbd(mock_context, dev)
 
@@ -756,7 +756,7 @@ Active Resources:
     @mock.patch('sys.exit')
     @mock.patch('builtins.open')
     @mock.patch('preflight_check.task.Task.error')
-    @mock.patch('tempfile.mktemp')
+    @mock.patch('tempfile.mkstemp')
     @mock.patch('shutil.copymode')
     @mock.patch('shutil.copyfile')
     @mock.patch('preflight_check.utils.msg_info')
@@ -765,7 +765,7 @@ Active Resources:
     @mock.patch('preflight_check.main.Context')
     def test_correct_sbd_run_exception(cls, mock_context, mock_os_path_exists,
                                        mock_utils_parse_sysconf, mock_msg_info, mock_copyfile,
-                                       mock_copymode, mock_mktemp, mock_msg_error,
+                                       mock_copymode, mock_mkstemp, mock_msg_error,
                                        mock_open, mock_exit):
         """
         Test correct_sbd
@@ -780,7 +780,7 @@ Active Resources:
             mock.mock_open(read_data="data1").return_value,
             mock.mock_open(read_data="data2").return_value
         ]
-        mock_mktemp.side_effect = [bak, edit]
+        mock_mkstemp.side_effect = [(1, bak), (2, edit)]
         mock_copymode.side_effect = Exception('Copy file error!')
 
         check.correct_sbd(mock_context, dev)

--- a/test/unittests/test_preflight_check.py
+++ b/test/unittests/test_preflight_check.py
@@ -1,17 +1,16 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-import unittest
 try:
-    from unittest import mock
+    from unittest import mock, TestCase
 except ImportError:
     import mock
 
-from preflight_check import check
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+from preflight_check import check, config
 
 
-class TestCheck(unittest.TestCase):
+class TestCheck(TestCase):
 
     @mock.patch('preflight_check.check.check_cluster')
     def test_check(self, mock_cluster_check):
@@ -134,7 +133,7 @@ class TestCheck(unittest.TestCase):
 
         mock_corosync_port.assert_called_once_with()
         task_inst.error.assert_called_once_with("Can not get corosync's port")
-    
+
     @mock.patch('preflight_check.check.crmshutils.get_stdout_stderr')
     @mock.patch('preflight_check.utils.corosync_port_list')
     def test_check_port_open(self, mock_corosync_port, mock_run):
@@ -188,7 +187,7 @@ class TestCheck(unittest.TestCase):
         mock_installed.assert_called_once_with("firewalld")
         mock_task_inst.info.assert_called_once_with("firewalld.service is available")
         mock_task_inst.warn.assert_called_once_with("firewalld.service is not active")
-    
+
     @mock.patch('preflight_check.check.check_port_open')
     @mock.patch('preflight_check.check.crmshutils.service_is_active')
     @mock.patch('preflight_check.check.crmshutils.package_is_installed')

--- a/test/unittests/test_preflight_main.py
+++ b/test/unittests/test_preflight_main.py
@@ -1,24 +1,23 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-import unittest
 try:
-    from unittest import mock
+    from unittest import mock, TestCase
 except ImportError:
     import mock
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 from preflight_check import utils, main, config, task
 
 
-class TestContext(unittest.TestCase):
+class TestContext(TestCase):
 
     def test_context(self):
         main.ctx.name = "xin"
         self.assertEqual(main.ctx.name, "xin")
 
 
-class TestMain(unittest.TestCase):
+class TestMain(TestCase):
 
     @mock.patch('sys.exit')
     @mock.patch('preflight_check.main.MyArgParseFormatter')
@@ -26,8 +25,8 @@ class TestMain(unittest.TestCase):
     def test_parse_argument_help(self, mock_parser, mock_myformatter, mock_exit):
         mock_parser_inst = mock.Mock()
         mock_parser.return_value = mock_parser_inst
-        ctx = mock.Mock(process_name="preflight_check", logfile="logfile1", jsonfile="jsonfile1",
-                report_path="/var/log/report")
+        ctx = mock.Mock(process_name="preflight_check", logfile="logfile1",
+                        jsonfile="jsonfile1", report_path="/var/log/report")
         mock_parse_args_inst = mock.Mock(help=True)
         mock_parser_inst.parse_args.return_value = mock_parse_args_inst
         mock_exit.side_effect = SystemExit
@@ -43,8 +42,8 @@ class TestMain(unittest.TestCase):
     def test_parse_argument(self, mock_parser, mock_myformatter):
         mock_parser_inst = mock.Mock()
         mock_parser.return_value = mock_parser_inst
-        ctx = mock.Mock(process_name="preflight_check", logfile="logfile1", jsonfile="jsonfile1",
-                report_path="/var/log/report")
+        ctx = mock.Mock(process_name="preflight_check", logfile="logfile1",
+                        jsonfile="jsonfile1", report_path="/var/log/report")
         mock_parse_args_inst = mock.Mock(help=False, env_check=True, sbd=True)
         mock_parser_inst.parse_args.return_value = mock_parse_args_inst
 
@@ -99,7 +98,7 @@ class TestMain(unittest.TestCase):
     @mock.patch('preflight_check.main.parse_argument')
     @mock.patch('preflight_check.main.setup_basic_context')
     def test_run(self, mock_setup, mock_parse, mock_is_root, mock_exists, mock_mkdir,
-            mock_setup_logging, mock_fix, mock_check, mock_kill, mock_fence, mock_sb):
+                 mock_setup_logging, mock_fix, mock_check, mock_kill, mock_fence, mock_sb):
         mock_is_root.return_value = True
         ctx = mock.Mock(var_dir="/var/lib/preflight_check")
         mock_exists.return_value = False
@@ -128,7 +127,7 @@ class TestMain(unittest.TestCase):
     @mock.patch('preflight_check.main.parse_argument')
     @mock.patch('preflight_check.main.setup_basic_context')
     def test_run_except(self, mock_setup, mock_parse, mock_is_root, mock_exists,
-            mock_setup_logging, mock_fix, mock_check, mock_dumps, mock_exit):
+                        mock_setup_logging, mock_fix, mock_check, mock_dumps, mock_exit):
         mock_is_root.return_value = True
         ctx = mock.Mock(var_dir="/var/lib/preflight_check")
         mock_exists.return_value = True
@@ -233,5 +232,6 @@ class TestMain(unittest.TestCase):
         mock_task_fence_inst.error.assert_called_once_with("error data")
         mock_exit.assert_called_once_with(1)
 
-    def test_MyArgParseFormatter(self):
-        inst = main.MyArgParseFormatter("test")
+    @classmethod
+    def test_MyArgParseFormatter(cls):
+        main.MyArgParseFormatter("test")

--- a/test/unittests/test_preflight_task.py
+++ b/test/unittests/test_preflight_task.py
@@ -774,9 +774,9 @@ class TestFixSBD(TestCase):
 
     @mock.patch('builtins.open')
     @mock.patch('os.path.isfile')
-    @mock.patch('tempfile.mktemp')
+    @mock.patch('tempfile.mkstemp')
     @mock.patch('preflight_check.utils.msg_info')
-    def setUp(self, mock_msg_info, mock_mktemp, mock_isfile, mock_open):
+    def setUp(self, mock_msg_info, mock_mkstemp, mock_isfile, mock_open):
         """
         Test setUp.
         """
@@ -786,7 +786,7 @@ class TestFixSBD(TestCase):
         mock_isfile.return_value = True
         mock_open.return_value = mock.mock_open(read_data="SBD_DEVICE={}".
                                                 format(dev)).return_value
-        mock_mktemp.side_effect = [bak, edit]
+        mock_mkstemp.side_effect = [(1, bak), (2, edit)]
 
         self.task_fixsbd = task.TaskFixSBD(dev, yes=False)
         mock_msg_info.assert_called_once_with('Replace SBD_DEVICE with candidate {}'.

--- a/test/unittests/test_preflight_task.py
+++ b/test/unittests/test_preflight_task.py
@@ -1,19 +1,18 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-import unittest
 try:
-    from unittest import mock
+    from unittest import mock, TestCase
 except ImportError:
     import mock
 import logging
 from datetime import datetime
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 from preflight_check import utils, main, config, task
 
 
-class TestTaskKill(unittest.TestCase):
+class TestTaskKill(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -47,7 +46,7 @@ class TestTaskKill(unittest.TestCase):
         mock_isdir.return_value = False
         main.ctx = mock.Mock(report_path="/path")
         with self.assertRaises(task.TaskError) as error:
-           self.task_kill_inst.enable_report()
+            self.task_kill_inst.enable_report()
         self.assertEqual("/path is not a directory", str(error.exception))
         mock_isdir.assert_called_once_with("/path")
 
@@ -104,7 +103,7 @@ Expected State:    a) sbd process restarted
         file_handle = mock_open_file.return_value.__enter__.return_value
 
         self.task_kill_inst.to_report()
-        
+
         file_handle.write.assert_has_calls([
             mock.call("#### header"),
             mock.call("\nLog:\n"),
@@ -196,7 +195,7 @@ Expected State:    a) sbd process restarted
         mock_sleep.assert_called_once_with(1)
 
 
-class TestTaskCheck(unittest.TestCase):
+class TestTaskCheck(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -299,7 +298,7 @@ class TestTaskCheck(unittest.TestCase):
         self.task_check_inst.print_result.assert_called_once_with()
 
 
-class TestTaskSplitBrain(unittest.TestCase):
+class TestTaskSplitBrain(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -494,7 +493,7 @@ Fence timeout:     60
         self.task_sp_inst.thread_stop_event.set.assert_called_once_with()
 
 
-class TestFence(unittest.TestCase):
+class TestFence(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -507,7 +506,7 @@ class TestFence(unittest.TestCase):
         """
         Test setUp.
         """
-        ctx = mock.Mock(fence_node="node1", yes=False) 
+        ctx = mock.Mock(fence_node="node1", yes=False)
         self.task_fence_inst = task.TaskFence(ctx)
         self.task_fence_inst.fence_action = "reboot"
         self.task_fence_inst.fence_timeout = 60
@@ -610,7 +609,7 @@ Fence timeout:     60
         self.task_fence_inst.fence_finish_event.wait.assert_called_once_with(60)
 
 
-class TestTask(unittest.TestCase):
+class TestTask(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -707,10 +706,10 @@ class TestTask(unittest.TestCase):
     def test_build_base_result(self):
         self.task_inst.build_base_result()
         expected_result = {
-                "Timestamp": self.task_inst.timestamp,
-                "Description": self.task_inst.description,
-                "Messages": []
-                }
+            "Timestamp": self.task_inst.timestamp,
+            "Description": self.task_inst.description,
+            "Messages": []
+        }
         self.assertDictEqual(expected_result, self.task_inst.result)
 
     @mock.patch('sys.exit')
@@ -743,9 +742,9 @@ class TestTask(unittest.TestCase):
         mock_run.side_effect = [(1, None, None), (0, output, None), (1, None, None), (0, output2, None)]
         self.task_inst.timestamp = "2021/01/19 16:08:24"
         mock_datetime.side_effect = [
-                datetime.strptime(self.task_inst.timestamp, '%Y/%m/%d %H:%M:%S'),
-                datetime.strptime("Tue Jan 19 16:08:37 2021", '%a %b %d %H:%M:%S %Y')
-                ]
+            datetime.strptime(self.task_inst.timestamp, '%Y/%m/%d %H:%M:%S'),
+            datetime.strptime("Tue Jan 19 16:08:37 2021", '%a %b %d %H:%M:%S %Y')
+        ]
 
         self.task_inst.fence_action_monitor()
 

--- a/test/unittests/test_preflight_utils.py
+++ b/test/unittests/test_preflight_utils.py
@@ -2,17 +2,17 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-import unittest
 try:
-    from unittest import mock
+    from unittest import mock, TestCase
 except ImportError:
     import mock
 import logging
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 from preflight_check import utils, main, config
 
 
-class TestMyLoggingFormatter(unittest.TestCase):
+class TestMyLoggingFormatter(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -38,7 +38,7 @@ class TestMyLoggingFormatter(unittest.TestCase):
         """
 
 
-class TestFenceInfo(unittest.TestCase):
+class TestFenceInfo(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -108,7 +108,7 @@ class TestFenceInfo(unittest.TestCase):
         mock_get_property.assert_called_once_with("stonith-timeout")
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(TestCase):
     '''
     Unitary tests for preflight_check/utils.py
     '''
@@ -270,13 +270,13 @@ totem.interface.1.ttl (u8) = 1
         mock_open_read_1 = mock.mock_open(read_data=b'/usr/sbin/cmd1\x00--user\x00')
         mock_open_read_2 = mock.mock_open(read_data=b'/usr/sbin/cmd2\x00')
         mock_open_file.side_effect = [
-                mock_open_read_1.return_value,
-                mock_open_read_2.return_value
-                ]
+            mock_open_read_1.return_value,
+            mock_open_read_2.return_value
+        ]
         mock_to_ascii.side_effect = [
-                "/usr/sbin/cmd1\x00--user\x00",
-                "/usr/sbin/cmd2\x00"
-                ]
+            "/usr/sbin/cmd1\x00--user\x00",
+            "/usr/sbin/cmd2\x00"
+        ]
         mock_basename.side_effect = ["cmd1", "cmd2"]
 
         rc, pid = utils.get_process_status("sbd")
@@ -308,13 +308,13 @@ totem.interface.1.ttl (u8) = 1
         mock_open_read_1 = mock.mock_open(read_data=b'/usr/sbin/cmd1\x00--user\x00')
         mock_open_read_2 = mock.mock_open(read_data=b'/usr/sbin/sbd\x00')
         mock_open_file.side_effect = [
-                mock_open_read_1.return_value,
-                mock_open_read_2.return_value
-                ]
+            mock_open_read_1.return_value,
+            mock_open_read_2.return_value
+        ]
         mock_to_ascii.side_effect = [
-                "/usr/sbin/cmd1\x00--user\x00",
-                "/usr/sbin/sbd\x00"
-                ]
+            "/usr/sbin/cmd1\x00--user\x00",
+            "/usr/sbin/sbd\x00"
+        ]
         mock_basename.side_effect = ["cmd1", "sbd"]
 
         rc, pid = utils.get_process_status("sbd")

--- a/test/unittests/test_preflight_utils.py
+++ b/test/unittests/test_preflight_utils.py
@@ -411,3 +411,145 @@ Node List:
         res = utils.peer_node_list()
         self.assertEqual(res, ["node2"])
         mock_online.assert_called_once_with()
+
+    # Test is_valid_sbd():
+    @classmethod
+    @mock.patch('os.path.exists')
+    def test_is_valid_sbd_not_exist(cls, mock_os_path_exists):
+        """
+        Test device not exist
+        """
+        dev = "/dev/disk/by-id/scsi-device1"
+        mock_os_path_exists.return_value = False
+
+        res = utils.is_valid_sbd(dev)
+        assert res is False
+
+    @classmethod
+    @mock.patch('preflight_check.utils.msg_error')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('os.path.exists')
+    def test_is_valid_sbd_cmd_error(cls, mock_os_path_exists,
+                                    mock_sbd_check_header, mock_msg_err):
+        """
+        Test device is not valid sbd
+        """
+        dev = "/dev/disk/by-id/scsi-device1"
+        mock_os_path_exists.return_value = True
+        mock_sbd_check_header.return_value = (-1, None, "Unknown error!")
+        mock_msg_err.return_value = ""
+
+        res = utils.is_valid_sbd(dev)
+        mock_msg_err.assert_called_once_with("Unknown error!")
+        assert res is False
+
+    @classmethod
+    @mock.patch('preflight_check.utils.msg_error')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('os.path.exists')
+    def test_is_valid_sbd_not_sbd(cls, mock_os_path_exists,
+                                  mock_sbd_check_header, mock_msg_err):
+        """
+        Test device is not SBD device
+        """
+        dev = "/dev/disk/by-id/scsi-device1"
+        err_output = """
+==Dumping header on disk {}
+==Header on disk {} NOT dumped
+sbd failed; please check the logs.
+""".format(dev, dev)
+        mock_os_path_exists.return_value = True
+        mock_sbd_check_header.return_value = (1, "==Dumping header on disk {}".format(dev),
+                                              err_output)
+
+        res = utils.is_valid_sbd(dev)
+        assert res is False
+        mock_msg_err.assert_called_once_with(err_output)
+
+    @classmethod
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('os.path.exists')
+    def test_is_valid_sbd_is_sbd(cls, mock_os_path_exists,
+                                 mock_sbd_check_header):
+        """
+        Test device is not SBD device
+        """
+        dev = "/dev/disk/by-id/scsi-device1"
+        std_output = """
+==Dumping header on disk {}
+Header version     : 2.1
+UUID               : f4c99362-6522-46fc-8ce4-7db60aff19bb
+Number of slots    : 255
+Sector size        : 512
+Timeout (watchdog) : 5
+Timeout (allocate) : 2
+Timeout (loop)     : 1
+Timeout (msgwait)  : 10
+==Header on disk {} is dumped
+""".format(dev, dev)
+        mock_os_path_exists.return_value = True
+        mock_sbd_check_header.return_value = (0, std_output, None)
+
+        res = utils.is_valid_sbd(dev)
+        assert res is True
+
+    # Test find_candidate_sbd() and _find_match_count()
+    @classmethod
+    @mock.patch('glob.glob')
+    @mock.patch('os.path.basename')
+    @mock.patch('os.path.dirname')
+    def test_find_candidate_no_dev(cls, mock_os_path_dname, mock_os_path_bname,
+                                   mock_glob):
+        """
+        Test no suitable device
+        """
+        mock_os_path_dname.return_value = "/dev/disk/by-id"
+        mock_os_path_bname.return_value = "scsi-label_CN_devA"
+        mock_glob.return_value = []
+
+        res = utils.find_candidate_sbd("/not-exist-folder/not-exist-dev")
+        assert res == ""
+
+    @classmethod
+    @mock.patch('preflight_check.utils.is_valid_sbd')
+    @mock.patch('glob.glob')
+    @mock.patch('os.path.basename')
+    @mock.patch('os.path.dirname')
+    def test_find_candidate_no_can(cls, mock_os_path_dname, mock_os_path_bname,
+                                   mock_glob, mock_is_valid_sbd):
+        """
+        Test no valid candidate device
+        """
+        mock_os_path_dname.return_value = "/dev/disk/by-id"
+        mock_os_path_bname.return_value = "scsi-label_CN_devA"
+        mock_glob.return_value = ["/dev/disk/by-id/scsi-label_DE_devA",
+                                  "/dev/disk/by-id/scsi-label_DE_devB",
+                                  "/dev/disk/by-id/scsi-label_DE_devC",
+                                  "/dev/disk/by-id/scsi-label_DE_devD"]
+        mock_is_valid_sbd.side_effect = [False, False, False, False]
+
+        res = utils.find_candidate_sbd("/dev/disk/by-id/scsi-label_CN_devA")
+        assert res == ""
+
+    @classmethod
+    @mock.patch('preflight_check.utils.is_valid_sbd')
+    @mock.patch('glob.glob')
+    @mock.patch('os.path.basename')
+    @mock.patch('os.path.dirname')
+    def test_find_candidate_has_multi(cls, mock_os_path_dname, mock_os_path_bname,
+                                      mock_glob, mock_is_valid_sbd):
+        """
+        Test has multiple valid candidate devices
+        """
+        mock_os_path_dname.return_value = "/dev/disk/by-id"
+        mock_os_path_bname.return_value = "scsi-label_CN_devA"
+        mock_glob.return_value = ["/dev/disk/by-id/scsi-label_DE_devA",
+                                  "/dev/disk/by-id/scsi-label_DE_devB",
+                                  "/dev/disk/by-id/scsi-label_CN_devC",
+                                  "/dev/disk/by-id/scsi-label_CN_devD",
+                                  "/dev/disk/by-id/scsi-mp_China_devE",
+                                  "/dev/disk/by-id/scsi-mp_China_devF"]
+        mock_is_valid_sbd.side_effect = [True, False, False, True, True, False]
+
+        res = utils.find_candidate_sbd("/dev/disk/by-id/scsi-label_CN_devA")
+        assert res == "/dev/disk/by-id/scsi-label_CN_devD"

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     {[base]deps}
 
 commands =
-    py.test -vv --cov=crmsh --cov=preflight_check --cov-config .coveragerc --cov-report term --cov-report html --cov-report html {posargs}
+    py.test -vv --cov=crmsh --cov=preflight_check --cov-config .coveragerc --cov-report term --cov-report html {posargs}
 
 [testenv:py38-codeclimate]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
The pull request including:
1. Unit test cases of ASR SBD device feature. Test coverage is 100% for the new code.
Overall report for all preflight check code:
```
----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name                                                                                     Stmts   Miss  Cover
------------------------------------------------------------------------------------------------------------
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/__init__.py       0      0   100%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/check.py        187      2    99%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/config.py         8      0   100%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/explain.py        6      0   100%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/main.py         128      1    99%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/task.py         364      2    99%
/warehouse/Source-code/git/HA-ClusterLabs/crmsh.git.review/preflight_check/utils.py        168      9    95%
------------------------------------------------------------------------------------------------------------
TOTAL                                                                                      861     14    98%

```

2. Fix a circular import error of utils.py
3. Fix: Replace utils.msg_info to task.info and replace mktemp() to mkstemp()
4. Fix: Remove the duplicate --cov-report html in tox.
5. Fix some lint issues like trailing-whitespace, bad-continuation