### PR TITLE
[crmsh-4.1] Fix: bootstrap: raise warning when configuring diskless SBD with less than 3 nodes

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -341,6 +341,7 @@ Configure SBD:
   specify here will be destroyed.
 """
     PARSE_RE = "[; ]"
+    DISKLESS_SBD_WARNING = "Diskless SBD requires cluster with three or more nodes."
 
     def __init__(self, sbd_devices=None, diskless_sbd=False):
         """
@@ -514,6 +515,8 @@ Configure SBD:
         if not self._sbd_devices and not self.diskless_sbd:
             invoke("systemctl disable sbd.service")
             return
+        if self.diskless_sbd:
+            warn(self.DISKLESS_SBD_WARNING)
         status_long("Initializing {}SBD...".format("diskless " if self.diskless_sbd else ""))
         self._initialize_sbd()
         self._update_configuration()
@@ -552,6 +555,10 @@ Configure SBD:
         dev_list = self._get_sbd_device_from_config()
         if dev_list:
             self._verify_sbd_device(dev_list, [peer_host])
+        else:
+            vote_dict = utils.get_quorum_votes_dict(peer_host)
+            if int(vote_dict['Expected']) < 2:
+                warn(self.DISKLESS_SBD_WARNING)
         status("Got {}SBD configuration".format("" if dev_list else "diskless "))
         invoke("systemctl enable sbd.service")
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2576,4 +2576,24 @@ def cluster_run_cmd(cmd):
     if not node_list:
         raise ValueError("Failed to get node list from cluster")
     parallax.parallax_call(node_list, cmd)
+
+
+def get_stdout_or_raise_error(cmd, remote=None, success_val=0):
+    """
+    Common function to get stdout from cmd or raise exception
+    """
+    if remote:
+        cmd = "ssh -o StrictHostKeyChecking=no root@{} \"{}\"".format(remote, cmd)
+    rc, out, err = get_stdout_stderr(cmd)
+    if rc != success_val:
+        raise ValueError("Failed to run \"{}\": {}".format(cmd, err))
+    return out
+
+
+def get_quorum_votes_dict(remote=None):
+    """
+    Return a dictionary which contain expect votes and total votes
+    """
+    out = get_stdout_or_raise_error("corosync-quorumtool -s", remote=remote)
+    return dict(re.findall("(Expected|Total) votes:\s+(\d+)", out))
 # vim:ts=4:sw=4:et:


### PR DESCRIPTION
backport #752 