### PR TITLE
Dev: bootstrap: raise exception and execute status_done on success

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -846,7 +846,9 @@ def status_long(msg):
         sys.stdout.flush()
     try:
         yield
-    finally:
+    except:
+        raise
+    else:
         status_done()
 
 


### PR DESCRIPTION
Changed after #803 
Should raise exception while only calling `status_done` function when success