### PR TITLE
Dev: ui_context: Add info when spell-corrections happen

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -79,6 +79,8 @@ class Context(object):
                 if self.command_name in self.command_info.aliases and self.command_name not in ["-h", "--help"]:
                     common_warn("This command '{}' is deprecated, please use '{}'"\
                             .format(self.command_name, self.command_info.name))
+                if token != self.command_info.name:
+                    common_info("\"{}\" is accepted as \"{}\"".format(token, self.command_info.name))
                 self.command_name = self.command_info.name
                 if self.command_info.type == 'level':
                     self.enter_level(self.command_info.level)

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -2,6 +2,7 @@
 .INP: options
 .INP: sort_elements false
 WARNING: 2: This command 'sort_elements' is deprecated, please use 'sort-elements'
+INFO: 2: "sort_elements" is accepted as "sort-elements"
 .INP: up
 .INP: configure
 .INP: erase
@@ -60,6 +61,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: options
 .INP: sort_elements false
 WARNING: 2: This command 'sort_elements' is deprecated, please use 'sort-elements'
+INFO: 2: "sort_elements" is accepted as "sort-elements"
 .INP: up
 .INP: configure
 .INP: load update bugs-test.txt

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -25,6 +25,7 @@
 .INP: delete m
 .INP: master m d4
 WARNING: 21: This command 'master' is deprecated, please use 'ms'
+INFO: 21: "master" is accepted as "ms"
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
@@ -43,8 +44,10 @@ WARNING: 21: This command 'master' is deprecated, please use 'ms'
 .INP: location l7 m5 	rule $id-ref=l2
 .INP: collocation c1 inf: m6 m5
 WARNING: 36: This command 'collocation' is deprecated, please use 'colocation'
+INFO: 36: "collocation" is accepted as "colocation"
 .INP: collocation c2 inf: m5:Master d1:Started
 WARNING: 37: This command 'collocation' is deprecated, please use 'colocation'
+INFO: 37: "collocation" is accepted as "colocation"
 .INP: order o1 Mandatory: m5 m6
 .INP: order o2 Optional: d1:start m5:promote
 .INP: order o3 Serialize: m5 m6

--- a/test/testcases/history.exp
+++ b/test/testcases/history.exp
@@ -319,6 +319,7 @@ Dec 14 20:08:43 xen-e crmd: [24228]: info: process_lrm_event: LRM operation d1_s
 .INP: # reduce report span
 .INP: timeframe "2012-12-14 20:07:30"
 WARNING: 21: This command 'timeframe' is deprecated, please use 'limit'
+INFO: 21: "timeframe" is accepted as "limit"
 .INP: peinputs
 history-test/xen-e/pengine/pe-input-47.bz2
 history-test/xen-e/pengine/pe-input-48.bz2
@@ -375,6 +376,7 @@ d1
 .INP: # reset timeframe
 .INP: timeframe
 WARNING: 32: This command 'timeframe' is deprecated, please use 'limit'
+INFO: 32: "timeframe" is accepted as "limit"
 .INP: session save _crmsh_regtest
 .INP: session load _crmsh_regtest
 .INP: session

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -143,6 +143,7 @@ resource p0 is NOT running
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1
 WARNING: This command 'migrate' is deprecated, please use 'move'
+INFO: "migrate" is accepted as "move"
 .EXT crm_resource --quiet --move --resource 'p3' --node 'node1'
 INFO: Move constraint created for p3 to node1
 .INP: configure
@@ -163,11 +164,13 @@ INFO: Move constraint created for p3 to node1
 .SETENV showobj=
 .TRY resource unmigrate p3
 WARNING: This command 'unmigrate' is deprecated, please use 'clear'
+INFO: "unmigrate" is accepted as "clear"
 .EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=cli-prefer-p3
 .TRY resource migrate p3 node1 force
 WARNING: This command 'migrate' is deprecated, please use 'move'
+INFO: "migrate" is accepted as "move"
 .EXT crm_resource --quiet --move --resource 'p3' --node 'node1' --force
 INFO: Move constraint created for p3 to node1
 .INP: configure
@@ -188,6 +191,7 @@ INFO: Move constraint created for p3 to node1
 .SETENV showobj=
 .TRY resource unmigrate p3
 WARNING: This command 'unmigrate' is deprecated, please use 'clear'
+INFO: "unmigrate" is accepted as "clear"
 .EXT crm_resource --quiet --clear --resource 'p3'
 INFO: Removed migration constraints for p3
 .SETENV showobj=p0
@@ -916,6 +920,7 @@ INFO: Trace set, restart p0 to trace the stop operation
 .TRY resource stop p3
 .TRY configure rm cg
 WARNING: This command 'rm' is deprecated, please use 'delete'
+INFO: "rm" is accepted as "delete"
 .TRY configure ms msg g
 .TRY resource scores
 .EXT crm_simulate -sUL


### PR DESCRIPTION
crmsh internally can correct some spell errors, like:
```
crm cluster ini   -->  crm cluster init
crm configure verfy --> crm configure verify
```
It will be helpful to add info when spell-corrections happen, like:
```
15sp2-1:~ # crm cluster ini
INFO: "ini" is accepted as "init"

15sp2-1:~ # crm configure
crm(live/15sp2-1)configure# verfy
INFO: "verfy" is accepted as "verify"
crm(live/15sp2-1)configure#
```