### PR TITLE
Support parse space in sbd device name

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -350,6 +350,7 @@ Configure SBD:
 """
     DISKLESS_SBD_WARNING = """Diskless SBD requires cluster with three or more nodes.
 If you want to use diskless SBD for two-nodes cluster, should be combined with QDevice."""
+    PARSE_RE = "[; ]"
 
     def __init__(self, sbd_devices=None, diskless_sbd=False):
         """
@@ -371,10 +372,7 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         """
         result_list = []
         for dev in self.sbd_devices_input:
-            if ';' in dev:
-                result_list.extend(dev.strip(';').split(';'))
-            else:
-                result_list.append(dev)
+            result_list += utils.re_split_string(self.PARSE_RE, dev)
         return result_list
 
     @staticmethod
@@ -445,7 +443,7 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
             if dev == "none":
                 self.diskless_sbd = True
                 return
-            dev_list = dev.strip(';').split(';')
+            dev_list = utils.re_split_string(self.PARSE_RE, dev)
             try:
                 self._verify_sbd_device(dev_list)
             except ValueError as err_msg:
@@ -500,15 +498,14 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
         csync2_update(SYSCONFIG_SBD)
 
-    @staticmethod
-    def _get_sbd_device_from_config():
+    def _get_sbd_device_from_config(self):
         """
         Gets currently configured SBD device, i.e. what's in /etc/sysconfig/sbd
         """
         conf = utils.parse_sysconfig(SYSCONFIG_SBD)
         res = conf.get("SBD_DEVICE")
         if res:
-            return res.strip(';').split(';')
+            return utils.re_split_string(self.PARSE_RE, res)
         else:
             return None
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2682,4 +2682,11 @@ def check_all_nodes_reachable():
     out = get_stdout_or_raise_error("crm_node -l")
     for node in re.findall("\d+ (.*) \w+", out):
         ping_node(node)
+
+
+def re_split_string(reg, string):
+    """
+    Split a string by a regrex, filter out empty items
+    """
+    return [x for x in re.split(reg, string) if x]
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1302,3 +1302,8 @@ Active Resources:
     res = utils.has_resource_running()
     assert res is False
     mock_run.assert_called_once_with("crm_mon -1")
+
+
+def test_re_split_string():
+    assert utils.re_split_string('[; ]', "/dev/sda1; /dev/sdb1 ; ") == ["/dev/sda1", "/dev/sdb1"]
+    assert utils.re_split_string('[; ]', "/dev/sda1 ") == ["/dev/sda1"]


### PR DESCRIPTION
## Problem

1. Not support space in value of `-s` option: `crm cluster init -s "/dev/sda1 " -y`
2. If has space between multi sbd devices in /etc/sysconfig/sbd, join process will raise an error:
`ERROR: cluster.join:  /dev/sdb1 doesn't look like a block device`
3. On init side, there was also an error if input space on interactive mode:
```
Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path []/dev/sda1; /dev/sdb1
ERROR:  /dev/sdb1 doesn't look like a block device
```
Anyway, it's too strict, should loose the limitation