### PR TITLE
Support OCF 1.1 if desired

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2994,7 +2994,7 @@ class CibFactory(object):
                 rc = False
                 continue
             ra = get_ra(r_node)
-            if not ra.mk_ra_node():  # no RA found?
+            if ra.mk_ra_node() is None:  # no RA found?
                 if not self.is_asymm_cluster():
                     ra.error("no resource agent found for %s" % obj_id)
                 continue
@@ -3015,7 +3015,10 @@ class CibFactory(object):
                             implied_ms_actions.remove(op)
                         elif op not in other_actions:
                             continue
-                        adv_timeout = ra.get_adv_timeout(op, c2)
+                        adv_timeout = None
+                        role = c2.get('role')
+                        depth = c2.get('depth')
+                        adv_timeout = ra.get_op_attr_value(op, "timeout", role=role, depth=depth)
                         if adv_timeout:
                             c2.set("timeout", adv_timeout)
                             obj_modified = True
@@ -3025,7 +3028,7 @@ class CibFactory(object):
             if is_ms_or_promotable_clone(obj.node.getparent()):
                 l += implied_ms_actions
             for op in l:
-                adv_timeout = ra.get_adv_timeout(op)
+                adv_timeout = ra.get_op_attr_value(op, "timeout")
                 if not adv_timeout:
                     continue
                 n = etree.Element('op')

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -252,6 +252,7 @@ DEFAULTS = {
         'ignore_missing_metadata': opt_boolean('no'),
         'report_tool_options': opt_string(''),
         'lock_timeout': opt_string('120'),
+        'OCF_1_1_SUPPORT': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },
     'path': {

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -505,6 +505,7 @@ END = '\033[0m'
 
 CIB_QUERY = "cibadmin -Q"
 CIB_REPLACE = "cibadmin -R -X '{xmlstr}'"
+CIB_UPGRADE = "cibadmin --upgrade --force"
 CIB_RAW_FILE = "/var/lib/pacemaker/cib/cib.xml"
 XML_NODE_PATH = "/cib/configuration/nodes/node"
 XML_STATUS_PATH = "/cib/status/node_state"
@@ -516,4 +517,8 @@ STONITH_TIMEOUT_DEFAULT = 60
 PCMK_DELAY_MAX = 30
 DLM_CONTROLD_RA = "ocf::pacemaker:controld"
 LVMLOCKD_RA = "ocf::heartbeat:lvmlockd"
+
+
+SCHEMA_MIN_VER_SUPPORT_OCF_1_1 = "pacemaker-3.7"
+PCMK_MIN_VER_SUPPORT_OCF_1_1 = "2.1.0"
 # vim:ts=4:sw=4:et:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -505,7 +505,7 @@ END = '\033[0m'
 
 CIB_QUERY = "cibadmin -Q"
 CIB_REPLACE = "cibadmin -R -X '{xmlstr}'"
-CIB_UPGRADE = "cibadmin --upgrade --force"
+CIB_UPGRADE = "crm configure upgrade force"
 CIB_RAW_FILE = "/var/lib/pacemaker/cib/cib.xml"
 XML_NODE_PATH = "/cib/configuration/nodes/node"
 XML_STATUS_PATH = "/cib/status/node_state"
@@ -520,5 +520,4 @@ LVMLOCKD_RA = "ocf::heartbeat:lvmlockd"
 
 
 SCHEMA_MIN_VER_SUPPORT_OCF_1_1 = "pacemaker-3.7"
-PCMK_MIN_VER_SUPPORT_OCF_1_1 = "2.1.0"
 # vim:ts=4:sw=4:et:

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -11,6 +11,7 @@ from .ra import disambiguate_ra_type, ra_type_validate
 from . import schema
 from .utils import keyword_cmp, verify_boolean, lines2cli
 from .utils import get_boolean, olist, canonical_boolean
+from .utils import convert_role_if_schema_not_supported
 from . import xmlutil
 from . import log
 
@@ -467,7 +468,7 @@ class BaseParser(object):
                     idref = True
                 rule.set(idtyp, idval)
             if self.try_match(_ROLE_RE):
-                rule.set('role', self.matched(1))
+                rule.set('role', convert_role_if_schema_not_supported(self.matched(1)))
             if idref:
                 continue
             if self.try_match(_SCORE_RE):
@@ -924,10 +925,13 @@ class ConstraintParser(BaseParser):
             out.set('rsc', self.match_resource())
 
         while self.try_match(_ATTR_RE):
-            out.set(self.matched(1), self.matched(2))
+            name = self.matched(1)
+            value = convert_role_if_schema_not_supported(self.matched(2), name=name)
+            out.set(name, value)
 
+        # not sure this is necessary after parse _ATTR_RE in a while loop
         if self.try_match(_ROLE_RE) or self.try_match(_ROLE2_RE):
-            out.set('role', self.matched(1))
+            out.set('role', convert_role_if_schema_not_supported(self.matched(1)))
 
         score = False
         if self.try_match(_SCORE_RE):
@@ -937,7 +941,7 @@ class ConstraintParser(BaseParser):
             # backwards compatibility: role used to be read here
             if 'role' not in out:
                 if self.try_match(_ROLE_RE) or self.try_match(_ROLE2_RE):
-                    out.set('role', self.matched(1))
+                    out.set('role', convert_role_if_schema_not_supported(self.matched(1)))
         if not score:
             rules = self.match_rules()
             out.extend(rules)
@@ -1040,7 +1044,7 @@ class ConstraintParser(BaseParser):
 
     def _split_setref(self, typename, classifier):
         rsc, typ = self.match_split()
-        typ, t = classifier(typ)
+        typ, t = classifier(convert_role_if_schema_not_supported(typ, name=typename))
         if typ and not t:
             self.err("Invalid %s '%s' for '%s'" % (typename, typ, rsc))
         return rsc, typ, t
@@ -1627,7 +1631,7 @@ class ResourceSet(object):
                     validator.resource_actions())
             else:
                 l[1] = validator.canonize(
-                    l[1],
+                    convert_role_if_schema_not_supported(l[1]),
                     validator.resource_roles())
             if not l[1]:
                 self.err('Invalid %s for %s' % (self.q_attr, p))

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -11,7 +11,7 @@ from .ra import disambiguate_ra_type, ra_type_validate
 from . import schema
 from .utils import keyword_cmp, verify_boolean, lines2cli
 from .utils import get_boolean, olist, canonical_boolean
-from .utils import convert_role_if_schema_not_supported
+from .utils import handle_role_for_ocf_1_1
 from . import xmlutil
 from . import log
 
@@ -468,7 +468,7 @@ class BaseParser(object):
                     idref = True
                 rule.set(idtyp, idval)
             if self.try_match(_ROLE_RE):
-                rule.set('role', convert_role_if_schema_not_supported(self.matched(1)))
+                rule.set('role', handle_role_for_ocf_1_1(self.matched(1)))
             if idref:
                 continue
             if self.try_match(_SCORE_RE):
@@ -926,12 +926,12 @@ class ConstraintParser(BaseParser):
 
         while self.try_match(_ATTR_RE):
             name = self.matched(1)
-            value = convert_role_if_schema_not_supported(self.matched(2), name=name)
+            value = handle_role_for_ocf_1_1(self.matched(2), name=name)
             out.set(name, value)
 
         # not sure this is necessary after parse _ATTR_RE in a while loop
         if self.try_match(_ROLE_RE) or self.try_match(_ROLE2_RE):
-            out.set('role', convert_role_if_schema_not_supported(self.matched(1)))
+            out.set('role', handle_role_for_ocf_1_1(self.matched(1)))
 
         score = False
         if self.try_match(_SCORE_RE):
@@ -941,7 +941,7 @@ class ConstraintParser(BaseParser):
             # backwards compatibility: role used to be read here
             if 'role' not in out:
                 if self.try_match(_ROLE_RE) or self.try_match(_ROLE2_RE):
-                    out.set('role', convert_role_if_schema_not_supported(self.matched(1)))
+                    out.set('role', handle_role_for_ocf_1_1(self.matched(1)))
         if not score:
             rules = self.match_rules()
             out.extend(rules)
@@ -1044,7 +1044,7 @@ class ConstraintParser(BaseParser):
 
     def _split_setref(self, typename, classifier):
         rsc, typ = self.match_split()
-        typ, t = classifier(convert_role_if_schema_not_supported(typ, name=typename))
+        typ, t = classifier(handle_role_for_ocf_1_1(typ, name=typename))
         if typ and not t:
             self.err("Invalid %s '%s' for '%s'" % (typename, typ, rsc))
         return rsc, typ, t
@@ -1631,7 +1631,7 @@ class ResourceSet(object):
                     validator.resource_actions())
             else:
                 l[1] = validator.canonize(
-                    convert_role_if_schema_not_supported(l[1]),
+                    handle_role_for_ocf_1_1(l[1]),
                     validator.resource_roles())
             if not l[1]:
                 self.err('Invalid %s for %s' % (self.q_attr, p))

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -303,7 +303,7 @@ class RAInfo(object):
     '''
     ra_tab = "    "  # four horses
     required_ops = ("start", "stop")
-    no_interval_ops = ("start", "stop")
+    no_interval_ops = ("start", "stop", "promote", "demote")
     skip_ops = ("meta-data", "validate-all")
     skip_op_attr = ("name",)
 
@@ -543,6 +543,7 @@ class RAInfo(object):
                     for idx, monitor_item in enumerate(actions_dict[op]):
                         if monitor_item['role'] == role:
                             return actions_dict[op][idx][key]
+                # Technically, there could be multiple entries defining different depths for a same role.
                 if depth:
                     for idx, monitor_item in enumerate(actions_dict[op]):
                         if monitor_item['depth'] == depth:

--- a/crmsh/schema.py
+++ b/crmsh/schema.py
@@ -151,14 +151,4 @@ def rng_xpath(xpath, namespaces=None):
     if _crm_schema is None:
         return []
     return _crm_schema.rng_xpath(xpath, namespaces=namespaces)
-
-
-def compare_with(schema1, schema2):
-    """
-    Compare with two schemas
-    Return True if schema1 less than schema2
-    """
-    schema1_ver = float(schema1.split('-')[1])
-    schema2_ver = float(schema2.split('-')[1])
-    return schema1_ver < schema2_ver
 # vim:ts=4:sw=4:et:

--- a/crmsh/schema.py
+++ b/crmsh/schema.py
@@ -153,4 +153,12 @@ def rng_xpath(xpath, namespaces=None):
     return _crm_schema.rng_xpath(xpath, namespaces=namespaces)
 
 
+def compare_with(schema1, schema2):
+    """
+    Compare with two schemas
+    Return True if schema1 less than schema2
+    """
+    schema1_ver = float(schema1.split('-')[1])
+    schema2_ver = float(schema2.split('-')[1])
+    return schema1_ver < schema2_ver
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -244,43 +244,47 @@ def _prim_meta_completer(agent, args):
 
 
 def _prim_op_completer(agent, args):
-    actions = agent.actions()
-    completing = args[-1]
-    if completing == 'op':
+
+    def concat_kv(k, v):
+        return "{}={}".format(k, v)
+
+    if args[-1] == 'op':
         return ['op']
+    actions = agent.actions()
+    if not actions:
+        return []
+    # list all actions, select one to complete
     if args[-2] == 'op':
-        # append action items which in agent default actions
-        # monitor_Master will be mapped to "monitor role=Master"
-        # monitor_Slave will be mapped to "monitor role=Slave"
-        op_list = list(constants.op_cli_names)
-        if "monitor_Master" in actions:
-            op_list.append("monitor_Master")
-        if "monitor_Slave" in actions:
-            op_list.append("monitor_Slave")
-        # remove action items which not in default actions
-        for item in ["monitor", "demote", "promote", "notify"]:
-            if item not in actions:
-                op_list.remove(item)
-        # remove action items which already used
-        for item in op_list:
-            if item in args[:-2]:
-                op_list.remove(item)
-        return op_list
+        return actions.keys()
+    # list all attributes of the action, select one to complete
     if args[-3] == 'op':
         res = []
-        # list all of default items
-        if actions and actions[args[-2]]:
-            for k, v in list(actions[args[-2]].items()):
-                res += ["%s=%s" % (k, v)]
-            return res
+        op_name = args[-2]
+        if op_name == 'monitor':
+            for one_monitor in actions[op_name]:
+                res += [concat_kv(k, v) for k, v in one_monitor.items()]
+        else:
+            res = [concat_kv(k, v) for k, v in actions[op_name].items()]
+        return res
+
     args.pop()
-    # make sure all of default items can be completed
-    if args[-2] in actions:
+    if '=' in args[-1]:
         res = []
-        for k, v in actions[args[-2]].items():
-            if args[-1].startswith(k+'='):
-                continue
-            res += ["%s=%s" % (k, v)]
+        # find latest action
+        op_name = None
+        for i, item in enumerate(reversed(args)):
+            if item in actions:
+                op_name = item
+                break
+        if not op_name:
+            return []
+        # list all left attributes of the action, select one to complete
+        actions_list_in_args = [arg.split('=')[0] for arg in args[len(args)-i:]]
+        if op_name == 'monitor':
+            for one_monitor in actions[op_name]:
+                res += [concat_kv(k, v) for k, v in one_monitor.items() if k not in actions_list_in_args]
+        else:
+            res = [concat_kv(k, v) for k, v in actions[op_name].items() if k not in actions_list_in_args]
         return res
 
     return []
@@ -331,7 +335,7 @@ def primitive_complete_complex(args):
         return []
 
     complete_results = completers_set[last_keyw](agent, args)
-    if len(args) > 4 and '=' in args[-2]: # args[-1] will be the space
+    if len(args) > 4 and '=' in args[-1]:
         return complete_results + keywords
 
     return complete_results
@@ -987,14 +991,7 @@ class CibConfig(command.UI):
             [op op_type [<attribute>=<value>...]
                         [[op_params] <param>=<value> [<param>=<value>...]]
                         [op_meta <attribute>=<value> [<attribute>=<value>...]] ...]]"""
-        tmp = list(args)
-        for item in ['monitor_Master', 'monitor_Slave']:
-            if item in tmp:
-                idx = tmp.index(item)
-                tmp.remove(item)
-                tmp.insert(idx, "monitor")
-                tmp.insert(idx+1, "role=%s" % item.split('_')[1])
-        return self.__conf_object(context.get_command_name(), *tuple(tmp))
+        return self.__conf_object(context.get_command_name(), *args)
 
     @command.completers_repeating(compl.attr_id, _container_type, container_complete_complex)
     def do_bundle(self, context, *args):

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -338,7 +338,8 @@ class RscMgmt(command.UI):
         if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
             logger.error("%s is not a promotable resource", rsc)
             return False
-        return utils.ext_cmd(self.rsc_setrole % (rsc, "Promoted")) == 0
+        role = "Promoted" if config.core.OCF_1_1_SUPPORT else "Master"
+        return utils.ext_cmd(self.rsc_setrole % (rsc, role)) == 0
 
     def do_scores(self, context):
         "usage: scores"
@@ -366,7 +367,8 @@ class RscMgmt(command.UI):
         if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
             logger.error("%s is not a promotable resource", rsc)
             return False
-        return utils.ext_cmd(self.rsc_setrole % (rsc, "Unpromoted")) == 0
+        role = "Unpromoted" if config.core.OCF_1_1_SUPPORT else "Slave"
+        return utils.ext_cmd(self.rsc_setrole % (rsc, role)) == 0
 
     @command.completers(compl.resources)
     def do_manage(self, context, rsc):

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -338,7 +338,7 @@ class RscMgmt(command.UI):
         if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
             logger.error("%s is not a promotable resource", rsc)
             return False
-        return utils.ext_cmd(self.rsc_setrole % (rsc, "Master")) == 0
+        return utils.ext_cmd(self.rsc_setrole % (rsc, "Promoted")) == 0
 
     def do_scores(self, context):
         "usage: scores"
@@ -366,7 +366,7 @@ class RscMgmt(command.UI):
         if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
             logger.error("%s is not a promotable resource", rsc)
             return False
-        return utils.ext_cmd(self.rsc_setrole % (rsc, "Slave")) == 0
+        return utils.ext_cmd(self.rsc_setrole % (rsc, "Unpromoted")) == 0
 
     @command.completers(compl.resources)
     def do_manage(self, context, rsc):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1257,13 +1257,6 @@ def multicolumn(l):
             print(s)
 
 
-def find_value(pl, name):
-    for n, v in pl:
-        if n == name:
-            return v
-    return None
-
-
 def cli_replace_attr(pl, name, new_val):
     for i, attr in enumerate(pl):
         if attr[0] == name:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3040,9 +3040,9 @@ def get_systemd_timeout_start_in_sec(time_res):
     return start_timeout
 
 
-def is_ocf_1_1_feature_on():
+def is_ocf_1_1_cib_schema_detected():
     """
-    Only turn on ocf_1_1 feature when the cib schema version is pacemaker-3.7 or above
+    Only turn on ocf_1_1 feature the cib schema version is pacemaker-3.7 or above
     """
     from .cibconfig import cib_factory
     return is_larger_than_min_version(cib_factory.get_schema(), constants.SCHEMA_MIN_VER_SUPPORT_OCF_1_1)
@@ -3051,7 +3051,7 @@ def is_ocf_1_1_feature_on():
 def handle_role_for_ocf_1_1(value, name='role'):
     """
     * Convert role from Promoted/Unpromoted to Master/Slave if schema doesn't support OCF 1.1
-    * Convert role from Master/Slave to Promoted/Unpromoted if schema support OCF 1.1
+    * Convert role from Master/Slave to Promoted/Unpromoted if ocf1.1 cib schema detected and OCF_1_1_SUPPORT is yes
     """
     role_names = ["role", "target-role"]
     downgrade_dict = {"Promoted": "Master", "Unpromoted": "Slave"}
@@ -3059,10 +3059,10 @@ def handle_role_for_ocf_1_1(value, name='role'):
 
     if name not in role_names:
         return value
-    if value in downgrade_dict and not is_ocf_1_1_feature_on():
+    if value in downgrade_dict and not is_ocf_1_1_cib_schema_detected():
         logger.warning('Convert "%s" to "%s" since the current schema version is old and not upgraded yet. Please consider "%s"', value, downgrade_dict[value], constants.CIB_UPGRADE)
         return downgrade_dict[value]
-    if value in upgrade_dict and is_ocf_1_1_feature_on():
+    if value in upgrade_dict and is_ocf_1_1_cib_schema_detected() and config.core.OCF_1_1_SUPPORT:
         logger.info('Convert deprecated "%s" to "%s"', value, upgrade_dict[value])
         return upgrade_dict[value]
 

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -14,7 +14,7 @@ from . import options
 from . import schema
 from . import constants
 from . import userdir
-from .utils import add_sudo, str2file, str2tmp, get_boolean, convert_role_if_schema_not_supported
+from .utils import add_sudo, str2file, str2tmp, get_boolean, handle_role_for_ocf_1_1
 from .utils import get_stdout, get_stdout_or_raise_error, stdout2list, crm_msec, crm_time_cmp
 from .utils import olist, get_cib_in_use, get_tempdir, to_ascii, is_boolean_true
 from . import log
@@ -1427,7 +1427,7 @@ def nvpair(name, value):
     """
     <nvpair name="" value="" />
     """
-    value = convert_role_if_schema_not_supported(value, name=name)
+    value = handle_role_for_ocf_1_1(value, name=name)
     return new("nvpair", name=name, value=value)
 
 

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -14,7 +14,7 @@ from . import options
 from . import schema
 from . import constants
 from . import userdir
-from .utils import add_sudo, str2file, str2tmp, get_boolean
+from .utils import add_sudo, str2file, str2tmp, get_boolean, convert_role_if_schema_not_supported
 from .utils import get_stdout, get_stdout_or_raise_error, stdout2list, crm_msec, crm_time_cmp
 from .utils import olist, get_cib_in_use, get_tempdir, to_ascii, is_boolean_true
 from . import log
@@ -1427,6 +1427,7 @@ def nvpair(name, value):
     """
     <nvpair name="" value="" />
     """
+    value = convert_role_if_schema_not_supported(value, name=name)
     return new("nvpair", name=name, value=value)
 
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -161,7 +161,7 @@ crm(live)# node standby node4
   primitive apcfence stonith:apcsmart \
     params ttydev=/dev/ttyS0 hostlist="node1 node2" \
     op start timeout=60s
-  primitive pingd pingd \
+  primitive pingd ocf:pacemaker:ping \
     params name=pingd dampen=5s multiplier=100 host_list="r1 r2"
   #
   # monitor apache and the UPS

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1691,10 +1691,10 @@ Usage:
 constraints <rsc>
 ................
 
-[[cmdhelp_resource_demote,demote a master-slave resource]]
+[[cmdhelp_resource_demote,demote a promotable resource]]
 ==== `demote`
 
-Demote a master-slave resource using the `target-role`
+Demote a promotable resource using the `target-role`
 attribute.
 
 Usage:
@@ -1831,10 +1831,10 @@ Example:
 param ip_0 show ip
 ...............
 
-[[cmdhelp_resource_promote,promote a master-slave resource]]
+[[cmdhelp_resource_promote,promote a promotable resource]]
 ==== `promote`
 
-Promote a master-slave resource using the `target-role`
+Promote a promotable resource using the `target-role`
 attribute.
 
 Usage:
@@ -2557,8 +2557,8 @@ Commands for resources are:
 - `primitive`
 - `monitor`
 - `group`
-- `clone`
-- `ms`/`master` (master-slave)
+- `clone` (promotable clones)
+- `ms`/`master` (master-slave) (deprecated)
 
 In order to streamline large configurations, it is possible to
 define a template which can later be referenced in primitives:
@@ -2739,6 +2739,9 @@ Enter edit and manage the CIB status section level. See the
 
 The `clone` command creates a resource clone. It may contain a
 single primitive resource or one group of resources.
+
++Promotable clones+ are clone resources with the +promotable=true+ meta attribute for the given promotable resources.
+It's used to deprecate the master-slave resources.
 
 Usage:
 ...............
@@ -3257,7 +3260,7 @@ monitor apcfence 60m:60s
 Note that after executing the command, the monitor operation may
 be shown as part of the primitive definition.
 
-[[cmdhelp_configure_ms,define a master-slave resource]]
+[[cmdhelp_configure_ms,define a master-slave resource (deprecated)]]
 ==== `ms` (`master`)
 
 The `ms` command creates a master/slave resource type. It may contain a
@@ -3409,7 +3412,7 @@ order o-4 first-resource then-resource
 ==== `primitive`
 
 The primitive command describes a resource. It may be referenced
-only once in group, clone, or master-slave objects. If it's not
+only once in group, or clone objects. If it's not
 referenced, then it is placed as a single resource in the CIB.
 
 Operations may be specified anonymously, as a group or by reference:
@@ -3429,6 +3432,7 @@ instance attributes of that operation. A typical example is
 +OCF_CHECK_LEVEL+.
 
 For multistate resources, roles are specified as +role=<role>+.
+The +Master/Slave+ resources are deprecated and replaced by +Promoted/Unpromoted+ promotable resources if desired.
 
 A template may be defined for resources which are of the same
 type and which share most of the configuration. See
@@ -3480,8 +3484,8 @@ primitive db0 mysql \
 
 primitive r0 ocf:linbit:drbd \
   params drbd_resource=r0 \
-  op monitor role=Master interval=60s \
-  op monitor role=Slave interval=300s
+  op monitor role=Promoted interval=60s \
+  op monitor role=Unpromoted interval=300s
 
 primitive xen0 @vm_scheme1 xmfile=/etc/xen/vm/xen0
 
@@ -3722,7 +3726,7 @@ Example:
 ...............
 rsc_ticket ticket-A_public-ip ticket-A: public-ip
 rsc_ticket ticket-A_bigdb ticket-A: bigdb loss-policy=fence
-rsc_ticket ticket-B_storage ticket-B: drbd-a:Master drbd-b:Master
+rsc_ticket ticket-B_storage ticket-B: drbd-a:Promoted drbd-b:Promoted
 ...............
 
 

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -21,6 +21,9 @@
 ; report_tool_options =
 ; lock_timeout = 120
 
+; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.
+; OCF_1_1_SUPPORT = yes
+
 ; obscure_pattern option is the persisent configuration of CLI.
 ; Example, for the high security concern, obscure_pattern = passw* | ip
 ; which makes `crm configure show` is equal to

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -48,12 +48,12 @@ Feature: Verify usercase master survive when split-brain
     When    Write multi lines to file "/etc/corosync/qdevice/check_master.sh"
       """
       #!/usr/bin/sh
-      crm_resource --locate -r promotable-1 2>&1 | grep Master | grep `crm_node -n` >/dev/null 2>&1
+      crm_resource --locate -r promotable-1 2>&1 | grep -E "Master|Promoted" | grep `crm_node -n` >/dev/null 2>&1
       """
     And     Run "chmod +x /etc/corosync/qdevice/check_master.sh" on "hanode1"
     And     Run "scp -p /etc/corosync/qdevice/check_master.sh root@hanode2:/etc/corosync/qdevice" on "hanode1"
     # Add a promotable clone resource and make sure hanode1 is master
-    And     Run "crm configure primitive stateful-1 ocf:pacemaker:Stateful op monitor_Slave interval=10s op monitor_Master interval=5s" on "hanode1"
+    And     Run "crm configure primitive stateful-1 ocf:pacemaker:Stateful op monitor role=Promoted interval=10s op monitor role=Unpromoted interval=5s" on "hanode1"
     And     Run "crm configure clone promotable-1 stateful-1 meta promotable=true" on "hanode1"
     And     Run "sleep 5" on "hanode1"
     Then    Show cluster status on "hanode1"

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -41,7 +41,7 @@ Operations' defaults (advisory minimum):
 
     start         timeout=20s
     stop          timeout=20s
-    monitor       timeout=20s interval=10s
+    monitor       timeout=20s interval=10s depth=0
     reload        timeout=20s
     reload-agent  timeout=20s
     migrate_to    timeout=20s


### PR DESCRIPTION
#### Changes
- Refactor `_prim_op_completer`, make it provide the correct role(Promoted/Unpromoted, or Master/Slave, depends on how RA written) to complete
```
crm(live/tbw-1)configure# primitive s ocf:pacemaker:Stateful op monitor 
depth=0           interval=10s      interval=11s      role=Promoted     role=Unpromoted   timeout=20s       
crm(live/tbw-1)configure# primitive s ocf:pacemaker:Stateful op monitor role=Promoted interval=10s op monitor 
depth=0           interval=10s      interval=11s      role=Promoted     role=Unpromoted   timeout=20s       
crm(live/tbw-1)configure# primitive s ocf:pacemaker:Stateful op monitor role=Promoted interval=10s op monitor role=Unpromoted interval=11s
```
```
crm(live/tbw-1)configure# primitive my ocf:heartbeat:mysql op monitor 
depth=0        interval=10s   interval=20s   interval=30s   role=Master    role=Slave     timeout=30s
```


- When cib schema not support OCF 1.1, convert Promoted/Unpromoted to Master/Slave
```
# For role in monitor
crm(live/15sp3-2)configure# primitive stateful-1 ocf:pacemaker:Stateful op monitor role=Promoted interval=10s op monitor role=Unpromoted interval=5s
WARNING: Convert "Promoted" to "Master" since the current schema version is old and not upgraded yet. Please consider "cibadmin --upgrade --force"
WARNING: Convert "Unpromoted" to "Slave" since the current schema version is old and not upgraded yet. Please consider "cibadmin --upgrade --force"
```
```
# For target-role in meta
crm(live/15sp3-2)configure# clone c1 stateful-1 meta target-role=Promoted
WARNING: Convert "Promoted" to "Master" since the current schema version is old and not upgraded yet. Please consider "cibadmin --upgrade --force"
```

  And can also convert role in constraints/rule/resoyyurce_set/rsc_ticket

- When cib schema support OCF 1.1, convert Master/Slave to Promoted/Unpromoted
```
crm(live/tbw-1)configure# primitive stateful-2 ocf:pacemaker:Stateful op monitor role=Master interval=10s op monitor role=Slave interval=5s
INFO: Convert deprecated "Master" to "Promoted"
INFO: Convert deprecated "Slave" to "Unpromoted"
crm(live/tbw-1)configure# clone c1 stateful-2 meta target-role=Master
INFO: Convert deprecated "Master" to "Promoted"
```
And can also convert role in constraints/rule/resource_set/rsc_ticket
- Dev: doc: Replace pingd as ocf:pacemaker:ping
- #915
- #909 
#### More inner changes
- In `RAInfo.actions`, store monitor as an array
- Change `RAInfo.get_adv_timeout` as `RAInfo.get_op_attr_value`, which is more generic;
  In `RAInfo.get_op_attr_value`, multi monitors can be distinguished by role or depth
- Refactor `RAInfo.sanity_check_ops`, make it more readable
- Remove unused functions
