### PR TITLE
[crmsh-4.3] Fix: ocfs2: skip verifying UUID for ocfs2 device on top of raid or lvm on the join node

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -6,9 +6,9 @@ name: crmsh CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ crmsh-4.3 ]
   pull_request:
-    branches: [ master ]
+    branches: [ crmsh-4.3 ]
 
 env:
   DOCKER_SCRIPT: ./test/docker_scripts.sh

--- a/crmsh/ocfs2.py
+++ b/crmsh/ocfs2.py
@@ -103,13 +103,6 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         self._verify_options()
         self._verify_devices()
 
-    def _static_verify_on_join(self, dev_list, peer, use_cluster_lvm2=False):
-        """
-        Verify before configuring on join process
-        """
-        self._verify_packages(use_cluster_lvm2)
-        utils.compare_uuid_with_peer_dev(dev_list, peer)
-
     def _dynamic_raise_error(self, error_msg):
         """
         Customize error message after cluster running
@@ -319,16 +312,6 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
                     raise ValueError("Filesystem require configure device")
         return None
 
-    def _get_device_list_on_join(self, target, peer, clvm2=False):
-        """
-        Return device list
-        When using cluster lvm, return pv device list
-        """
-        if not clvm2:
-            return [target]
-        out = utils.get_stdout_or_raise_error("lvs {} -o +devices".format(target), remote=peer)
-        return re.findall("(/dev/.*)[(]", out)
-
     def join_ocfs2(self, peer):
         """
         Called on join process, to verify ocfs2 environment
@@ -338,8 +321,9 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
             return
         with bootstrap.status_long("Verify OCFS2 environment"):
             use_cluster_lvm2 = utils.has_resource_configured("ocf::heartbeat:lvmlockd", peer)
-            dev_list = self._get_device_list_on_join(target, peer, use_cluster_lvm2)
-            self._static_verify_on_join(dev_list, peer, use_cluster_lvm2)
+            self._verify_packages(use_cluster_lvm2)
+            if utils.is_dev_a_plain_raw_disk_or_partition(target, peer):
+                utils.compare_uuid_with_peer_dev([target], peer)
 
     @classmethod
     def verify_ocfs2(cls, ctx):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2845,7 +2845,15 @@ def is_dev_used_for_lvm(dev, peer=None):
     """
     Check if device is LV
     """
-    return get_dev_info(dev, "TYPE", peer=peer) == "lvm"
+    return "lvm" in get_dev_info(dev, "TYPE", peer=peer)
+
+
+def is_dev_a_plain_raw_disk_or_partition(dev, peer=None):
+    """
+    Check if device is a raw disk or partition
+    """
+    out = get_dev_info(dev, "TYPE", peer=peer)
+    return re.search("(disk|part)", out) is not None
 
 
 def compare_uuid_with_peer_dev(dev_list, peer):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1371,6 +1371,14 @@ def test_is_dev_used_for_lvm(mock_dev_info):
     mock_dev_info.assert_called_once_with("/dev/sda1", "TYPE", peer=None)
 
 
+@mock.patch('crmsh.utils.get_dev_info')
+def test_is_dev_a_plain_raw_disk_or_partition(mock_dev_info):
+    mock_dev_info.return_value = "raid1\nlvm"
+    res = utils.is_dev_a_plain_raw_disk_or_partition("/dev/md127")
+    assert res is False
+    mock_dev_info.assert_called_once_with("/dev/md127", "TYPE", peer=None)
+
+
 @mock.patch('crmsh.utils.get_stdout_or_raise_error')
 def test_get_dev_info(mock_run):
     mock_run.return_value = "data"


### PR DESCRIPTION
backport #833 