### PR TITLE
Add sbd stage on a running cluster

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -115,6 +115,7 @@ class Context(object):
         self.ui_context = None
         self.interfaces_inst = None
         self.with_other_user = True
+        self.cluster_is_running = None
         self.default_nic_list = []
         self.default_ip_list = []
         self.local_ip_list = []
@@ -144,20 +145,28 @@ class Context(object):
                 cmds=self.qdevice_heuristics,
                 mode=self.qdevice_heuristics_mode)
 
+    def _validate_sbd_option(self):
+        """
+        Validate sbd options
+        """
+        if self.sbd_devices and self.diskless_sbd:
+            error("Can't use -s and -S options together")
+        if self.stage == "sbd":
+            if not self.sbd_devices and not self.diskless_sbd and self.yes_to_all:
+                error("Stage sbd should specify sbd device by -s or diskless sbd by -S option")
+            if utils.service_is_active("sbd.service"):
+                error("Cannot configure stage sbd: sbd.service already running!")
+            if self.cluster_is_running:
+                utils.check_all_nodes_reachable()
+
     def validate_option(self):
         """
         Validate options
         """
         if self.admin_ip:
-            try:
-                Validation.valid_admin_ip(self.admin_ip)
-            except ValueError as err:
-                error(err)
+            Validation.valid_admin_ip(self.admin_ip)
         if self.qdevice_inst:
-            try:
-                self.qdevice_inst.valid_attr()
-            except ValueError as err:
-                error(err)
+            self.qdevice_inst.valid_attr()
         if self.nic_list:
             if len(self.nic_list) > 2:
                 error("Maximum number of interface is 2")
@@ -167,6 +176,7 @@ class Context(object):
             warn("--no-overwrite-sshkey option is deprecated since crmsh does not overwrite ssh keys by default anymore and will be removed in future versions")
         if self.type == "join" and self.watchdog:
             warn("-w option is deprecated and will be removed in future versions")
+        self._validate_sbd_option()
 
     def init_sbd_manager(self):
         self.sbd_manager = SBDManager(self.sbd_devices, self.diskless_sbd)
@@ -375,6 +385,7 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         self.diskless_sbd = diskless_sbd
         self._sbd_devices = None
         self._watchdog_inst = None
+        self._stonith_watchdog_timeout = "10s"
 
     def _parse_sbd_device(self):
         """
@@ -510,6 +521,17 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
         csync2_update(SYSCONFIG_SBD)
 
+    def _determine_stonith_watchdog_timeout(self):
+        """
+        Determine value of stonith-watchdog-timeout
+        """
+        conf = utils.parse_sysconfig(SYSCONFIG_SBD)
+        res = conf.get("SBD_WATCHDOG_TIMEOUT")
+        if res:
+            self._stonith_watchdog_timeout = -1
+        elif "390" in os.uname().machine:
+            self._stonith_watchdog_timeout = "30s"
+
     def _get_sbd_device_from_config(self):
         """
         Gets currently configured SBD device, i.e. what's in /etc/sysconfig/sbd
@@ -520,6 +542,48 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
             return utils.re_split_string(self.PARSE_RE, res)
         else:
             return None
+
+    def _restart_cluster_and_configure_sbd_ra(self):
+        """
+        Try to configure sbd resource, restart cluster on needed
+        """
+        if not utils.has_resource_running():
+            status("Restarting cluster service")
+            utils.cluster_run_cmd("crm cluster restart")
+            wait_for_cluster()
+            self.configure_sbd_resource()
+        else:
+            warn("To start sbd.service, need to restart cluster service manually on each node")
+            if self.diskless_sbd:
+                warn("Then run \"crm configure property stonith-enabled=true stonith-watchdog-timeout={}\" on any node".format(self._stonith_watchdog_timeout))
+            else:
+                self.configure_sbd_resource()
+
+    def _enable_sbd_service(self):
+        """
+        Try to enable sbd service
+        """
+        if _context.cluster_is_running:
+            # in sbd stage, enable sbd.service on cluster wide
+            utils.cluster_run_cmd("systemctl enable sbd.service")
+            self._restart_cluster_and_configure_sbd_ra()
+        else:
+            # in init process
+            invoke("systemctl enable sbd.service")
+
+    def _warn_diskless_sbd(self, peer=None):
+        """
+        Give warning when configuring diskless sbd
+        """
+        # When in sbd stage or join process
+        if (self.diskless_sbd and _context.cluster_is_running) or peer:
+            vote_dict = utils.get_quorum_votes_dict(peer)
+            expected_vote = int(vote_dict['Expected'])
+            if (expected_vote < 2 and peer) or (expected_vote < 3 and not peer):
+                warn(self.DISKLESS_SBD_WARNING)
+        # When in init process
+        elif self.diskless_sbd:
+            warn(self.DISKLESS_SBD_WARNING)
 
     def sbd_init(self):
         """
@@ -536,28 +600,30 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         if not self._sbd_devices and not self.diskless_sbd:
             invoke("systemctl disable sbd.service")
             return
-        if self.diskless_sbd:
-            warn(self.DISKLESS_SBD_WARNING)
+        self._warn_diskless_sbd()
         with status_long("Initializing {}SBD...".format("diskless " if self.diskless_sbd else "")):
             self._initialize_sbd()
             self._update_configuration()
-            invoke("systemctl enable sbd.service")
+        self._determine_stonith_watchdog_timeout()
+        self._enable_sbd_service()
 
     def configure_sbd_resource(self):
         """
         Configure stonith-sbd resource and stonith-enabled property
         """
-        if not utils.package_is_installed("sbd"):
+        if not utils.package_is_installed("sbd") or \
+                not utils.service_is_enabled("sbd.service") or \
+                utils.has_resource_configured("stonith:external/sbd"):
             return
-        if utils.service_is_enabled("sbd.service"):
-            if self._get_sbd_device_from_config():
-                if not invokerc("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
-                    error("Can't create stonith-sbd primitive")
-                if not invokerc("crm configure property stonith-enabled=true"):
-                    error("Can't enable STONITH for SBD")
-            else:
-                if not invokerc("crm configure property stonith-enabled=true stonith-watchdog-timeout=5s"):
-                    error("Can't enable STONITH for diskless SBD")
+
+        if self._get_sbd_device_from_config():
+            if not invokerc("crm configure primitive stonith-sbd stonith:external/sbd pcmk_delay_max=30s"):
+                error("Can't create stonith-sbd primitive")
+            if not invokerc("crm configure property stonith-enabled=true"):
+                error("Can't enable STONITH for SBD")
+        else:
+            if not invokerc("crm configure property stonith-enabled=true stonith-watchdog-timeout={}".format(self._stonith_watchdog_timeout)):
+                error("Can't enable STONITH for diskless SBD")
 
     def join_sbd(self, peer_host):
         """
@@ -576,9 +642,7 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         if dev_list:
             self._verify_sbd_device(dev_list, [peer_host])
         else:
-            vote_dict = utils.get_quorum_votes_dict(peer_host)
-            if int(vote_dict['Expected']) < 2:
-                warn(self.DISKLESS_SBD_WARNING)
+            self._warn_diskless_sbd(peer_host)
         status("Got {}SBD configuration".format("" if dev_list else "diskless "))
         invoke("systemctl enable sbd.service")
 
@@ -2562,7 +2626,7 @@ def bootstrap_init(context):
     elif stage == "":
         if corosync_active:
             error("Cluster is currently active - can't run")
-    elif stage not in ("ssh", "ssh_remote", "csync2", "csync2_remote"):
+    elif stage not in ("ssh", "ssh_remote", "csync2", "csync2_remote", "sbd"):
         if corosync_active:
             error("Cluster is currently active - can't run %s stage" % (stage))
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -285,15 +285,13 @@ Note:
         elif re.search("--qdevice-.*", ' '.join(sys.argv)) or (stage == "qdevice" and options.yes_to_all):
             parser.error("Option --qnetd-hostname is required if want to configure qdevice")
 
-        if options.sbd_devices and options.diskless_sbd:
-            parser.error("Can't use -s and -S options together")
-
         # if options.geo and options.name == "hacluster":
         #    parser.error("For a geo cluster, each cluster must have a unique name (use --name to set)")
         boot_context = bootstrap.Context.set_context(options)
         boot_context.ui_context = context
         boot_context.stage = stage
         boot_context.args = args
+        boot_context.cluster_is_running = utils.service_is_active("pacemaker.service")
         boot_context.type = "init"
 
         bootstrap.bootstrap_init(boot_context)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2675,6 +2675,14 @@ def has_resource_running():
     return re.search("No active resources", out) is None
 
 
+def has_resource_configured(ra_type):
+    """
+    Check if the RA configured
+    """
+    out = get_stdout_or_raise_error("crm configure show")
+    return re.search(r' {} '.format(ra_type), out) is not None
+
+
 def check_all_nodes_reachable():
     """
     Check if all cluster nodes are reachable

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1307,3 +1307,13 @@ Active Resources:
 def test_re_split_string():
     assert utils.re_split_string('[; ]', "/dev/sda1; /dev/sdb1 ; ") == ["/dev/sda1", "/dev/sdb1"]
     assert utils.re_split_string('[; ]', "/dev/sda1 ") == ["/dev/sda1"]
+
+
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_has_resource_configured(mock_run):
+    mock_run.return_value = """
+primitive stonith-sbd stonith:external/sbd \
+        params pcmk_delay_max=30s
+    """
+    res = utils.has_resource_configured("stonith:external/sbd")
+    assert res is True


### PR DESCRIPTION
## 1. Add sbd on an running cluster (without any RA running)
```
# crm cluster init sbd -s /dev/sda1 -y
  Initializing SBD......done
  Restarting cluster service
  Waiting for cluster..............done
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
Then we can see `stonith-sbd (stonith:external/sbd)` and sbd.service started on each node

## 2. Add sbd on an running cluster (with any RA running)
```
# crm cluster init sbd -s /dev/sda1 -y
  Initializing SBD......done
WARNING: To start sbd.service, need to restart cluster service manually on each node
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
Then we can restart cluster service at suitable time (`stonith-sbd (stonith:external/sbd)` already configured), then we can see sbd.service started on each node

## 3. Add diskless-sbd on an running cluster (without any RA running)
```
# crm cluster init sbd -S -y
  Initializing diskless SBD......done
  Restarting cluster service
  Waiting for cluster..............done
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
Then we can see sbd.service started on each node

## 4. Add diskless-sbd on an running cluster (with any RA running)
```
# crm cluster init sbd -S -y                                                                                                                                                        
  Initializing diskless SBD......done
WARNING: To start sbd.service, need to restart cluster service manually on each node
WARNING: Then run "crm configure property stonith-enabled=true stonith-watchdog-timeout=5s" on any node
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
Restart cluster service:
```
15sp2-1:~ # crm cluster run "crm cluster restart"                                                                                                                                            
OK: [15sp2-2]
OK: [15sp2-3]
OK: [15sp2-1]
```
Check cluster status:
```
15sp2-1:~ # crm_mon -1
Cluster Summary:
  * Stack: corosync
  * Current DC: 15sp2-2 (version 2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a) - partition with quorum
  * Last updated: Mon Mar 29 14:27:37 2021
  * Last change:  Mon Mar 29 14:27:22 2021 by hacluster via crmd on 15sp2-2
  * 3 nodes configured
  * 1 resource instance configured

Node List:
  * Online: [ 15sp2-1 15sp2-2 15sp2-3 ]

Active Resources:
  * d   (ocf::heartbeat:Dummy):  Started 15sp2-2
```
Check sbd status:
```
15sp2-1:~ # ps -ef|grep sbd
root     24316     1  0 14:27 ?        00:00:00 sbd: inquisitor
root     24318 24316  0 14:27 ?        00:00:00 sbd: watcher: Pacemaker
root     24319 24316  0 14:27 ?        00:00:00 sbd: watcher: Cluster
root     24349 10035  0 14:27 pts/1    00:00:00 grep --color=auto sbd
```
Set stonith related properties:
```
15sp2-1:~ # crm configure property stonith-enabled=true stonith-watchdog-timeout=5s
```

## 5. Add sbd on interactive mode on an running cluster
```
# crm cluster init sbd
  
Configure SBD:
  If you have shared storage, for example a SAN or iSCSI target,
  you can use it avoid split-brain scenarios by configuring SBD.
  This requires a 1 MB partition, accessible to all nodes in the
  cluster.  The device path must be persistent and consistent
  across all nodes in the cluster, so /dev/disk/by-id/* devices
  are a good choice.  Note that all data on the partition you
  specify here will be destroyed.

Do you wish to use SBD (y/n)? y
SBD is already configured to use /dev/sda1 - overwrite (y/n)? y
  Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path []/dev/sda1
WARNING: All data on /dev/sda1 will be destroyed!
Are you sure you wish to use this device (y/n)? y
  Initializing SBD......done
  Restarting cluster service
  Waiting for cluster..............done
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
Then we can see stonith-sbd (stonith:external/sbd) and sbd.service started on each node

## 6. Validate
When some cluster nodes down:
```
# crm cluster init sbd -s /dev/sda1 -y
ERROR: cluster.init: host "15sp2-2" is unreachable:
```
When missing -s or -S option:
```
# crm cluster init sbd -y
ERROR: cluster.init: Stage sbd should specify sbd device by -s or diskless sbd by -S option
```
When already has sbd.service running
```
# crm cluster init sbd -s /dev/sda1 -y
ERROR: cluster.init: Cannot configure stage sbd: sbd.service already running!
```

## 7. Functional test
ff1e5ec86503b6e3c58954b6c1884e5f566a3f68