### PR TITLE
Change lock directory under /run

### DIFF
--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -28,7 +28,7 @@ class Lock(object):
     A base class define a lock mechanism used to exclude other nodes
     """
 
-    LOCK_DIR = "/tmp/.crmsh_lock_directory"
+    LOCK_DIR = "/run/.crmsh_lock_directory"
     MKDIR_CMD = "mkdir {}".format(LOCK_DIR)
     RM_CMD = "rm -rf {}".format(LOCK_DIR)
 

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -92,7 +92,7 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode2"
     # Try to simulate the join process hanging on hanode2 or hanode2 died
     # Just leave the lock directory unremoved
-    When    Run "mkdir /tmp/.crmsh_lock_directory" on "hanode1"
+    When    Run "mkdir /run/.crmsh_lock_directory" on "hanode1"
     When    Try "crm cluster join -c hanode1 -y" on "hanode3"
-    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/tmp/.crmsh_lock_directory)"
-    When    Run "rm -rf /tmp/.crmsh_lock_directory" on "hanode1"
+    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/run/.crmsh_lock_directory)"
+    When    Run "rm -rf /run/.crmsh_lock_directory" on "hanode1"

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -73,7 +73,7 @@ class TestLock(unittest.TestCase):
         mock_create.return_value = False
         with self.assertRaises(lock.ClaimLockError) as err:
             self.local_inst._lock_or_fail()
-        self.assertEqual("Failed to claim lock (the lock directory exists at /tmp/.crmsh_lock_directory)", str(err.exception))
+        self.assertEqual("Failed to claim lock (the lock directory exists at {})".format(lock.Lock.LOCK_DIR), str(err.exception))
         mock_create.assert_called_once_with()
 
     @mock.patch('crmsh.lock.Lock._run')
@@ -210,7 +210,7 @@ class TestRemoteLock(unittest.TestCase):
 
         with self.assertRaises(lock.ClaimLockError) as err:
             self.lock_inst._lock_or_wait()
-        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:/tmp/.crmsh_lock_directory)", str(err.exception))
+        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:{})".format(lock.Lock.LOCK_DIR), str(err.exception))
 
         mock_time.assert_has_calls([ mock.call(), mock.call()])
         mock_time_out.assert_has_calls([mock.call(), mock.call(), mock.call()])


### PR DESCRIPTION
## Problem
**Just when** finished setup two nodes cluster with diskless SBD, I reboot node two **immediately**, then node one also be fenced by sbd.

After reboot, I found the lock directory not be deleted on node one, which should already be deleted when node two finished bootstrap join 
## Solution
Should run `sync` command after remove lock directory, otherwise, the lock directory might not be deleted in time