### PR TITLE
[crmsh-4.3] Fix: doc: Note that resource tracing is only supported by OCF RAs

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2006,6 +2006,10 @@ To trace the probe operation which exists for all resources, either
 set a trace for `monitor` with interval `0`, or use `probe` as the
 operation name.
 
+Note: RA tracing is only supported by OCF resource agents;
+The pacemaker-execd daemon does not log recurring monitor operations
+unless an error occurred.
+
 Usage:
 ...............
 trace <rsc> [<op> [<interval>] ]


### PR DESCRIPTION
backport #855 