### PR TITLE
Fix: bootstrap: update sbd watchdog timeout when using diskless SBD with qdevice

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2868,4 +2868,15 @@ def append_res_to_group(group_id, res_id):
     """
     cmd = "crm configure modgroup {} add {}".format(group_id, res_id)
     get_stdout_or_raise_error(cmd)
+
+
+def get_qdevice_sync_timeout():
+    """
+    Get qdevice sync_timeout
+    """
+    out = get_stdout_or_raise_error("crm corosync status qdevice")
+    res = re.search("Sync HB interval:\s+(\d+)ms", out)
+    if not res:
+        raise ValueError("Cannot find qdevice sync timeout")
+    return int(int(res.group(1))/1000)
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -476,7 +476,7 @@ class TestSBDManager(unittest.TestCase):
         self.sbd_inst_diskless._restart_cluster_and_configure_sbd_ra()
         mock_warn.assert_has_calls([
             mock.call("To start sbd.service, need to restart cluster service manually on each node"),
-            mock.call("Then run \"crm configure property stonith-enabled=true stonith-watchdog-timeout=10s\" on any node")
+            mock.call("Then run \"crm configure property stonith-enabled=true stonith-watchdog-timeout=10s stonith-timeout=60s\" on any node")
             ])
 
     @mock.patch('crmsh.bootstrap.SBDManager.configure_sbd_resource')
@@ -600,7 +600,7 @@ class TestSBDManager(unittest.TestCase):
         mock_package.assert_called_once_with("sbd")
         mock_enabled.assert_called_once_with("sbd.service")
         mock_get_device.assert_called_once_with()
-        mock_invoke.assert_called_once_with("crm configure property stonith-enabled=true stonith-watchdog-timeout=10s")
+        mock_invoke.assert_called_once_with("crm configure property stonith-enabled=true stonith-watchdog-timeout=10s stonith-timeout=60s")
         mock_error.assert_called_once_with("Can't enable STONITH for diskless SBD")
         mock_ra_configured.assert_called_once_with("stonith:external/sbd")
 
@@ -771,20 +771,16 @@ class TestSBDManager(unittest.TestCase):
         mock_parse.assert_called_once_with(bootstrap.SYSCONFIG_SBD)
         mock_parse_inst.get.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
 
-    @mock.patch('os.uname')
     @mock.patch('crmsh.utils.parse_sysconfig')
-    def test_determine_watchdog_timeout_s390(self, mock_parse, mock_uname):
+    def test_determine_watchdog_timeout_s390(self, mock_parse):
         mock_parse_inst = mock.Mock()
         mock_parse.return_value = mock_parse_inst
         mock_parse_inst.get.return_value = None
-        mock_uname_inst = mock.Mock()
-        mock_uname.return_value = mock_uname_inst
-        mock_uname_inst.machine = "s390"
+        self.sbd_inst._is_s390 = True
         self.sbd_inst._determine_stonith_watchdog_timeout()
         assert self.sbd_inst._stonith_watchdog_timeout == "30s"
         mock_parse.assert_called_once_with(bootstrap.SYSCONFIG_SBD)
         mock_parse_inst.get.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
-        mock_uname.assert_called_once_with()
 
 
 class TestBootstrap(unittest.TestCase):


### PR DESCRIPTION
When using diskless SBD with qdevice, **SBD_WATCHDOG_TIMEOUT** in /etc/sysconfig/sbd should larger than qdevice sync_timeout, see https://github.com/corosync/corosync-qdevice/issues/21


#### Changed logic include:
- **When set diskless SBD and qdevice together**, like `crm cluster init -S --qnetd-hostname <qnetd_addr>`, set **SBD_WATCHDOG_TIMEOUT**=35, set **stonith-timeou**t as (SBD_WATCHDOG_TIMEOUT*2+20)s，stonith-watchdog-timeout=-1

- **When adding qdevice on a running cluster also with diskless SBD running**, like `crm cluster init qdevice --qnetd-hostname <qnetd_addr>`, set **SBD_WATCHDOG_TIMEOUT**=35, and sync the sbd config file, **stonith-timeou**t=90s (stonith-watchdog-timeout already been set as -1), then restart the cluster service on needed (auto restart when no RA running; hints manually restart when RA running)

- **When adding diskless SBD on a running cluster also with qdevice runing**, like `crm cluster init sbd -S -y`, get the value of qdevice sync_timeout(default is 30s), then plus with 5s as the value of **SBD_WATCHDOG_TIMEOUT**， set **stonith-timeout** as (SBD_WATCHDOG_TIMEOUT*2+20)s, and set stonith-watchdog-timeout=-1