### PR TITLE
Dev: ui_node: Improve node standby/online methods

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -508,20 +508,7 @@ CIB_REPLACE = "cibadmin -R -X '{xmlstr}'"
 CIB_RAW_FILE = "/var/lib/pacemaker/cib/cib.xml"
 XML_NODE_PATH = "/cib/configuration/nodes/node"
 XML_STATUS_PATH = "/cib/status/node_state"
-XML_NODE_QUERY_STANDBY_PATH = "//nodes/node[@id='{node_id}']/instance_attributes/nvpair[@name='standby']/@value"
-XML_STATUS_QUERY_STANDBY_PATH = "//status/node_state[@id='{node_id}']/transient_attributes/instance_attributes/nvpair[@name='standby']/@value"
-STANDBY_TEMPLATE = """
-<instance_attributes id="nodes-{node_id}">
-  <nvpair id="nodes-{node_id}-standby" name="standby" value="{value}"/>
-</instance_attributes>
-"""
-STANDBY_TEMPLATE_REBOOT = """
-<transient_attributes id="{node_id}">
-  <instance_attributes id="status-{node_id}">
-    <nvpair id="status-{node_id}-standby" name="standby" value="{value}"/>
-  </instance_attributes>
-</transient_attributes>
-"""
-STANDBY_NV_RE = r'(<nvpair.*{node_id}.*name="standby".*)value="{value}"(.*)'
+XML_NODE_QUERY_STANDBY_PATH = "//nodes/node[@id='{node_id}']/instance_attributes/nvpair[@name='standby']"
+XML_STATUS_QUERY_STANDBY_PATH = "//status/node_state[@id='{node_id}']/transient_attributes/instance_attributes/nvpair[@name='standby']"
 CRM_MON_ONE_SHOT = "crm_mon -1"
 # vim:ts=4:sw=4:et:

--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -3,6 +3,7 @@
 #
 # Make sure that ids are unique.
 
+import re
 import copy
 from . import constants
 from . import xmlutil
@@ -45,6 +46,8 @@ def new(node, pfx):
     '''
     Create a unique id for the xml node.
     '''
+    if re.search(r'^\d+$', pfx) and node.tag != "node":
+        pfx = "num-{}".format(pfx)
     name = node.get("name")
     if node.tag == "nvpair":
         node_id = "%s-%s" % (pfx, name)


### PR DESCRIPTION
In #797, standby/online part, there were issues:
- Can not handle and replace `false/no/n/0` value for standby
- standby nvpair could not contain node_id, then replace will not matched and failed

To avoid above issues:
- Not use re.sub to replace whole cib string
- Use xml query then `set` the value directly

Other than that:
- Avoid leading with number for xml ID
- Drop already standby/online check
- When doing standby, remove another type of lifetime standby
