### PR TITLE
Remove crm node status subcommand

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -250,13 +250,6 @@ class NodeMgmt(command.UI):
                 return False
         return True
 
-    @command.completers(compl.nodes)
-    def do_status(self, context, node=None):
-        'usage: status [<node>]'
-        a = node and ('--xpath "//nodes/node[@uname=\'%s\']"' % node) or \
-            '-o nodes'
-        return utils.ext_cmd("%s %s" % (xmlutil.cib_dump, a)) == 0
-
     @command.alias('list')
     @command.completers(compl.nodes)
     def do_show(self, context, node=None):

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2539,18 +2539,6 @@ Example:
 standby bob reboot
 ...............
 
-
-[[cmdhelp_node_status,show nodes' status as XML]]
-==== `status`
-
-Show nodes' status as XML. If the node parameter is omitted then
-all nodes are shown.
-
-Usage:
-...............
-status [<node>]
-...............
-
 [[cmdhelp_node_status-attr,manage status attributes]]
 ==== `status-attr`
 


### PR DESCRIPTION
I think it's useless to leave a such subcommand just to show xml, which might increase confusing, see #685 