### PR TITLE
bootstrap: Change default transport type as udpu

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -97,6 +97,7 @@ class Context(object):
         self.no_overwrite_sshkey = None
         self.nic_list = None
         self.unicast = None
+        self.multicast = None
         self.admin_ip = None
         self.second_heartbeat = None
         self.ipv6 = None
@@ -1171,7 +1172,7 @@ def init_corosync():
         if not confirm("%s already exists - overwrite?" % (corosync.conf())):
             return
 
-    if _context.unicast or _context.cloud_type:
+    if _context.unicast or _context.cloud_type or not _context.multicast:
         init_corosync_unicast()
     else:
         init_corosync_multicast()

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -312,8 +312,9 @@ Note:
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
                                    help="Bind to IP address on interface IF. Use -i second time for second interface")
         network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
-                                   help="Configure corosync to communicate over unicast (UDP), and not multicast. " +
-                                   "Default is multicast unless an environment where multicast cannot be used is detected.")
+                                   help="Configure corosync to communicate over unicast(udpu). This is the default transport type")
+        network_group.add_argument("-U", "--multicast", action="store_true", dest="multicast",
+                                   help="Configure corosync to communicate over multicast. Default is unicast")
         network_group.add_argument("-A", "--admin-ip", dest="admin_ip", metavar="IP",
                                    help="Configure IP address as an administration virtual IP")
         network_group.add_argument("-M", "--multi-heartbeats", action="store_true", dest="second_heartbeat",

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -8,6 +8,7 @@ Feature: crmsh bootstrap process - options
       "-n":      Set the name of the configured cluster
       "-A":      Configure IP address as an administration virtual IP
       "-u":      Configure corosync to communicate over unicast
+      "-U":      Configure corosync to communicate over multicast
   Tag @clean means need to stop cluster service if the service is available
 
   @clean
@@ -58,6 +59,7 @@ Feature: crmsh bootstrap process - options
     And     IP "172.17.0.2" is used by corosync on "hanode1"
     And     IP "10.10.10.2" is used by corosync on "hanode1"
     And     Show corosync ring status
+    And     Corosync working on "unicast" mode
 
   @clean
   Scenario: Using multiple network interface using "-i" option
@@ -103,7 +105,7 @@ Feature: crmsh bootstrap process - options
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     IP "2001:db8:10::3" is used by corosync on "hanode2"
-    And     Corosync working on "multicast" mode
+    And     Corosync working on "unicast" mode
 
   @clean
   Scenario: Init cluster service with ipv6 unicast using "-I" and "-u" option
@@ -117,3 +119,14 @@ Feature: crmsh bootstrap process - options
     And     IP "2001:db8:10::3" is used by corosync on "hanode2"
     And     Show cluster status on "hanode1"
     And     Corosync working on "unicast" mode
+
+  @clean
+  Scenario: Init cluster service with multicast using "-U" option (bsc#1132375)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -U -i eth1 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Show cluster status on "hanode1"
+    And     Corosync working on "multicast" mode

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -41,7 +41,7 @@ Feature: Verify usercase master survive when split-brain
     # Setup a two-nodes cluster
     When    Run "crm cluster init -y -i eth0" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    When    Run "crm cluster join -c hanode1 -y -i eth0" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
 
     # Generate script to check whether this node is master

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -87,10 +87,10 @@ Network configuration:
   -i IF, --interface IF
                         Bind to IP address on interface IF. Use -i second time
                         for second interface
-  -u, --unicast         Configure corosync to communicate over unicast (UDP),
-                        and not multicast. Default is multicast unless an
-                        environment where multicast cannot be used is
-                        detected.
+  -u, --unicast         Configure corosync to communicate over unicast(udpu).
+                        This is the default transport type
+  -U, --multicast       Configure corosync to communicate over multicast.
+                        Default is unicast
   -A IP, --admin-ip IP  Configure IP address as an administration virtual IP
   -M, --multi-heartbeats
                         Configure corosync with second heartbeat line

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -288,7 +288,7 @@ def step_impl(context, cmd):
 @then('Corosync working on "{transport_type}" mode')
 def step_impl(context, transport_type):
     if transport_type == "multicast":
-        assert corosync.get_value("totem.transport") != "udpu"
+        assert corosync.get_value("totem.transport") is None
     if transport_type == "unicast":
         assert corosync.get_value("totem.transport") == "udpu"
 

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -88,6 +88,7 @@ pcmk_delay_base (time, [0s]): Enable a base delay for fencing actions and specif
     This prevents double fencing when different delays are configured on the nodes.
     Use this to enable a static delay for fencing actions.
     The overall delay is derived from a random delay value adding this static delay so that the sum is kept below the maximum delay.
+    Set to eg. node1:1s;node2:5 to set different value per node.
 
 pcmk_action_limit (integer, [1]): The maximum number of actions can be performed in parallel on this device
     Cluster property concurrent-fencing=true needs to be configured first.


### PR DESCRIPTION
- Add `-U, --multicast` option for `crm cluster init` sub-command, to configure multicast
- `crm cluster init` will configure udpu cluster by default 
- Add functional test for the new added -U option
