### PR TITLE
Fix: ui_configure: raise error when params not exist

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -520,21 +520,21 @@ class RAInfo(object):
         rc = 0
         d = {}
         for nvp in nvpairs:
-            if 'name' in nvp.attrib and 'value' in nvp.attrib:
+            if 'name' in nvp.attrib:
                 d[nvp.get('name')] = nvp.get('value')
         if not existence_only:
             for p in reqd_params_list():
                 if unreq_param(p):
                     continue
                 if p not in d:
-                    common_err("%s: required parameter %s not defined" % (ident, p))
+                    common_err("{}: required parameter \"{}\" not defined".format(ident, p))
                     rc |= utils.get_check_rc()
         for p in d:
             if p.startswith("$"):
                 # these are special, non-RA parameters
                 continue
             if p not in self.params():
-                common_err("%s: parameter %s does not exist" % (ident, p))
+                common_err("{}: parameter \"{}\" is not known".format(ident, p))
                 rc |= utils.get_check_rc()
         return rc
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -327,7 +327,11 @@ def primitive_complete_complex(args):
     if last_keyw is None:
         return []
 
-    return completers_set[last_keyw](agent, args) + keywords
+    complete_results = completers_set[last_keyw](agent, args)
+    if len(args) > 4 and '=' in args[-2]: # args[-1] will be the space
+        return complete_results + keywords
+
+    return complete_results
 
 
 def container_helptxt(params, helptxt, topic):


### PR DESCRIPTION
## Problem
crmsh allow to configure undefined RA parameter in this way:
```
primitive id=d Dummy params test fake=xxx # here "test" was undefined
```
Then commit without any error raise, got this xml:
```
      <primitive id="d" class="ocf" provider="heartbeat" type="Dummy">
        <instance_attributes id="d-instance_attributes">
          <nvpair name="test" id="d-instance_attributes-test"/>
          <nvpair name="fake" value="xxx" id="d-instance_attributes-fake"/>
        </instance_attributes>
      </primitive>
```
## Solution
In `ra.sanity_check_params`, crmsh did check if giving parameter exists, but did not check parameter without a value
So after change, in this case will raise an error
```
# crm configure primitive id=d Dummy params test fake=xxx
ERROR: d: parameter test does not exist
Do you still want to commit (y/n)?
```

Also, the completer of `crm configure primitive` might mislead user to add that undefined parameter, like:
```
crm(live/15sp2-1)configure# primitive id=d Dummy params 
fake=    meta     op       params   state=
```
Complete `meta/op/params` after `params` was meaningless
So I changed the behavior of this completer in this way:
```
crm(live/15sp2-1)configure# primitive id=d Dummy params 
fake=    state=   
crm(live/15sp2-1)configure# primitive id=d Dummy params fake=xxx 
meta     op       params   state=   
crm(live/15sp2-1)configure# primitive id=d Dummy params fake=xxx op monitor 
interval=10s   timeout=20s    
crm(live/15sp2-1)configure# primitive id=d Dummy params fake=xxx op monitor interval=10s timeout=20s 
meta     op       params   
```