### PR TITLE
Adjust qdevice configure process with diskless sbd

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -113,7 +113,7 @@ class Cluster(command.UI):
             if not utils.service_is_active("corosync.service"):
                 err_buf.info("Cluster services already stopped")
                 return
-            if utils.is_qdevice_configured():
+            if utils.service_is_active("corosync-qdevice"):
                 utils.stop_service("corosync-qdevice")
             utils.stop_service("corosync")
             err_buf.info("Cluster services stopped")

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -14,6 +14,8 @@ Feature: corosync qdevice/qnetd setup/remove process
   Scenario: Setup qdevice/qnetd during init/join process
     When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
+    # for bsc#1181415
+    Then    Expected "Restarting cluster service" in stdout
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
@@ -35,6 +37,8 @@ Feature: corosync qdevice/qnetd setup/remove process
     When    Run "echo "# This is a test for bsc#1166684" >> /etc/corosync/corosync.conf" on "hanode1"
     When    Run "scp /etc/corosync/corosync.conf root@hanode2:/etc/corosync" on "hanode1"
     When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode1"
+    # for bsc#1181415
+    Then    Expected "Starting corosync-qdevice.service in cluster" in stdout
     Then    Service "corosync-qdevice" is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode2"
     And     Service "corosync-qnetd" is "started" on "qnetd-node"

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -47,6 +47,16 @@ def step_impl(context, cmd, addr):
     context.stdout = out
 
 
+@then('Print stdout')
+def step_impl(context):
+    context.logger.info("\n{}".format(context.stdout))
+
+
+@then('Print stderr')
+def step_impl(context):
+    context.logger.info("\n{}".format(context.command_error_output))
+
+
 @when('Try "{cmd}" on "{addr}"')
 def step_impl(context, cmd, addr):
     run_command_local_or_remote(context, cmd, addr, err_record=True)

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -69,17 +69,14 @@ class TestCluster(unittest.TestCase):
         mock_info.assert_called_once_with("Cluster services already stopped")
 
     @mock.patch('crmsh.ui_cluster.err_buf.info')
-    @mock.patch('crmsh.utils.is_qdevice_configured')
     @mock.patch('crmsh.utils.stop_service')
     @mock.patch('crmsh.utils.service_is_active')
-    def test_do_stop(self, mock_active, mock_stop, mock_qdevice_configured, mock_info):
+    def test_do_stop(self, mock_active, mock_stop, mock_info):
         context_inst = mock.Mock()
-        mock_active.return_value = True
-        mock_qdevice_configured.return_value = True
+        mock_active.side_effect = [True, True]
 
         self.ui_cluster_inst.do_stop(context_inst)
 
-        mock_active.assert_called_once_with("corosync.service")
+        mock_active.assert_has_calls([mock.call("corosync.service"), mock.call("corosync-qdevice")])
         mock_stop.assert_has_calls([mock.call("corosync-qdevice"), mock.call("corosync")])
-        mock_qdevice_configured.assert_called_once_with()
         mock_info.assert_called_once_with("Cluster services stopped")


### PR DESCRIPTION
## Poblem
Configuring qdevice with diskless SBD during init process will cause init node rebooted
And, removing qdevice with diskless SBD will also got the node rebooted

## Reason
When setup qdevice, the current order was:

- Add qdevice configuration
- Run corosync reload (then quorum lost)
- Certification process (take a relative long time, then node got rebooted)
- Start qdevice service

When removing qdevice, the current order was:

- Stop qdevice service (then quorum lost)
- Remove configuration (the node got rebooted)
- Run corosync reload

In short, Diskless SBD require quorum, when reload qdevice configuration, quorum will lost for a while, then then node got rebooted

## Solution
**Process 1**. Setup qdevice with bootstrap init process from beginning
**Process 2**. Append qdevice on an existing running cluster via bootstrap qdevice stage

**For process 1**, as the qdevice was configuring from the beginning without any RA configured, it's no harm to **restart cluster** service when all configuration was ready; In this way, diskless SBD service will also restated, without any risk to fence the node

**For process 2**, we restrict qdevice stage must be deployed on a 2+ nodes cluster, otherwise, crmsh will raise an error like "**Cannot configure qdevice stage on a single node cluster**"

**For removal process**, we restrict command "crm cluster remove --qdevice" only works when 2+ nodes online, otherwise, for signle node cluster raise an error like "**Cannot remove qdevice service from a single node cluster**"