### PR TITLE
[crmsh-3.0] Fix: bootstrap: raise warning when configuring diskless SBD with less than 3 nodes

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -318,6 +318,7 @@ Configure SBD:
   specify here will be destroyed.
 """
     PARSE_RE = "[; ]"
+    DISKLESS_SBD_WARNING = "Diskless SBD requires cluster with three or more nodes."
 
     def __init__(self, sbd_devices=None, diskless_sbd=False):
         """
@@ -491,6 +492,8 @@ Configure SBD:
         if not self._sbd_devices and not self.diskless_sbd:
             invoke("systemctl disable sbd.service")
             return
+        if self.diskless_sbd:
+            warn(self.DISKLESS_SBD_WARNING)
         status_long("Initializing {}SBD...".format("diskless " if self.diskless_sbd else ""))
         self._initialize_sbd()
         self._update_configuration()
@@ -529,6 +532,10 @@ Configure SBD:
         dev_list = self._get_sbd_device_from_config()
         if dev_list:
             self._verify_sbd_device(dev_list, [peer_host])
+        else:
+            vote_dict = utils.get_quorum_votes_dict(peer_host)
+            if int(vote_dict['Expected']) < 2:
+                warn(self.DISKLESS_SBD_WARNING)
         status("Got {}SBD configuration".format("" if dev_list else "diskless "))
         invoke("systemctl enable sbd.service")
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2508,4 +2508,24 @@ def cluster_run_cmd(cmd):
     if not node_list:
         raise ValueError("Failed to get node list from cluster")
     parallax_helper.parallax_call(node_list, cmd)
+
+
+def get_stdout_or_raise_error(cmd, remote=None, success_val=0):
+    """
+    Common function to get stdout from cmd or raise exception
+    """
+    if remote:
+        cmd = "ssh -o StrictHostKeyChecking=no root@{} \"{}\"".format(remote, cmd)
+    rc, out, err = get_stdout_stderr(cmd)
+    if rc != success_val:
+        raise ValueError("Failed to run \"{}\": {}".format(cmd, err))
+    return out
+
+
+def get_quorum_votes_dict(remote=None):
+    """
+    Return a dictionary which contain expect votes and total votes
+    """
+    out = get_stdout_or_raise_error("corosync-quorumtool -s", remote=remote)
+    return dict(re.findall("(Expected|Total) votes:\s+(\d+)", out))
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -601,6 +601,7 @@ class TestSBDManager(unittest.TestCase):
         mock_watchdog_inst.init_watchdog.assert_called_once_with()
         mock_invoke.assert_called_once_with("systemctl disable sbd.service")
 
+    @mock.patch('crmsh.bootstrap.warn')
     @mock.patch('crmsh.bootstrap.status_done')
     @mock.patch('crmsh.bootstrap.SBDManager._update_configuration')
     @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
@@ -608,7 +609,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
     @mock.patch('crmsh.bootstrap.Watchdog')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_sbd_init(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done):
+    def test_sbd_init(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_status_done, mock_warn):
         bootstrap._context = mock.Mock(watchdog=None)
         mock_package.return_value = True
         mock_watchdog_inst = mock.Mock()
@@ -624,6 +625,7 @@ class TestSBDManager(unittest.TestCase):
         mock_status_done.assert_called_once_with()
         mock_watchdog.assert_called_once_with(_input=None)
         mock_watchdog_inst.init_watchdog.assert_called_once_with()
+        mock_warn.assert_called_once_with(bootstrap.SBDManager.DISKLESS_SBD_WARNING)
 
     @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.bootstrap.invokerc')
@@ -744,6 +746,38 @@ class TestSBDManager(unittest.TestCase):
         mock_verify.assert_called_once_with(["/dev/sdb1"], ["node1"])
         mock_enabled.assert_called_once_with("sbd.service", "node1")
         mock_status.assert_called_once_with("Got SBD configuration")
+        mock_watchdog.assert_called_once_with(peer_host="node1")
+        mock_watchdog_inst.join_watchdog.assert_called_once_with()
+
+    @mock.patch('crmsh.bootstrap.status')
+    @mock.patch('crmsh.bootstrap.warn')
+    @mock.patch('crmsh.utils.get_quorum_votes_dict')
+    @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
+    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('os.path.exists')
+    @mock.patch('crmsh.utils.package_is_installed')
+    def test_join_sbd_diskless(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_watchdog, mock_get_device, mock_quorum_votes, mock_warn, mock_status):
+        mock_package.return_value = True
+        mock_exists.return_value = True
+        mock_enabled.return_value = True
+        mock_get_device.return_value = []
+        mock_watchdog_inst = mock.Mock()
+        mock_watchdog.return_value = mock_watchdog_inst
+        mock_watchdog_inst.join_watchdog = mock.Mock()
+        mock_quorum_votes.return_value = {'Expected': '1', 'Total': '1'}
+
+        self.sbd_inst.join_sbd("node1")
+
+        mock_package.assert_called_once_with("sbd")
+        mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
+        mock_invoke.assert_called_once_with("systemctl enable sbd.service")
+        mock_get_device.assert_called_once_with()
+        mock_quorum_votes.assert_called_once_with("node1")
+        mock_warn.assert_called_once_with(bootstrap.SBDManager.DISKLESS_SBD_WARNING)
+        mock_enabled.assert_called_once_with("sbd.service", "node1")
+        mock_status.assert_called_once_with("Got diskless SBD configuration")
         mock_watchdog.assert_called_once_with(peer_host="node1")
         mock_watchdog_inst.join_watchdog.assert_called_once_with()
 

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -929,3 +929,36 @@ def test_ping_node(mock_run):
 def test_re_split_string():
     assert utils.re_split_string('[; ]', "/dev/sda1; /dev/sdb1 ; ") == ["/dev/sda1", "/dev/sdb1"]
     assert utils.re_split_string('[; ]', "/dev/sda1 ") == ["/dev/sda1"]
+
+
+@mock.patch("crmsh.utils.get_stdout_stderr")
+def test_get_stdout_or_raise_error_failed(mock_run):
+    mock_run.return_value = (1, None, "error data")
+    with pytest.raises(ValueError) as err:
+        utils.get_stdout_or_raise_error("cmd")
+    assert str(err.value) == 'Failed to run "cmd": error data'
+    mock_run.assert_called_once_with("cmd")
+
+
+@mock.patch("crmsh.utils.get_stdout_stderr")
+def test_get_stdout_or_raise_error(mock_run):
+    mock_run.return_value = (0, "output data", None)
+    res = utils.get_stdout_or_raise_error("cmd", remote="node1")
+    assert res == "output data"
+    mock_run.assert_called_once_with("ssh -o StrictHostKeyChecking=no root@node1 \"cmd\"")
+
+
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_get_quorum_votes_dict(mock_run):
+    mock_run.return_value = """
+Votequorum information
+----------------------
+Expected votes:   1
+Highest expected: 1
+Total votes:      1
+Quorum:           1
+Flags:            Quorate
+    """
+    res = utils.get_quorum_votes_dict()
+    assert res == {'Expected': '1', 'Total': '1'}
+    mock_run.assert_called_once_with("corosync-quorumtool -s", remote=None)


### PR DESCRIPTION
backport #752 