### PR TITLE
Fix: resource: make untrace consistent with trace

### DIFF
--- a/data-manifest
+++ b/data-manifest
@@ -194,6 +194,7 @@ test/unittests/test_objset.py
 test/unittests/test_ocfs2.py
 test/unittests/test_parallax.py
 test/unittests/test_parse.py
+test/unittests/test_ratrace.py
 test/unittests/test_report.py
 test/unittests/test_sbd.py
 test/unittests/test_scripts.py

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -343,25 +343,6 @@ def test_tagset():
     assert set(x.obj_id for x in elems) == set(['r1', 'r2'])
 
 
-def test_ratrace():
-    xml = '''<primitive class="ocf" id="%s" provider="pacemaker" type="Dummy"/>'''
-    factory.create_from_node(etree.fromstring(xml % ('r1')))
-    factory.create_from_node(etree.fromstring(xml % ('r2')))
-    factory.create_from_node(etree.fromstring(xml % ('r3')))
-
-    context = object()
-
-    from crmsh.ui_resource import RscMgmt
-    obj = factory.find_object('r1')
-    RscMgmt()._trace_resource(context, 'r1', obj)
-
-    obj = factory.find_object('r1')
-    ops = obj.node.xpath('./operations/op')
-    for op in ops:
-        assert op.xpath('./instance_attributes/nvpair[@name="trace_ra"]/@value') == ["1"]
-    assert set(obj.node.xpath('./operations/op/@name')) == set(['start', 'stop'])
-
-
 def test_op_role():
     xml = '''<primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy">
         <operations>

--- a/test/unittests/test_ratrace.py
+++ b/test/unittests/test_ratrace.py
@@ -1,0 +1,123 @@
+import unittest
+from lxml import etree
+
+from crmsh import cibconfig
+from crmsh.ui_context import Context
+from crmsh.ui_resource import RscMgmt
+from crmsh.ui_root import Root
+
+
+class TestRATrace(unittest.TestCase):
+    """Unit tests for enabling/disabling RA tracing."""
+
+    context = Context(Root())
+    factory = cibconfig.cib_factory
+
+    def setUp(self):
+        self.factory._push_state()
+
+    def tearDown(self):
+        self.factory._pop_state()
+
+    def test_ratrace_resource(self):
+        """Check setting RA tracing for a resource."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy"/>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+
+        # Trace the resource.
+        RscMgmt()._trace_resource(self.context, obj.obj_id, obj)
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-start-0', 'r1-stop-0'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-start-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-stop-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+        # Untrace the resource.
+        RscMgmt()._untrace_resource(self.context, obj.obj_id, obj)
+        self.assertEqual(obj.node.xpath('operations/op/@id'), [])
+        self.assertEqual(obj.node.xpath('.//*[@name="trace_ra"]'), [])
+
+    def test_ratrace_op(self):
+        """Check setting RA tracing for a specific operation."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">
+            <operations>
+              <op id="r1-monitor-10" interval="10" name="monitor"/>
+            </operations>
+          </primitive>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+
+        # Trace the operation.
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+        # Untrace the operation.
+        RscMgmt()._untrace_op(self.context, obj.obj_id, obj, 'monitor')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
+        self.assertEqual(obj.node.xpath('.//*[@name="trace_ra"]'), [])
+
+        # Try untracing a non-existent operation.
+        with self.assertRaises(ValueError) as err:
+            RscMgmt()._untrace_op(self.context, obj.obj_id, obj, 'invalid-op')
+        self.assertEqual(str(err.exception), "Operation invalid-op not found in r1")
+
+    def test_ratrace_new(self):
+        """Check setting RA tracing for an operation that is not in CIB."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">
+          </primitive>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+
+        # Trace a regular operation that is not yet defined in CIB. The request
+        # should succeed and introduce an op node for the operation.
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'start')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-start-0'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-start-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+        # Try tracing the monitor operation in the same way. The request should
+        # get rejected because no explicit interval is specified.
+        with self.assertRaises(ValueError) as err:
+            RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+        self.assertEqual(str(err.exception), "No monitor operation configured for r1")
+
+    def test_ratrace_op_stateful(self):
+        """Check setting RA tracing for an operation on a stateful resource."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">
+            <operations>
+              <op id="r1-monitor-10" interval="10" name="monitor" role="Master"/>
+              <op id="r1-monitor-11" interval="11" name="monitor" role="Slave"/>
+            </operations>
+          </primitive>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+
+        # Trace the operation.
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10', 'r1-monitor-11'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-11"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+        # Untrace the operation.
+        RscMgmt()._untrace_op(self.context, obj.obj_id, obj, 'monitor')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10', 'r1-monitor-11'])
+        self.assertEqual(obj.node.xpath('.//*[@name="trace_ra"]'), [])
+
+    def test_ratrace_op_interval(self):
+        """Check setting RA tracing for an operation+interval."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">
+            <operations>
+              <op id="r1-monitor-10" interval="10" name="monitor"/>
+            </operations>
+          </primitive>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+
+        # Trace the operation.
+        RscMgmt()._trace_op_interval(self.context, obj.obj_id, obj, 'monitor', '10')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+        # Untrace the operation.
+        RscMgmt()._untrace_op_interval(self.context, obj.obj_id, obj, 'monitor', '10')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
+        self.assertEqual(obj.node.xpath('.//*[@name="trace_ra"]'), [])
+
+        # Try untracing a non-existent operation.
+        with self.assertRaises(ValueError) as err:
+            RscMgmt()._untrace_op_interval(self.context, obj.obj_id, obj, 'invalid-op', '10')
+        self.assertEqual(str(err.exception), "Operation invalid-op with interval 10 not found in r1")


### PR DESCRIPTION
* Split logic in `do_untrace()` into separate methods `_untrace_resource()`, `_untrace_op()` and `_untrace_op_interval()` in the same way how the trace logic is organized.
* When processing `untrace <rsc> <op>`, look up matching operations and remove the trace_ra flag from all of them. This deals with a situation when a stateful resource has two monitor operations, `trace <rsc> monitor` would set the trace_ra flag on both of them but a subsequent call to `untrace <rsc> monitor` would fail to remove these flags.
* When processing `untrace <rsc> probe`, search only for a monitor operation with interval="0". This improves consistency between `trace <rsc> probe` and `untrace <rsc> probe`. The trace variant always sets the trace_ra flag on a monitor operation with interval="0". The untrace variant now only removes the flag from this exact operation while it was previously possible that it could remove it from a normal monitor operation if no probe operation was defined in CIB.
* Add unit tests for the trace+untrace functionality.

Clean ups:
* When removing the trace flag from an operation, do not look for `trace_ra` attributes but only `name=trace_ra` as the former seems no longer needed.
* Expand xpaths `.//op` to `operations/op` and similarly be explicit about accessing `instance_attributes/nvpair`.
* Remove unused variables and imports.