### PR TITLE
[crmsh-3.0] Dev: utils: change default file mod as 644 for str2file function

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -649,4 +649,3 @@ def create_configuration(clustername="hacluster",
                               _COROSYNC_CONF_TEMPLATE_RING_ALL + \
                               _COROSYNC_CONF_TEMPLATE_TAIL
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config_common, conf())
-    os.chmod(conf(), 0o644)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -489,13 +489,14 @@ def open_atomic(filepath, mode="r", buffering=-1, fsync=False):
         os.rename(tmppath, filepath)
 
 
-def str2file(s, fname):
+def str2file(s, fname, mod=0o644):
     '''
     Write a string to a file.
     '''
     try:
         with open_atomic(fname, 'w') as dst:
             dst.write(s)
+        os.chmod(fname, mod)
     except IOError, msg:
         common_err(msg)
         return False


### PR DESCRIPTION
backport #747