### PR TITLE
Parametrize the log dir

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -230,6 +230,7 @@ alert_meta_attributes = (
     "timeout", "timestamp-format"
 )
 trace_ra_attr = "trace_ra"
+trace_dir_attr = "trace_dir"
 score_types = {'advisory': '0', 'mandatory': 'INFINITY'}
 boolean_ops = ('or', 'and')
 binary_ops = ('lt', 'gt', 'lte', 'gte', 'eq', 'ne')

--- a/doc/website-v1/man-3.adoc
+++ b/doc/website-v1/man-3.adoc
@@ -2214,10 +2214,10 @@ stop <rsc> [<rsc> ...]
 [[cmdhelp_resource_trace,start RA tracing]]
 ==== `trace`
 
-Start tracing RA for the given operation. The trace files are
-stored in `$HA_VARLIB/trace_ra`. If the operation to be traced is
-monitor, note that the number of trace files can grow very
-quickly.
+Start tracing RA for the given operation. When `[<log-dir>]`
+is not specified the trace files are stored in `$HA_VARLIB/trace_ra`.
+If the operation to be traced is monitor, note that the number
+of trace files can grow very quickly.
 
 If no operation name is given, crmsh will attempt to trace all
 operations for the RA. This includes any configured operations, start
@@ -2229,14 +2229,14 @@ operation name.
 
 Usage:
 ...............
-trace <rsc> [<op> [<interval>] ]
+trace <rsc> [<op> [<interval>] [<log-dir>]]
 ...............
 Example:
 ...............
 trace fs start
 trace webserver
 trace webserver probe
-trace fs monitor 0
+trace fs monitor 0 /var/log/foo/bar
 ...............
 
 [[cmdhelp_resource_unmanage,put a resource into unmanaged mode]]


### PR DESCRIPTION
By default all logs are stored in /var/lib/heartbeat/trace_ra
This patch adds a new resource attribute trace_dir to the cib.file
The trace_dir should come alongside the trace_ra,
whereas trace_ra signals that the resource is traced,
the trace_dir defines the path.
IMPORTANT: This patch changes the syntax of the $ crm resource trace
command. Now, the action should be prepanded with the -a key
and the interval with the -i key and the directory with the -d command.
Those keys are required because they are optional and can be umbiguous.