### PR TITLE
Fix: xmlutil: Parse promotable clone correctly and also consider compatibility

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -32,7 +32,7 @@ from .utils import page_string, cibadmin_can_patch, str2tmp, ensure_sudo_readabl
 from .utils import run_ptest, is_id_valid, edit_file, get_boolean, filter_string
 from .xmlutil import is_child_rsc, rsc_constraint, sanitize_cib, rename_id, get_interesting_nodes
 from .xmlutil import is_pref_location, get_topnode, new_cib, get_rscop_defaults_meta_node
-from .xmlutil import rename_rscref, is_ms, silly_constraint, is_container, fix_comments
+from .xmlutil import rename_rscref, is_ms_or_promotable_clone, silly_constraint, is_container, fix_comments
 from .xmlutil import sanity_check_nvpairs, merge_nodes, op2list, mk_rsc_type, is_resource
 from .xmlutil import stuff_comments, is_comment, is_constraint, read_cib, processing_sort_cli
 from .xmlutil import find_operation, get_rsc_children_ids, is_primitive, referenced_resources
@@ -3011,7 +3011,7 @@ class CibFactory(object):
                             implied_actions.remove(op)
                         elif can_migrate(r_node) and op in implied_migrate_actions:
                             implied_migrate_actions.remove(op)
-                        elif is_ms(obj.node.getparent()) and op in implied_ms_actions:
+                        elif is_ms_or_promotable_clone(obj.node.getparent()) and op in implied_ms_actions:
                             implied_ms_actions.remove(op)
                         elif op not in other_actions:
                             continue
@@ -3022,7 +3022,7 @@ class CibFactory(object):
             l = implied_actions
             if can_migrate(r_node):
                 l += implied_migrate_actions
-            if is_ms(obj.node.getparent()):
+            if is_ms_or_promotable_clone(obj.node.getparent()):
                 l += implied_ms_actions
             for op in l:
                 adv_timeout = ra.get_adv_timeout(op)

--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -28,5 +28,5 @@ def verify(cib):
             else:
                 logger.error(_prettify(line, 0))
         else:
-            logger.info(_prettify(line, 7))
+            logger.error(_prettify(line, 7))
     return rc

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -51,7 +51,7 @@ def resources(args=None):
     nodes = xmlutil.get_interesting_nodes(cib_el, [])
     rsc_id_list = [x.get("id") for x in nodes if xmlutil.is_resource(x)]
     if args and args[0] in ['promote', 'demote']:
-        return [item for item in rsc_id_list if xmlutil.RscState().is_ms(item)]
+        return [item for item in rsc_id_list if xmlutil.RscState().is_ms_or_promotable_clone(item)]
     if args and args[0] == "started":
         return [item for item in rsc_id_list if xmlutil.RscState().is_running(item)]
     if args and args[0] == "stopped":

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -4,7 +4,7 @@
 import os
 import sys
 from .utils import rmdir_r, quote, this_node, ext_cmd
-from .xmlutil import get_topmost_rsc, get_op_timeout, get_child_nvset_node, is_ms, is_cloned
+from .xmlutil import get_topmost_rsc, get_op_timeout, get_child_nvset_node, is_ms_or_promotable_clone, is_cloned
 from . import log
 
 
@@ -69,8 +69,8 @@ class RADriver(object):
     def debug(self, s):
         logger.debug("%s: %s", self.id_str(), s)
 
-    def is_ms(self):
-        return is_ms(get_topmost_rsc(self.rscdef_node))
+    def is_ms_or_promotable_clone(self):
+        return is_ms_or_promotable_clone(get_topmost_rsc(self.rscdef_node))
 
     def nvset2env(self, set_n):
         if set_n is None:
@@ -195,7 +195,7 @@ class RADriver(object):
         """
         Make sure resource is stopped on node.
         """
-        if self.is_ms():
+        if self.is_ms_or_promotable_clone():
             self.runop("demote", (node,))
         self.runop("stop", (node,))
         ok = self.is_ok(node)
@@ -209,7 +209,7 @@ class RADriver(object):
         Perform test of resource on node.
         """
         self.runop("start", (node,))
-        if self.is_ms() and self.is_ok(node):
+        if self.is_ms_or_promotable_clone() and self.is_ok(node):
             self.runop("promote", (node,))
         return self.is_ok(node)
 
@@ -227,7 +227,7 @@ class RADriver(object):
         if not stopped:
             if self.is_ok(node):
                 self.warn("resource running at %s" % (node))
-            elif self.is_ms() and self.is_master(node):
+            elif self.is_ms_or_promotable_clone() and self.is_master(node):
                 self.warn("resource is master at %s" % (node))
             else:
                 self.warn("resource not clean at %s" % (node))

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1027,6 +1027,9 @@ class CibConfig(command.UI):
         """usage: ms <name> <rsc>
         [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
+        format_str = " " if "meta" in args else " meta "
+        new_cmd_str = ' '.join(args) + "{}promotable=true".format(format_str)
+        logger.warning('"ms" is deprecated. Please use "clone {}"'.format(new_cmd_str))
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('administrator')

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -335,8 +335,8 @@ class RscMgmt(command.UI):
         "usage: promote <rsc>"
         if not utils.is_name_sane(rsc):
             return False
-        if not xmlutil.RscState().is_ms(rsc):
-            logger.error("%s is not a master-slave resource", rsc)
+        if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
+            logger.error("%s is not a promotable resource", rsc)
             return False
         return utils.ext_cmd(self.rsc_setrole % (rsc, "Master")) == 0
 
@@ -363,8 +363,8 @@ class RscMgmt(command.UI):
         "usage: demote <rsc>"
         if not utils.is_name_sane(rsc):
             return False
-        if not xmlutil.RscState().is_ms(rsc):
-            logger.error("%s is not a master-slave resource", rsc)
+        if not xmlutil.RscState().is_ms_or_promotable_clone(rsc):
+            logger.error("%s is not a promotable resource", rsc)
             return False
         return utils.ext_cmd(self.rsc_setrole % (rsc, "Slave")) == 0
 
@@ -653,7 +653,7 @@ class RscMgmt(command.UI):
                 context.fatal_error("Failed to add trace for %s:%s" % (rsc_id, name))
         trace('start')
         trace('stop')
-        if xmlutil.is_ms(rsc.node):
+        if xmlutil.is_ms_or_promotable_clone(rsc.node):
             trace('promote')
             trace('demote')
         for op_node in op_nodes:

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -16,7 +16,7 @@ from . import constants
 from . import userdir
 from .utils import add_sudo, str2file, str2tmp, get_boolean
 from .utils import get_stdout, get_stdout_or_raise_error, stdout2list, crm_msec, crm_time_cmp
-from .utils import olist, get_cib_in_use, get_tempdir, to_ascii
+from .utils import olist, get_cib_in_use, get_tempdir, to_ascii, is_boolean_true
 from . import log
 
 
@@ -218,14 +218,14 @@ class RscState(object):
         except (IndexError, AttributeError):
             return None
 
-    def is_ms(self, ident):
+    def is_ms_or_promotable_clone(self, ident):
         '''
         Test if the resource is master-slave.
         '''
         rsc_node = self.rsc2node(ident)
         if rsc_node is None:
             return False
-        return is_ms(rsc_node)
+        return is_ms_or_promotable_clone(rsc_node)
 
     def rsc_clone(self, ident):
         '''
@@ -540,8 +540,10 @@ def is_group(node):
     return node.tag == "group"
 
 
-def is_ms(node):
-    return node.tag in ("master", "ms")
+def is_ms_or_promotable_clone(node):
+    is_promotable = is_boolean_true(get_attr_value(get_child_nvset_node(node), "promotable"))
+    is_ms = node.tag in ("master", "ms")
+    return is_ms or is_promotable
 
 
 def is_clone(node):

--- a/test/crm-interface
+++ b/test/crm-interface
@@ -32,7 +32,7 @@ primitive p2 ocf:heartbeat:Delay \
 primitive p3 ocf:pacemaker:Dummy
 primitive st stonith:null params hostlist=node1
 clone c1 p1
-ms m1 p2
+clone m1 p2 meta promotable=true
 op_defaults timeout=60s
 commit
 up

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -22,15 +22,19 @@
 .INP: clone c d3 	meta clone-max=1
 .INP: primitive d4 ocf:pacemaker:Dummy
 .INP: ms m d4
+WARNING: 19: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
 .INP: delete m
 .INP: master m d4
 WARNING: 21: This command 'master' is deprecated, please use 'ms'
 INFO: 21: "master" is accepted as "ms"
+WARNING: 21: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
 .INP: ms m5 s5
+WARNING: 24: "ms" is deprecated. Please use "clone m5 s5 meta promotable=true"
 .INP: ms m6 s6
+WARNING: 25: "ms" is deprecated. Please use "clone m6 s6 meta promotable=true"
 .INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive d8 ocf:pacemaker:Dummy

--- a/test/testcases/file.exp
+++ b/test/testcases/file.exp
@@ -8,8 +8,9 @@ primitive p2 Delay \
 primitive p3 ocf:pacemaker:Dummy
 primitive st stonith:null \
 	params hostlist=node1
-ms m1 p2
 clone c1 p1
+clone m1 p2 \
+       meta promotable=true
 rsc_defaults build-resource-defaults: \
        resource-stickiness=1
 op_defaults op-options: \
@@ -44,8 +45,9 @@ primitive p3 ocf:pacemaker:Dummy
 primitive st stonith:null \
 	params hostlist=node1
 # comment
-ms m1 p2
 clone c1 p1
+clone m1 p2 \
+       meta promotable=true
 property cib-bootstrap-options: \
 	cluster-recheck-interval=10m
 rsc_defaults build-resource-defaults: \

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -96,8 +96,9 @@ resource p0 is NOT running
     <crm_config/>
     <nodes/>
     <resources>
-      <master id="m1">
+      <clone id="m1">
         <meta_attributes id="m1-meta_attributes">
+          <nvpair name="promotable" value="true" id="m1-meta_attributes-promotable"/>
           <nvpair id="m1-meta_attributes-maintenance" name="maintenance" value="true"/>
         </meta_attributes>
         <primitive id="p2" class="ocf" provider="heartbeat" type="Delay">
@@ -107,7 +108,7 @@ resource p0 is NOT running
             <nvpair name="stopdelay" value="2" id="p2-instance_attributes-stopdelay"/>
           </instance_attributes>
         </primitive>
-      </master>
+      </clone>
     </resources>
     <constraints/>
   </configuration>
@@ -123,8 +124,9 @@ resource p0 is NOT running
     <crm_config/>
     <nodes/>
     <resources>
-      <master id="m1">
+      <clone id="m1">
         <meta_attributes id="m1-meta_attributes">
+          <nvpair name="promotable" value="true" id="m1-meta_attributes-promotable"/>
           <nvpair id="m1-meta_attributes-maintenance" name="maintenance" value="false"/>
         </meta_attributes>
         <primitive id="p2" class="ocf" provider="heartbeat" type="Delay">
@@ -134,7 +136,7 @@ resource p0 is NOT running
             <nvpair name="stopdelay" value="2" id="p2-instance_attributes-stopdelay"/>
           </instance_attributes>
         </primitive>
-      </master>
+      </clone>
     </resources>
     <constraints/>
   </configuration>
@@ -927,6 +929,7 @@ INFO: Stop tracing p0 for operation stop
 WARNING: This command 'rm' is deprecated, please use 'delete'
 INFO: "rm" is accepted as "delete"
 .TRY configure ms msg g
+WARNING: "ms" is deprecated. Please use "clone msg g meta promotable=true"
 .TRY resource scores
 .EXT crm_simulate -sUL
 2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure


### PR DESCRIPTION
- For promotable clone resource, crmsh should find attribute promotable=true in xml
- Consider the compatibility, also keep the old way
- Give a deprecated warning when using "ms" subcommand
