### PR TITLE
[crmsh-4.3] Fix: sbd: not overwrite SYSCONFIG_SBD and sbd-disk-metadata if input 'n'(bsc#1194870)

### DIFF
--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -449,7 +449,7 @@ class TestSBDManager(unittest.TestCase):
 
         mock_package.assert_called_once_with("sbd")
         mock_get_device.assert_called_once_with()
-        mock_status.assert_called_once_with("Initializing diskless SBD...")
+        mock_status.assert_called_once_with("Configuring diskless SBD")
         mock_initialize.assert_called_once_with()
         mock_update.assert_called_once_with()
         mock_watchdog.assert_called_once_with(_input=None)


### PR DESCRIPTION
On interactive mode, when detect sbd already configured and input 'n', the sbd configure file shouldn't be overwritten