### PR TITLE
Dev: utils: remove unused utils.cluster_stack and its related codes

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -19,10 +19,6 @@ def conf():
     return os.getenv('COROSYNC_MAIN_CONFIG_FILE', '/etc/corosync/corosync.conf')
 
 
-def is_corosync_stack():
-    return utils.cluster_stack() == 'corosync'
-
-
 def check_tools():
     return all(utils.is_program(p)
                for p in ['corosync-cfgtool', 'corosync-quorumtool', 'corosync-cmapctl'])

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -589,26 +589,21 @@ Cluster Description
         '''
         Quick cluster health status. Corosync status, DRBD status...
         '''
-
-        stack = utils.cluster_stack()
-        if not stack:
-            err_buf.error("No supported cluster stack found (tried heartbeat|openais|corosync)")
-        if utils.cluster_stack() == 'corosync':
-            print("Name: {}\n".format(get_cluster_name()))
-            print("Services:")
-            for svc in ["corosync", "pacemaker"]:
-                info = utils.service_info(svc)
-                if info:
-                    print("%-16s %s" % (svc, info))
-                else:
-                    print("%-16s unknown" % (svc))
-
-            rc, outp = utils.get_stdout(['corosync-cfgtool', '-s'], shell=False)
-            if rc == 0:
-                print("")
-                print(outp)
+        print("Name: {}\n".format(get_cluster_name()))
+        print("Services:")
+        for svc in ["corosync", "pacemaker"]:
+            info = utils.service_info(svc)
+            if info:
+                print("%-16s %s" % (svc, info))
             else:
-                print("Failed to get corosync status")
+                print("%-16s unknown" % (svc))
+
+        rc, outp = utils.get_stdout(['corosync-cfgtool', '-s'], shell=False)
+        if rc == 0:
+            print("")
+            print(outp)
+        else:
+            print("Failed to get corosync status")
 
     @command.completers_repeating(compl.choice(['10', '60', '600']))
     def do_wait_for_startup(self, context, timeout='10'):

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -52,10 +52,6 @@ class Corosync(command.UI):
     name = "corosync"
 
     def requires(self):
-        stack = utils.cluster_stack()
-        if len(stack) > 0 and stack != 'corosync':
-            err_buf.warning("Unsupported cluster stack %s detected." % (stack))
-            return False
         return corosync.check_tools()
 
     @command.completers(completers.choice(['ring', 'quorum', 'qnetd']))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1103,17 +1103,6 @@ def print_stacktrace():
     traceback.print_stack(sf)
 
 
-@memoize
-def cluster_stack():
-    if is_process("heartbeat:.[m]aster"):
-        return "heartbeat"
-    elif is_process("[a]isexec"):
-        return "openais"
-    elif os.path.exists("/etc/corosync/corosync.conf") or is_program('corosync-cfgtool'):
-        return "corosync"
-    return ""
-
-
 def edit_file(fname):
     'Edit a file.'
     if not fname:


### PR DESCRIPTION
I think under current live branches, no need to detect if the cluster stack is corosync