### PR TITLE
Dev: ui_cluster: Improvement for stop process

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -513,4 +513,5 @@ XML_STATUS_QUERY_STANDBY_PATH = "//status/node_state[@id='{node_id}']/transient_
 CRM_MON_ONE_SHOT = "crm_mon -1"
 STONITH_TIMEOUT_DEFAULT = 60
 PCMK_DELAY_MAX = 30
+DLM_CONTROLD_RA = "ocf::pacemaker:controld"
 # vim:ts=4:sw=4:et:

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -297,6 +297,7 @@ class LoggerUtils(object):
         try:
             yield
         except:
+            print("")
             raise
         else:
             self.status_done()

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -186,9 +186,9 @@ class Cluster(command.UI):
         if not node_list:
             return
 
-        # When dlm configured and quorum is lost, before stop cluster service, should set
+        # When dlm running and quorum is lost, before stop cluster service, should set
         # enable_quorum_fencing=0, enable_quorum_lockspace=0 for dlm config option
-        if utils.is_dlm_configured() and not utils.is_quorate():
+        if utils.is_dlm_running() and not utils.is_quorate():
             logger.debug("Quorum is lost; Set enable_quorum_fencing=0 and enable_quorum_lockspace=0 for dlm")
             utils.set_dlm_option(enable_quorum_fencing=0, enable_quorum_lockspace=0)
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -186,18 +186,16 @@ class Cluster(command.UI):
         if not node_list:
             return
 
-        bootstrap.wait_for_cluster("Waiting for {} online".format(' '.join(node_list)), node_list)
-
         # When dlm configured and quorum is lost, before stop cluster service, should set
         # enable_quorum_fencing=0, enable_quorum_lockspace=0 for dlm config option
-        if utils.is_dlm_configured(node_list[0]) and not utils.is_quorate(node_list[0]):
+        if utils.is_dlm_configured() and not utils.is_quorate():
             logger.debug("Quorum is lost; Set enable_quorum_fencing=0 and enable_quorum_lockspace=0 for dlm")
-            utils.set_dlm_option(peer=node_list[0], enable_quorum_fencing=0, enable_quorum_lockspace=0)
+            utils.set_dlm_option(enable_quorum_fencing=0, enable_quorum_lockspace=0)
 
         # Stop pacemaker since it can make sure cluster has quorum until stop corosync
         utils.stop_service("pacemaker", node_list=node_list)
         # Then, stop qdevice if is active
-        if utils.service_is_active("corosync-qdevice.service", node_list[0]):
+        if utils.service_is_active("corosync-qdevice.service"):
             utils.stop_service("corosync-qdevice.service", node_list=node_list)
         # Last, stop corosync
         utils.stop_service("corosync", node_list=node_list)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -186,6 +186,10 @@ class Cluster(command.UI):
         if not node_list:
             return
 
+        if not utils.get_dc(timeout=5):
+            logger.error("No DC found currently, please wait if the cluster is still starting")
+            return False
+
         # When dlm running and quorum is lost, before stop cluster service, should set
         # enable_quorum_fencing=0, enable_quorum_lockspace=0 for dlm config option
         if utils.is_dlm_running() and not utils.is_quorate():

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -836,9 +836,11 @@ def append_file(dest, src):
         return False
 
 
-def get_dc():
+def get_dc(timeout=None):
     cmd = "crmadmin -D"
-    rc, s = get_stdout(add_sudo(cmd))
+    if timeout:
+        cmd += " -t {}".format(timeout)
+    rc, s, _ = get_stdout_stderr(add_sudo(cmd))
     if rc != 0:
         return None
     if not s.startswith("Designated"):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2936,38 +2936,38 @@ def is_standby(node):
     return re.search(r'Node\s+{}:\s+standby'.format(node), out) is not None
 
 
-def get_dlm_option_dict(peer=None):
+def get_dlm_option_dict():
     """
     Get dlm config option dictionary
     """
-    out = get_stdout_or_raise_error("dlm_tool dump_config", remote=peer)
+    out = get_stdout_or_raise_error("dlm_tool dump_config")
     return dict(re.findall("(\w+)=(\w+)", out))
 
 
-def set_dlm_option(peer=None, **kargs):
+def set_dlm_option(**kargs):
     """
     Set dlm option
     """
-    dlm_option_dict = get_dlm_option_dict(peer=peer)
+    dlm_option_dict = get_dlm_option_dict()
     for option, value in kargs.items():
         if option not in dlm_option_dict:
             raise ValueError('"{}" is not dlm config option'.format(option))
         if dlm_option_dict[option] != value:
-            get_stdout_or_raise_error('dlm_tool set_config "{}={}"'.format(option, value), remote=peer)
+            get_stdout_or_raise_error('dlm_tool set_config "{}={}"'.format(option, value))
 
 
-def is_dlm_configured(peer=None):
+def is_dlm_configured():
     """
     Check if dlm configured
     """
-    return has_resource_configured("ocf::pacemaker:controld", peer=peer)
+    return has_resource_configured("ocf::pacemaker:controld")
 
 
-def is_quorate(peer=None):
+def is_quorate():
     """
     Check if cluster is quorated
     """
-    out = get_stdout_or_raise_error("corosync-quorumtool -s", remote=peer, success_val_list=[0, 2])
+    out = get_stdout_or_raise_error("corosync-quorumtool -s", success_val_list=[0, 2])
     res = re.search(r'Quorate:\s+(.*)', out)
     if res:
         return res.group(1) == "Yes"

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2698,7 +2698,10 @@ def has_resource_running(ra_type=None):
     """
     Check if any RA is running
     """
-    out = get_stdout_or_raise_error("crm_mon -1")
+    cmd = "crm_mon -1"
+    if ra_type:
+        cmd = "crm_mon -1rR"
+    out = get_stdout_or_raise_error(cmd)
     if ra_type:
         return re.search("{}.*Started".format(ra_type), out) is not None
     else:
@@ -2956,11 +2959,18 @@ def set_dlm_option(**kargs):
             get_stdout_or_raise_error('dlm_tool set_config "{}={}"'.format(option, value))
 
 
+def is_dlm_running():
+    """
+    Check if dlm ra controld is running
+    """
+    return has_resource_running(constants.DLM_CONTROLD_RA)
+
+
 def is_dlm_configured():
     """
     Check if dlm configured
     """
-    return has_resource_configured("ocf::pacemaker:controld")
+    return has_resource_configured(constants.DLM_CONTROLD_RA)
 
 
 def is_quorate():

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -26,12 +26,14 @@ Feature: crmsh bootstrap process - init, join and remove
     When    Run "crm node online --all" on "hanode1"
     Then    Node "hanode1" is online
     And     Node "hanode2" is online
+    When    Wait for DC
     When    Run "crm cluster stop --all" on "hanode1"
     Then    Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster start --all" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
+    When    Wait for DC
     When    Run "crm cluster stop hanode2" on "hanode1"
     Then    Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster start hanode2" on "hanode1"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from crmsh import utils, parallax
+import time
 
 
 def get_online_nodes():
@@ -25,8 +26,8 @@ def before_tag(context, tag):
         online_nodes = get_online_nodes()
         if online_nodes:
             resource_cleanup()
-            try:
-                parallax.parallax_call(online_nodes, 'crm cluster stop')
-            except ValueError as err:
-                context.logger.error("{}\n".format(err))
-                context.failed = True
+            while True:
+                time.sleep(1)
+                if utils.get_dc():
+                    break
+            utils.get_stdout_or_raise_error("crm cluster stop --all")

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -378,3 +378,11 @@ def step_impl(context, path, value):
         data = yaml.load(f, Loader=yaml.SafeLoader)
     sec_name, key = path.split(':')
     assert str(data[sec_name][key]) == str(value)
+
+
+@when('Wait for DC')
+def step_impl(context):
+    while True:
+        time.sleep(1)
+        if crmutils.get_dc():
+            break

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -97,22 +97,23 @@ class TestCluster(unittest.TestCase):
     @mock.patch('crmsh.utils.stop_service')
     @mock.patch('crmsh.utils.set_dlm_option')
     @mock.patch('crmsh.utils.is_quorate')
-    @mock.patch('crmsh.utils.is_dlm_configured')
-    @mock.patch('crmsh.bootstrap.wait_for_cluster')
+    @mock.patch('crmsh.utils.is_dlm_running')
+    @mock.patch('crmsh.utils.get_dc')
     @mock.patch('crmsh.utils.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
-    def test_do_stop(self, mock_parse_nodes, mock_active, mock_wait, mock_dlm_configured, mock_is_quorate, mock_set_dlm, mock_stop, mock_info, mock_debug):
+    def test_do_stop(self, mock_parse_nodes, mock_active, mock_get_dc, mock_dlm_running, mock_is_quorate, mock_set_dlm, mock_stop, mock_info, mock_debug):
         context_inst = mock.Mock()
         mock_parse_nodes.return_value = ["node1"]
         mock_active.side_effect = [True, True]
-        mock_dlm_configured.return_value = True
+        mock_dlm_running.return_value = True
         mock_is_quorate.return_value = False
+        mock_get_dc.return_value = "node1"
 
         self.ui_cluster_inst.do_stop(context_inst, "node1")
 
         mock_active.assert_has_calls([
             mock.call("corosync.service", remote_addr="node1"),
-            mock.call("corosync-qdevice.service", "node1")
+            mock.call("corosync-qdevice.service")
             ])
         mock_stop.assert_has_calls([
             mock.call("pacemaker", node_list=["node1"]),

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1500,7 +1500,7 @@ key2=value2
             "key1": "value1",
             "key2": "value2"
             }
-    mock_run.assert_called_once_with("dlm_tool dump_config", remote=None)
+    mock_run.assert_called_once_with("dlm_tool dump_config")
 
 
 @mock.patch('crmsh.utils.get_dlm_option_dict')
@@ -1522,14 +1522,14 @@ def test_set_dlm_option(mock_get_dict, mock_run):
             "key2": "value2"
             }
     utils.set_dlm_option(key2="test")
-    mock_run.assert_called_once_with('dlm_tool set_config "key2=test"', remote=None)
+    mock_run.assert_called_once_with('dlm_tool set_config "key2=test"')
 
 
 @mock.patch('crmsh.utils.has_resource_configured')
 def test_is_dlm_configured(mock_configured):
     mock_configured.return_value = True
     assert utils.is_dlm_configured() is True
-    mock_configured.assert_called_once_with("ocf::pacemaker:controld", peer=None)
+    mock_configured.assert_called_once_with("ocf::pacemaker:controld")
 
 
 @mock.patch('crmsh.utils.get_stdout_or_raise_error')
@@ -1538,7 +1538,7 @@ def test_is_quorate_exception(mock_run):
     with pytest.raises(ValueError) as err:
         utils.is_quorate()
     assert str(err.value) == "Failed to get quorate status from corosync-quorumtool"
-    mock_run.assert_called_once_with("corosync-quorumtool -s", remote=None, success_val_list=[0, 2])
+    mock_run.assert_called_once_with("corosync-quorumtool -s", success_val_list=[0, 2])
 
 
 @mock.patch('crmsh.utils.get_stdout_or_raise_error')
@@ -1548,7 +1548,7 @@ Ring ID:          1084783297/440
 Quorate:          Yes
     """
     assert utils.is_quorate() is True
-    mock_run.assert_called_once_with("corosync-quorumtool -s", remote=None, success_val_list=[0, 2])
+    mock_run.assert_called_once_with("corosync-quorumtool -s", success_val_list=[0, 2])
 
 
 @mock.patch('crmsh.utils.etree.fromstring')


### PR DESCRIPTION
- Revert "Dev: ui_cluster: Make sure node is online when stop service"
  Since to wait for node online when stopping cluster seems no make sense

- Dev: log: In status_long function, add a blank line when exception
  To make the error message has more clear format

- Dev: ui_cluster: check dlm controld ra is running when stop cluster
  When dlm controld is stopped, this time trying to stop cluster will cause error when trying to fetch dlm options

- Dev: ui_cluster: Exit stop process when there is no DC
