### PR TITLE
[crmsh-4.1] Fix: bootstrap: get the peer node name correctly 

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -745,17 +745,14 @@ def wait_for_cluster():
 
 def get_cluster_node_hostname():
     """
-    Get the hostname of the cluster node used during the join process if an IP address is used.
+    Get the hostname of the cluster node
     """
     peer_node = None
     if _context.cluster_node:
-        if utils.IP.is_valid_ip(_context.cluster_node):
-            rc, out, err = utils.get_stdout_stderr("ssh {} crm_node --name".format(_context.cluster_node))
-            if rc != 0:
-                error(err)
-            peer_node = out
-        else:
-            peer_node = _context.cluster_node
+        rc, out, err = utils.get_stdout_stderr("ssh {} crm_node --name".format(_context.cluster_node))
+        if rc != 0:
+            error(err)
+        peer_node = out
     return peer_node
 
 

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -98,3 +98,18 @@ Feature: Regression test for bootstrap bugs
     When    Try "crm cluster join -c hanode1 -y" on "hanode3"
     Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/run/.crmsh_lock_directory)"
     When    Run "rm -rf /run/.crmsh_lock_directory" on "hanode1"
+
+  @clean
+  Scenario: Change host name in /etc/hosts as alias(bsc#1183654)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "echo '10.10.10.2 HANODE1' >> /etc/hosts" on "hanode1"
+    When    Run "echo '10.10.10.3 HANODE2' >> /etc/hosts" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c HANODE1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    When    Run "crm cluster remove HANODE2 -y" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode2"
+    And     Online nodes are "hanode1"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1128,41 +1128,28 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
 
-    @mock.patch('crmsh.utils.IP.is_valid_ip')
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_cluster_node_hostname_None(self, mock_stdout_stderr, mock_valid_ip):
-        bootstrap._context = mock.Mock(cluster_node=None)
+    def test_get_cluster_node_hostname(self, mock_stdout_stderr):
+        bootstrap._context = mock.Mock(cluster_node="node1")
+        mock_stdout_stderr.return_value = (0, "Node1", None)
 
         peer_node = bootstrap.get_cluster_node_hostname()
-        assert peer_node is None
+        assert peer_node == "Node1"
 
-        mock_valid_ip.assert_not_called()
-        mock_stdout_stderr.assert_not_called()
+        mock_stdout_stderr.assert_called_once_with("ssh node1 crm_node --name")
 
-    @mock.patch('crmsh.utils.IP.is_valid_ip')
+    @mock.patch('crmsh.bootstrap.error')
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_cluster_node_hostname_IP(self, mock_stdout_stderr, mock_valid_ip):
-        bootstrap._context = mock.Mock(cluster_node="1.1.1.1")
-        mock_valid_ip.return_value = True
-        mock_stdout_stderr.return_value = (0, "node1", None)
-
-        peer_node = bootstrap.get_cluster_node_hostname()
-        assert peer_node == "node1"
-
-        mock_valid_ip.assert_called_once_with("1.1.1.1")
-        mock_stdout_stderr.assert_called_once_with("ssh 1.1.1.1 crm_node --name")
-
-    @mock.patch('crmsh.utils.IP.is_valid_ip')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_cluster_node_hostname_HOST(self, mock_stdout_stderr, mock_valid_ip):
+    def test_get_cluster_node_hostname_error(self, mock_stdout_stderr, mock_error):
         bootstrap._context = mock.Mock(cluster_node="node2")
-        mock_valid_ip.return_value = False
+        mock_stdout_stderr.return_value = (1, None, "error")
+        mock_error.side_effect = SystemExit
 
-        peer_node = bootstrap.get_cluster_node_hostname()
-        assert peer_node == "node2"
+        with self.assertRaises(SystemExit):
+            bootstrap.get_cluster_node_hostname()
 
-        mock_valid_ip.assert_called_once_with("node2")
-        mock_stdout_stderr.assert_not_called()
+        mock_stdout_stderr.assert_called_once_with("ssh node2 crm_node --name")
+        mock_error.assert_called_once_with("error")
 
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('re.search')


### PR DESCRIPTION
backport #784 