### PR TITLE
Configure qdevice on interactive mode

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -282,8 +282,14 @@ class QDevice(object):
         if not utils.valid_port(self.port):
             raise ValueError("invalid qdevice port range(1024 - 65535)")
 
-        if self.tie_breaker not in ["lowest", "highest"] and not utils.valid_nodeid(self.tie_breaker):
+        if self.algo not in ("ffsplit", "lms"):
+            raise ValueError("invalid ALGORITHM choice: '{}' (choose from 'ffsplit', 'lms')".format(self.algo))
+
+        if self.tie_breaker not in ("lowest", "highest") and not utils.valid_nodeid(self.tie_breaker):
             raise ValueError("invalid qdevice tie_breaker(lowest/highest/valid_node_id)")
+
+        if self.tls not in ("on", "off", "required"):
+            raise ValueError("invalid TLS choice: '{}' (choose from 'on', 'off', 'required')".format(self.tls))
 
         if self.cmds:
             for cmd in self.cmds.strip(';').split(';'):

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -243,17 +243,17 @@ Note:
         qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr", metavar="HOST",
                                    help="HOST or IP of the QNetd server to be used")
         qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int, default=5403,
-                                   help="TCP PORT of QNetd server(default:5403)")
+                                   help="TCP PORT of QNetd server (default:5403)")
         qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", default="ffsplit", choices=['ffsplit', 'lms'],
-                                   help="QNetd decision ALGORITHM(ffsplit/lms, default:ffsplit)")
+                                   help="QNetd decision ALGORITHM (ffsplit/lms, default:ffsplit)")
         qdevice_group.add_argument("--qdevice-tie-breaker", dest="qdevice_tie_breaker", metavar="TIE_BREAKER", default="lowest",
-                                   help="QNetd TIE_BREAKER(lowest/highest/valid_node_id, default:lowest)")
+                                   help="QNetd TIE_BREAKER (lowest/highest/valid_node_id, default:lowest)")
         qdevice_group.add_argument("--qdevice-tls", dest="qdevice_tls", metavar="TLS", default="on", choices=['on', 'off', 'required'],
-                                   help="Whether using TLS on QDevice/QNetd(on/off/required, default:on)")
+                                   help="Whether using TLS on QDevice/QNetd (on/off/required, default:on)")
         qdevice_group.add_argument("--qdevice-heuristics", dest="qdevice_heuristics", metavar="COMMAND",
-                                   help="COMMAND to run with absolute path. For multiple commands, use \";\" to separate(details about heuristics can see man 8 corosync-qdevice)")
+                                   help="COMMAND to run with absolute path. For multiple commands, use \";\" to separate (details about heuristics can see man 8 corosync-qdevice)")
         qdevice_group.add_argument("--qdevice-heuristics-mode", dest="qdevice_heuristics_mode", metavar="MODE", choices=['on', 'sync', 'off'],
-                                   help="MODE of operation of heuristics(on/sync/off, default:sync)")
+                                   help="MODE of operation of heuristics (on/sync/off, default:sync)")
 
         storage_group = parser.add_argument_group("Storage configuration", "Options for configuring shared storage.")
         storage_group.add_argument("-p", "--partition-device", dest="shared_device", metavar="DEVICE",
@@ -277,7 +277,7 @@ Note:
             if options.qdevice_heuristics_mode and not options.qdevice_heuristics:
                 parser.error("Option --qdevice-heuristics is required if want to configure heuristics mode")
             options.qdevice_heuristics_mode = options.qdevice_heuristics_mode or "sync"
-        elif re.search("--qdevice-.*", ' '.join(sys.argv)) or stage == "qdevice":
+        elif re.search("--qdevice-.*", ' '.join(sys.argv)) or (stage == "qdevice" and options.yes_to_all):
             parser.error("Option --qnetd-hostname is required if want to configure qdevice")
 
         if options.sbd_devices and options.diskless_sbd:

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -102,7 +102,7 @@ Feature: corosync qdevice/qnetd options validate
     Given   Cluster service is "stopped" on "hanode1"
     When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    When    Try "crm cluster init qdevice"
+    When    Try "crm cluster init qdevice -y"
     Then    Except multiple lines
       """
       usage: init [options] [STAGE]

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -98,20 +98,21 @@ QDevice configuration:
 
   --qnetd-hostname HOST
                         HOST or IP of the QNetd server to be used
-  --qdevice-port PORT   TCP PORT of QNetd server(default:5403)
+  --qdevice-port PORT   TCP PORT of QNetd server (default:5403)
   --qdevice-algo ALGORITHM
-                        QNetd decision ALGORITHM(ffsplit/lms, default:ffsplit)
+                        QNetd decision ALGORITHM (ffsplit/lms,
+                        default:ffsplit)
   --qdevice-tie-breaker TIE_BREAKER
-                        QNetd TIE_BREAKER(lowest/highest/valid_node_id,
+                        QNetd TIE_BREAKER (lowest/highest/valid_node_id,
                         default:lowest)
-  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd(on/off/required,
+  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd (on/off/required,
                         default:on)
   --qdevice-heuristics COMMAND
                         COMMAND to run with absolute path. For multiple
-                        commands, use ";" to separate(details about heuristics
-                        can see man 8 corosync-qdevice)
+                        commands, use ";" to separate (details about
+                        heuristics can see man 8 corosync-qdevice)
   --qdevice-heuristics-mode MODE
-                        MODE of operation of heuristics(on/sync/off,
+                        MODE of operation of heuristics (on/sync/off,
                         default:sync)
 
 Storage configuration:


### PR DESCRIPTION
#### Configure qdevice on a running cluster
```Bash
15sp2-1:~ # crm cluster init -y
  Configuring csync2
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
  Configuring corosync
WARNING: Not configuring SBD (/etc/sysconfig/sbd left untouched).
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
15sp2-1:~ # crm cluster init qdevice
Do you want to configure QDevice (y/n)? y
  HOST or IP of the QNetd server to be used []15sp2-3
  TCP PORT of QNetd server [5403]
  QNetd decision ALGORITHM(ffsplit/lms) [ffsplit]
  QNetd TIE_BREAKER(lowest/highest/valid node id) [lowest]
  Whether using TLS on QDevice/QNetd(on/off/required) [on]
  COMMAND to run with absolute path; For multiple commands, use ";" to separate []
  
Configure Qdevice/Qnetd:
  Update configuration...done
  Qdevice certification process...done
  Enable corosync-qdevice.service in cluster
  Restarting cluster service
  Waiting for cluster..............done
  Enable corosync-qnetd.service on 15sp2-3
  Starting corosync-qnetd.service on 15sp2-3
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
#### Configure qdevice from beginning
```Bash
15sp2-1:~ # crm cluster init
  Configuring csync2
csync2 is already configured - overwrite (y/n)? y
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
/etc/corosync/authkey already exists - overwrite (y/n)? y
/etc/corosync/corosync.conf already exists - overwrite (y/n)? y
  
Configure Corosync:
  This will configure the cluster messaging layer.  You will need
  to specify a network address over which to communicate (default
  is eth0's network, but you can use the network address of any
  active interface).

  IP or network address to bind to [192.168.122.193]
  Multicast address [239.197.122.212]
  Multicast port [5405]
/etc/pacemaker/authkey already exists - overwrite (y/n)? y
  
Configure SBD:
  If you have shared storage, for example a SAN or iSCSI target,
  you can use it avoid split-brain scenarios by configuring SBD.
  This requires a 1 MB partition, accessible to all nodes in the
  cluster.  The device path must be persistent and consistent
  across all nodes in the cluster, so /dev/disk/by-id/* devices
  are a good choice.  Note that all data on the partition you
  specify here will be destroyed.

Do you wish to use SBD (y/n)? n
WARNING: Not configuring SBD - STONITH will be disabled.
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
  
Configure Administration IP Address:
  Optionally configure an administration virtual IP
  address. The purpose of this IP address is to
  provide a single IP that can be used to interact
  with the cluster, rather than using the IP address
  of any specific cluster node.

Do you wish to configure a virtual IP address (y/n)? n
Do you want to configure QDevice (y/n)? y
  HOST or IP of the QNetd server to be used []15sp2-3
  TCP PORT of QNetd server [5403]
  QNetd decision ALGORITHM(ffsplit/lms) [ffsplit]
  QNetd TIE_BREAKER(lowest/highest/valid node id) [lowest]
  Whether using TLS on QDevice/QNetd(on/off/required) [on]
  COMMAND to run with absolute path; For multiple commands, use ";" to separate []
  
Configure Qdevice/Qnetd:
  Update configuration...done
  Qdevice certification process...done
  Enable corosync-qdevice.service in cluster
  Restarting cluster service
  Waiting for cluster..............done
  Enable corosync-qnetd.service on 15sp2-3
  Starting corosync-qnetd.service on 15sp2-3
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```