### PR TITLE
Dev: add "crm corosync status qdevice" sub-command

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -36,14 +36,16 @@ def query_status(status_type):
     """
     Query status of corosync
 
-    Possible types could be ring/quorum/qnetd
+    Possible types could be ring/quorum/qdevice/qnetd
     """
-    if status_type == "ring":
-        query_ring_status()
-    elif status_type == "quorum":
-        query_quorum_status()
-    elif status_type == "qnetd":
-        query_qnetd_status()
+    status_func_dict = {
+            "ring": query_ring_status,
+            "quorum": query_quorum_status,
+            "qdevice": query_qdevice_status,
+            "qnetd": query_qnetd_status
+            }
+    if status_type in status_func_dict:
+        status_func_dict[status_type]()
     else:
         raise ValueError("Wrong type \"{}\" to query status".format(status_type))
 
@@ -72,6 +74,18 @@ def query_quorum_status():
     # that means no problem appeared but node is not quorate
     if rc in [0, 2] and out:
         print(out)
+
+
+def query_qdevice_status():
+    """
+    Query qdevice status
+    """
+    if not utils.is_qdevice_configured():
+        raise ValueError("QDevice/QNetd not configured!")
+    cmd = "corosync-qdevice-tool -sv"
+    out = utils.get_stdout_or_raise_error(cmd)
+    utils.print_cluster_nodes()
+    print(out)
 
 
 def query_qnetd_status():

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -54,7 +54,7 @@ class Corosync(command.UI):
     def requires(self):
         return corosync.check_tools()
 
-    @command.completers(completers.choice(['ring', 'quorum', 'qnetd']))
+    @command.completers(completers.choice(['ring', 'quorum', 'qdevice', 'qnetd']))
     def do_status(self, context, status_type="ring"):
         '''
         Quick cluster health status. Corosync status or QNetd status

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1745,11 +1745,11 @@ show
 [[cmdhelp_corosync_status,Display the corosync status]]
 ==== `status`
 
-Displays the corosync ring status(default), quorum status and qnetd status.
+Displays the corosync ring status(default), also can display quorum/qdevice/qnetd status.
 
 Usage:
 .........
-status [ring|quorum|qnetd]
+status [ring|quorum|qdevice|qnetd]
 .........
 
 [[cmdhelp_cib,CIB shadow management]]

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -42,6 +42,37 @@ def _print(parser):
     print(parser.to_string())
 
 
+def test_query_status_exception():
+    with pytest.raises(ValueError) as err:
+        corosync.query_status("test")
+    assert str(err.value) == "Wrong type \"test\" to query status"
+
+
+@mock.patch('crmsh.corosync.query_ring_status')
+def test_query_status(mock_ring_status):
+    corosync.query_status("ring")
+    mock_ring_status.assert_called_once_with()
+
+
+@mock.patch('crmsh.utils.is_qdevice_configured')
+def test_query_qdevice_status_exception(mock_configured):
+    mock_configured.return_value = False
+    with pytest.raises(ValueError) as err:
+        corosync.query_qdevice_status()
+    assert str(err.value) == "QDevice/QNetd not configured!"
+    mock_configured.assert_called_once_with()
+
+
+@mock.patch('crmsh.utils.print_cluster_nodes')
+@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.utils.is_qdevice_configured')
+def test_query_qdevice_status(mock_configured, mock_run, mock_print):
+    mock_configured.return_value = True
+    corosync.query_qdevice_status()
+    mock_run.assert_called_once_with("corosync-qdevice-tool -sv")
+    mock_print.assert_called_once_with()
+
+
 @mock.patch("crmsh.corosync.query_ring_status")
 def test_query_status_ring(mock_ring_status):
     corosync.query_status("ring")


### PR DESCRIPTION
```Bash
# crm corosync status qdevice
1084783311 15sp2-1 member
1084783193 15sp2-2 member

Qdevice information
-------------------
Model:                  Net
Node ID:                1084783311
HB interval:            10000ms
Sync HB interval:       30000ms
Configured node list:
    0   Node ID = 1084783193
    1   Node ID = 1084783311
Heuristics:             Disabled
Ring ID:                40a87a59.10c
Membership node list:   1084783193, 1084783311
Quorate:                Yes
Quorum node list:
    0   Node ID = 1084783193, State = member
    1   Node ID = 1084783311, State = member
Expected votes:         3
Last poll call:         2021-04-12T10:37:09 (cast vote)

Qdevice-net information
----------------------
Cluster name:           hacluster
QNetd host:             15sp2-3:5403
Connect timeout:        8000ms
HB interval:            8000ms
VQ vote timer interval: 5000ms
TLS:                    Supported
Algorithm:              Fifty-Fifty split
Tie-breaker:            Node with lowest node ID
Poll timer running:     Yes (cast vote)
State:                  Connected
TLS active:             Yes (client certificate sent)
Connected since:        2021-04-12T10:36:04
Echo reply received:    2021-04-12T10:37:08
```