### PR TITLE
Dev: ui_cluster: add qdevice help info

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -33,6 +33,7 @@ from . import clidisplay
 from . import term
 from . import lock
 from . import userdir
+from . import constants
 
 
 LOG_FILE = "/var/log/crmsh/ha-cluster-bootstrap.log"
@@ -1871,7 +1872,10 @@ def configure_qdevice_interactive():
     """
     Configure qdevice on interactive mode
     """
-    if _context.yes_to_all or not confirm("Do you want to configure QDevice?"):
+    if _context.yes_to_all:
+        return
+    status("\nConfigure Qdevice/Qnetd:\n" + constants.qdevice_help_info + "\n")
+    if not confirm("Do you want to configure QDevice?"):
         return
     qnetd_addr = prompt_for_string("HOST or IP of the QNetd server to be used")
     if not qnetd_addr:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -481,4 +481,10 @@ container_helptxt = {
     }
 }
 
+
+qdevice_help_info = """  QDevice participates in quorum decisions. With the assistance of 
+  a third-party arbitrator Qnetd, it provides votes so that a cluster 
+  is able to sustain more node failures than standard quorum rules 
+  allow. It is recommended for clusters with an even number of nodes 
+  and highly recommended for 2 node clusters."""
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -13,6 +13,7 @@ from . import completers as compl
 from . import bootstrap
 from . import corosync
 from .cibconfig import cib_factory
+from . import constants
 
 
 class ArgParser(ArgumentParser):
@@ -243,7 +244,7 @@ Note:
         network_group.add_argument("-I", "--ipv6", action="store_true", dest="ipv6",
                                    help="Configure corosync use IPv6")
 
-        qdevice_group = parser.add_argument_group("QDevice configuration", "Options for configuring QDevice and QNetd.")
+        qdevice_group = parser.add_argument_group("QDevice configuration", re.sub('  ', '', constants.qdevice_help_info) + "\n\nOptions for configuring QDevice and QNetd.")
         qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr", metavar="HOST",
                                    help="HOST or IP of the QNetd server to be used")
         qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int, default=5403,

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -94,6 +94,12 @@ Network configuration:
   -I, --ipv6            Configure corosync use IPv6
 
 QDevice configuration:
+  QDevice participates in quorum decisions. With the assistance of 
+  a third-party arbitrator Qnetd, it provides votes so that a cluster 
+  is able to sustain more node failures than standard quorum rules 
+  allow. It is recommended for clusters with an even number of nodes 
+  and highly recommended for 2 node clusters.
+  
   Options for configuring QDevice and QNetd.
 
   --qnetd-hostname HOST


### PR DESCRIPTION
#### For help output
```
# crm cluster init -h

QDevice configuration:
  QDevice is a separate quorum device which acts as a third-party 
  arbitration device for the cluster. Its primary use is to allow 
  a cluster to sustain more node failures than standard quorum rules allow.
  Options for configuring QDevice and QNetd.

  --qnetd-hostname HOST
                        HOST or IP of the QNetd server to be used
  --qdevice-port PORT   TCP PORT of QNetd server (default:5403)
  --qdevice-algo ALGORITHM
                        QNetd decision ALGORITHM (ffsplit/lms,
                        default:ffsplit)
  --qdevice-tie-breaker TIE_BREAKER
                        QNetd TIE_BREAKER (lowest/highest/valid_node_id,
                        default:lowest)
  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd (on/off/required,
                        default:on)
  --qdevice-heuristics COMMAND
                        COMMAND to run with absolute path. For multiple
                        commands, use ";" to separate (details about
                        heuristics can see man 8 corosync-qdevice)
  --qdevice-heuristics-mode MODE
                        MODE of operation of heuristics (on/sync/off,
                        default:sync)
```
#### For bootstrap interactive mode
```
# crm cluster init

Configure SBD:
  If you have shared storage, for example a SAN or iSCSI target,
  you can use it avoid split-brain scenarios by configuring SBD.
  This requires a 1 MB partition, accessible to all nodes in the
  cluster.  The device path must be persistent and consistent
  across all nodes in the cluster, so /dev/disk/by-id/* devices
  are a good choice.  Note that all data on the partition you
  specify here will be destroyed.

Do you wish to use SBD (y/n)? n
WARNING: Not configuring SBD - STONITH will be disabled.
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
  
Configure Administration IP Address:
  Optionally configure an administration virtual IP
  address. The purpose of this IP address is to
  provide a single IP that can be used to interact
  with the cluster, rather than using the IP address
  of any specific cluster node.

Do you wish to configure a virtual IP address (y/n)? n
  
Configure Qdevice/Qnetd:
  QDevice is a separate quorum device which acts as a third-party 
  arbitration device for the cluster. Its primary use is to allow 
  a cluster to sustain more node failures than standard quorum rules allow.

Do you want to configure QDevice (y/n)
```