### PR TITLE
Medium: ra: performance/usability improvement (avoid systemd)

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -65,7 +65,7 @@ def can_use_lrmadmin():
 
 @utils.memoize
 def can_use_crm_resource():
-    _rc, s = get_stdout("crm_resource --list-standards", stderr_on=False)
+    _rc, s = get_stdout("crm_resource --list-ocf-providers", stderr_on=False)
     return s != ""
 
 

--- a/test/testcases/common.excl
+++ b/test/testcases/common.excl
@@ -8,7 +8,7 @@ Error setting s1=1 2 3 \(section=status, set=status-node1\): The object/attribut
 Error signing on to the CRMd service
 Error connecting to the controller
 Error performing operation: Transport endpoint is not connected
-.EXT crm_resource --list-standards
+.EXT crm_resource --list-ocf-providers
 .EXT crm_resource --list-ocf-alternatives Delay
 .EXT crm_resource --list-ocf-alternatives Dummy
 ^\.EXT crmd version


### PR DESCRIPTION
Use --list-ocf-providers to check the crm_resource compatibility.
The --list-standards invokes systemd which takes quite some time.
Unfortunately, it doesn't seem like that will be fixed and, at any rate,
it's better to depend less on other system components.

This is no change in functionality, but a major improvement in
user experience. See #459 for more information.