### PR TITLE
Run hb_report under hacluster

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -31,6 +31,7 @@ from . import tmpfiles
 from . import clidisplay
 from . import term
 from . import lock
+from . import userdir
 
 
 LOG_FILE = "/var/log/crmsh/ha-cluster-bootstrap.log"
@@ -42,10 +43,8 @@ SYSCONFIG_FW = "/etc/sysconfig/SuSEfirewall2"
 SYSCONFIG_FW_CLUSTER = "/etc/sysconfig/SuSEfirewall2.d/services/cluster"
 PCMK_REMOTE_AUTH = "/etc/pacemaker/authkey"
 COROSYNC_CONF_ORIG = tmpfiles.create()[1]
-RSA_PRIVATE_KEY = "/root/.ssh/id_rsa"
-RSA_PUBLIC_KEY = "/root/.ssh/id_rsa.pub"
-AUTHORIZED_KEYS_FILE = "/root/.ssh/authorized_keys"
 SERVICES_STOP_LIST = ["corosync-qdevice.service", "corosync.service", "hawk.service"]
+USER_LIST = ["root", "hacluster"]
 
 INIT_STAGES = ("ssh", "ssh_remote", "csync2", "csync2_remote", "corosync", "storage", "sbd", "cluster", "vgfs", "admin", "qdevice")
 
@@ -95,6 +94,7 @@ class Context(object):
         self.args = None
         self.ui_context = None
         self.interfaces_inst = None
+        self.with_other_user = True
         self.default_nic_list = []
         self.default_ip_list = []
         self.local_ip_list = []
@@ -1134,22 +1134,66 @@ def init_ssh():
     Configure passwordless SSH.
     """
     utils.start_service("sshd.service", enable=True)
-    configure_local_ssh_key()
+    for user in USER_LIST:
+        configure_local_ssh_key(user)
 
 
-def configure_local_ssh_key():
+def key_files(user):
+    """
+    Find home directory for user and return key files with abspath
+    """
+    keyfile_dict = {}
+    home_dir = userdir.gethomedir(user)
+    keyfile_dict['private'] = "{}/.ssh/id_rsa".format(home_dir)
+    keyfile_dict['public'] = "{}/.ssh/id_rsa.pub".format(home_dir)
+    keyfile_dict['authorized'] = "{}/.ssh/authorized_keys".format(home_dir)
+    return keyfile_dict
+
+
+def is_nologin(user):
+    """
+    Check if user's shell is /sbin/nologin
+    """
+    with open("/etc/passwd") as f:
+        return re.search("{}:.*:/sbin/nologin".format(user), f.read())
+
+
+def change_user_shell(user):
+    """
+    To change user's login shell
+    """
+    if user != "root" and is_nologin(user):
+        if not _context.yes_to_all:
+            status("""
+User {} will be changed the login shell as /bin/bash, and
+be setted up authorized ssh access among cluster nodes""".format(user))
+            if not confirm("Continue?"):
+                _context.with_other_user = False
+                return
+        invoke("usermod -s /bin/bash {}".format(user))
+
+
+def configure_local_ssh_key(user="root"):
     """
     Configure ssh rsa key locally
 
-    If /root/.ssh/id_rsa not exist, generate a new one
-    Add /root/.ssh/id_rsa.pub to /root/.ssh/authorized_keys anyway, make sure itself authorized
+    If <home_dir>/.ssh/id_rsa not exist, generate a new one
+    Add <home_dir>/.ssh/id_rsa.pub to <home_dir>/.ssh/authorized_keys anyway, make sure itself authorized
     """
-    if not os.path.exists(RSA_PRIVATE_KEY):
-        status("Generating SSH key")
-        invoke("ssh-keygen -q -f {} -C 'Cluster Internal on {}' -N ''".format(RSA_PRIVATE_KEY, utils.this_node()))
-    if not os.path.exists(AUTHORIZED_KEYS_FILE):
-        open(AUTHORIZED_KEYS_FILE, 'w').close()
-    append_unique(RSA_PUBLIC_KEY, AUTHORIZED_KEYS_FILE)
+    change_user_shell(user)
+
+    private_key, public_key, authorized_file = key_files(user).values()
+    if not os.path.exists(private_key):
+        status("Generating SSH key for {}".format(user))
+        cmd = "ssh-keygen -q -f {} -C 'Cluster Internal on {}' -N ''".format(private_key, utils.this_node())
+        cmd = utils.add_su(cmd, user)
+        rc, _, err = invoke(cmd)
+        if not rc:
+            error("Failed to generate ssh key for {}: {}".format(user, err))
+
+    if not os.path.exists(authorized_file):
+        open(authorized_file, 'w').close()
+    append_unique(public_key, authorized_file)
 
 
 def init_ssh_remote():
@@ -1871,8 +1915,9 @@ def join_ssh(seed_host):
         error("No existing IP/hostname specified (use -c option)")
 
     utils.start_service("sshd.service", enable=True)
-    configure_local_ssh_key()
-    swap_public_ssh_key(seed_host)
+    for user in USER_LIST:
+        configure_local_ssh_key(user)
+        swap_public_ssh_key(seed_host, user)
 
     # This makes sure the seed host has its own SSH keys in its own
     # authorized_keys file (again, to help with the case where the
@@ -1883,30 +1928,34 @@ def join_ssh(seed_host):
         error("Can't invoke crm cluster init -i {} ssh_remote on {}: {}".format(_context.default_nic_list[0], seed_host, err))
 
 
-def swap_public_ssh_key(remote_node):
+def swap_public_ssh_key(remote_node, user="root"):
     """
     Swap public ssh key between remote_node and local
     """
+    if user != "root" and not _context.with_other_user:
+        return
+
+    _, public_key, authorized_file = key_files(user).values()
     # Detect whether need password to login to remote_node
-    if utils.check_ssh_passwd_need(remote_node):
+    if utils.check_ssh_passwd_need(remote_node, user):
         # If no passwordless configured, paste /root/.ssh/id_rsa.pub to remote_node's /root/.ssh/authorized_keys
-        status("Configuring SSH passwordless with root@{}".format(remote_node))
+        status("Configuring SSH passwordless with {}@{}".format(user, remote_node))
         # After this, login to remote_node is passwordless
-        append_to_remote_file(RSA_PUBLIC_KEY, remote_node, AUTHORIZED_KEYS_FILE)
+        append_to_remote_file(public_key, remote_node, authorized_file)
 
     try:
         # Fetch public key file from remote_node
-        public_key_file_remote = fetch_public_key_from_remote_node(remote_node)
+        public_key_file_remote = fetch_public_key_from_remote_node(remote_node, user)
     except ValueError as err:
         warn(err)
         return
     # Append public key file from remote_node to local's /root/.ssh/authorized_keys
     # After this, login from remote_node is passwordless
     # Should do this step even passwordless is True, to make sure we got two-way passwordless
-    append_unique(public_key_file_remote, AUTHORIZED_KEYS_FILE)
+    append_unique(public_key_file_remote, authorized_file)
 
 
-def fetch_public_key_from_remote_node(node):
+def fetch_public_key_from_remote_node(node, user="root"):
     """
     Fetch public key file from remote node
     Return a temp file contains public key
@@ -1915,8 +1964,9 @@ def fetch_public_key_from_remote_node(node):
 
     # For dsa, might need to add PubkeyAcceptedKeyTypes=+ssh-dss to config file, see
     # https://superuser.com/questions/1016989/ssh-dsa-keys-no-longer-work-for-password-less-authentication
+    home_dir = userdir.gethomedir(user)
     for key in ("id_rsa", "id_ecdsa", "id_ed25519", "id_dsa"):
-        public_key_file = "/root/.ssh/{}.pub".format(key)
+        public_key_file = "{}/.ssh/{}.pub".format(home_dir, key)
         cmd = "ssh -oStrictHostKeyChecking=no root@{} 'test -f {}'".format(node, public_key_file)
         if not invokerc(cmd):
             continue
@@ -2128,7 +2178,8 @@ def setup_passwordless_with_other_nodes(init_node):
 
     # Swap ssh public key between join node and other cluster nodes
     for node in cluster_nodes_list:
-        swap_public_ssh_key(node)
+        for user in USER_LIST:
+            swap_public_ssh_key(node, user)
 
 
 def join_cluster(seed_host):
@@ -2487,7 +2538,7 @@ def bootstrap_join(context):
     check_tty()
 
     corosync_active = utils.service_is_active("corosync.service")
-    if corosync_active:
+    if corosync_active and _context.stage != "ssh":
         error("Abort: Cluster is currently active. Run this command on a node joining the cluster.")
 
     if not check_prereqs("join"):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -344,6 +344,15 @@ def add_sudo(cmd):
     return cmd
 
 
+def add_su(cmd, user):
+    """
+    Wrapped cmd with su -c "<cmd>" <user>
+    """
+    if user == "root":
+        return cmd
+    return "su -c \"{}\" {}".format(cmd, user)
+
+
 def chown(path, user, group):
     if isinstance(user, int):
         uid = user
@@ -2084,12 +2093,13 @@ def get_iplist_corosync_using():
     return re.findall(r'id\s*=\s*(.*)', out)
 
 
-def check_ssh_passwd_need(host):
+def check_ssh_passwd_need(host, user="root"):
     """
     Check whether access to host need password
     """
     ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
     ssh_cmd = "ssh {} -T -o Batchmode=yes {} true".format(ssh_options, host)
+    ssh_cmd = add_su(ssh_cmd, user)
     rc, _, _ = get_stdout_stderr(ssh_cmd)
     return rc != 0
 

--- a/hb_report/hb_report.in
+++ b/hb_report/hb_report.in
@@ -82,7 +82,10 @@ def get_log():
     if constants.CTS:
         pass  # TODO
     else:
-        getstampproc = utillib.find_getstampproc(constants.HA_LOG)
+        try:
+            getstampproc = utillib.find_getstampproc(constants.HA_LOG)
+        except PermissionError:
+            return
         if getstampproc:
             constants.GET_STAMP_FUNC = getstampproc
             if utillib.dump_logset(constants.HA_LOG, constants.FROM_TIME, constants.TO_TIME, outf):

--- a/hb_report/utillib.py
+++ b/hb_report/utillib.py
@@ -1521,14 +1521,12 @@ def stdchannel_redirected(stdchannel, dest_filename):
 
 def start_slave_collector(node, arg_str):
     if node == constants.WE:
-        cmd = r"hb_report __slave".format(os.getcwd())
+        cmd = r"/usr/sbin/hb_report __slave".format(os.getcwd())
         for item in arg_str.split():
             cmd += " {}".format(str(item))
         _, out = crmutils.get_stdout(cmd)
     else:
-        cmd = r'ssh {} {} "{} hb_report __slave"'.\
-              format(constants.SSH_OPTS, node,
-                     constants.SUDO, os.getcwd())
+        cmd = r'ssh {} {} "/usr/sbin/hb_report __slave"'.format(constants.SSH_OPTS, node, os.getcwd())
         for item in arg_str.split():
             cmd += " {}".format(str(item))
         code, out, err = crmutils.get_stdout_stderr(cmd)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -839,30 +839,104 @@ class TestBootstrap(unittest.TestCase):
     def test_init_ssh(self, mock_start_service, mock_config_ssh):
         bootstrap.init_ssh()
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
-        mock_config_ssh.assert_called_once_with()
+        mock_config_ssh.assert_has_calls([
+            mock.call("root"),
+            mock.call("hacluster")
+            ])
 
-    @mock.patch('crmsh.bootstrap.append_unique')
-    @mock.patch('builtins.open', create=True)
+    @mock.patch('crmsh.userdir.gethomedir')
+    def test_key_files(self, mock_gethome):
+        mock_gethome.return_value = "/root"
+        expected_res = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
+        self.assertEqual(bootstrap.key_files("root"), expected_res)
+        mock_gethome.assert_called_once_with("root")
+
+    @mock.patch('builtins.open')
+    def test_is_nologin(self, mock_open_file):
+        data = "hacluster:x:90:90:heartbeat processes:/var/lib/heartbeat/cores/hacluster:/sbin/nologin"
+        mock_open_file.return_value = mock.mock_open(read_data=data).return_value
+        assert bootstrap.is_nologin("hacluster") is not None
+        mock_open_file.assert_called_once_with("/etc/passwd")
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.is_nologin')
+    def test_change_user_shell_return(self, mock_nologin, mock_status, mock_confirm):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_nologin.return_value = True
+        mock_confirm.return_value = False
+
+        bootstrap.change_user_shell("hacluster")
+
+        mock_nologin.assert_called_once_with("hacluster")
+        mock_confirm.assert_called_once_with("Continue?")
+
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.bootstrap.is_nologin')
+    def test_change_user_shell_return(self, mock_nologin, mock_invoke):
+        bootstrap._context = mock.Mock(yes_to_all=True)
+        mock_nologin.return_value = True
+
+        bootstrap.change_user_shell("hacluster")
+
+        mock_nologin.assert_called_once_with("hacluster")
+        mock_invoke.assert_called_once_with("usermod -s /bin/bash hacluster")
+
     @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('os.path.exists')
-    def test_configure_local_ssh_key(self, mock_exists, mock_status, mock_invoke,
-            mock_this_node, mock_open_file, mock_append):
+    @mock.patch('crmsh.bootstrap.key_files')
+    @mock.patch('crmsh.bootstrap.change_user_shell')
+    def test_configure_local_ssh_key_error(self, mock_change_shell, mock_key_files, mock_exists, mock_status, mock_invoke, mock_error, mock_this_node):
+        mock_key_files.return_value = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
+        mock_exists.return_value = False
+        mock_invoke.return_value = (False, None, "error")
+        mock_this_node.return_value = "node1"
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit) as err:
+            bootstrap.configure_local_ssh_key("root")
+
+        mock_change_shell.assert_called_once_with("root")
+        mock_key_files.assert_called_once_with("root")
+        mock_exists.assert_called_once_with("/root/.ssh/id_rsa")
+        mock_status.assert_called_once_with("Generating SSH key for root")
+        mock_invoke.assert_called_once_with("ssh-keygen -q -f /root/.ssh/id_rsa -C 'Cluster Internal on node1' -N ''")
+        mock_error.assert_called_once_with("Failed to generate ssh key for root: error")
+
+    @mock.patch('crmsh.bootstrap.append_unique')
+    @mock.patch('builtins.open', create=True)
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.utils.add_su')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.bootstrap.key_files')
+    @mock.patch('crmsh.bootstrap.change_user_shell')
+    def test_configure_local_ssh_key(self, mock_change_shell, mock_key_files, mock_exists, mock_status, mock_this_node, mock_su, mock_invoke, mock_open_file, mock_append):
+        bootstrap._context = mock.Mock(yes_to_all=True)
+        mock_key_files.return_value = {"private": "/test/.ssh/id_rsa", "public": "/test/.ssh/id_rsa.pub", "authorized": "/test/.ssh/authorized_keys"}
         mock_exists.side_effect = [False, False]
         mock_this_node.return_value = "node1"
+        mock_invoke.return_value = (True, None, None)
+        mock_su.return_value = "cmd with su"
 
-        bootstrap.configure_local_ssh_key()
+        bootstrap.configure_local_ssh_key("test")
 
+        mock_change_shell.assert_called_once_with("test")
+        mock_key_files.assert_called_once_with("test")
         mock_exists.assert_has_calls([
-            mock.call(bootstrap.RSA_PRIVATE_KEY),
-            mock.call(bootstrap.AUTHORIZED_KEYS_FILE)
+            mock.call("/test/.ssh/id_rsa"),
+            mock.call("/test/.ssh/authorized_keys")
             ])
-        mock_status.assert_called_once_with("Generating SSH key")
-        mock_invoke.assert_called_once_with("ssh-keygen -q -f {} -C 'Cluster Internal on {}' -N ''".format(bootstrap.RSA_PRIVATE_KEY, mock_this_node.return_value))
+        mock_status.assert_called_once_with("Generating SSH key for test")
+        mock_invoke.assert_called_once_with("cmd with su")
+        mock_su.assert_called_once_with("ssh-keygen -q -f /test/.ssh/id_rsa -C 'Cluster Internal on node1' -N ''", "test")
         mock_this_node.assert_called_once_with()
-        mock_open_file.assert_called_once_with(bootstrap.AUTHORIZED_KEYS_FILE, 'w')
-        mock_append.assert_called_once_with(bootstrap.RSA_PUBLIC_KEY, bootstrap.AUTHORIZED_KEYS_FILE)
+        mock_open_file.assert_called_once_with("/test/.ssh/authorized_keys", 'w')
+        mock_append.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys")
 
     @mock.patch('crmsh.bootstrap.append')
     @mock.patch('crmsh.utils.check_file_content_included')
@@ -931,40 +1005,56 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.join_ssh("node1")
 
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
-        mock_config_ssh.assert_called_once_with()
-        mock_swap.assert_called_once_with("node1")
+        mock_config_ssh.assert_has_calls([
+            mock.call("root"),
+            mock.call("hacluster")
+            ])
+        mock_swap.assert_has_calls([
+            mock.call("node1", "root"),
+            mock.call("node1", "hacluster")
+            ])
         mock_invoke.assert_called_once_with("ssh root@node1 crm cluster init -i eth1 ssh_remote")
         mock_error.assert_called_once_with("Can't invoke crm cluster init -i eth1 ssh_remote on node1: error")
+
+    def test_swap_public_ssh_key_return(self):
+        bootstrap._context = mock.Mock(with_other_user=False)
+        bootstrap.swap_public_ssh_key("node1", "hacluster")
 
     @mock.patch('crmsh.bootstrap.warn')
     @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    def test_swap_public_ssh_key_exception(self, mock_check_passwd, mock_fetch, mock_warn):
+    @mock.patch('crmsh.bootstrap.key_files')
+    def test_swap_public_ssh_key_exception(self, mock_key_files, mock_check_passwd, mock_fetch, mock_warn):
+        mock_key_files.return_value = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
         mock_check_passwd.return_value = False
         mock_fetch.side_effect = ValueError("No key exist")
 
         bootstrap.swap_public_ssh_key("node1")
 
+        mock_key_files.assert_called_once_with("root")
         mock_warn.assert_called_once_with(mock_fetch.side_effect)
-        mock_check_passwd.assert_called_once_with("node1")
-        mock_fetch.assert_called_once_with("node1")
+        mock_check_passwd.assert_called_once_with("node1", "root")
+        mock_fetch.assert_called_once_with("node1", "root")
 
     @mock.patch('crmsh.bootstrap.append_unique')
     @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')
     @mock.patch('crmsh.bootstrap.append_to_remote_file')
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    def test_swap_public_ssh_key(self, mock_check_passwd, mock_status, mock_append_remote, mock_fetch, mock_append_unique):
+    @mock.patch('crmsh.bootstrap.key_files')
+    def test_swap_public_ssh_key(self, mock_key_files, mock_check_passwd, mock_status, mock_append_remote, mock_fetch, mock_append_unique):
+        mock_key_files.return_value = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
         mock_check_passwd.return_value = True
         mock_fetch.return_value = "file1"
 
         bootstrap.swap_public_ssh_key("node1")
 
-        mock_check_passwd.assert_called_once_with("node1")
+        mock_key_files.assert_called_once_with("root")
+        mock_check_passwd.assert_called_once_with("node1", "root")
         mock_status.assert_called_once_with("Configuring SSH passwordless with root@node1")
-        mock_append_remote.assert_called_once_with(bootstrap.RSA_PUBLIC_KEY, "node1", bootstrap.AUTHORIZED_KEYS_FILE)
-        mock_fetch.assert_called_once_with("node1")
-        mock_append_unique.assert_called_once_with("file1", bootstrap.AUTHORIZED_KEYS_FILE)
+        mock_append_remote.assert_called_once_with("/root/.ssh/id_rsa.pub", "node1", "/root/.ssh/authorized_keys")
+        mock_fetch.assert_called_once_with("node1", "root")
+        mock_append_unique.assert_called_once_with("file1", "/root/.ssh/authorized_keys")
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.utils.get_stdout_stderr')
@@ -1014,7 +1104,10 @@ class TestBootstrap(unittest.TestCase):
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 crm_node -l"),
             mock.call("ssh -o StrictHostKeyChecking=no root@node1 hostname")
             ])
-        mock_swap.assert_called_once_with("node2")
+        mock_swap.assert_has_calls([
+            mock.call("node2", "root"),
+            mock.call("node2", "hacluster")
+            ])
 
     @mock.patch('builtins.open')
     @mock.patch('crmsh.bootstrap.append')


### PR DESCRIPTION
## Problem
It didn't work if run **hb_report** or **crm cluster copy** under **hacluster** user, which was required from Hawk

## Solution

- Change function `bootstrap.configure_local_ssh_key` and `bootstrap.swap_public_ssh_key` to accept non-root user parameter; That is, for common user, bootstrap process also setup password-less among cluster nodes
- Assign `/usr/bin/sh` to hacluster's login shell, otherwise, it's impossible to run command remotely
- On interactive mode, behavior about changing hacluster's login shell and setup ssh access will be asked for confirm
- For `runtime` existing cluster, need to use `ssh` stage to setup password-less access for hacluster
  * on init node, run `crm cluster init ssh -y`
  * on join node, run `crm cluster join ssh -c <init node> -y`
  
- For `runtime` existing cluster, `/etc/corosync/corosync.conf` and `/etc/sysconfig/sbd` might has 400 mod, which will cause `Permission denied` exceptions when running hb_report under hacluster, #747 try to resolve this, but not works for `runtime` existing cluster, to avoid that, before running hb_report under hacluster:
  * Run `chmod 644 /etc/corosync/corosync.conf`
  * Run `chmod 644 /etc/sysconfig/sbd`

Test rpm link: https://build.opensuse.org/package/show/home:XinLiang:branches:crmsh_testing7/crmsh