### PR TITLE
Fix: cibconfig: don't show xml when cli not supported

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -882,13 +882,6 @@ class CibObject(object):
                                 self.parent and self.parent.obj_id or "",
                                 len(self.children)))
 
-    def _repr_cli_xml(self, format_mode):
-        with clidisplay.nopretty(format_mode < 0):
-            h = clidisplay.keyword("xml")
-            l = xml_tostring(self.node, pretty_print=True).split('\n')
-            l = [x for x in l if x]  # drop empty lines
-            return "%s %s" % (h, cli_format(l, break_lines=(format_mode > 0), xml=True))
-
     def _gv_rsc_id(self):
         if self.parent and self.parent.obj_type in constants.clonems_tags:
             return "%s:%s" % (self.parent.obj_type, self.obj_id)
@@ -928,8 +921,6 @@ class CibObject(object):
         CLI representation for the node.
         _repr_cli_head and _repr_cli_child in subclasess.
         '''
-        if self.nocli:
-            return self._repr_cli_xml(format_mode)
         l = []
         with clidisplay.nopretty(format_mode < 0):
             head_s = self._repr_cli_head(format_mode)


### PR DESCRIPTION
This is a fix PR to fix the regression came from #817 

When previous cluster already has empty property before applying #817, like
```
# crm configure show
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
        params pcmk_delay_max=30s
property cib-bootstrap-options: \
        have-watchdog=true \
        dc-version="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=true \
        stonith-timeout=120 \
        stonith-timeout
rsc_defaults rsc-options: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

After applying #817, the output become mess
```
# crm configure show
ERROR: syntax in property: Unknown arguments: stonith-timeout near <stonith-timeout> parsing 'property cib-bootstrap-options: have-watchdog=true dc-version=2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a cluster-infrastructure=corosync cluster-name=hacluster stonith-enabled=true stonith-timeout=120 stonith-timeout'
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
        params pcmk_delay_max=30s
xml <cluster_property_set id="cib-bootstrap-options"> \
  <nvpair name="have-watchdog" value="true" id="cib-bootstrap-options-have-watchdog"/> \
  <nvpair name="dc-version" value="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" id="cib-bootstrap-options-dc-version"/> \
  <nvpair name="cluster-infrastructure" value="corosync" id="cib-bootstrap-options-cluster-infrastructure"/> \
  <nvpair name="cluster-name" value="hacluster" id="cib-bootstrap-options-cluster-name"/> \
  <nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/> \
  <nvpair name="stonith-timeout" value="120" id="cib-bootstrap-options-stonith-timeout"/> \
  <nvpair name="stonith-timeout" id="cib-bootstrap-options-stonith-timeout-0"/> \
</cluster_property_set>
rsc_defaults rsc-options: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

And `crm configure edit` could not adjust on this time
```
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
        params pcmk_delay_max=30s
xml <cluster_property_set id="cib-bootstrap-options"> \
  <nvpair name="have-watchdog" value="true" id="cib-bootstrap-options-have-watchdog"/> \
  <nvpair name="dc-version" value="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" id="cib-bootstrap-options-dc-version"/> \
  <nvpair name="cluster-infrastructure" value="corosync" id="cib-bootstrap-options-cluster-infrastructure"/> \
  <nvpair name="cluster-name" value="hacluster" id="cib-bootstrap-options-cluster-name"/> \
  <nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/> \
  <nvpair name="stonith-timeout" value="120" id="cib-bootstrap-options-stonith-timeout"/> \
  <nvpair name="stonith-timeout" id="cib-bootstrap-options-stonith-timeout-0"/> \
</cluster_property_set>
rsc_defaults rsc-options: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

So from my opinion, I want to remove function `_repr_cli_xml`