### PR TITLE
Fix: bootstrap: Change log info when need to change user login shell

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -770,10 +770,10 @@ def change_user_shell(user):
     """
     To change user's login shell
     """
+    message = "The user '{}' will have the login shell configuration changed to /bin/bash"
     if user != "root" and is_nologin(user):
         if not _context.yes_to_all:
-            logger.info("""User {}'s login shell will be changed to /bin/bash, and
-be setted up authorized ssh access among cluster nodes""".format(user))
+            logger.info(message.format(user))
             if not confirm("Continue?"):
                 _context.with_other_user = False
                 return


### PR DESCRIPTION
When revisit the case, I think it's proper to just keep
```
The user 'hacluster' will have the login shell configuration changed to /bin/bash
```
Since each join node will show
```
Configuring SSH passwordless with hacluster@<node>
```
later
