### PR TITLE
Add warnings for damage options in preflight_check

### DIFF
--- a/crmsh/preflight_check/check.py
+++ b/crmsh/preflight_check/check.py
@@ -74,7 +74,7 @@ def correct_sbd(context, can):
     Only support one path SBD_DEVICE in the current version
     """
 
-    task_inst = task.TaskFixSBD(can, context.yes)
+    task_inst = task.TaskFixSBD(can, context.force)
     try:
         task_inst.pre_check()
         task_inst.print_header()

--- a/crmsh/preflight_check/main.py
+++ b/crmsh/preflight_check/main.py
@@ -41,7 +41,7 @@ class Context(object):
         self.loop = None
 
         # set by argument(additional options)
-        self.yes = None
+        self.force = None
         self.help = None
 
     def __setattr__(self, name, value):
@@ -124,7 +124,7 @@ def split_brain(context):
     if not context.sp_iptables:
         return
 
-    task_inst = task.TaskSplitBrain(context.yes)
+    task_inst = task.TaskSplitBrain(context.force)
     try:
         task_inst.pre_check()
         task_inst.print_header()
@@ -192,8 +192,8 @@ For each --kill-* testcase, report directory: {}'''.format(context.logfile,
                         help='Kill process in loop')
 
     other_options = parser.add_argument_group('other options')
-    other_options.add_argument('-y', '--yes', dest='yes', action='store_true',
-                               help='Answer "yes" if asked to run the test')
+    other_options.add_argument('-f', '--force', dest='force', action='store_true',
+                               help='Force to skip all prompts (Use with caution, this is destructive)')
     other_options.add_argument('-h', '--help', dest='help', action='store_true',
                                help='Show this help message and exit')
 

--- a/crmsh/preflight_check/utils.py
+++ b/crmsh/preflight_check/utils.py
@@ -299,3 +299,15 @@ def find_candidate_sbd(dev):
         i += 1
 
     return candidates[index]
+
+
+def warning_ask(warn_string):
+    from . import main
+    if main.ctx.force:
+        return False
+        
+    try:
+        ans = input(CYELLOW + warn_string + CEND)
+    except EOFError:
+        return False
+    return True if ans == "Yes" else False

--- a/test/unittests/test_preflight_main.py
+++ b/test/unittests/test_preflight_main.py
@@ -173,7 +173,7 @@ class TestMain(TestCase):
 
     @mock.patch('crmsh.preflight_check.task.TaskSplitBrain')
     def test_split_brain(self, mock_sp):
-        ctx = mock.Mock(sp_iptables=True, yes=False)
+        ctx = mock.Mock(sp_iptables=True, force=False)
         mock_sp_inst = mock.Mock()
         mock_sp.return_value = mock_sp_inst
         mock_sp_inst.do_block.return_value.__enter__ = mock.Mock()

--- a/test/unittests/test_preflight_task.py
+++ b/test/unittests/test_preflight_task.py
@@ -711,7 +711,7 @@ class TestTask(TestCase):
         }
         self.assertDictEqual(expected_result, self.task_inst.result)
 
-    @mock.patch('crmsh.preflight_check.task.crmshutils.ask')
+    @mock.patch('crmsh.preflight_check.utils.warning_ask')
     def test_print_header(self, mock_ask):
         self.task_inst.header = mock.Mock()
         self.task_inst.info = mock.Mock()
@@ -721,7 +721,7 @@ class TestTask(TestCase):
             self.task_inst.print_header()
 
         self.task_inst.header.assert_called_once_with()
-        mock_ask.assert_called_once_with("Run?")
+        mock_ask.assert_called_once_with(task.Task.REBOOT_WARNING)
         self.task_inst.info.assert_called_once_with("Testcase cancelled")
 
     @mock.patch('crmsh.preflight_check.utils.str_to_datetime')
@@ -785,7 +785,7 @@ class TestFixSBD(TestCase):
                                                 format(dev)).return_value
         mock_mkstemp.side_effect = [(1, bak), (2, edit)]
 
-        self.task_fixsbd = task.TaskFixSBD(dev, yes=False)
+        self.task_fixsbd = task.TaskFixSBD(dev, force=False)
         mock_msg_info.assert_called_once_with('Replace SBD_DEVICE with candidate {}'.
                                               format(dev), to_stdout=False)
 


### PR DESCRIPTION
#### Changes
1. replace --yes as --force
```
-f, --force             Force to skip all prompts (Use with caution, this is destructive)
```
2. Add warnings for damage options
```
# crm analyze preflight_check --kill-corosync


==============================================
Testcase:          Force kill corosync
Looping Kill:      False
Expected State:    a) corosync process restarted
                   b) Or, this node fenced.

!!! WARNING WARNING WARNING !!!
THIS CASE MAY LEAD TO NODE BE FENCED.
TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE:
```

![Screenshot from 2021-04-26 14-55-29](https://user-images.githubusercontent.com/1650862/116041184-6fedf580-a65c-11eb-8f6f-7e68ec7e8fe8.png)
