### PR TITLE
[crmsh-4.1] Fix: history: use utils.mkdirp instead of system mkdir command

### DIFF
--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -465,6 +465,8 @@ class Report(object):
             return None
 
         d = self._live_loc()
+        if not utils.is_path_sane(d):
+            return None
         utils.rmdir_r(d)
         tarball = "%s.tar.bz2" % d
         to_option = ""
@@ -473,8 +475,7 @@ class Report(object):
         nodes_option = ""
         if self.setnodes:
             nodes_option = "'-n %s'" % ' '.join(self.setnodes)
-        if utils.pipe_cmd_nosudo("mkdir -p %s" % os.path.dirname(d)) != 0:
-            return None
+        utils.mkdirp(os.path.dirname(d))
         common_info("Retrieving information from cluster nodes, please wait...")
         rc = utils.pipe_cmd_nosudo("%s -Z -Q -f '%s' %s %s %s %s" %
                                    (extcmd,
@@ -981,6 +982,8 @@ class Report(object):
 
     def manage_session(self, subcmd, name):
         session_dir = self.get_session_dir(name)
+        if not utils.is_path_sane(session_dir):
+            return False
         if subcmd == "save" and os.path.exists(session_dir):
             common_err("history session %s exists" % name)
             return False
@@ -988,8 +991,7 @@ class Report(object):
             common_err("history session %s does not exist" % name)
             return False
         if subcmd == "save":
-            if utils.pipe_cmd_nosudo("mkdir -p %s" % session_dir) != 0:
-                return False
+            utils.mkdirp(session_dir)
             if self.source == "live":
                 rc = utils.pipe_cmd_nosudo("tar -C '%s' -c . | tar -C '%s' -x" %
                                            (self._live_loc(), session_dir))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -602,14 +602,14 @@ def safe_close_w(f):
 
 
 def is_path_sane(name):
-    if re.search(r"['`#*?$\[\]]", name):
+    if re.search(r"['`#*?$\[\];]", name):
         common_err("%s: bad path" % name)
         return False
     return True
 
 
 def is_filename_sane(name):
-    if re.search(r"['`/#*?$\[\]]", name):
+    if re.search(r"['`/#*?$\[\];]", name):
         common_err("%s: bad filename" % name)
         return False
     return True

--- a/test/testcases/history.exp
+++ b/test/testcases/history.exp
@@ -376,7 +376,6 @@ d1
 .INP: timeframe
 WARNING: 32: This command 'timeframe' is deprecated, please use 'limit'
 .INP: session save _crmsh_regtest
-.EXT mkdir -p /var/cache/crm/history-root/session/_crmsh_regtest
 .INP: session load _crmsh_regtest
 .INP: session
 current session: _crmsh_regtest


### PR DESCRIPTION
backport #827 