### PR TITLE
Fix: ui_resource: Parse node and lifetime correctly

### DIFF
--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -306,3 +306,15 @@ def step_impl(context, f):
     cmd = "crm cluster diff {}".format(f)
     rc, out = run_command(context, cmd)
     assert out == ""
+
+
+@given('Resource "{res_id}" is started on "{node}"')
+def step_impl(context, res_id, node):
+    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None
+
+
+@then('Resource "{res_id}" is started on "{node}"')
+def step_impl(context, res_id, node):
+    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None


### PR DESCRIPTION
## Changes
- To support these format correctly:
```
crm resource move <res> <node>
crm resource move <res> <node> <lifetime>
crm resource move <res> <node> <lifetime> force
crm resource move <res> <lifetime> force
crm resource move <res> force
crm resource move <res> <node> force
```

- Add usage when more than 3 options after `<res>`
```
"usage: {} <rsc> [<node>] [<lifetime>] [force]".format(action)
```

- Remove move completer's option "reboot" and "forever"
