### PR TITLE
Fix: bootstrap: raise warning when configuring diskless SBD with less than 3 nodes

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2658,21 +2658,23 @@ def is_quorate(expected_votes, actual_votes):
     return int(actual_votes)/int(expected_votes) > 0.5
 
 
-def get_stdout_or_raise_error(cmd):
+def get_stdout_or_raise_error(cmd, remote=None, success_val=0):
     """
     Common function to get stdout from cmd or raise exception
     """
+    if remote:
+        cmd = "ssh -o StrictHostKeyChecking=no root@{} \"{}\"".format(remote, cmd)
     rc, out, err = get_stdout_stderr(cmd)
-    if rc != 0:
+    if rc != success_val:
         raise ValueError("Failed to run \"{}\": {}".format(cmd, err))
     return out
 
 
-def get_quorum_votes_dict():
+def get_quorum_votes_dict(remote=None):
     """
     Return a dictionary which contain expect votes and total votes
     """
-    out = get_stdout_or_raise_error("corosync-quorumtool -s")
+    out = get_stdout_or_raise_error("corosync-quorumtool -s", remote=remote)
     return dict(re.findall("(Expected|Total) votes:\s+(\d+)", out))
 
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -581,6 +581,7 @@ class TestSBDManager(unittest.TestCase):
         mock_watchdog_inst.init_watchdog.assert_called_once_with()
         mock_invoke.assert_called_once_with("systemctl disable sbd.service")
 
+    @mock.patch('crmsh.bootstrap.warn')
     @mock.patch('crmsh.bootstrap.status_done')
     @mock.patch('crmsh.bootstrap.SBDManager._update_configuration')
     @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
@@ -588,7 +589,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
     @mock.patch('crmsh.bootstrap.Watchdog')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_sbd_init(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done):
+    def test_sbd_init(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done, mock_warn):
         bootstrap._context = mock.Mock(watchdog=None)
         mock_package.return_value = True
         mock_watchdog_inst = mock.Mock()
@@ -604,6 +605,7 @@ class TestSBDManager(unittest.TestCase):
         mock_status_done.assert_called_once_with()
         mock_watchdog.assert_called_once_with(_input=None)
         mock_watchdog_inst.init_watchdog.assert_called_once_with()
+        mock_warn.assert_called_once_with(bootstrap.SBDManager.DISKLESS_SBD_WARNING)
 
     @mock.patch('crmsh.utils.package_is_installed')
     def test_configure_sbd_resource_not_installed(self, mock_package):
@@ -736,6 +738,38 @@ class TestSBDManager(unittest.TestCase):
         mock_verify.assert_called_once_with(["/dev/sdb1"], ["node1"])
         mock_enabled.assert_called_once_with("sbd.service", "node1")
         mock_status.assert_called_once_with("Got SBD configuration")
+        mock_watchdog.assert_called_once_with(peer_host="node1")
+        mock_watchdog_inst.join_watchdog.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.warn')
+    @mock.patch('crmsh.utils.get_quorum_votes_dict')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.utils.package_is_installed')
+    def test_join_sbd_diskless(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_watchdog, mock_get_device, mock_quorum_votes, mock_warn, mock_status):
+        mock_package.return_value = True
+        mock_exists.return_value = True
+        mock_enabled.return_value = True
+        mock_get_device.return_value = []
+        mock_watchdog_inst = mock.Mock()
+        mock_watchdog.return_value = mock_watchdog_inst
+        mock_watchdog_inst.join_watchdog = mock.Mock()
+        mock_quorum_votes.return_value = {'Expected': '1', 'Total': '1'}
+
+        self.sbd_inst.join_sbd("node1")
+
+        mock_package.assert_called_once_with("sbd")
+        mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_invoke.assert_called_once_with("systemctl enable sbd.service")
+        mock_get_device.assert_called_once_with()
+        mock_quorum_votes.assert_called_once_with("node1")
+        mock_warn.assert_called_once_with(bootstrap.SBDManager.DISKLESS_SBD_WARNING)
+        mock_enabled.assert_called_once_with("sbd.service", "node1")
+        mock_status.assert_called_once_with("Got diskless SBD configuration")
         mock_watchdog.assert_called_once_with(peer_host="node1")
         mock_watchdog_inst.join_watchdog.assert_called_once_with()
 

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1269,9 +1269,9 @@ def test_get_stdout_or_raise_error_failed(mock_run):
 @mock.patch("crmsh.utils.get_stdout_stderr")
 def test_get_stdout_or_raise_error(mock_run):
     mock_run.return_value = (0, "output data", None)
-    res = utils.get_stdout_or_raise_error("cmd")
+    res = utils.get_stdout_or_raise_error("cmd", remote="node1")
     assert res == "output data"
-    mock_run.assert_called_once_with("cmd")
+    mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 \"cmd\"")
 
 
 @mock.patch("crmsh.utils.get_stdout_or_raise_error")
@@ -1287,7 +1287,7 @@ Flags:            Quorate
     """
     res = utils.get_quorum_votes_dict()
     assert res == {'Expected': '1', 'Total': '1'}
-    mock_run.assert_called_once_with("corosync-quorumtool -s")
+    mock_run.assert_called_once_with("corosync-quorumtool -s", remote=None)
 
 
 @mock.patch("crmsh.utils.get_stdout_or_raise_error")


### PR DESCRIPTION
## Problem
Using diskless SBD with less than 3 nodes was not recommend, it'd better if bootstrap giving related warning while configuring diskless SBD