### PR TITLE
[crmsh-4.1] Dev: utils: change default file mod as 644 for str2file function

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -688,4 +688,3 @@ def create_configuration(clustername="hacluster",
                               _COROSYNC_CONF_TEMPLATE_RING_ALL + \
                               _COROSYNC_CONF_TEMPLATE_TAIL
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config_common, conf())
-    os.chmod(conf(), 0o644)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -531,13 +531,14 @@ def open_atomic(filepath, mode="r", buffering=-1, fsync=False, encoding=None):
         os.rename(tmppath, filepath)
 
 
-def str2file(s, fname):
+def str2file(s, fname, mod=0o644):
     '''
     Write a string to a file.
     '''
     try:
         with open_atomic(fname, 'w', encoding='utf-8') as dst:
             dst.write(to_ascii(s))
+        os.chmod(fname, mod)
     except IOError as msg:
         common_err(msg)
         return False


### PR DESCRIPTION
backport #747 