### PR TITLE
Fix: bootstrap: sync files before finished joining

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -41,6 +41,8 @@ CSYNC2_KEY = "/etc/csync2/key_hagroup"
 CSYNC2_CFG = "/etc/csync2/csync2.cfg"
 COROSYNC_AUTH = "/etc/corosync/authkey"
 SYSCONFIG_SBD = "/etc/sysconfig/sbd"
+SYSCONFIG_PCMK = "/etc/sysconfig/pacemaker"
+SYSCONFIG_NFS = "/etc/sysconfig/nfs"
 SYSCONFIG_FW = "/etc/sysconfig/SuSEfirewall2"
 SYSCONFIG_FW_CLUSTER = "/etc/sysconfig/SuSEfirewall2.d/services/cluster"
 PCMK_REMOTE_AUTH = "/etc/pacemaker/authkey"
@@ -49,6 +51,13 @@ SERVICES_STOP_LIST = ["corosync-qdevice.service", "corosync.service", "hawk.serv
 USER_LIST = ["root", "hacluster"]
 QDEVICE_ADD = "add"
 QDEVICE_REMOVE = "remove"
+WATCHDOG_CFG = "/etc/modules-load.d/watchdog.conf"
+BOOTH_DIR = "/etc/booth"
+BOOTH_CFG = "/etc/booth/booth.conf"
+BOOTH_AUTH = "/etc/booth/authkey"
+FILES_TO_SYNC = (BOOTH_DIR, corosync.conf(), COROSYNC_AUTH, CSYNC2_CFG, CSYNC2_KEY, "/etc/ctdb/nodes",
+        "/etc/drbd.conf", "/etc/drbd.d", "/etc/ha.d/ldirectord.cf", "/etc/lvm/lvm.conf", "/etc/multipath.conf",
+        "/etc/samba/smb.conf", SYSCONFIG_NFS, SYSCONFIG_PCMK, SYSCONFIG_SBD, PCMK_REMOTE_AUTH, WATCHDOG_CFG)
 
 INIT_STAGES = ("ssh", "ssh_remote", "csync2", "csync2_remote", "corosync", "storage", "sbd", "cluster", "vgfs", "admin", "qdevice")
 
@@ -200,7 +209,7 @@ class Watchdog(object):
         """
         Load specific watchdog driver
         """
-        invoke("echo {} > /etc/modules-load.d/watchdog.conf".format(driver))
+        invoke("echo {} > {}".format(driver, WATCHDOG_CFG))
         invoke("systemctl restart systemd-modules-load")
 
     @staticmethod
@@ -1253,29 +1262,17 @@ def init_csync2():
         error("Can't create csync2 key {}".format(CSYNC2_KEY))
     status_done()
 
+    csync2_file_list = ""
+    for f in FILES_TO_SYNC:
+        csync2_file_list += "include {};\n".format(f)
+
     utils.str2file("""group ha_group
-{
+{{
 key /etc/csync2/key_hagroup;
-host %s;
-include /etc/booth;
-include /etc/corosync/corosync.conf;
-include /etc/corosync/authkey;
-include /etc/csync2/csync2.cfg;
-include /etc/csync2/key_hagroup;
-include /etc/ctdb/nodes;
-include /etc/drbd.conf;
-include /etc/drbd.d;
-include /etc/ha.d/ldirectord.cf;
-include /etc/lvm/lvm.conf;
-include /etc/multipath.conf;
-include /etc/samba/smb.conf;
-include /etc/sysconfig/nfs;
-include /etc/sysconfig/pacemaker;
-include /etc/sysconfig/sbd;
-include /etc/pacemaker/authkey;
-include /etc/modules-load.d/watchdog.conf;
-}
-    """ % (utils.this_node()), CSYNC2_CFG)
+host {};
+{}
+}}
+    """.format(utils.this_node(), csync2_file_list), CSYNC2_CFG)
 
     utils.start_service("csync2.socket", enable=True)
     status_long("csync2 checking files")
@@ -1337,7 +1334,7 @@ def init_corosync_auth():
         if not confirm("%s already exists - overwrite?" % (COROSYNC_AUTH)):
             return
         rmfile(COROSYNC_AUTH)
-    invoke("corosync-keygen -l")
+    invoke("corosync-keygen -l -k {}".format(COROSYNC_AUTH))
 
 
 def init_remote_auth():
@@ -2264,6 +2261,15 @@ def setup_passwordless_with_other_nodes(init_node):
             swap_public_ssh_key(node, user)
 
 
+def sync_files_to_disk():
+    """
+    Sync file content to disk between cluster nodes
+    """
+    files_string = ' '.join(filter(lambda f: os.path.isfile(f), FILES_TO_SYNC))
+    if files_string:
+        utils.cluster_run_cmd("sync {}".format(files_string.strip()))
+
+
 def join_cluster(seed_host):
     """
     Cluster configuration for joining node.
@@ -2410,6 +2416,8 @@ def join_cluster(seed_host):
                 continue
             update_nodeid(int(nodeid_dict[node]), node)
         update_nodeid(local_nodeid)
+
+    sync_files_to_disk()
     status_done()
 
     if is_qdevice_configured:
@@ -2780,10 +2788,6 @@ def init_common_geo():
         error("Booth not installed - Not configurable as a geo cluster node.")
 
 
-BOOTH_CFG = "/etc/booth/booth.conf"
-BOOTH_AUTH = "/etc/booth/authkey"
-
-
 def init_csync2_geo():
     """
     TODO: Configure csync2 for geo cluster
@@ -2853,7 +2857,7 @@ def bootstrap_init_geo(context):
     create_booth_authkey()
     create_booth_config(_context.arbitrator, _context.clusters, _context.tickets)
     status("Sync booth configuration across cluster")
-    csync2_update("/etc/booth")
+    csync2_update(BOOTH_DIR)
     init_csync2_geo()
     geo_cib_config(_context.clusters)
 
@@ -2862,7 +2866,7 @@ def geo_fetch_config(node):
     # TODO: clean this up
     status("Retrieving configuration - This may prompt for root@%s:" % (node))
     tmpdir = tmpfiles.create_dir()
-    rc, _, err = invoke("scp -oStrictHostKeyChecking=no root@%s:'/etc/booth/*' %s/" % (node, tmpdir))
+    rc, _, err = invoke("scp -oStrictHostKeyChecking=no root@{}:'{}/*' {}/".format(node, BOOTH_DIR, tmpdir))
     if not rc:
         error("Failed to retrieve configuration: {}".format(err))
     try:
@@ -2905,7 +2909,7 @@ def bootstrap_join_geo(context):
     check_tty()
     geo_fetch_config(_context.cluster_node)
     status("Sync booth configuration across cluster")
-    csync2_update("/etc/booth")
+    csync2_update(BOOTH_DIR)
     geo_cib_config(_context.clusters)
 
 

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -11,7 +11,6 @@ import socket
 from . import utils
 from . import tmpfiles
 from . import parallax
-from . import bootstrap
 from .msg import err_buf, common_debug
 
 
@@ -333,6 +332,7 @@ class QDevice(object):
         self.manage_qnetd("stop")
 
     def debug_and_log_to_bootstrap(self, msg):
+        from . import bootstrap
         common_debug(msg)
         bootstrap.log("# " + msg)
 
@@ -640,11 +640,7 @@ class QDevice(object):
                 cmd_name = re.sub("[.-]", "_", os.path.basename(cmd.split()[0]))
                 exec_name = "exec_{}{}".format(cmd_name, i)
                 p.set('quorum.device.heuristics.{}'.format(exec_name), cmd)
-
-        with open(conf(), 'w') as f:
-            f.write(p.to_string())
-            f.flush()
-            os.fsync(f)
+        utils.str2file(p.to_string(), conf())
 
     def remove_qdevice_config(self):
         """
@@ -653,10 +649,7 @@ class QDevice(object):
         with open(conf()) as f:
             p = Parser(f.read())
             p.remove("quorum.device")
-        with open(conf(), 'w') as f:
-            f.write(p.to_string())
-            f.flush()
-            os.fsync(f)
+        utils.str2file(p.to_string(), conf())
 
     def remove_qdevice_db(self):
         """
@@ -982,9 +975,7 @@ def set_value(path, value):
     f = open(conf()).read()
     p = Parser(f)
     p.set(path, value)
-    f = open(conf(), 'w')
-    f.write(p.to_string())
-    f.close()
+    utils.str2file(p.to_string(), conf())
 
 
 class IPAlreadyConfiguredError(Exception):
@@ -1045,8 +1036,7 @@ def add_node_ucast(ip_list, node_id=None):
     if p.get("quorum.device.model") == "net":
         p.set('quorum.two_node', '0')
 
-    with open(conf(), 'w') as f:
-        f.write(p.to_string())
+    utils.str2file(p.to_string(), conf())
 
 
 def add_node(addr, name=None):
@@ -1094,9 +1084,7 @@ def add_node(addr, name=None):
     if p.get("quorum.device.model") == "net":
         p.set('quorum.two_node', '0')
 
-    f = open(conf(), 'w')
-    f.write(p.to_string())
-    f.close()
+    utils.str2file(p.to_string(), conf())
 
     # update running config (if any)
     if nodes:
@@ -1127,9 +1115,7 @@ def del_node(addr):
     if p.get("quorum.device.model") == "net":
         p.set('quorum.two_node', '0')
 
-    f = open(conf(), 'w')
-    f.write(p.to_string())
-    f.close()
+    utils.str2file(p.to_string(), conf())
 
 
 _COROSYNC_CONF_TEMPLATE_HEAD = """# Please read the corosync.conf.5 manual page

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -528,7 +528,7 @@ def str2file(s, fname, mod=0o644):
     Write a string to a file.
     '''
     try:
-        with open_atomic(fname, 'w', encoding='utf-8') as dst:
+        with open_atomic(fname, 'w', encoding='utf-8', fsync=True) as dst:
             dst.write(to_ascii(s))
         os.chmod(fname, mod)
     except IOError as msg:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1716,6 +1716,15 @@ class TestBootstrap(unittest.TestCase):
         mock_quorate.assert_called_once_with(2, 1)
         mock_ra_running.assert_called_once_with()
 
+    @mock.patch('crmsh.utils.cluster_run_cmd')
+    @mock.patch('os.path.isfile')
+    def test_sync_files_to_disk(self, mock_isfile, mock_cluster_cmd):
+        bootstrap.FILES_TO_SYNC = ("file1", "file2")
+        mock_isfile.side_effect = [True, True]
+        bootstrap.sync_files_to_disk()
+        mock_isfile.assert_has_calls([mock.call("file1"), mock.call("file2")])
+        mock_cluster_cmd.assert_called_once_with("sync file1 file2")
+
 
 class TestValidation(unittest.TestCase):
     """


### PR DESCRIPTION
## Problem
I found that corosync.conf will become empty when reset init node just after join process finished, so the cluster service wouldn't be started on init node then.

How to reproduce it:
1. On init node: crm cluster init -u -i eth1 -i eth2 -y
2. On join node: crm cluster join -c <init_node> -y -i eth1 -i eth2 -y
3. Just when join process finished, quickly force reset the init node
4. After init node started, corosync.conf become empty

## Solution

- Before finishing join process, run `sync <files>` command between cluster nodes, to make sure all these files' contents sync to disk
- Use `utils.str2file` to write data into file, `utils.str2file` could execute `os.fsync` internally


## Other changes
Change more string values as constants