### PR TITLE
Fix: bootstrap: check for missing fields in 'crm_node -l' output (bsc#1182131)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1671,9 +1671,21 @@ def setup_passwordless_with_other_nodes(init_node):
         error("Can't fetch cluster nodes list from {}: {}".format(init_node, err))
     cluster_nodes_list = []
     for line in out.splitlines():
-        _, node, stat = line.split()
-        if stat == "member":
-            cluster_nodes_list.append(node)
+        # Parse line in format: <id> <nodename> <state>, and collect the
+        # nodename.
+        tokens = line.split()
+        if len(tokens) == 0:
+            pass  # Skip any spurious empty line.
+        elif len(tokens) < 3:
+            warn("Unable to configure passwordless ssh with nodeid {}. The "
+                 "node has no known name and/or state information".format(
+                     tokens[0]))
+        elif tokens[2] != "member":
+            warn("Skipping configuration of passwordless ssh with node {} in "
+                 "state '{}'. The node is not a current member".format(
+                     tokens[1], tokens[2]))
+        else:
+            cluster_nodes_list.append(tokens[1])
 
     # Filter out init node from cluster_nodes_list
     cmd = "ssh {} root@{} hostname".format(SSH_OPTION, init_node)
@@ -1809,9 +1821,16 @@ def join_cluster(seed_host):
             nodeid_dict = {}
             _rc, outp, _ = utils.get_stdout_stderr("crm_node -l")
             if _rc == 0:
-                for line in outp.split('\n'):
-                    tmp = line.split()
-                    nodeid_dict[tmp[1]] = tmp[0]
+                for line in outp.splitlines():
+                    tokens = line.split()
+                    if len(tokens) == 0:
+                        pass  # Skip any spurious empty line.
+                    elif len(tokens) < 3:
+                        warn("Unable to update configuration for nodeid {}. "
+                             "The node has no known name and/or state "
+                             "information".format(tokens[0]))
+                    else:
+                        nodeid_dict[tokens[1]] = tokens[0]
 
         # apply nodelist in cluster
         if is_unicast or is_qdevice_configured:


### PR DESCRIPTION
The bootstrap code expects that each line in the output from `crm_node -l` is in the following form: `<id> <nodename> <state>`, with all three fields always present. This is the usual situation but it is in some cases possible that `<nodename>` and/or `<state>` can be missing. For instance, a node can be configured in the `nodelist` in `corosync.conf` but until the node has joined the cluster, `crm_node -l` will report only its id. This configuration can even happen as a result of a previous incomplete `crm cluster join` run.

Two places that parse `crm_node -l` output in the bootstrap code are: in `setup_passwordless_with_other_nodes()` when setting up passwordless SSH, in `join_cluster()` when updating nodeids for IPv6. These functions can fail with `ValueError: not enough values to unpack (expected 3, got 1)` or `IndexError: list index out of range` when a nodename is missing in the output.

The proposed patch adds error handling for this situation. The code newly reports a warning if a node state is incomplete and provides information what operation is not possible to perform on the node. This allows bootstrap of the new node to continue but indicates to the user that an update of the old problematic node might be needed if it should rejoin the cluster again in future.