### PR TITLE
Fix: parse: Should still be able to show the empty property if already exists

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -833,7 +833,7 @@ def parse_cli_to_xml(cli, oldnode=None):
         for s in lines2cli(cli):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
-        node = parse.parse(cli, comments=comments)
+        node = parse.parse(cli, comments=comments, ignore_empty=False)
     if node is False:
         return None, None, None
     elif node is None:


### PR DESCRIPTION
This is a fix PR to fix the regression came from #817

When previous cluster already has empty property before applying #817, like
```
# crm configure show
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
        params pcmk_delay_max=30s
property cib-bootstrap-options: \
        have-watchdog=true \
        dc-version="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=true \
        stonith-timeout=120 \
        stonith-timeout
rsc_defaults rsc-options: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

After applying #817, the output become mess
```
# crm configure show
ERROR: syntax in property: Unknown arguments: stonith-timeout near <stonith-timeout> parsing 'property cib-bootstrap-options: have-watchdog=true dc-version=2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a cluster-infrastructure=corosync cluster-name=hacluster stonith-enabled=true stonith-timeout=120 stonith-timeout'
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
        params pcmk_delay_max=30s
xml <cluster_property_set id="cib-bootstrap-options"> \
  <nvpair name="have-watchdog" value="true" id="cib-bootstrap-options-have-watchdog"/> \
  <nvpair name="dc-version" value="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" id="cib-bootstrap-options-dc-version"/> \
  <nvpair name="cluster-infrastructure" value="corosync" id="cib-bootstrap-options-cluster-infrastructure"/> \
  <nvpair name="cluster-name" value="hacluster" id="cib-bootstrap-options-cluster-name"/> \
  <nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/> \
  <nvpair name="stonith-timeout" value="120" id="cib-bootstrap-options-stonith-timeout"/> \
  <nvpair name="stonith-timeout" id="cib-bootstrap-options-stonith-timeout-0"/> \
</cluster_property_set>
rsc_defaults rsc-options: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```
We should keep existing configure not break while raise error when trying to configure new empty property, like:
```
# crm configure 
crm(live/15sp2-1)configure# show
node 1084783297: 15sp2-1
primitive stonith-sbd stonith:external/sbd \
	params pcmk_delay_max=30s
property cib-bootstrap-options: \
	have-watchdog=true \
	dc-version="2.0.4+20200616.2deceaa3a-3.3.1-2.0.4+20200616.2deceaa3a" \
	cluster-infrastructure=corosync \
	cluster-name=hacluster \
	stonith-enabled=true \
	stonith-timeout=120 \
	stonith-timeout
rsc_defaults rsc-options: \
	resource-stickiness=1 \
	migration-threshold=3
op_defaults op-options: \
	timeout=600 \
	record-pending=true
crm(live/15sp2-1)configure# property maintenance-mode
ERROR: syntax in property: Unknown arguments: maintenance-mode near <maintenance-mode> parsing 'property maintenance-mode'
crm(live/15sp2-1)configure# property maintenance-mode=
ERROR: syntax in property: Empty value for maintenance-mode is not allowed parsing 'property maintenance-mode='
```