### PR TITLE
[WIP] New configure parser

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -843,8 +843,10 @@ class Parser(object):
         The contextmanager for convert between config dict and list
         """
         self._config_list = list(self._config_dict.items())
-        yield
-        self._config_dict = dict(self._config_list)
+        try:
+            yield
+        finally:
+            self._config_dict = dict(self._config_list)
 
     @staticmethod
     def _section_item(key):

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -860,7 +860,7 @@ class Parser(object):
 
     def _find_last_match(self, section_path):
         """
-        When adding seciton, need to find an anchor
+        When adding section, need to find an anchor
         Then the new section name will insert just after or before this anchor
 
         Example:
@@ -962,7 +962,7 @@ class Parser(object):
 
     def to_string(self):
         """
-        Use tokenize.untokenize to convert self._config_dit to string
+        Use tokenize.untokenize to convert self._config_dict into string
         """
         token_list = []
         for index, (key, value) in enumerate(self._config_dict.items()):

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -747,10 +747,20 @@ class Parser(object):
             key = re.sub("__[0-9]+", "__{}".format(index), key)
         return key
 
+    def _verify_config_file(self):
+        """
+        """
+        with open(self._config_file) as f:
+            data = f.read()
+            if len(re.findall("[{}]", data)) % 2 != 0:
+                raise ValueError("Missing closing brace")
+
     def load_config_file(self):
         """
         Use tokenize.generate_tokens to generate dict self._config_dict
         """
+        self._verify_config_file()
+
         key_prefix = ""
         key_prefix_list = []
         section_key_list = []

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -162,7 +162,7 @@ class Corosync(command.UI):
         corosync.del_node(name)
 
     @command.skill_level('administrator')
-    @command.completers(completers.call(corosync.get_all_paths))
+    @command.completers(completers.call(corosync.Parser.get_all_paths))
     def do_get(self, context, path):
         "Get a corosync configuration value"
         for v in corosync.get_values(path):


### PR DESCRIPTION
## Highlights compare with original solution

- **Reuse std library**

This PR: Using python standard library [tokenize](https://docs.python.org/3/library/tokenize.html);
Original: Implemented similar functionality by [corosync.corosync_tokenizer](https://github.com/ClusterLabs/crmsh/blob/master/crmsh/corosync.py#L672)

- **API: more simple**
```Python
# In this PR
from crmsh import corosync

inst = corosync.Parser()
inst.load_config_file()
# get value
inst.get("totem.cluster_name")
# set value
inst.set("nodelist.node.nodeid", "2")
# add new empty node entry under nodelist section
inst.add_section("nodelist.node")
# write back to config file
inst.write_to_file()
```
```Python
# Original
from crmsh import corosync

with open("/etc/corosync/corosync.conf") as f:
    data = f.read()
inst = corosync.Parser(data)
# get value
inst.get("totem.cluster_name")
# set value
inst.set("nodelist.node.nodeid", "3")
# add new empty node entry under nodelist section
inst.add('nodelist', corosync.make_section('node', []))
# write back to config file
with open("/etc/corosync/corosync.conf", 'w') as f:
    f.write(inst.to_string())
```
- **API: enable get/set value by index**

corosync.conf might has multi entries for `interface/nodelist`, original API has no way to get/set them by index; I think this feature should be more convenience for corosync3 since corosync3 might has more interface or nodelist to configure

```Python
# In this PR
from crmsh import corosync

inst = corosync.Parser()
inst.load_config_file()
# get value by index
inst.get("nodelist.node.nodeid", 1)
# set value, the first entry of nodelist by default
inst.set("nodelist.node.nodeid", "2")
# set value by index, the second entry of nodelist
inst.set("nodelist.node.nodeid", "3", 1)
```
```Python
# Original
from crmsh import corosync

with open("/etc/corosync/corosync.conf") as f:
    data = f.read()
inst = corosync.Parser(data)
# No way to get value by index, always get the first one
inst.get("nodelist.node.nodeid")
# No way to set value by index, always set the first one
inst.set("nodelist.node.nodeid", "3")
```
- **API: more pythonic**
```Python
# In this PR, consolidate related methods into one class
    @classmethod
    def get_value(cls, path, index=0):
        """
        Class method to get value
        Return None if not found
        """
        inst = cls()
        inst.load_config_file()
        return inst.get(path, index)

    @classmethod
    def get_values(cls, path):
        """
        Class method to get value list matched by path
        Return [] if not matched
        """
        inst = cls()
        inst.load_config_file()
        return inst.get_all(path)

    @classmethod
    def set_value(cls, path, value, index=0):
        """
        Class method to set value and write back to file
        """
        inst = cls()
        inst.load_config_file()
        inst.set(path, value, index)
        inst.write_to_file()
```
```Python
# Original
def get_value(path):
    f = open(conf()).read()
    p = Parser(f)
    return p.get(path)


def get_values(path):
    f = open(conf()).read()
    p = Parser(f)
    return p.get_all(path)


def set_value(path, value):
    f = open(conf()).read()
    p = Parser(f)
    p.set(path, value)
    f = open(conf(), 'w')
    f.write(p.to_string())
    f.close()
```
- **Exception handling**
```Python
# In this PR when having miss-configured braces
>>> from crmsh import corosync
>>> p = corosync.Parser()
>>> p.load_config_file()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/crmsh/corosync.py", line 762, in load_config_file
    self._verify_config_file()
  File "/usr/lib/python3.6/site-packages/crmsh/corosync.py", line 756, in _verify_config_file
    raise ValueError("Missing closing brace")
ValueError: Missing closing brace
```
Original: no error raised when having miss-configured braces
- **Unit test**

This PR: with defining more specific and small methods, the inner logic should be easier to test, so in this PR, we will archive good test coverage
Original: lack of unit test