### PR TITLE
Fix: ocfs2: skip verifying UUID for ocfs2 device on top of raid or lvm on the join node 

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2845,7 +2845,15 @@ def is_dev_used_for_lvm(dev, peer=None):
     """
     Check if device is LV
     """
-    return get_dev_info(dev, "TYPE", peer=peer) == "lvm"
+    return "lvm" in get_dev_info(dev, "TYPE", peer=peer)
+
+
+def is_dev_a_plain_raw_disk_or_partition(dev, peer=None):
+    """
+    Check if device is a raw disk or partition
+    """
+    out = get_dev_info(dev, "TYPE", peer=peer)
+    return re.search("(disk|part)", out) is not None
 
 
 def compare_uuid_with_peer_dev(dev_list, peer):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1371,6 +1371,14 @@ def test_is_dev_used_for_lvm(mock_dev_info):
     mock_dev_info.assert_called_once_with("/dev/sda1", "TYPE", peer=None)
 
 
+@mock.patch('crmsh.utils.get_dev_info')
+def test_is_dev_a_plain_raw_disk_or_partition(mock_dev_info):
+    mock_dev_info.return_value = "raid1\nlvm"
+    res = utils.is_dev_a_plain_raw_disk_or_partition("/dev/md127")
+    assert res is False
+    mock_dev_info.assert_called_once_with("/dev/md127", "TYPE", peer=None)
+
+
 @mock.patch('crmsh.utils.get_stdout_or_raise_error')
 def test_get_dev_info(mock_run):
     mock_run.return_value = "data"


### PR DESCRIPTION
When detecting the OCFS2 device(value of `device` option in Filesystem RA) is a device-mapper device like lvm or raid, skip comparing the UUID on join node and init node