### PR TITLE
Bootstrap support ocfs2 option

### DIFF
--- a/crmsh/ocfs2.py
+++ b/crmsh/ocfs2.py
@@ -1,0 +1,350 @@
+import re
+from contextlib import contextmanager
+from . import utils
+from . import bootstrap
+from . import ra
+from . import corosync
+from .msg import err_buf
+
+
+class OCFS2Manager(object):
+    """
+    Class to manage OCFS2 and configure related resources
+    """
+    RA_ID_PREFIX = "ocfs2-"
+    DLM_RA_ID = "{}dlm".format(RA_ID_PREFIX)
+    FS_RA_ID = "{}clusterfs".format(RA_ID_PREFIX)
+    LVMLOCKD_RA_ID = "{}lvmlockd".format(RA_ID_PREFIX)
+    LVMACTIVATE_RA_ID = "{}lvmactivate".format(RA_ID_PREFIX)
+    GROUP_ID = "{}group".format(RA_ID_PREFIX)
+    CLONE_ID = "{}clone".format(RA_ID_PREFIX)
+    VG_ID = "{}vg".format(RA_ID_PREFIX)
+    LV_ID = "{}lv".format(RA_ID_PREFIX)
+
+    MAX_CLONE_NUM = 8
+    # Note: using undocumented '-x' switch to avoid prompting if overwriting
+    MKFS_CMD = "mkfs.ocfs2 --cluster-stack pcmk --cluster-name {} -N {} -x {}"
+    HINTS_WHEN_RUNNING = """
+The cluster service has already been initialized, but the prerequisites are missing
+to configure OCFS2. Please fix it and use the stage procedure to configure OCFS2 separately,
+e.g. crm cluster init ocfs2 -o <ocfs2_device>
+    """
+
+    def __init__(self, context):
+        """
+        Init function
+        """
+        self.ocfs2_devices = utils.parse_append_action_argument(context.ocfs2_devices)
+        self.use_cluster_lvm2 = context.use_cluster_lvm2
+        self.mount_point = context.mount_point
+        self.use_stage = context.stage == "ocfs2"
+        self.yes_to_all = context.yes_to_all
+        self.cluster_name = None
+        self.exist_ra_id_list = []
+        self.vg_id = None
+        self.group_id = None
+        self.target_device = None
+
+    def _verify_packages(self, use_cluster_lvm2=False):
+        """
+        Find if missing required package
+        """
+        required_packages = ["ocfs2-tools"]
+        if use_cluster_lvm2:
+            required_packages.append("lvm2-lockd")
+        for pkg in required_packages:
+            if not utils.package_is_installed(pkg):
+                raise ValueError("Missing required package for configuring OCFS2: {}".format(pkg))
+
+    def _verify_options(self):
+        """
+        Verify options related with OCFS2
+        """
+        if self.use_stage and not self.ocfs2_devices:
+            raise ValueError("ocfs2 stage require -o option")
+        if len(self.ocfs2_devices) > 1 and not self.use_cluster_lvm2:
+            raise ValueError("Without Cluster LVM2 (-C option), -o option only support one device")
+        if self.use_cluster_lvm2 and not self.ocfs2_devices:
+            raise ValueError("-C option only valid together with -o option")
+        if len(self.ocfs2_devices) != len(set(self.ocfs2_devices)):
+            raise ValueError("Duplicated inputs for -o option")
+        if self.mount_point and utils.has_mount_point_used(self.mount_point):
+            raise ValueError("Mount point {} already mounted".format(self.mount_point))
+
+    def _verify_devices(self):
+        """
+        Verify ocfs2 devices
+        """
+        for dev in self.ocfs2_devices:
+            if not utils.is_block_device(dev):
+                raise ValueError("{} doesn't look like a block device".format(dev))
+            if utils.is_dev_used_for_lvm(dev) and self.use_cluster_lvm2:
+                raise ValueError("{} is a Logical Volume, cannot be used with the -C option".format(dev))
+            if utils.has_disk_mounted(dev):
+                raise ValueError("{} already mounted".format(dev))
+
+    def _check_if_already_configured(self):
+        """
+        Check if ocfs2 related resource already configured
+        """
+        if not self.use_stage:
+            return
+        out = utils.get_stdout_or_raise_error("crm configure show")
+        if "fstype=ocfs2" in out:
+            err_buf.info("Already configured OCFS2 related resources")
+            raise utils.TerminateSubCommand
+
+    def _static_verify(self):
+        """
+        Verify before configuring on init process
+        """
+        self._verify_packages(self.use_cluster_lvm2)
+        self._check_if_already_configured()
+        self._verify_options()
+        self._verify_devices()
+
+    def _static_verify_on_join(self, dev_list, peer, use_cluster_lvm2=False):
+        """
+        Verify before configuring on join process
+        """
+        self._verify_packages(use_cluster_lvm2)
+        utils.compare_uuid_with_peer_dev(dev_list, peer)
+
+    def _dynamic_raise_error(self, error_msg):
+        """
+        Customize error message after cluster running
+        """
+        raise ValueError(error_msg + ("" if self.use_stage else self.HINTS_WHEN_RUNNING))
+
+    def _check_sbd_and_ocfs2_dev(self):
+        """
+        Raise error when ocfs2 device is the same with sbd device
+        """
+        if utils.service_is_enabled("sbd.service"):
+            sbd_device_list = bootstrap.SBDManager.get_sbd_device_from_config()
+            for dev in self.ocfs2_devices:
+                if dev in sbd_device_list:
+                    self._dynamic_raise_error("{} cannot be the same with SBD device".format(dev))
+
+    def _confirm_to_overwrite_ocfs2_dev(self):
+        """
+        Confirm to overwrit ocfs2 device on interactive mode
+        """
+        for dev in self.ocfs2_devices:
+            msg = ""
+            if utils.has_dev_partitioned(dev):
+                msg = "Found a partition table in {}".format(dev)
+            else:
+                fs_type = utils.get_dev_fs_type(dev)
+                if fs_type:
+                    msg = "{} contains a {} file system".format(dev, fs_type)
+            if msg and not bootstrap.confirm("{} - Proceed anyway?".format(msg)):
+                raise utils.TerminateSubCommand
+
+        for dev in self.ocfs2_devices:
+            utils.get_stdout_or_raise_error("wipefs -a {}".format(dev))
+
+    def _dynamic_verify(self):
+        """
+        Verify after cluster running
+        """
+        if not utils.has_stonith_running():
+            self._dynamic_raise_error("OCFS2 requires stonith device configured and running")
+
+        self._check_sbd_and_ocfs2_dev()
+        self._confirm_to_overwrite_ocfs2_dev()
+
+    def _gen_ra_scripts(self, ra_type, kv):
+        """
+        Generate ra scripts
+        Return id and scripts
+        """
+        config_scripts = ""
+        kv["id"] = utils.gen_unused_id(self.exist_ra_id_list, kv["id"])
+        config_scripts = ra.CONFIGURE_RA_TEMPLATE_DICT[ra_type].format(**kv)
+        return kv["id"], config_scripts
+
+    def _mkfs(self, target):
+        """
+        Creating OCFS2 filesystem for the target device
+        """
+        with bootstrap.status_long("  Creating OCFS2 filesystem for {}".format(target)):
+            self.cluster_name = corosync.get_value('totem.cluster_name')
+            utils.get_stdout_or_raise_error(self.MKFS_CMD.format(self.cluster_name, self.MAX_CLONE_NUM, target))
+
+    @contextmanager
+    def _vg_change(self):
+        """
+        vgchange process using contextmanager
+        """
+        utils.get_stdout_or_raise_error("vgchange -ay {}".format(self.vg_id))
+        try:
+            yield
+        finally:
+            utils.get_stdout_or_raise_error("vgchange -an {}".format(self.vg_id))
+
+    def _create_lv(self):
+        """
+        Create PV, VG, LV and return LV path
+        """
+        disks_string = ' '.join(self.ocfs2_devices)
+
+        # Create PV
+        with bootstrap.status_long("  Creating PV for {}".format(disks_string)):
+            utils.get_stdout_or_raise_error("pvcreate {} -y".format(disks_string))
+
+        # Create VG
+        self.vg_id = utils.gen_unused_id(utils.get_all_vg_name(), self.VG_ID)
+        with bootstrap.status_long("  Creating VG {}".format(self.vg_id)):
+            utils.get_stdout_or_raise_error("vgcreate --shared {} {} -y".format(self.vg_id, disks_string))
+
+        # Create LV
+        with bootstrap.status_long("  Creating LV {} on VG {}".format(self.LV_ID, self.vg_id)):
+            pe_number = utils.get_pe_number(self.vg_id)
+            utils.get_stdout_or_raise_error("lvcreate -l {} {} -n {} -y".format(pe_number, self.vg_id, self.LV_ID))
+ 
+        return "/dev/{}/{}".format(self.vg_id, self.LV_ID)
+
+    def _gen_group_and_clone_scripts(self, ra_list):
+        """
+        Generate group and clone scripts
+        """
+        # Group
+        group_kv = {"id":self.GROUP_ID, "ra_string":' '.join(ra_list)}
+        self.group_id, group_scripts = self._gen_ra_scripts("GROUP", group_kv)
+        # Clone
+        clone_kv = {"id":self.CLONE_ID, "group_id":self.group_id}
+        _, clone_scripts = self._gen_ra_scripts("CLONE", clone_kv)
+        return group_scripts + clone_scripts
+
+    def _gen_fs_scripts(self):
+        """
+        Generate Filesystem scripts
+        """
+        fs_kv = {
+                "id": self.FS_RA_ID,
+                "mnt_point": self.mount_point,
+                "fs_type": "ocfs2",
+                "device": self.target_device
+                }
+        return self._gen_ra_scripts("Filesystem", fs_kv)
+
+    def _load_append_and_wait(self, scripts, res_id, msg, need_append=True):
+        """
+        Load scripts, append to exist group and wait resource started
+        """
+        bootstrap.crm_configure_load("update", scripts)
+        if need_append:
+            utils.append_res_to_group(self.group_id, res_id)
+        bootstrap.wait_for_resource(msg, res_id)
+
+    def _config_dlm(self):
+        """
+        Configure DLM resource
+        """
+        config_scripts = ""
+        dlm_id, dlm_scripts = self._gen_ra_scripts("DLM", {"id":self.DLM_RA_ID})
+        group_clone_scripts = self._gen_group_and_clone_scripts([dlm_id])
+        config_scripts = dlm_scripts + group_clone_scripts
+        self._load_append_and_wait(config_scripts, dlm_id, "  Wait for DLM({}) start".format(dlm_id), need_append=False)
+
+    def _config_lvmlockd(self):
+        """
+        Configure LVMLockd resource
+        """
+        _id, _scripts = self._gen_ra_scripts("LVMLockd", {"id":self.LVMLOCKD_RA_ID})
+        self._load_append_and_wait(_scripts, _id, "  Wait for LVMLockd({}) start".format(_id))
+
+    def _config_lvmactivate(self):
+        """
+        Configure LVMActivate resource
+        """
+        _id, _scripts = self._gen_ra_scripts("LVMActivate", {"id": self.LVMACTIVATE_RA_ID, "vgname": self.vg_id})
+        self._load_append_and_wait(_scripts, _id, "  Wait for LVMActivate({}) start".format(_id))
+
+    def _config_fs(self):
+        """
+        Configure Filesystem resource
+        """
+        utils.mkdirp(self.mount_point)
+        _id, _scripts = self._gen_fs_scripts()
+        self._load_append_and_wait(_scripts, _id, "  Wait for Filesystem({}) start".format(_id))
+
+    def _config_resource_stack_lvm2(self):
+        """
+        Configure dlm + lvmlockd + lvm-activate + Filesystem
+        """
+        self._config_dlm()
+        self._config_lvmlockd()
+        self.target_device = self._create_lv()
+        with self._vg_change():
+            self._mkfs(self.target_device)
+        self._config_lvmactivate()
+        self._config_fs()
+
+    def _config_resource_stack_ocfs2_along(self):
+        """
+        Configure dlm + Filesystem
+        """
+        self._config_dlm()
+        self.target_device = self.ocfs2_devices[0]
+        self._mkfs(self.target_device)
+        self._config_fs()
+
+    def init_ocfs2(self):
+        """
+        OCFS2 configure process on init node
+        """
+        bootstrap.status("{}Configuring OCFS2".format("" if self.yes_to_all else "\n"))
+        self._dynamic_verify()
+        self.exist_ra_id_list = utils.all_exist_id()
+
+        if self.use_cluster_lvm2:
+            self._config_resource_stack_lvm2()
+        else:
+            self._config_resource_stack_ocfs2_along()
+        bootstrap.status("  OCFS2 device {} mounted on {}".format(self.target_device, self.mount_point))
+
+    def _find_target_on_join(self, peer):
+        """
+        Find device name from OCF Filesystem param on peer node
+        """
+        out = utils.get_stdout_or_raise_error("crm configure show", remote=peer)
+        for line in out.splitlines():
+            if "fstype=ocfs2" in line:
+                res = re.search("device=\"(.*?)\"", line)
+                if res:
+                    return res.group(1)
+                else:
+                    raise ValueError("Filesystem require configure device")
+        return None
+
+    def _get_device_list_on_join(self, target, peer, clvm2=False):
+        """
+        Return device list
+        When using cluster lvm, return pv device list
+        """
+        if not clvm2:
+            return [target]
+        out = utils.get_stdout_or_raise_error("lvs {} -o +devices".format(target), remote=peer)
+        return re.findall("(/dev/.*)[(]", out)
+
+    def join_ocfs2(self, peer):
+        """
+        Called on join process, to verify ocfs2 environment
+        """
+        target = self._find_target_on_join(peer)
+        if not target:
+            return
+        with bootstrap.status_long("Verify OCFS2 environment"):
+            use_cluster_lvm2 = utils.has_resource_configured("ocf::heartbeat:lvmlockd", peer)
+            dev_list = self._get_device_list_on_join(target, peer, use_cluster_lvm2)
+            self._static_verify_on_join(dev_list, peer, use_cluster_lvm2)
+
+    @classmethod
+    def verify_ocfs2(cls, ctx):
+        """
+        Verify OCFS2 related packages and environment
+        """
+        inst = cls(ctx)
+        inst._static_verify()

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -875,4 +875,40 @@ def validate_agent(agentname, params, log=False):
     return p.returncode, out
 
 
+DLM_RA_SCRIPTS = """
+primitive {id} ocf:pacemaker:controld \
+op start timeout=90 \
+op stop timeout=100 \
+op monitor interval=60 timeout=60"""
+FILE_SYSTEM_RA_SCRIPTS = """
+primitive {id} ocf:heartbeat:Filesystem \
+params directory="{mnt_point}" fstype="{fs_type}" device="{device}" \
+op monitor interval=20 timeout=40 \
+op start timeout=60 \
+op stop timeout=60"""
+LVMLOCKD_RA_SCRIPTS = """
+primitive {id} ocf:heartbeat:lvmlockd \
+op start timeout=90 \
+op stop timeout=100 \
+op monitor interval=30 timeout=90"""
+LVMACTIVATE_RA_SCRIPTS = """
+primitive {id} ocf:heartbeat:LVM-activate \
+params vgname={vgname} vg_access_mode=lvmlockd activation_mode=shared \
+op start timeout=90s \
+op stop timeout=90s \
+op monitor interval=30s timeout=90s"""
+GROUP_SCRIPTS = """
+group {id} {ra_string}"""
+CLONE_SCRIPTS = """
+clone {id} {group_id} meta interleave=true"""
+
+
+CONFIGURE_RA_TEMPLATE_DICT = {
+        "DLM": DLM_RA_SCRIPTS,
+        "Filesystem": FILE_SYSTEM_RA_SCRIPTS,
+        "LVMLockd": LVMLOCKD_RA_SCRIPTS,
+        "LVMActivate": LVMACTIVATE_RA_SCRIPTS,
+        "GROUP": GROUP_SCRIPTS,
+        "CLONE": CLONE_SCRIPTS
+        }
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_analyze.py
+++ b/crmsh/ui_analyze.py
@@ -20,8 +20,5 @@ class Analyze(command.UI):
     def do_preflight_check(self, context, *args):
         sys.argv[1:] = args
         main.ctx.process_name = context.command_name
-        try:
-            main.run(main.ctx)
-        except utils.TerminateSubCommand:
-            return False
+        main.run(main.ctx)
         return True

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -101,6 +101,8 @@ class Context(object):
                 sys.stdout.flush()
             common_err("%s: %s" % (self.get_qualified_name(), msg))
             rv = False
+        except utils.TerminateSubCommand:
+            return False
         if cmd or (rv is False):
             rv = self._back_out() and rv
 

--- a/test/features/ocfs2.feature
+++ b/test/features/ocfs2.feature
@@ -1,0 +1,61 @@
+@ocfs2
+Feature: OCFS2 configuration/verify using bootstrap
+
+@clean
+Scenario: Configure ocfs2 along with init process
+  Given   Has disk "/dev/sda1" on "hanode1"
+  And     Has disk "/dev/sda2" on "hanode1"
+  When    Run "crm cluster init -s /dev/sda1 -o /dev/sda2 -y" on "hanode1"
+  Then    Cluster service is "started" on "hanode1"
+  And     Service "sbd" is "started" on "hanode1"
+  And     Resource "stonith-sbd" type "external/sbd" is "Started"
+  And     Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
+
+@clean
+Scenario: Configure cluster lvm2 + ocfs2 with init process
+  Given   Has disk "/dev/sda1" on "hanode1"
+  And     Has disk "/dev/sda2" on "hanode1"
+  And     Has disk "/dev/sda3" on "hanode1"
+  When    Run "crm cluster init -s /dev/sda1 -o /dev/sda2 -o /dev/sda3 -C -y" on "hanode1"
+  Then    Cluster service is "started" on "hanode1"
+  And     Service "sbd" is "started" on "hanode1"
+  And     Resource "stonith-sbd" type "external/sbd" is "Started"
+  And     Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "ocfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
+  And     Resource "ocfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
+  And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
+
+@clean
+Scenario: Add ocfs2 alone on a running cluster
+  Given   Has disk "/dev/sda1" on "hanode1"
+  And     Has disk "/dev/sda2" on "hanode1"
+  And     Has disk "/dev/sda1" on "hanode2"
+  And     Has disk "/dev/sda2" on "hanode2"
+  When    Run "crm cluster init -s /dev/sda1 -y" on "hanode1"
+  And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+  Then    Online nodes are "hanode1 hanode2"
+  And     Service "sbd" is "started" on "hanode1"
+  And     Service "sbd" is "started" on "hanode2"
+  And     Resource "stonith-sbd" type "external/sbd" is "Started"
+  When    Run "crm cluster init ocfs2 -o /dev/sda2 -y" on "hanode1"
+  Then    Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
+
+@clean
+Scenario: Add cluster lvm2 + ocfs2 on a running cluster
+  Given   Has disk "/dev/sda1" on "hanode1"
+  And     Has disk "/dev/sda2" on "hanode1"
+  And     Has disk "/dev/sda1" on "hanode2"
+  And     Has disk "/dev/sda2" on "hanode2"
+  When    Run "crm cluster init -s /dev/sda1 -y" on "hanode1"
+  And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+  Then    Online nodes are "hanode1 hanode2"
+  And     Service "sbd" is "started" on "hanode1"
+  And     Service "sbd" is "started" on "hanode2"
+  And     Resource "stonith-sbd" type "external/sbd" is "Started"
+  When    Run "crm cluster init ocfs2 -o /dev/sda2 -C -y" on "hanode1"
+  Then    Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "ocfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
+  And     Resource "ocfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
+  And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -59,12 +59,10 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution, this is
-                        destructive, especially during the "storage" stage.
-                        The /root/.ssh/id_rsa key will be overwritten unless
-                        the option "--no-overwrite-sshkey" is used)
-  -t TEMPLATE, --template TEMPLATE
-                        Optionally configure cluster with template "name"
-                        (currently only "ocfs2" is valid here)
+                        destructive, especially those storage related
+                        configurations and stages. The /root/.ssh/id_rsa key
+                        will be overwritten unless the option "--no-overwrite-
+                        sshkey" is used)
   -n NAME, --name NAME  Set the name of the configured cluster.
   -N NODES, --nodes NODES
                         Additional nodes to add to the created cluster. May
@@ -124,38 +122,38 @@ QDevice configuration:
 Storage configuration:
   Options for configuring shared storage.
 
-  -p DEVICE, --partition-device DEVICE
-                        Partition this shared storage device (only used in
-                        "storage" stage)
   -s DEVICE, --sbd-device DEVICE
                         Block device to use for SBD fencing, use ";" as
                         separator or -s multiple times for multi path (up to 3
                         devices)
   -o DEVICE, --ocfs2-device DEVICE
-                        Block device to use for OCFS2 (only used in "vgfs"
-                        stage)
+                        Block device to use for OCFS2; When using Cluster LVM2
+                        to manage the shared storage, user can specify one or
+                        multiple raw disks, use ";" as separator or -o
+                        multiple times for multi path (must specify -C option)
+                        NOTE: this is a Technical Preview
+  -C, --cluster-lvm2    Use Cluster LVM2 (only valid together with -o option)
+                        NOTE: this is a Technical Preview
+  -m MOUNT, --mount-point MOUNT
+                        Mount point for OCFS2 device (default is
+                        /srv/clusterfs, only valid together with -o option)
+                        NOTE: this is a Technical Preview
 
 Stage can be one of:
     ssh         Create SSH keys for passwordless SSH between cluster nodes
     csync2      Configure csync2
     corosync    Configure corosync
-    storage     Partition shared storage (ocfs2 template only)
     sbd         Configure SBD (requires -s <dev>)
     cluster     Bring the cluster online
+    ocfs2       Configure OCFS2 (requires -o <dev>) NOTE: this is a Technical Preview
     vgfs        Create volume group and filesystem (ocfs2 template only,
-                requires -o <dev>)
+                    requires -o <dev>) NOTE: this stage is an alias of ocfs2 stage
     admin       Create administration virtual IP (optional)
     qdevice     Configure qdevice and qnetd
 
 Note:
   - If stage is not specified, the script will run through each stage
-    in sequence, with prompts for required information.
-  - If using the ocfs2 template, the storage stage will partition a block
-    device into two pieces, one for SBD, the remainder for OCFS2.  This is
-    good for testing and demonstration, but not ideal for production.
-    To use storage you have already configured, pass -s and -o to specify
-    the block devices for SBD and OCFS2, and the automatic partitioning
-    will be skipped.'''
+    in sequence, with prompts for required information.'''
 
 
 CRM_CLUSTER_JOIN_H_OUTPUT = '''usage: join [options] [STAGE]

--- a/test/features/steps/step_implenment.py
+++ b/test/features/steps/step_implenment.py
@@ -214,9 +214,9 @@ def step_impl(context, res, res_type, state):
     result = None
     while try_count < 5:
         time.sleep(1)
-        _, out = run_command(context, "crm_mon -1")
+        _, out = run_command(context, "crm_mon -1rR")
         if out:
-            result = re.search(r'\s{}\s+.*:{}\):\s+{} '.format(res, res_type, state), out)
+            result = re.search(r'\s{}\s+.*:+{}\):\s+{} '.format(res, res_type, state), out)
             if not result:
                 try_count += 1
             else:

--- a/test/run-in-travis.sh
+++ b/test/run-in-travis.sh
@@ -27,7 +27,7 @@ case "$1" in
 		configure
 		make_install
 		exit $?;;
-	bootstrap|qdevice|hb_report|resource|geo|configure|constraints)
+	bootstrap|qdevice|hb_report|resource|geo|configure|constraints|ocfs2)
 		functional_tests $1 $2
 		exit $?;;
 	*|original)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -286,16 +286,6 @@ class TestSBDManager(unittest.TestCase):
             mock.call(bootstrap.SBDManager.PARSE_RE, "/dev/sdb1"),
             ])
 
-    @mock.patch('crmsh.utils.re_split_string')
-    def test_parse_sbd_device(self, mock_split):
-        mock_split.side_effect = [["/dev/sdb1"], ["/dev/sdc1"]]
-        res = self.sbd_inst._parse_sbd_device()
-        assert res == ["/dev/sdb1", "/dev/sdc1"]
-        mock_split.assert_has_calls([
-            mock.call(bootstrap.SBDManager.PARSE_RE, "/dev/sdb1"),
-            mock.call(bootstrap.SBDManager.PARSE_RE, "/dev/sdc1")
-            ])
-
     def test_verify_sbd_device_gt_3(self):
         assert self.sbd_inst_devices_gt_3.sbd_devices_input == ["/dev/sdb1", "/dev/sdc1", "/dev/sdd1", "/dev/sde1"]
         dev_list = self.sbd_inst_devices_gt_3.sbd_devices_input
@@ -304,7 +294,7 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("Maximum number of SBD device is 3", str(err.exception))
 
     @mock.patch('crmsh.bootstrap.SBDManager._compare_device_uuid')
-    @mock.patch('crmsh.bootstrap.is_block_device')
+    @mock.patch('crmsh.utils.is_block_device')
     def test_verify_sbd_device_not_block(self, mock_block_device, mock_compare):
         assert self.sbd_inst.sbd_devices_input == ["/dev/sdb1", "/dev/sdc1"]
         dev_list = self.sbd_inst.sbd_devices_input
@@ -318,11 +308,11 @@ class TestSBDManager(unittest.TestCase):
         mock_compare.assert_called_once_with("/dev/sdb1", [])
 
     @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
-    @mock.patch('crmsh.bootstrap.SBDManager._parse_sbd_device')
+    @mock.patch('crmsh.utils.parse_append_action_argument')
     def test_get_sbd_device_from_option(self, mock_parse, mock_verify):
         mock_parse.return_value = ["/dev/sdb1", "/dev/sdc1"]
         self.sbd_inst._get_sbd_device()
-        mock_parse.assert_called_once_with()
+        mock_parse.assert_called_once_with(mock_parse.return_value)
         mock_verify.assert_called_once_with(mock_parse.return_value)
 
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_interactive')

--- a/test/unittests/test_ocfs2.py
+++ b/test/unittests/test_ocfs2.py
@@ -1,0 +1,459 @@
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+from crmsh import ocfs2, utils, ra
+
+
+class TestOCFS2Manager(unittest.TestCase):
+    """
+    Unitary tests for crmsh.bootstrap.SBDManager
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        context1 = mock.Mock(ocfs2_devices=[])
+        self.ocfs2_inst1 = ocfs2.OCFS2Manager(context1)
+
+        context2 = mock.Mock(ocfs2_devices=[],
+                stage="ocfs2",
+                yes_to_all=True)
+        self.ocfs2_inst2 = ocfs2.OCFS2Manager(context2)
+
+        context3 = mock.Mock(ocfs2_devices=["/dev/sdb2", "/dev/sdc2"],
+                use_cluster_lvm2=False)
+        self.ocfs2_inst3 = ocfs2.OCFS2Manager(context3)
+
+        context4 = mock.Mock(ocfs2_devices=[],
+                use_cluster_lvm2=True)
+        self.ocfs2_inst4 = ocfs2.OCFS2Manager(context4)
+
+        context5 = mock.Mock(ocfs2_devices=["/dev/sda2", "/dev/sda2"])
+        self.ocfs2_inst5 = ocfs2.OCFS2Manager(context5)
+
+        context6 = mock.Mock(ocfs2_devices=["/dev/sda2"],
+                mount_point="/data")
+        self.ocfs2_inst6 = ocfs2.OCFS2Manager(context6)
+
+        context7 = mock.Mock(ocfs2_devices=["/dev/sdb2"],
+                use_cluster_lvm2=True)
+        self.ocfs2_inst7 = ocfs2.OCFS2Manager(context7)
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    @mock.patch('crmsh.utils.package_is_installed')
+    def test_verify_packages(self, mock_installed):
+        mock_installed.side_effect = [True, False]
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst1._verify_packages(use_cluster_lvm2=True)
+        self.assertEqual("Missing required package for configuring OCFS2: lvm2-lockd", str(err.exception))
+        mock_installed.assert_has_calls([
+            mock.call("ocfs2-tools"),
+            mock.call("lvm2-lockd")
+            ])
+
+    def test_verify_options_stage_miss_option(self):
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst2._verify_options()
+        self.assertEqual("ocfs2 stage require -o option", str(err.exception))
+
+    def test_verify_options_two_devices(self):
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst3._verify_options()
+        self.assertEqual("Without Cluster LVM2 (-C option), -o option only support one device", str(err.exception))
+
+    def test_verify_options_only_C(self):
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst4._verify_options()
+        self.assertEqual("-C option only valid together with -o option", str(err.exception))
+
+    def test_verify_options_dup(self):
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst5._verify_options()
+        self.assertEqual("Duplicated inputs for -o option", str(err.exception))
+
+    @mock.patch('crmsh.utils.has_mount_point_used')
+    def test_verify_options_mount(self, mock_mount):
+        mock_mount.return_value = True
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst6._verify_options()
+        self.assertEqual("Mount point /data already mounted", str(err.exception))
+        mock_mount.assert_called_once_with("/data")
+
+    @mock.patch('crmsh.utils.is_block_device')
+    def test_verify_devices_not_block(self, mock_is_block):
+        mock_is_block.return_value = False
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst3._verify_devices()
+        self.assertEqual("/dev/sdb2 doesn't look like a block device", str(err.exception))
+        mock_is_block.assert_called_once_with("/dev/sdb2")
+
+    @mock.patch('crmsh.utils.is_dev_used_for_lvm')
+    @mock.patch('crmsh.utils.is_block_device')
+    def test_verify_devices_lvm(self, mock_is_block, mock_lvm):
+        mock_lvm.return_value = True
+        mock_is_block.return_value = True
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst7._verify_devices()
+        self.assertEqual("/dev/sdb2 is a Logical Volume, cannot be used with the -C option", str(err.exception))
+        mock_is_block.assert_called_once_with("/dev/sdb2")
+        mock_lvm.assert_called_once_with("/dev/sdb2")
+
+    @mock.patch('crmsh.utils.has_disk_mounted')
+    @mock.patch('crmsh.utils.is_dev_used_for_lvm')
+    @mock.patch('crmsh.utils.is_block_device')
+    def test_verify_devices_mounted(self, mock_is_block, mock_lvm, mock_mounted):
+        mock_lvm.return_value = False
+        mock_is_block.return_value = True
+        mock_mounted.return_value = True
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst7._verify_devices()
+        self.assertEqual("/dev/sdb2 already mounted", str(err.exception))
+        mock_is_block.assert_called_once_with("/dev/sdb2")
+        mock_lvm.assert_called_once_with("/dev/sdb2")
+        mock_mounted.assert_called_once_with("/dev/sdb2")
+
+    def test_check_if_already_configured_return(self):
+        self.ocfs2_inst3._check_if_already_configured()
+
+    @mock.patch('crmsh.ocfs2.err_buf')
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_check_if_already_configured(self, mock_run, mock_buf):
+        mock_run.return_value = "data xxx fstype=ocfs2  sss"
+        mock_buf.info = mock.Mock()
+        with self.assertRaises(utils.TerminateSubCommand):
+            self.ocfs2_inst2._check_if_already_configured()
+        mock_run.assert_called_once_with("crm configure show")
+        mock_buf.info.assert_called_once_with("Already configured OCFS2 related resources")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._verify_devices')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._check_if_already_configured')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._verify_options')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._verify_packages')
+    def test_static_verify(self, mock_verify_packages, mock_verify_options, mock_configured, mock_verify_devices):
+        self.ocfs2_inst3._static_verify()
+        mock_verify_packages.assert_called_once_with(False)
+        mock_verify_options.assert_called_once_with()
+        mock_configured.assert_called_once_with()
+        mock_verify_devices.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.compare_uuid_with_peer_dev')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._verify_packages')
+    def test_static_verify_on_join(self, mock_verify_packages, mock_uuid):
+        self.ocfs2_inst1._static_verify_on_join(["/dev/sda1"], "node1")
+        mock_verify_packages.assert_called_once_with(False)
+        mock_uuid.assert_called_once_with(["/dev/sda1"], "node1")
+
+    def test_dynamic_raise_error(self):
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst2._dynamic_raise_error("error messages")
+        self.assertEqual("error messages", str(err.exception))
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_raise_error')
+    @mock.patch('crmsh.bootstrap.SBDManager.get_sbd_device_from_config')
+    @mock.patch('crmsh.utils.service_is_enabled')
+    def test_check_sbd_and_ocfs2_dev(self, mock_enabled, mock_get_device, mock_error):
+        mock_enabled.return_value = True
+        mock_get_device.return_value = ["/dev/sdb2"]
+        self.ocfs2_inst3._check_sbd_and_ocfs2_dev()
+        mock_enabled.assert_called_once_with("sbd.service")
+        mock_get_device.assert_called_once_with()
+        mock_error.assert_called_once_with("/dev/sdb2 cannot be the same with SBD device")
+
+    @mock.patch('crmsh.bootstrap.confirm')
+    @mock.patch('crmsh.utils.get_dev_fs_type')
+    @mock.patch('crmsh.utils.has_dev_partitioned')
+    def test_confirm_to_overwrite_ocfs2_dev(self, mock_has_parted, mock_fstype, mock_confirm):
+        mock_has_parted.side_effect = [True, False]
+        mock_fstype.return_value = "ext4"
+        mock_confirm.side_effect = [True, False]
+        with self.assertRaises(utils.TerminateSubCommand) as err:
+            self.ocfs2_inst3._confirm_to_overwrite_ocfs2_dev()
+        mock_has_parted.assert_has_calls([
+            mock.call("/dev/sdb2"),
+            mock.call("/dev/sdc2")
+            ])
+        mock_fstype.assert_called_once_with("/dev/sdc2")
+        mock_confirm.assert_has_calls([
+            mock.call("Found a partition table in /dev/sdb2 - Proceed anyway?"),
+            mock.call("/dev/sdc2 contains a ext4 file system - Proceed anyway?")
+            ])
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_raise_error')
+    @mock.patch('crmsh.utils.has_stonith_running')
+    def test_dynamic_verify_error(self, mock_has_stonith, mock_error):
+        mock_has_stonith.return_value = False
+        mock_error.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            self.ocfs2_inst3._dynamic_verify()
+        mock_has_stonith.assert_called_once_with()
+        mock_error.assert_called_once_with("OCFS2 requires stonith device configured and running")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._confirm_to_overwrite_ocfs2_dev')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._check_sbd_and_ocfs2_dev')
+    @mock.patch('crmsh.utils.has_stonith_running')
+    def test_dynamic_verify(self, mock_has_stonith, mock_check_dev, mock_confirm):
+        mock_has_stonith.return_value = True
+        self.ocfs2_inst3._dynamic_verify()
+        mock_has_stonith.assert_called_once_with()
+        mock_check_dev.assert_called_once_with()
+        mock_confirm.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.gen_unused_id')
+    def test_gen_ra_scripts(self, mock_gen_unused):
+        self.ocfs2_inst3.exist_ra_id_list = []
+        mock_gen_unused.return_value = "g1"
+        res = self.ocfs2_inst3._gen_ra_scripts("GROUP", {"id": "g1", "ra_string": "d vip"})
+        assert res == ("g1", "\ngroup g1 d vip")
+        mock_gen_unused.assert_called_once_with([], "g1")
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.corosync.get_value')
+    @mock.patch('crmsh.bootstrap.status_long')
+    def test_mkfs(self, mock_long, mock_get_value, mock_run):
+        mock_get_value.return_value = "hacluster"
+        self.ocfs2_inst3._mkfs("/dev/sdb2")
+        mock_long.assert_called_once_with("  Creating OCFS2 filesystem for /dev/sdb2")
+        mock_get_value.assert_called_once_with("totem.cluster_name")
+        mock_run.assert_called_once_with("mkfs.ocfs2 --cluster-stack pcmk --cluster-name hacluster -N 8 -x /dev/sdb2")
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_vg_change(self, mock_run):
+        self.ocfs2_inst3.vg_id = "vg1"
+        with self.ocfs2_inst3._vg_change():
+            pass
+        mock_run.assert_has_calls([
+            mock.call("vgchange -ay vg1"),
+            mock.call("vgchange -an vg1")
+            ])
+
+    @mock.patch('crmsh.utils.get_pe_number')
+    @mock.patch('crmsh.utils.gen_unused_id')
+    @mock.patch('crmsh.utils.get_all_vg_name')
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.bootstrap.status_long')
+    def test_create_lv(self, mock_long, mock_run, mock_all_vg, mock_unused, mock_pe_num):
+        mock_all_vg.return_value = []
+        mock_unused.return_value = "vg1"
+        mock_pe_num.return_value = 1234
+        res = self.ocfs2_inst3._create_lv()
+        self.assertEqual(res, "/dev/vg1/ocfs2-lv")
+        mock_run.assert_has_calls([
+            mock.call("pvcreate /dev/sdb2 /dev/sdc2 -y"),
+            mock.call("vgcreate --shared vg1 /dev/sdb2 /dev/sdc2 -y"),
+            mock.call("lvcreate -l 1234 vg1 -n ocfs2-lv -y")
+            ])
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_ra_scripts')
+    def test_gen_group_and_clone_scripts(self, mock_gen):
+        mock_gen.side_effect = [("id1", "group_script\n"), ("id2", "clone_script\n")]
+        res = self.ocfs2_inst3._gen_group_and_clone_scripts(["ra1", "ra2"])
+        self.assertEqual(res, "group_script\nclone_script\n")
+        mock_gen.assert_has_calls([
+            mock.call('GROUP', {'id': 'ocfs2-group', 'ra_string': 'ra1 ra2'}),
+            mock.call('CLONE', {'id': 'ocfs2-clone', 'group_id': 'id1'})
+            ])
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_ra_scripts')
+    def test_gen_fs_scripts(self, mock_gen):
+        mock_gen.return_value = "scripts"
+        self.ocfs2_inst3.mount_point = "/data"
+        self.ocfs2_inst3.target_device = "/dev/sda1"
+        res = self.ocfs2_inst3._gen_fs_scripts()
+        self.assertEqual(res, "scripts")
+        mock_gen.assert_called_once_with("Filesystem", {'id': 'ocfs2-clusterfs', 'mnt_point': '/data', 'fs_type': 'ocfs2', 'device': '/dev/sda1'})
+
+    @mock.patch('crmsh.bootstrap.wait_for_resource')
+    @mock.patch('crmsh.utils.append_res_to_group')
+    @mock.patch('crmsh.bootstrap.crm_configure_load')
+    def test_load_append_and_wait(self, mock_load, mock_append, mock_wait):
+        self.ocfs2_inst3.group_id = "g1"
+        self.ocfs2_inst3._load_append_and_wait("scripts", "res_id", "messages data")
+        mock_load.assert_called_once_with("update", "scripts")
+        mock_append.assert_called_once_with("g1", "res_id")
+        mock_wait.assert_called_once_with("messages data", "res_id")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._load_append_and_wait')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_group_and_clone_scripts')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_ra_scripts')
+    def test_config_dlm(self, mock_gen_ra, mock_gen_group, mock_load_wait):
+        mock_gen_ra.return_value = ("dlm_id", "dlm_scripts\n")
+        mock_gen_group.return_value = "group_scripts\n"
+        self.ocfs2_inst3._config_dlm()
+        mock_gen_ra.assert_called_once_with("DLM", {"id": "ocfs2-dlm"})
+        mock_gen_group.assert_called_once_with(["dlm_id"])
+        mock_load_wait.assert_called_once_with("dlm_scripts\ngroup_scripts\n", "dlm_id", "  Wait for DLM(dlm_id) start", need_append=False)
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._load_append_and_wait')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_ra_scripts')
+    def test_config_lvmlockd(self, mock_gen_ra, mock_load_wait):
+        mock_gen_ra.return_value = ("ra_id", "ra_scripts\n")
+        self.ocfs2_inst3._config_lvmlockd()
+        mock_gen_ra.assert_called_once_with("LVMLockd", {"id": "ocfs2-lvmlockd"})
+        mock_load_wait.assert_called_once_with("ra_scripts\n", "ra_id", "  Wait for LVMLockd(ra_id) start")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._load_append_and_wait')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_ra_scripts')
+    def test_config_lvmactivate(self, mock_gen_ra, mock_load_wait):
+        mock_gen_ra.return_value = ("ra_id", "ra_scripts\n")
+        self.ocfs2_inst3.vg_id = "vg1"
+        self.ocfs2_inst3._config_lvmactivate()
+        mock_gen_ra.assert_called_once_with("LVMActivate", {"id": "ocfs2-lvmactivate", "vgname": "vg1"})
+        mock_load_wait.assert_called_once_with("ra_scripts\n", "ra_id", "  Wait for LVMActivate(ra_id) start")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._load_append_and_wait')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._gen_fs_scripts')
+    @mock.patch('crmsh.utils.mkdirp')
+    def test_config_fs(self, mock_mkdir, mock_gen_fs, mock_load_wait):
+        mock_gen_fs.return_value = ("ra_id", "ra_scripts\n")
+        self.ocfs2_inst3.mount_point = "/data"
+        self.ocfs2_inst3._config_fs()
+        mock_mkdir.assert_called_once_with("/data")
+        mock_gen_fs.assert_called_once_with()
+        mock_load_wait.assert_called_once_with("ra_scripts\n", "ra_id", "  Wait for Filesystem(ra_id) start")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_fs')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_lvmactivate')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._mkfs')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._vg_change')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._create_lv')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_lvmlockd')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_dlm')
+    def test_config_resource_stack_lvm2(self, mock_dlm, mock_lvmlockd, mock_lv, mock_vg, mock_mkfs, mock_lvmactivate, mock_fs):
+        mock_lv.return_value = "/dev/sda1"
+        self.ocfs2_inst3._config_resource_stack_lvm2()
+        mock_dlm.assert_called_once_with()
+        mock_lvmlockd.assert_called_once_with()
+        mock_lv.assert_called_once_with()
+        mock_mkfs.assert_called_once_with("/dev/sda1")
+        mock_lvmactivate.assert_called_once_with()
+        mock_fs.assert_called_once_with()
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_fs')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._mkfs')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_dlm')
+    def test_config_resource_stack_ocfs2_along(self, mock_dlm, mock_mkfs, mock_fs):
+        self.ocfs2_inst3._config_resource_stack_ocfs2_along()
+        mock_dlm.assert_called_once_with()
+        mock_mkfs.assert_called_once_with("/dev/sdb2")
+        mock_fs.assert_called_once_with()
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_resource_stack_lvm2')
+    @mock.patch('crmsh.utils.all_exist_id')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_verify')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_ocfs2_lvm2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_lvm2):
+        mock_all_id.return_value = []
+        self.ocfs2_inst7.mount_point = "/data"
+        self.ocfs2_inst7.target_device = "/dev/vg1/lv1"
+        self.ocfs2_inst7.init_ocfs2()
+        mock_status.assert_has_calls([
+            mock.call("Configuring OCFS2"),
+            mock.call("  OCFS2 device /dev/vg1/lv1 mounted on /data")
+            ])
+        mock_dynamic_verify.assert_called_once_with()
+        mock_all_id.assert_called_once_with()
+        mock_lvm2.assert_called_once_with()
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._config_resource_stack_ocfs2_along')
+    @mock.patch('crmsh.utils.all_exist_id')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_verify')
+    @mock.patch('crmsh.bootstrap.status')
+    def test_init_ocfs2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_ocfs2):
+        mock_all_id.return_value = []
+        self.ocfs2_inst3.mount_point = "/data"
+        self.ocfs2_inst3.target_device = "/dev/sda1"
+        self.ocfs2_inst3.init_ocfs2()
+        mock_status.assert_has_calls([
+            mock.call("Configuring OCFS2"),
+            mock.call("  OCFS2 device /dev/sda1 mounted on /data")
+            ])
+        mock_dynamic_verify.assert_called_once_with()
+        mock_all_id.assert_called_once_with()
+        mock_ocfs2.assert_called_once_with()
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_find_target_on_join_none(self, mock_run):
+        mock_run.return_value = "data"
+        res = self.ocfs2_inst3._find_target_on_join("node1")
+        assert res is None
+        mock_run.assert_called_once_with("crm configure show", remote="node1")
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_find_target_on_join_exception(self, mock_run):
+        mock_run.return_value = """
+params directory="/srv/clusterfs" fstype=ocfs2
+        """
+        with self.assertRaises(ValueError) as err:
+            self.ocfs2_inst3._find_target_on_join("node1")
+        self.assertEqual("Filesystem require configure device", str(err.exception))
+        mock_run.assert_called_once_with("crm configure show", remote="node1")
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_find_target_on_join(self, mock_run):
+        mock_run.return_value = """
+params directory="/srv/clusterfs" fstype=ocfs2 device="/dev/sda2"
+        """
+        res = self.ocfs2_inst3._find_target_on_join("node1")
+        self.assertEqual(res, "/dev/sda2")
+        mock_run.assert_called_once_with("crm configure show", remote="node1")
+
+    def test_get_device_list_on_join_return(self):
+        res = self.ocfs2_inst3._get_device_list_on_join("/dev/sda2", "node1")
+        self.assertEqual(res, ["/dev/sda2"])
+
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    def test_get_device_list_on_join(self, mock_run):
+        mock_run.return_value = """
+LV       VG       Attr       LSize Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert Devices
+ocfs2-lv ocfs2-vg -wi-ao---- 5.99g                                                     /dev/sda2(0)
+ocfs2-lv ocfs2-vg -wi-ao---- 5.99g                                                     /dev/sda3(0)
+        """
+        res = self.ocfs2_inst3._get_device_list_on_join("/dev/vg1/lv1", "node1", True)
+        self.assertEqual(res, ["/dev/sda2", "/dev/sda3"])
+        mock_run.assert_called_once_with("lvs /dev/vg1/lv1 -o +devices", remote="node1")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._find_target_on_join')
+    def test_join_ocfs2_return(self, mock_find):
+        mock_find.return_value = None
+        self.ocfs2_inst3.join_ocfs2("node1")
+        mock_find.assert_called_once_with("node1")
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._static_verify_on_join')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._get_device_list_on_join')
+    @mock.patch('crmsh.utils.has_resource_configured')
+    @mock.patch('crmsh.bootstrap.status_long')
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._find_target_on_join')
+    def test_join_ocfs2(self, mock_find, mock_long, mock_configured, mock_get_devlist, mock_static_verify):
+        mock_find.return_value = "/dev/sda2"
+        mock_configured.return_value = False
+        mock_get_devlist.return_value = ["/dev/sda2"]
+        self.ocfs2_inst3.join_ocfs2("node1")
+        mock_find.assert_called_once_with("node1")
+        mock_configured.assert_called_once_with("ocf::heartbeat:lvmlockd", "node1")
+        mock_get_devlist.assert_called_once_with("/dev/sda2", "node1", False)
+        mock_static_verify.assert_called_once_with(["/dev/sda2"], "node1", False)
+
+    @mock.patch('crmsh.ocfs2.OCFS2Manager._static_verify')
+    def test_verify_ocfs2(self, mock_static_verify):
+        context1 = mock.Mock(ocfs2_devices=[])
+        ocfs2.OCFS2Manager.verify_ocfs2(context1)
+        mock_static_verify.assert_called_once_with()


### PR DESCRIPTION
## Motivation
To make the OCFS2 configure process more simple, flexible and solid, also to extend using scenarios for OCFS2 + Cluster LVM, I refactored the code for configuring OCFS2

## RPM link for testing
https://build.opensuse.org/package/show/home:XinLiang:branches:crmsh_ocfs2/crmsh

## TODO list

- [x] Compare UUID between nodes, like #687 
- [x] Unit test
- [x] Functional test

## Highlights
#### Related -h output
```
Storage configuration:
  Options for configuring shared storage.

  -s DEVICE, --sbd-device DEVICE
                        Block device to use for SBD fencing, use ";" as
                        separator or -s multiple times for multi path (up to 3
                        devices)
  -o DEVICE, --ocfs2-device DEVICE
                        Block device to use for OCFS2; When using Cluster LVM2
                        to manage the shared storage, user can specify one or
                        multiple raw disks, use ";" as separator or -o
                        multiple times for multi path (must specify -C option)
                        NOTE: this is a Technical Preview
  -C, --cluster-lvm2    Use Cluster LVM2 for OCFS2 (only valid together with
                        -o option) NOTE: this is a Technical Preview
  -m MOUNT, --mount-point MOUNT
                        Mount point for OCFS2 device (default is
                        /srv/clusterfs, only valid together with -o option)
                        NOTE: this is a Technical Preview

Stage can be one of:
    ssh         Create SSH keys for passwordless SSH between cluster nodes
    csync2      Configure csync2
    corosync    Configure corosync
    sbd         Configure SBD (requires -s <dev>)
    cluster     Bring the cluster online
    ocfs2       Configure OCFS2 (requires -o <dev>) NOTE: this is a Technical Preview
    vgfs        Create volume group and filesystem (ocfs2 template only,
                    requires -o <dev>) NOTE: this stage is an alias of ocfs2 stage
    admin       Create administration virtual IP (optional)
    qdevice     Configure qdevice and qnetd
```
#### Scenarios
1. OCFS2 along
```Bash
# crm cluster init -s /dev/sda1 -o /dev/sda2 -y
  Configuring csync2
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
  Configuring corosync
  Initializing SBD......done
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
  Configuring OCFS2
    Waiting for DLM(ocfs2-dlm) start......done
    Waiting for Filesystem(ocfs2-clusterfs) start....done
    OCFS2 device /dev/sda2 mounted on /srv/clusterfs
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
2. OCFS2 + Cluster LVM
```Bash
# crm cluster init -s /dev/sda1 -o /dev/sda2 -o /dev/sda3 -C -y
  Configuring csync2
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
  Configuring corosync
  Initializing SBD......done
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
  Configuring OCFS2
    Waiting for DLM(ocfs2-dlm) start......done
    Waiting for LVMLockd(ocfs2-lvmlockd) start....done
    Creating PV for /dev/sda2 /dev/sda3...done
    Creating VG ocfs2-vg...done
    Creating LV ocfs2-lv on VG ocfs2-vg...done
    Creating OCFS2 filesystem for /dev/ocfs2-vg/ocfs2-lv...done
    Waiting for LVMActivate(ocfs2-lvmactivate) start....done
    Waiting for Filesystem(ocfs2-clusterfs) start....done
    OCFS2 device /dev/ocfs2-vg/ocfs2-lv mounted on /srv/clusterfs
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
3. Append OCFS2 as stage on running cluster
```Bash
# crm cluster init ocfs2 -o /dev/sda2 -o /dev/sda3 -C -y
  Configuring OCFS2
    Waiting for DLM(ocfs2-dlm) start....done
    Waiting for LVMLockd(ocfs2-lvmlockd) start....done
    Creating PV for /dev/sda2 /dev/sda3...done
    Creating VG ocfs2-vg...done
    Creating LV ocfs2-lv on VG ocfs2-vg...done
    Creating OCFS2 filesystem for /dev/ocfs2-vg/ocfs2-lv...done
    Waiting for LVMActivate(ocfs2-lvmactivate) start...done
    Waiting for Filesystem(ocfs2-clusterfs) start....done
    OCFS2 device /dev/ocfs2-vg/ocfs2-lv mounted on /srv/clusterfs
  Done (log saved to /var/log/crmsh/ha-cluster-bootstrap.log)
```
#### Validation
1. When missing ocfs2-tools:
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdb2 -y
ERROR: cluster.init: Missing required package for configuring OCFS2: ocfs2-tools
```
2. After installed `ocfs2-tools`, want to configure with Cluster LVM by using `-C` option:
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdb2 -C -y
ERROR: cluster.init: Missing required package for configuring OCFS2: lvm2-lockd
```
3. Multi -o options without -C option
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdb2 -o /dev/sdc2 -y
ERROR: cluster.init: Without Cluster LVM2 (-C option), -o option only support one device
```
4. Device belongs to existing LV
```Bash
# crm cluster init -s /dev/sda1 -o /dev/vg2/test2 -C
ERROR: cluster.init: /dev/vg2/test2 is a Logical Volume, cannot use with -C option
```
5. Invalid block device
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdd1 -y
ERROR: cluster.init: /dev/sdd1 doesn't look like a block device
```
6. Device already mounted
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdc2 -y
ERROR: cluster.init: /dev/sdc2 already mounted
```
7. Missing stonith when trying to add ocfs2 on running cluster
```Bash
# crm cluster init ocfs2 -o /dev/sdb2 -y
ERROR: cluster.init: OCFS2 requires stonith device configured and running
```
8. Same device name with sbd
```Bash
# crm cluster init -s /dev/sdb1 -o /dev/sdb1 -y
  Configuring csync2
  Generating csync2 shared key (this may take a while)...done
  csync2 checking files...done
  Configuring corosync
  Initializing SBD......done
WARNING: Hawk not installed - not configuring web management interface.
  Waiting for cluster..............done
  Loading initial cluster configuration
ERROR: cluster.init: /dev/sda1 cannot be the same with SBD device
The cluster service has already been initialized, but the prerequisites are missing
to configure OCFS2. Please fix it and use the stage procedure to configure OCFS2 separately,
e.g. crm cluster init ocfs2 -o <ocfs2_device>
```
9. Missing -o option for ocfs2 stage
```Bash
# crm cluster init ocfs2 -y
ERROR: cluster.init: ocfs2 stage require -o option
```