### PR TITLE
Dev: Give warning when no-quorum-policy not set as freeze while using DLM

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2599,6 +2599,8 @@ class CibFactory(object):
             if is_live_cib():
                 self.last_commit_time = t
             self.refresh()
+
+            utils.check_no_quorum_policy_with_dlm()
         return rc
 
     def _update_schema(self):

--- a/crmsh/ocfs2.py
+++ b/crmsh/ocfs2.py
@@ -297,16 +297,16 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         self._dynamic_verify()
         self.exist_ra_id_list = utils.all_exist_id()
 
+        no_quorum_policy_value = utils.get_property("no-quorum-policy")
+        if not no_quorum_policy_value or no_quorum_policy_value != "freeze":
+            utils.set_property(no_quorum_policy="freeze")
+            logger.info("  'no-quorum-policy' is changed to \"freeze\"")
+
         if self.use_cluster_lvm2:
             self._config_resource_stack_lvm2()
         else:
             self._config_resource_stack_ocfs2_along()
         logger.info("  OCFS2 device %s mounted on %s", self.target_device, self.mount_point)
-
-        res = utils.get_stdout_or_raise_error("crm configure get_property no-quorum-policy")
-        if res != "freeze":
-            utils.get_stdout_or_raise_error("crm configure property no-quorum-policy=freeze")
-            logger.info("  'no-quorum-policy' is changed to \"freeze\"")
 
     def _find_target_on_join(self, peer):
         """

--- a/test/unittests/test_ocfs2.py
+++ b/test/unittests/test_ocfs2.py
@@ -373,48 +373,47 @@ class TestOCFS2Manager(unittest.TestCase):
         mock_mkfs.assert_called_once_with("/dev/sdb2")
         mock_fs.assert_called_once_with()
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
     @mock.patch('crmsh.ocfs2.OCFS2Manager._config_resource_stack_lvm2')
+    @mock.patch('crmsh.utils.set_property')
+    @mock.patch('crmsh.utils.get_property')
     @mock.patch('crmsh.utils.all_exist_id')
     @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_verify')
     @mock.patch('logging.Logger.info')
-    def test_init_ocfs2_lvm2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_lvm2, mock_run):
+    def test_init_ocfs2_lvm2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_get, mock_set, mock_lvm2):
         mock_all_id.return_value = []
-        mock_run.return_value = "freeze"
+        mock_get.return_value = None
         self.ocfs2_inst7.mount_point = "/data"
         self.ocfs2_inst7.target_device = "/dev/vg1/lv1"
         self.ocfs2_inst7.init_ocfs2()
         mock_status.assert_has_calls([
             mock.call("Configuring OCFS2"),
+            mock.call('  \'no-quorum-policy\' is changed to "freeze"'),
             mock.call('  OCFS2 device %s mounted on %s', '/dev/vg1/lv1', '/data')
             ])
         mock_dynamic_verify.assert_called_once_with()
         mock_all_id.assert_called_once_with()
         mock_lvm2.assert_called_once_with()
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
     @mock.patch('crmsh.ocfs2.OCFS2Manager._config_resource_stack_ocfs2_along')
+    @mock.patch('crmsh.utils.set_property')
+    @mock.patch('crmsh.utils.get_property')
     @mock.patch('crmsh.utils.all_exist_id')
     @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_verify')
     @mock.patch('logging.Logger.info')
-    def test_init_ocfs2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_ocfs2, mock_run):
+    def test_init_ocfs2(self, mock_status, mock_dynamic_verify, mock_all_id, mock_get, mock_set, mock_ocfs2):
         mock_all_id.return_value = []
-        mock_run.side_effect = ["stop", None]
+        mock_get.return_value = None
         self.ocfs2_inst3.mount_point = "/data"
         self.ocfs2_inst3.target_device = "/dev/sda1"
         self.ocfs2_inst3.init_ocfs2()
         mock_status.assert_has_calls([
             mock.call("Configuring OCFS2"),
-            mock.call('  OCFS2 device %s mounted on %s', '/dev/sda1', '/data'),
-            mock.call('  \'no-quorum-policy\' is changed to "freeze"')
+            mock.call('  \'no-quorum-policy\' is changed to "freeze"'),
+            mock.call('  OCFS2 device %s mounted on %s', '/dev/sda1', '/data')
             ])
         mock_dynamic_verify.assert_called_once_with()
         mock_all_id.assert_called_once_with()
         mock_ocfs2.assert_called_once_with()
-        mock_run.assert_has_calls([
-            mock.call("crm configure get_property no-quorum-policy"),
-            mock.call("crm configure property no-quorum-policy=freeze")
-            ])
 
     @mock.patch('crmsh.utils.get_stdout_or_raise_error')
     def test_find_target_on_join_none(self, mock_run):

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -443,7 +443,7 @@ class TestQDevice(unittest.TestCase):
         mock_conf.assert_called_once_with()
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
-    @mock.patch("crmsh.utils.get_stdout_stderr")
+    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
     @mock.patch("crmsh.corosync.conf")
     @mock.patch("crmsh.corosync.get_value")
     def test_create_ca_request(self, mock_get_value, mock_conf, mock_stdout_stderr, mock_log):


### PR DESCRIPTION
Changes:
- Give warning `The DLM cluster best practice suggests to set the cluster property \"no-quorum-policy=freeze\"` when commit,
while detecting `no-quorum-policy` not set as `freeze` when using DLM
- To avoid give above warning, adjust the code position to set no-quorum-policy as freeze when using ocfs2 stage to configure dlm+ocfs2 cluster

Related PR on pacemaker: https://github.com/ClusterLabs/pacemaker/pull/2583