### PR TITLE
Adjust/Disable unnecessary warnings

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -349,6 +349,7 @@ Configure SBD:
   are a good choice.  Note that all data on the partition you
   specify here will be destroyed.
 """
+    SBD_WARNING = "Not configuring SBD - STONITH will be disabled."
     DISKLESS_SBD_WARNING = """Diskless SBD requires cluster with three or more nodes.
 If you want to use diskless SBD for two-nodes cluster, should be combined with QDevice."""
     PARSE_RE = "[; ]"
@@ -422,13 +423,13 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         Get sbd device on interactive mode
         """
         if _context.yes_to_all:
-            warn("Not configuring SBD ({} left untouched).".format(SYSCONFIG_SBD))
+            warn(self.SBD_WARNING)
             return
 
         status(self.SBD_STATUS_DESCRIPTION)
 
         if not confirm("Do you wish to use SBD?"):
-            warn("Not configuring SBD - STONITH will be disabled.")
+            warn(self.SBD_WARNING)
             return
 
         configured_dev_list = self._get_sbd_device_from_config()
@@ -1024,8 +1025,6 @@ def configure_firewall(tcp=None, udp=None):
         init_firewall_suse(tcp, udp)
     elif utils.package_is_installed("ufw"):
         init_firewall_ufw(tcp, udp)
-    else:
-        warn("Failed to detect firewall: Could not open ports tcp={}, udp={}".format("|".join(tcp), "|".join(udp)))
 
 
 def firewall_open_basic_ports():

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -354,7 +354,7 @@ class TestSBDManager(unittest.TestCase):
     def test_get_sbd_device_interactive_yes_to_all(self, mock_warn):
         bootstrap._context = mock.Mock(yes_to_all=True)
         self.sbd_inst._get_sbd_device_interactive()
-        mock_warn.assert_called_once_with("Not configuring SBD ({} left untouched).".format(bootstrap.SYSCONFIG_SBD))
+        mock_warn.assert_called_once_with(bootstrap.SBDManager.SBD_WARNING)
 
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.status')


### PR DESCRIPTION
- Adjust warning for sbd `Not configuring SBD - STONITH will be disabled.` when not provide any sbd related options
- No need to show `Failed to detect firewall: Could not open ports..` when detecting no firewall running