### PR TITLE
Split class Watchdog into watchdog.py from bootstrap.py

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -36,6 +36,7 @@ from . import lock
 from . import userdir
 from .constants import SSH_OPTION, QDEVICE_HELP_INFO
 
+
 LOG_FILE = "/var/log/crmsh/ha-cluster-bootstrap.log"
 CSYNC2_KEY = "/etc/csync2/key_hagroup"
 CSYNC2_CFG = "/etc/csync2/csync2.cfg"
@@ -179,178 +180,6 @@ class Context(object):
 
     def init_sbd_manager(self):
         self.sbd_manager = SBDManager(self.sbd_devices, self.diskless_sbd)
-
-
-class Watchdog(object):
-    """
-    Class to find valid watchdog device name
-    """
-    QUERY_CMD = "sbd query-watchdog"
-    DEVICE_FIND_REGREX = "\[[0-9]+\] (/dev/.*)\n.*\nDriver: (.*)"
-
-    def __init__(self, _input=None, peer_host=None):
-        """
-        Init function
-        """
-        self._input = _input
-        self._peer_host = peer_host
-        self._watchdog_info_dict = {}
-        self._watchdog_device_name = None
-    
-    @property
-    def watchdog_device_name(self):
-        return self._watchdog_device_name
-
-    @staticmethod
-    def _verify_watchdog_device(dev, ignore_error=False):
-        """
-        Use wdctl to verify watchdog device
-        """
-        rc, _, err = utils.get_stdout_stderr("wdctl {}".format(dev))
-        if rc != 0:
-            if ignore_error:
-                return False
-            else:
-                error("Invalid watchdog device {}: {}".format(dev, err))
-        return True
-
-    @staticmethod
-    def _load_watchdog_driver(driver):
-        """
-        Load specific watchdog driver
-        """
-        invoke("echo {} > {}".format(driver, WATCHDOG_CFG))
-        invoke("systemctl restart systemd-modules-load")
-
-    @staticmethod
-    def _get_watchdog_device_from_sbd_config():
-        """
-        Try to get watchdog device name from sbd config file
-        """
-        conf = utils.parse_sysconfig(SYSCONFIG_SBD)
-        return conf.get("SBD_WATCHDOG_DEV")
-
-    @staticmethod
-    def _driver_is_loaded(driver):
-        """
-        Check if driver was already loaded
-        """
-        _, out, _ = utils.get_stdout_stderr("lsmod")
-        return re.search("\n{}\s+".format(driver), out)
-
-    def _set_watchdog_info(self):
-        """
-        Set watchdog info through sbd query-watchdog command
-        Content in self._watchdog_info_dict: {device_name: driver_name}
-        """
-        rc, out, err = utils.get_stdout_stderr(self.QUERY_CMD)
-        if rc == 0 and out:
-            # output format might like:
-            #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n
-            self._watchdog_info_dict = dict(re.findall(self.DEVICE_FIND_REGREX, out))
-        else:
-            error("Failed to run {}: {}".format(self.QUERY_CMD, err))
-
-    def _get_device_through_driver(self, driver_name):
-        """
-        Get watchdog device name which has driver_name
-        """
-        for device, driver in self._watchdog_info_dict.items():
-            if driver == driver_name and self._verify_watchdog_device(device):
-                return device
-        return None
-
-    def _get_driver_through_device_remotely(self, dev_name):
-        """
-        Given watchdog device name, get driver name on remote node
-        """
-        cmd = "ssh {} root@{} {}".format(SSH_OPTION, self._peer_host, self.QUERY_CMD)
-        rc, out, err = utils.get_stdout_stderr(cmd)
-        if rc == 0 and out:
-            # output format might like:
-            #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n
-            device_driver_dict = dict(re.findall(self.DEVICE_FIND_REGREX, out))
-            if device_driver_dict and dev_name in device_driver_dict:
-                return device_driver_dict[dev_name]
-            else:
-                return None
-        else:
-            error("Failed to run {} remotely: {}".format(self.QUERY_CMD, err))
-
-    def _get_first_unused_device(self):
-        """
-        Get first unused watchdog device name
-        """
-        for dev in self._watchdog_info_dict:
-            if self._verify_watchdog_device(dev, ignore_error=True):
-                return dev
-        return None
-
-    def _set_input(self):
-        """
-        If self._input was not provided by option:
-          1. Try to get it from sbd config file
-          2. Try to get the first valid device from result of sbd query-watchdog
-          3. Set the self._input as softdog
-        """
-        if not self._input:
-            dev = self._get_watchdog_device_from_sbd_config()
-            if dev and self._verify_watchdog_device(dev, ignore_error=True):
-                self._input = dev
-                return
-            first_unused = self._get_first_unused_device()
-            self._input = first_unused if first_unused else "softdog"
-
-    def _valid_device(self, dev):
-        """
-        Is an unused watchdog device
-        """
-        if dev in self._watchdog_info_dict and self._verify_watchdog_device(dev):
-            return True
-        return False
-
-    def join_watchdog(self):
-        """
-        In join proces, get watchdog device from config
-        If that device not exist, get driver name from init node, and load that driver
-        """
-        self._set_watchdog_info()
-
-        res = self._get_watchdog_device_from_sbd_config()
-        if not res:
-            error("Failed to get watchdog device from {}".format(SYSCONFIG_SBD))
-        self._input = res
-
-        if not self._valid_device(self._input):
-            driver = self._get_driver_through_device_remotely(self._input)
-            self._load_watchdog_driver(driver)
-
-    def init_watchdog(self):
-        """
-        In init process, find valid watchdog device
-        """
-        self._set_watchdog_info()
-        self._set_input()
-
-        # self._input is a device name
-        if self._valid_device(self._input):
-            self._watchdog_device_name = self._input
-            return
-
-        # self._input is invalid, exit
-        if not invokerc("modinfo {}".format(self._input)):
-            error("Should provide valid watchdog device or driver name by -w option")
-
-        # self._input is a driver name, load it if it was unloaded
-        if not self._driver_is_loaded(self._input):
-            self._load_watchdog_driver(self._input)
-            self._set_watchdog_info()
-
-        # self._input is a loaded driver name, find corresponding device name
-        res = self._get_device_through_driver(self._input)
-        if res:
-            self._watchdog_device_name = res
-            return
 
 
 class SBDManager(object):
@@ -591,6 +420,8 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         2. Initialize sbd device
         3. Write config file /etc/sysconfig/sbd
         """
+        from .watchdog import Watchdog
+
         if not utils.package_is_installed("sbd"):
             return
         self._watchdog_inst = Watchdog(_input=_context.watchdog)
@@ -630,6 +461,8 @@ If you want to use diskless SBD for two-nodes cluster, should be combined with Q
         On joining process, check whether peer node has enabled sbd.service
         If so, check prerequisites of SBD and verify sbd device on join node
         """
+        from .watchdog import Watchdog
+
         if not utils.package_is_installed("sbd"):
             return
         if not os.path.exists(SYSCONFIG_SBD) or not utils.service_is_enabled("sbd.service", peer_host):

--- a/crmsh/watchdog.py
+++ b/crmsh/watchdog.py
@@ -1,0 +1,176 @@
+import re
+from . import utils
+from .constants import SSH_OPTION
+from .bootstrap import error, invoke, invokerc, WATCHDOG_CFG, SYSCONFIG_SBD
+
+
+class Watchdog(object):
+    """
+    Class to find valid watchdog device name
+    """
+    QUERY_CMD = "sbd query-watchdog"
+    DEVICE_FIND_REGREX = "\[[0-9]+\] (/dev/.*)\n.*\nDriver: (.*)"
+
+    def __init__(self, _input=None, peer_host=None):
+        """
+        Init function
+        """
+        self._input = _input
+        self._peer_host = peer_host
+        self._watchdog_info_dict = {}
+        self._watchdog_device_name = None
+
+    @property
+    def watchdog_device_name(self):
+        return self._watchdog_device_name
+
+    @staticmethod
+    def _verify_watchdog_device(dev, ignore_error=False):
+        """
+        Use wdctl to verify watchdog device
+        """
+        rc, _, err = utils.get_stdout_stderr("wdctl {}".format(dev))
+        if rc != 0:
+            if ignore_error:
+                return False
+            else:
+                error("Invalid watchdog device {}: {}".format(dev, err))
+        return True
+
+    @staticmethod
+    def _load_watchdog_driver(driver):
+        """
+        Load specific watchdog driver
+        """
+        invoke("echo {} > {}".format(driver, WATCHDOG_CFG))
+        invoke("systemctl restart systemd-modules-load")
+
+    @staticmethod
+    def _get_watchdog_device_from_sbd_config():
+        """
+        Try to get watchdog device name from sbd config file
+        """
+        conf = utils.parse_sysconfig(SYSCONFIG_SBD)
+        return conf.get("SBD_WATCHDOG_DEV")
+
+    @staticmethod
+    def _driver_is_loaded(driver):
+        """
+        Check if driver was already loaded
+        """
+        _, out, _ = utils.get_stdout_stderr("lsmod")
+        return re.search("\n{}\s+".format(driver), out)
+
+    def _set_watchdog_info(self):
+        """
+        Set watchdog info through sbd query-watchdog command
+        Content in self._watchdog_info_dict: {device_name: driver_name}
+        """
+        rc, out, err = utils.get_stdout_stderr(self.QUERY_CMD)
+        if rc == 0 and out:
+            # output format might like:
+            #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n
+            self._watchdog_info_dict = dict(re.findall(self.DEVICE_FIND_REGREX, out))
+        else:
+            error("Failed to run {}: {}".format(self.QUERY_CMD, err))
+
+    def _get_device_through_driver(self, driver_name):
+        """
+        Get watchdog device name which has driver_name
+        """
+        for device, driver in self._watchdog_info_dict.items():
+            if driver == driver_name and self._verify_watchdog_device(device):
+                return device
+        return None
+
+    def _get_driver_through_device_remotely(self, dev_name):
+        """
+        Given watchdog device name, get driver name on remote node
+        """
+        cmd = "ssh {} root@{} {}".format(SSH_OPTION, self._peer_host, self.QUERY_CMD)
+        rc, out, err = utils.get_stdout_stderr(cmd)
+        if rc == 0 and out:
+            # output format might like:
+            #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n
+            device_driver_dict = dict(re.findall(self.DEVICE_FIND_REGREX, out))
+            if device_driver_dict and dev_name in device_driver_dict:
+                return device_driver_dict[dev_name]
+            else:
+                return None
+        else:
+            error("Failed to run {} remotely: {}".format(self.QUERY_CMD, err))
+
+    def _get_first_unused_device(self):
+        """
+        Get first unused watchdog device name
+        """
+        for dev in self._watchdog_info_dict:
+            if self._verify_watchdog_device(dev, ignore_error=True):
+                return dev
+        return None
+
+    def _set_input(self):
+        """
+        If self._input was not provided by option:
+          1. Try to get it from sbd config file
+          2. Try to get the first valid device from result of sbd query-watchdog
+          3. Set the self._input as softdog
+        """
+        if not self._input:
+            dev = self._get_watchdog_device_from_sbd_config()
+            if dev and self._verify_watchdog_device(dev, ignore_error=True):
+                self._input = dev
+                return
+            first_unused = self._get_first_unused_device()
+            self._input = first_unused if first_unused else "softdog"
+
+    def _valid_device(self, dev):
+        """
+        Is an unused watchdog device
+        """
+        if dev in self._watchdog_info_dict and self._verify_watchdog_device(dev):
+            return True
+        return False
+
+    def join_watchdog(self):
+        """
+        In join proces, get watchdog device from config
+        If that device not exist, get driver name from init node, and load that driver
+        """
+        self._set_watchdog_info()
+
+        res = self._get_watchdog_device_from_sbd_config()
+        if not res:
+            error("Failed to get watchdog device from {}".format(SYSCONFIG_SBD))
+        self._input = res
+
+        if not self._valid_device(self._input):
+            driver = self._get_driver_through_device_remotely(self._input)
+            self._load_watchdog_driver(driver)
+
+    def init_watchdog(self):
+        """
+        In init process, find valid watchdog device
+        """
+        self._set_watchdog_info()
+        self._set_input()
+
+        # self._input is a device name
+        if self._valid_device(self._input):
+            self._watchdog_device_name = self._input
+            return
+
+        # self._input is invalid, exit
+        if not invokerc("modinfo {}".format(self._input)):
+            error("Should provide valid watchdog device or driver name by -w option")
+
+        # self._input is a driver name, load it if it was unloaded
+        if not self._driver_is_loaded(self._input):
+            self._load_watchdog_driver(self._input)
+            self._set_watchdog_info()
+
+        # self._input is a loaded driver name, find corresponding device name
+        res = self._get_device_through_driver(self._input)
+        if res:
+            self._watchdog_device_name = res
+            return

--- a/data-manifest
+++ b/data-manifest
@@ -197,6 +197,7 @@ test/unittests/test_scripts.py
 test/unittests/test_time.py
 test/unittests/test_ui_cluster.py
 test/unittests/test_utils.py
+test/unittests/test_watchdog.py
 test/update-expected-output.sh
 utils/crm_clean.py
 utils/crm_init.py

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -146,303 +146,6 @@ class TestContext(unittest.TestCase):
         mock_sbd.assert_called_once_with(["/dev/sda1"], False)
 
 
-class TestWatchdog(unittest.TestCase):
-    """
-    Unitary tests for crmsh.bootstrap.Watchdog
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Global setUp.
-        """
-
-    def setUp(self):
-        """
-        Test setUp.
-        """
-        self.watchdog_inst = bootstrap.Watchdog()
-        self.watchdog_join_inst = bootstrap.Watchdog(peer_host="node1")
-
-    def tearDown(self):
-        """
-        Test tearDown.
-        """
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Global tearDown.
-        """
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_verify_watchdog_device_ignore_error(self, mock_run):
-        mock_run.return_value = (1, None, "error")
-        res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog", True)
-        self.assertEqual(res, False)
-        mock_run.assert_called_once_with("wdctl /dev/watchdog")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_verify_watchdog_device_error(self, mock_run, mock_error):
-        mock_run.return_value = (1, None, "error")
-        mock_error.side_effect = ValueError
-        with self.assertRaises(ValueError) as err:
-            self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
-        mock_error.assert_called_once_with("Invalid watchdog device /dev/watchdog: error")
-        mock_run.assert_called_once_with("wdctl /dev/watchdog")
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_verify_watchdog_device(self, mock_run):
-        mock_run.return_value = (0, None, None)
-        res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
-        self.assertEqual(res, True)
-
-    @mock.patch('crmsh.bootstrap.invoke')
-    def test_load_watchdog_driver(self, mock_invoke):
-        self.watchdog_inst._load_watchdog_driver("softdog")
-        mock_invoke.assert_has_calls([
-            mock.call("echo softdog > /etc/modules-load.d/watchdog.conf"),
-            mock.call("systemctl restart systemd-modules-load")
-            ])
-
-    @mock.patch('crmsh.utils.parse_sysconfig')
-    def test_get_watchdog_device_from_sbd_config(self, mock_parse):
-        mock_parse_inst = mock.Mock()
-        mock_parse.return_value = mock_parse_inst
-        mock_parse_inst.get.return_value = "/dev/watchdog"
-        res = self.watchdog_inst._get_watchdog_device_from_sbd_config()
-        self.assertEqual(res, "/dev/watchdog")
-        mock_parse.assert_called_once_with(bootstrap.SYSCONFIG_SBD)
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_driver_is_loaded(self, mock_run):
-        output = """
-button                 24576  0
-softdog                16384  2
-btrfs                1474560  1
-        """
-        mock_run.return_value = (0, output, None)
-        res = self.watchdog_inst._driver_is_loaded("softdog")
-        assert res is not None
-        mock_run.assert_called_once_with("lsmod")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_set_watchdog_info_error(self, mock_run, mock_error):
-        mock_run.return_value = (1, None, "error")
-        mock_error.side_effect = ValueError
-        with self.assertRaises(ValueError):
-            self.watchdog_inst._set_watchdog_info()
-        mock_run.assert_called_once_with(bootstrap.Watchdog.QUERY_CMD)
-        mock_error.assert_called_once_with("Failed to run {}: error".format(bootstrap.Watchdog.QUERY_CMD))
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_set_watchdog_info(self, mock_run):
-        output = """
-Discovered 3 watchdog devices:
-
-[1] /dev/watchdog
-Identity: Software Watchdog
-Driver: softdog
-CAUTION: Not recommended for use with sbd.
-
-[2] /dev/watchdog0
-Identity: Software Watchdog
-Driver: softdog
-CAUTION: Not recommended for use with sbd.
-
-[3] /dev/watchdog1
-Identity: iTCO_wdt
-Driver: iTCO_wdt
-        """
-        mock_run.return_value = (0, output, None)
-        self.watchdog_inst._set_watchdog_info()
-        self.assertEqual(self.watchdog_inst._watchdog_info_dict, {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'})
-
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    def test_get_device_through_driver_none(self, mock_verify):
-        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
-        mock_verify.return_value = False
-        res = self.watchdog_inst._get_device_through_driver("iTCO_wdt")
-        self.assertEqual(res, None)
-        mock_verify.assert_called_once_with("/dev/watchdog1")
-
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    def test_get_device_through_driver(self, mock_verify):
-        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
-        mock_verify.return_value = True
-        res = self.watchdog_inst._get_device_through_driver("iTCO_wdt")
-        self.assertEqual(res, "/dev/watchdog1")
-        mock_verify.assert_called_once_with("/dev/watchdog1")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_driver_through_device_remotely_error(self, mock_run, mock_error):
-        mock_run.return_value = (1, None, "error")
-        self.watchdog_join_inst._get_driver_through_device_remotely("test")
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
-        mock_error.assert_called_once_with("Failed to run sbd query-watchdog remotely: error")
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_driver_through_device_remotely_none(self, mock_run):
-        mock_run.return_value = (0, "data", None)
-        res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
-        self.assertEqual(res, None)
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
-
-    @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_driver_through_device_remotely(self, mock_run):
-        output = """
-Discovered 3 watchdog devices:
-
-[1] /dev/watchdog
-Identity: Software Watchdog
-Driver: softdog
-CAUTION: Not recommended for use with sbd.
-
-[2] /dev/watchdog0
-Identity: Software Watchdog
-Driver: softdog
-CAUTION: Not recommended for use with sbd.
-
-[3] /dev/watchdog1
-Identity: iTCO_wdt
-Driver: iTCO_wdt
-        """
-        mock_run.return_value = (0, output, None)
-        res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
-        self.assertEqual(res, "softdog")
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
-
-    def test_get_first_unused_device_none(self):
-        res = self.watchdog_inst._get_first_unused_device()
-        self.assertEqual(res, None)
-
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    def test_get_first_unused_device(self, mock_verify):
-        mock_verify.return_value = True
-        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
-        res = self.watchdog_inst._get_first_unused_device()
-        self.assertEqual(res, "/dev/watchdog")
-        mock_verify.assert_called_once_with("/dev/watchdog", ignore_error=True)
-
-    @mock.patch('crmsh.bootstrap.Watchdog._get_first_unused_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._get_watchdog_device_from_sbd_config')
-    def test_set_input_from_config(self, mock_from_config, mock_verify, mock_first):
-        mock_from_config.return_value = "/dev/watchdog"
-        mock_verify.return_value = True
-        self.watchdog_inst._set_input()
-        mock_first.assert_not_called()
-        mock_from_config.assert_called_once_with()
-
-    @mock.patch('crmsh.bootstrap.Watchdog._get_first_unused_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._get_watchdog_device_from_sbd_config')
-    def test_set_input(self, mock_from_config, mock_verify, mock_first):
-        mock_from_config.return_value = None
-        mock_first.return_value = None
-        self.watchdog_inst._set_input()
-        self.assertEqual(self.watchdog_inst._input, "softdog")
-        mock_from_config.assert_called_once_with()
-        mock_verify.assert_not_called()
-        mock_first.assert_called_once_with()
-
-    def test_valid_device_false(self):
-        res = self.watchdog_inst._valid_device("test")
-        self.assertEqual(res, False)
-
-    @mock.patch('crmsh.bootstrap.Watchdog._verify_watchdog_device')
-    def test_valid_device(self, mock_verify):
-        mock_verify.return_value = True
-        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
-        res = self.watchdog_inst._valid_device("/dev/watchdog")
-        self.assertEqual(res, True)
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.Watchdog._get_watchdog_device_from_sbd_config')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_watchdog_info')
-    def test_join_watchdog_error(self, mock_set_info, mock_from_config, mock_error):
-        mock_from_config.return_value = None
-        mock_error.side_effect = SystemExit
-        with self.assertRaises(SystemExit):
-            self.watchdog_join_inst.join_watchdog()
-        mock_set_info.assert_called_once_with()
-        mock_from_config.assert_called_once_with()
-        mock_error.assert_called_once_with("Failed to get watchdog device from {}".format(bootstrap.SYSCONFIG_SBD))
-
-    @mock.patch('crmsh.bootstrap.Watchdog._load_watchdog_driver')
-    @mock.patch('crmsh.bootstrap.Watchdog._get_driver_through_device_remotely')
-    @mock.patch('crmsh.bootstrap.Watchdog._valid_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._get_watchdog_device_from_sbd_config')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_watchdog_info')
-    def test_join_watchdog(self, mock_set_info, mock_from_config, mock_valid, mock_get_driver_remotely, mock_load):
-        mock_from_config.return_value = "/dev/watchdog"
-        mock_valid.return_value = False
-        mock_get_driver_remotely.return_value = "softdog"
-
-        self.watchdog_join_inst.join_watchdog()
-
-        mock_set_info.assert_called_once_with()
-        mock_from_config.assert_called_once_with()
-        mock_valid.assert_called_once_with("/dev/watchdog")
-        mock_get_driver_remotely.assert_called_once_with("/dev/watchdog")
-        mock_load.assert_called_once_with("softdog")
-
-    @mock.patch('crmsh.bootstrap.invokerc')
-    @mock.patch('crmsh.bootstrap.Watchdog._valid_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_input')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_watchdog_info')
-    def test_init_watchdog_valid(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc):
-        mock_valid.return_value = True
-        self.watchdog_inst._input = "/dev/watchdog"
-        self.watchdog_inst.init_watchdog()
-        mock_invokerc.assert_not_called()
-        mock_valid.assert_called_once_with("/dev/watchdog")
-
-    @mock.patch('crmsh.bootstrap.error')
-    @mock.patch('crmsh.bootstrap.invokerc')
-    @mock.patch('crmsh.bootstrap.Watchdog._valid_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_input')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_watchdog_info')
-    def test_init_watchdog_error(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc, mock_error):
-        mock_valid.return_value = False
-        mock_invokerc.return_value = False
-        self.watchdog_inst._input = "test"
-        mock_error.side_effect = SystemExit
-
-        with self.assertRaises(SystemExit):
-            self.watchdog_inst.init_watchdog()
-
-        mock_valid.assert_called_once_with("test")
-        mock_invokerc.assert_called_once_with("modinfo test")
-        mock_error.assert_called_once_with("Should provide valid watchdog device or driver name by -w option")
-
-    @mock.patch('crmsh.bootstrap.Watchdog._get_device_through_driver')
-    @mock.patch('crmsh.bootstrap.Watchdog._load_watchdog_driver')
-    @mock.patch('crmsh.bootstrap.Watchdog._driver_is_loaded')
-    @mock.patch('crmsh.bootstrap.invokerc')
-    @mock.patch('crmsh.bootstrap.Watchdog._valid_device')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_input')
-    @mock.patch('crmsh.bootstrap.Watchdog._set_watchdog_info')
-    def test_init_watchdog(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc, mock_is_loaded, mock_load, mock_get_device):
-        mock_valid.return_value = False
-        self.watchdog_inst._input = "softdog"
-        mock_invokerc.return_value = True
-        mock_is_loaded.return_value = False
-        mock_get_device.return_value = "/dev/watchdog"
-
-        self.watchdog_inst.init_watchdog()
-
-        mock_valid.assert_called_once_with("softdog")
-        mock_invokerc.assert_called_once_with("modinfo softdog")
-        mock_is_loaded.assert_called_once_with("softdog")
-        mock_load.assert_called_once_with("softdog")
-        mock_set_info.assert_has_calls([mock.call(), mock.call()])
-        mock_get_device.assert_called_once_with("softdog")
-
-
 class TestSBDManager(unittest.TestCase):
     """
     Unitary tests for crmsh.bootstrap.SBDManager
@@ -714,7 +417,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
     @mock.patch('crmsh.bootstrap.status_long')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
-    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_sbd_init_return(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_invoke):
         mock_package.return_value = True
@@ -742,7 +445,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.SBDManager._initialize_sbd')
     @mock.patch('crmsh.bootstrap.status_long')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device')
-    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_sbd_init(self, mock_package, mock_watchdog, mock_get_device, mock_status, mock_initialize, mock_update, mock_warn, mock_enable_sbd, mock_determine):
         bootstrap._context = mock.Mock(watchdog=None)
@@ -947,7 +650,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.SBDManager._verify_sbd_device')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('os.path.exists')
@@ -976,7 +679,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.status')
     @mock.patch('crmsh.bootstrap.SBDManager._warn_diskless_sbd')
     @mock.patch('crmsh.bootstrap.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.bootstrap.Watchdog')
+    @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('os.path.exists')

--- a/test/unittests/test_watchdog.py
+++ b/test/unittests/test_watchdog.py
@@ -1,0 +1,311 @@
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from crmsh import watchdog
+from crmsh import bootstrap
+from crmsh import constants
+
+
+class TestWatchdog(unittest.TestCase):
+    """
+    Unitary tests for crmsh.watchdog.Watchdog
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Global setUp.
+        """
+
+    def setUp(self):
+        """
+        Test setUp.
+        """
+        self.watchdog_inst = watchdog.Watchdog()
+        self.watchdog_join_inst = watchdog.Watchdog(peer_host="node1")
+
+    def tearDown(self):
+        """
+        Test tearDown.
+        """
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Global tearDown.
+        """
+
+    def test_watchdog_device_name(self):
+        res = self.watchdog_inst.watchdog_device_name
+        assert res is None
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_verify_watchdog_device_ignore_error(self, mock_run):
+        mock_run.return_value = (1, None, "error")
+        res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog", True)
+        self.assertEqual(res, False)
+        mock_run.assert_called_once_with("wdctl /dev/watchdog")
+
+    @mock.patch('crmsh.watchdog.error')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_verify_watchdog_device_error(self, mock_run, mock_error):
+        mock_run.return_value = (1, None, "error")
+        mock_error.side_effect = ValueError
+        with self.assertRaises(ValueError) as err:
+            self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
+        mock_error.assert_called_once_with("Invalid watchdog device /dev/watchdog: error")
+        mock_run.assert_called_once_with("wdctl /dev/watchdog")
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_verify_watchdog_device(self, mock_run):
+        mock_run.return_value = (0, None, None)
+        res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
+        self.assertEqual(res, True)
+
+    @mock.patch('crmsh.watchdog.invoke')
+    def test_load_watchdog_driver(self, mock_invoke):
+        self.watchdog_inst._load_watchdog_driver("softdog")
+        mock_invoke.assert_has_calls([
+            mock.call("echo softdog > /etc/modules-load.d/watchdog.conf"),
+            mock.call("systemctl restart systemd-modules-load")
+            ])
+
+    @mock.patch('crmsh.utils.parse_sysconfig')
+    def test_get_watchdog_device_from_sbd_config(self, mock_parse):
+        mock_parse_inst = mock.Mock()
+        mock_parse.return_value = mock_parse_inst
+        mock_parse_inst.get.return_value = "/dev/watchdog"
+        res = self.watchdog_inst._get_watchdog_device_from_sbd_config()
+        self.assertEqual(res, "/dev/watchdog")
+        mock_parse.assert_called_once_with(bootstrap.SYSCONFIG_SBD)
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_driver_is_loaded(self, mock_run):
+        output = """
+button                 24576  0
+softdog                16384  2
+btrfs                1474560  1
+        """
+        mock_run.return_value = (0, output, None)
+        res = self.watchdog_inst._driver_is_loaded("softdog")
+        assert res is not None
+        mock_run.assert_called_once_with("lsmod")
+
+    @mock.patch('crmsh.watchdog.error')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_set_watchdog_info_error(self, mock_run, mock_error):
+        mock_run.return_value = (1, None, "error")
+        mock_error.side_effect = ValueError
+        with self.assertRaises(ValueError):
+            self.watchdog_inst._set_watchdog_info()
+        mock_run.assert_called_once_with(watchdog.Watchdog.QUERY_CMD)
+        mock_error.assert_called_once_with("Failed to run {}: error".format(watchdog.Watchdog.QUERY_CMD))
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_set_watchdog_info(self, mock_run):
+        output = """
+Discovered 3 watchdog devices:
+
+[1] /dev/watchdog
+Identity: Software Watchdog
+Driver: softdog
+CAUTION: Not recommended for use with sbd.
+
+[2] /dev/watchdog0
+Identity: Software Watchdog
+Driver: softdog
+CAUTION: Not recommended for use with sbd.
+
+[3] /dev/watchdog1
+Identity: iTCO_wdt
+Driver: iTCO_wdt
+        """
+        mock_run.return_value = (0, output, None)
+        self.watchdog_inst._set_watchdog_info()
+        self.assertEqual(self.watchdog_inst._watchdog_info_dict, {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'})
+
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    def test_get_device_through_driver_none(self, mock_verify):
+        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
+        mock_verify.return_value = False
+        res = self.watchdog_inst._get_device_through_driver("iTCO_wdt")
+        self.assertEqual(res, None)
+        mock_verify.assert_called_once_with("/dev/watchdog1")
+
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    def test_get_device_through_driver(self, mock_verify):
+        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
+        mock_verify.return_value = True
+        res = self.watchdog_inst._get_device_through_driver("iTCO_wdt")
+        self.assertEqual(res, "/dev/watchdog1")
+        mock_verify.assert_called_once_with("/dev/watchdog1")
+
+    @mock.patch('crmsh.watchdog.error')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_driver_through_device_remotely_error(self, mock_run, mock_error):
+        mock_run.return_value = (1, None, "error")
+        self.watchdog_join_inst._get_driver_through_device_remotely("test")
+        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
+        mock_error.assert_called_once_with("Failed to run sbd query-watchdog remotely: error")
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_driver_through_device_remotely_none(self, mock_run):
+        mock_run.return_value = (0, "data", None)
+        res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
+        self.assertEqual(res, None)
+        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
+
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_get_driver_through_device_remotely(self, mock_run):
+        output = """
+Discovered 3 watchdog devices:
+
+[1] /dev/watchdog
+Identity: Software Watchdog
+Driver: softdog
+CAUTION: Not recommended for use with sbd.
+
+[2] /dev/watchdog0
+Identity: Software Watchdog
+Driver: softdog
+CAUTION: Not recommended for use with sbd.
+
+[3] /dev/watchdog1
+Identity: iTCO_wdt
+Driver: iTCO_wdt
+        """
+        mock_run.return_value = (0, output, None)
+        res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
+        self.assertEqual(res, "softdog")
+        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
+
+    def test_get_first_unused_device_none(self):
+        res = self.watchdog_inst._get_first_unused_device()
+        self.assertEqual(res, None)
+
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    def test_get_first_unused_device(self, mock_verify):
+        mock_verify.return_value = True
+        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
+        res = self.watchdog_inst._get_first_unused_device()
+        self.assertEqual(res, "/dev/watchdog")
+        mock_verify.assert_called_once_with("/dev/watchdog", ignore_error=True)
+
+    @mock.patch('crmsh.watchdog.Watchdog._get_first_unused_device')
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    @mock.patch('crmsh.watchdog.Watchdog._get_watchdog_device_from_sbd_config')
+    def test_set_input_from_config(self, mock_from_config, mock_verify, mock_first):
+        mock_from_config.return_value = "/dev/watchdog"
+        mock_verify.return_value = True
+        self.watchdog_inst._set_input()
+        mock_first.assert_not_called()
+        mock_from_config.assert_called_once_with()
+
+    @mock.patch('crmsh.watchdog.Watchdog._get_first_unused_device')
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    @mock.patch('crmsh.watchdog.Watchdog._get_watchdog_device_from_sbd_config')
+    def test_set_input(self, mock_from_config, mock_verify, mock_first):
+        mock_from_config.return_value = None
+        mock_first.return_value = None
+        self.watchdog_inst._set_input()
+        self.assertEqual(self.watchdog_inst._input, "softdog")
+        mock_from_config.assert_called_once_with()
+        mock_verify.assert_not_called()
+        mock_first.assert_called_once_with()
+
+    def test_valid_device_false(self):
+        res = self.watchdog_inst._valid_device("test")
+        self.assertEqual(res, False)
+
+    @mock.patch('crmsh.watchdog.Watchdog._verify_watchdog_device')
+    def test_valid_device(self, mock_verify):
+        mock_verify.return_value = True
+        self.watchdog_inst._watchdog_info_dict = {'/dev/watchdog': 'softdog', '/dev/watchdog0': 'softdog', '/dev/watchdog1': 'iTCO_wdt'}
+        res = self.watchdog_inst._valid_device("/dev/watchdog")
+        self.assertEqual(res, True)
+
+    @mock.patch('crmsh.watchdog.error')
+    @mock.patch('crmsh.watchdog.Watchdog._get_watchdog_device_from_sbd_config')
+    @mock.patch('crmsh.watchdog.Watchdog._set_watchdog_info')
+    def test_join_watchdog_error(self, mock_set_info, mock_from_config, mock_error):
+        mock_from_config.return_value = None
+        mock_error.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            self.watchdog_join_inst.join_watchdog()
+        mock_set_info.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+        mock_error.assert_called_once_with("Failed to get watchdog device from {}".format(bootstrap.SYSCONFIG_SBD))
+
+    @mock.patch('crmsh.watchdog.Watchdog._load_watchdog_driver')
+    @mock.patch('crmsh.watchdog.Watchdog._get_driver_through_device_remotely')
+    @mock.patch('crmsh.watchdog.Watchdog._valid_device')
+    @mock.patch('crmsh.watchdog.Watchdog._get_watchdog_device_from_sbd_config')
+    @mock.patch('crmsh.watchdog.Watchdog._set_watchdog_info')
+    def test_join_watchdog(self, mock_set_info, mock_from_config, mock_valid, mock_get_driver_remotely, mock_load):
+        mock_from_config.return_value = "/dev/watchdog"
+        mock_valid.return_value = False
+        mock_get_driver_remotely.return_value = "softdog"
+
+        self.watchdog_join_inst.join_watchdog()
+
+        mock_set_info.assert_called_once_with()
+        mock_from_config.assert_called_once_with()
+        mock_valid.assert_called_once_with("/dev/watchdog")
+        mock_get_driver_remotely.assert_called_once_with("/dev/watchdog")
+        mock_load.assert_called_once_with("softdog")
+
+    @mock.patch('crmsh.watchdog.invokerc')
+    @mock.patch('crmsh.watchdog.Watchdog._valid_device')
+    @mock.patch('crmsh.watchdog.Watchdog._set_input')
+    @mock.patch('crmsh.watchdog.Watchdog._set_watchdog_info')
+    def test_init_watchdog_valid(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc):
+        mock_valid.return_value = True
+        self.watchdog_inst._input = "/dev/watchdog"
+        self.watchdog_inst.init_watchdog()
+        mock_invokerc.assert_not_called()
+        mock_valid.assert_called_once_with("/dev/watchdog")
+
+    @mock.patch('crmsh.watchdog.error')
+    @mock.patch('crmsh.watchdog.invokerc')
+    @mock.patch('crmsh.watchdog.Watchdog._valid_device')
+    @mock.patch('crmsh.watchdog.Watchdog._set_input')
+    @mock.patch('crmsh.watchdog.Watchdog._set_watchdog_info')
+    def test_init_watchdog_error(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc, mock_error):
+        mock_valid.return_value = False
+        mock_invokerc.return_value = False
+        self.watchdog_inst._input = "test"
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            self.watchdog_inst.init_watchdog()
+
+        mock_valid.assert_called_once_with("test")
+        mock_invokerc.assert_called_once_with("modinfo test")
+        mock_error.assert_called_once_with("Should provide valid watchdog device or driver name by -w option")
+
+    @mock.patch('crmsh.watchdog.Watchdog._get_device_through_driver')
+    @mock.patch('crmsh.watchdog.Watchdog._load_watchdog_driver')
+    @mock.patch('crmsh.watchdog.Watchdog._driver_is_loaded')
+    @mock.patch('crmsh.watchdog.invokerc')
+    @mock.patch('crmsh.watchdog.Watchdog._valid_device')
+    @mock.patch('crmsh.watchdog.Watchdog._set_input')
+    @mock.patch('crmsh.watchdog.Watchdog._set_watchdog_info')
+    def test_init_watchdog(self, mock_set_info, mock_set_input, mock_valid, mock_invokerc, mock_is_loaded, mock_load, mock_get_device):
+        mock_valid.return_value = False
+        self.watchdog_inst._input = "softdog"
+        mock_invokerc.return_value = True
+        mock_is_loaded.return_value = False
+        mock_get_device.return_value = "/dev/watchdog"
+
+        self.watchdog_inst.init_watchdog()
+
+        mock_valid.assert_called_once_with("softdog")
+        mock_invokerc.assert_called_once_with("modinfo softdog")
+        mock_is_loaded.assert_called_once_with("softdog")
+        mock_load.assert_called_once_with("softdog")
+        mock_set_info.assert_has_calls([mock.call(), mock.call()])
+        mock_get_device.assert_called_once_with("softdog")


### PR DESCRIPTION
bootstrap.py is huge, should split some classes into specific .py file, also make easier for maintain and testing