### PR TITLE
Fix: utils: Improve detect_cloud function and support non-Hyper-V in Azure

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -490,4 +490,9 @@ QDEVICE_HELP_INFO = """  QDevice participates in quorum decisions. With the assi
 
 
 SSH_OPTION = "-o StrictHostKeyChecking=no"
+
+
+CLOUD_AWS = "amazon-web-services"
+CLOUD_AZURE = "microsoft-azure"
+CLOUD_GCP = "google-cloud-platform"
 # vim:ts=4:sw=4:et:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1995,11 +1995,6 @@ def gen_nodeid_from_ipv6(addr):
     return int(ipaddress.ip_address(addr)) % 1000000000
 
 
-# Set by detect_cloud()
-# to avoid multiple requests
-_ip_for_cloud = None
-
-
 def _cloud_metadata_request(uri, headers={}):
     try:
         import urllib2 as urllib
@@ -2016,6 +2011,51 @@ def _cloud_metadata_request(uri, headers={}):
         return content.strip()
     except urllib.URLError:
         return None
+
+
+def detect_aws():
+    """
+    Detect if in AWS
+    """
+    system_version = get_stdout_or_raise_error("dmidecode -s system-version")
+    return re.search(r".*amazon.*", system_version) is not None
+
+
+def detect_azure():
+    """
+    Detect if in Azure
+    """
+    # Should check both system-manufacturer and chassis-asset-tag
+    # In some azure environment, dmidecode -s system-manufacturer
+    # might return American Megatrends Inc. instead of Microsoft Corporation in Azure.
+    # The better way is to check the result of dmidecode -s chassis-asset-tag is
+    # 7783-7084-3265-9085-8269-3286-77, aka. the ascii code of MSFT AZURE VM
+    system_manufacturer = get_stdout_or_raise_error("dmidecode -s system-manufacturer")
+    chassis_asset_tag = get_stdout_or_raise_error("dmidecode -s chassis-asset-tag")
+    if "microsoft corporation" in system_manufacturer.lower() or \
+            ''.join([chr(int(n)) for n in re.findall("\d\d", chassis_asset_tag)]) == "MSFT AZURE VM":
+        # To detect azure we also need to make an API request
+        result = _cloud_metadata_request(
+            "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
+            headers={"Metadata": "true"})
+        if result:
+            return True
+    return False
+
+
+def detect_gcp():
+    """
+    Detect if in GCP
+    """
+    bios_vendor = get_stdout_or_raise_error("dmidecode -s bios-vendor")
+    if "Google" in bios_vendor:
+        # To detect GCP we also need to make an API request
+        result = _cloud_metadata_request(
+            "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
+            headers={"Metadata-Flavor": "Google"})
+        if result:
+            return True
+    return False
 
 
 @memoize
@@ -2037,33 +2077,17 @@ def detect_cloud():
     * google-cloud-platform
 
     """
-    global _ip_for_cloud
-
     if not is_program("dmidecode"):
         return None
-    rc, system_version = get_stdout("dmidecode -s system-version")
-    if re.search(r".*amazon.*", system_version) is not None:
-        return "amazon-web-services"
-    if rc != 0:
-        return None
-    rc, system_manufacturer = get_stdout("dmidecode -s system-manufacturer")
-    if rc == 0 and "microsoft corporation" in system_manufacturer.lower():
-        # To detect azure we also need to make an API request
-        result = _cloud_metadata_request(
-            "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
-            headers={"Metadata": "true"})
-        if result:
-            _ip_for_cloud = result
-            return "microsoft-azure"
-    rc, bios_vendor = get_stdout("dmidecode -s bios-vendor")
-    if rc == 0 and "Google" in bios_vendor:
-        # To detect GCP we also need to make an API request
-        result = _cloud_metadata_request(
-            "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
-            headers={"Metadata-Flavor": "Google"})
-        if result:
-            _ip_for_cloud = result
-            return "google-cloud-platform"
+    aws = detect_aws()
+    if aws:
+        return constants.CLOUD_AWS
+    azure = detect_azure()
+    if azure:
+        return constants.CLOUD_AZURE
+    gcp = detect_gcp()
+    if gcp:
+        return constants.CLOUD_GCP
     return None
 
 

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -12,9 +12,7 @@ import unittest
 import pytest
 from unittest import mock
 from itertools import chain
-from crmsh import utils
-from crmsh import config
-from crmsh import tmpfiles
+from crmsh import utils, config, tmpfiles, constants
 
 def setup_function():
     utils._ip_for_cloud = None
@@ -528,149 +526,98 @@ def test_valid_nodeid_true(mock_is_active, mock_nodeinfo):
     mock_is_active.assert_called_once_with('corosync.service')
     mock_nodeinfo.assert_called_once_with()
 
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_aws(mock_run):
+    mock_run.return_value = "in amazon host"
+    assert utils.detect_aws() is True
+    mock_run.assert_called_once_with("dmidecode -s system-version")
+
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_azure_false(mock_run):
+    mock_run.side_effect = ["test", "test"]
+    assert utils.detect_azure() is False
+    mock_run.assert_has_calls([
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s chassis-asset-tag")
+        ])
+
+@mock.patch("crmsh.utils._cloud_metadata_request")
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_azure_microsoft_corporation(mock_run, mock_request):
+    mock_run.side_effect = ["microsoft corporation", "test"]
+    mock_request.return_value = "data"
+    assert utils.detect_azure() is True
+    mock_run.assert_has_calls([
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s chassis-asset-tag")
+        ])
+
+@mock.patch("crmsh.utils._cloud_metadata_request")
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_azure_chassis(mock_run, mock_request):
+    mock_run.side_effect = ["test", "7783-7084-3265-9085-8269-3286-77"]
+    mock_request.return_value = "data"
+    assert utils.detect_azure() is True
+    mock_run.assert_has_calls([
+        mock.call("dmidecode -s system-manufacturer"),
+        mock.call("dmidecode -s chassis-asset-tag")
+        ])
+
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_gcp_false(mock_run):
+    mock_run.return_value = "test"
+    assert utils.detect_gcp() is False
+    mock_run.assert_called_once_with("dmidecode -s bios-vendor")
+
+@mock.patch("crmsh.utils._cloud_metadata_request")
+@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+def test_detect_gcp(mock_run, mock_request):
+    mock_run.return_value = "Google instance"
+    mock_request.return_value = "data"
+    assert utils.detect_gcp() is True
+    mock_run.assert_called_once_with("dmidecode -s bios-vendor")
+
 @mock.patch("crmsh.utils.is_program")
-def test_detect_cloud_not_dmidecode(mock_is_program):
+def test_detect_cloud_no_cmd(mock_is_program):
     mock_is_program.return_value = False
     assert utils.detect_cloud() is None
     mock_is_program.assert_called_once_with("dmidecode")
 
+@mock.patch("crmsh.utils.detect_aws")
 @mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-def test_detect_cloud_aws(mock_get_stdout, mock_is_program):
+def test_detect_cloud_aws(mock_is_program, mock_aws):
     mock_is_program.return_value = True
-    mock_get_stdout.return_value = (0, "4.2.amazon")
-    assert utils.detect_cloud() == "amazon-web-services"
+    mock_aws.return_value = True
+    assert utils.detect_cloud() == constants.CLOUD_AWS
     mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_called_once_with("dmidecode -s system-version")
+    mock_aws.assert_called_once_with()
 
-
+@mock.patch("crmsh.utils.detect_azure")
+@mock.patch("crmsh.utils.detect_aws")
 @mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-def test_detect_cloud_aws_error(mock_get_stdout, mock_is_program):
+def test_detect_cloud_azure(mock_is_program, mock_aws, mock_azure):
     mock_is_program.return_value = True
-    mock_get_stdout.return_value = (1, "other")
-    assert utils.detect_cloud() is None
+    mock_aws.return_value = False
+    mock_azure.return_value = True
+    assert utils.detect_cloud() == constants.CLOUD_AZURE
     mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_called_once_with("dmidecode -s system-version")
+    mock_aws.assert_called_once_with()
+    mock_azure.assert_called_once_with()
 
-
+@mock.patch("crmsh.utils.detect_gcp")
+@mock.patch("crmsh.utils.detect_azure")
+@mock.patch("crmsh.utils.detect_aws")
 @mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_microsoft(mock_metadata, mock_get_stdout, mock_is_program):
+def test_detect_cloud_gcp(mock_is_program, mock_aws, mock_azure, mock_gcp):
     mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [(0, "other"), (0, "microsoft corporation")]
-    mock_metadata.return_value = "10.10.10.10"
-    assert utils.detect_cloud() == "microsoft-azure"
+    mock_aws.return_value = False
+    mock_azure.return_value = False
+    mock_gcp.return_value = True
+    assert utils.detect_cloud() == constants.CLOUD_GCP
     mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer")
-    ])
-    mock_metadata.assert_called_once_with(
-        "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
-        headers={"Metadata": "true"})
-    assert utils._ip_for_cloud == "10.10.10.10"
-
-
-@mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_microsoft_error(mock_metadata, mock_get_stdout, mock_is_program):
-    mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [
-        (0, "other"), (0, "microsoft corporation"), (0, "microsoft corporation")]
-    mock_metadata.return_value = None
-    assert utils.detect_cloud() is None
-    mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer")
-    ])
-    mock_metadata.assert_called_once_with(
-        "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-08-01&format=text",
-        headers={"Metadata": "true"})
-    assert utils._ip_for_cloud is None
-
-
-@mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_microsoft_rc_error(mock_metadata, mock_get_stdout, mock_is_program):
-    mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [
-        (0, "other"), (1, "other"), (0, "other")]
-    mock_metadata.return_value = None
-    assert utils.detect_cloud() is None
-    mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer")
-    ])
-    assert mock_metadata.call_count == 0
-    assert utils._ip_for_cloud is None
-
-
-@mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_gcp(mock_metadata, mock_get_stdout, mock_is_program):
-    mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [
-        (0, "other"), (1, "other"), (0, "Google")]
-    mock_metadata.return_value = "10.10.10.10"
-    assert utils.detect_cloud() == "google-cloud-platform"
-    mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer"),
-        mock.call("dmidecode -s bios-vendor")
-    ])
-    mock_metadata.assert_called_once_with(
-        "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
-        headers={"Metadata-Flavor": "Google"})
-    assert utils._ip_for_cloud == "10.10.10.10"
-
-
-@mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_gcp_error(mock_metadata, mock_get_stdout, mock_is_program):
-    mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [
-        (0, "other"), (0, "other"), (0, "Google")]
-    mock_metadata.return_value = None
-    assert utils.detect_cloud() is None
-    mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer"),
-        mock.call("dmidecode -s bios-vendor")
-    ])
-    mock_metadata.assert_called_once_with(
-        "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip",
-        headers={"Metadata-Flavor": "Google"})
-    assert utils._ip_for_cloud is None
-
-
-@mock.patch("crmsh.utils.is_program")
-@mock.patch("crmsh.utils.get_stdout")
-@mock.patch("crmsh.utils._cloud_metadata_request")
-def test_detect_cloud_gcp_rc_error(mock_metadata, mock_get_stdout, mock_is_program):
-    mock_is_program.return_value = True
-    mock_get_stdout.side_effect = [
-        (0, "other"), (0, "other"), (1, "other")]
-    mock_metadata.return_value = None
-    assert utils.detect_cloud() is None
-    mock_is_program.assert_called_once_with("dmidecode")
-    mock_get_stdout.assert_has_calls([
-        mock.call("dmidecode -s system-version"),
-        mock.call("dmidecode -s system-manufacturer"),
-        mock.call("dmidecode -s bios-vendor")
-    ])
-    assert mock_metadata.call_count == 0
-    assert utils._ip_for_cloud is None
-
+    mock_aws.assert_called_once_with()
+    mock_azure.assert_called_once_with()
+    mock_gcp.assert_called_once_with()
 
 @mock.patch("crmsh.utils.get_stdout")
 def test_interface_choice(mock_get_stdout):


### PR DESCRIPTION
* split into 3 functions for specific cloud type
* need to support non-Hyper-V in Azure case, see https://github.com/trento-project/trento/issues/194