### PR TITLE
[crmsh-4.3] Fix: parse: Should still be able to show the empty property if already exists

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -833,7 +833,7 @@ def parse_cli_to_xml(cli, oldnode=None):
         for s in lines2cli(cli):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
-        node = parse.parse(cli, comments=comments)
+        node = parse.parse(cli, comments=comments, ignore_empty=False)
     if node is False:
         return None, None, None
     elif node is None:


### PR DESCRIPTION
backport #845 