### PR TITLE
Dev: Parametrize the log dir

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -230,6 +230,7 @@ alert_meta_attributes = (
     "timeout", "timestamp-format"
 )
 trace_ra_attr = "trace_ra"
+trace_dir_attr = "trace_dir"
 score_types = {'advisory': '0', 'mandatory': 'INFINITY'}
 boolean_ops = ('or', 'and')
 binary_ops = ('lt', 'gt', 'lte', 'gte', 'eq', 'ne')

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1963,10 +1963,10 @@ stop <rsc> [<rsc> ...]
 [[cmdhelp_resource_trace,start RA tracing]]
 ==== `trace`
 
-Start tracing RA for the given operation. The trace files are
-stored in `$HA_VARLIB/trace_ra`. If the operation to be traced is
-monitor, note that the number of trace files can grow very
-quickly.
+Start tracing RA for the given operation. When `[<log-dir>]`
+is not specified the trace files are stored in `$HA_VARLIB/trace_ra`.
+If the operation to be traced is monitor, note that the number
+of trace files can grow very quickly.
 
 If no operation name is given, crmsh will attempt to trace all
 operations for the RA. This includes any configured operations, start
@@ -1982,14 +1982,14 @@ unless an error occurred.
 
 Usage:
 ...............
-trace <rsc> [<op> [<interval>] ]
+trace <rsc> [<op> [<interval>] [<log-dir>]]
 ...............
 Example:
 ...............
 trace fs start
 trace webserver
 trace webserver probe
-trace fs monitor 0
+trace fs monitor 0 /var/log/foo/bar
 ...............
 
 [[cmdhelp_resource_unmanage,put a resource into unmanaged mode]]

--- a/test/unittests/test_ratrace.py
+++ b/test/unittests/test_ratrace.py
@@ -29,7 +29,7 @@ class TestRATrace(unittest.TestCase):
         obj = self.factory.create_from_node(etree.fromstring(xml))
 
         # Trace the resource.
-        RscMgmt()._trace_resource(self.context, obj.obj_id, obj)
+        RscMgmt()._trace_resource(self.context, obj.obj_id, obj, '/var/lib/heartbeat/trace_ra')
         self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-start-0', 'r1-stop-0'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-start-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-stop-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
@@ -50,7 +50,7 @@ class TestRATrace(unittest.TestCase):
         obj = self.factory.create_from_node(etree.fromstring(xml))
 
         # Trace the operation.
-        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor', '/var/lib/heartbeat/trace_ra')
         self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
 
@@ -73,14 +73,14 @@ class TestRATrace(unittest.TestCase):
 
         # Trace a regular operation that is not yet defined in CIB. The request
         # should succeed and introduce an op node for the operation.
-        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'start')
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'start', '/var/lib/heartbeat/trace_ra')
         self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-start-0'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-start-0"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
 
         # Try tracing the monitor operation in the same way. The request should
         # get rejected because no explicit interval is specified.
         with self.assertRaises(ValueError) as err:
-            RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+            RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor', '/var/lib/heartbeat/trace_ra')
         self.assertEqual(str(err.exception), "No monitor operation configured for r1")
 
     @mock.patch('logging.Logger.error')
@@ -95,7 +95,7 @@ class TestRATrace(unittest.TestCase):
         obj = self.factory.create_from_node(etree.fromstring(xml))
 
         # Trace the operation.
-        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor')
+        RscMgmt()._trace_op(self.context, obj.obj_id, obj, 'monitor', '/var/lib/heartbeat/trace_ra')
         self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10', 'r1-monitor-11'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-11"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
@@ -116,7 +116,7 @@ class TestRATrace(unittest.TestCase):
         obj = self.factory.create_from_node(etree.fromstring(xml))
 
         # Trace the operation.
-        RscMgmt()._trace_op_interval(self.context, obj.obj_id, obj, 'monitor', '10')
+        RscMgmt()._trace_op_interval(self.context, obj.obj_id, obj, 'monitor', '10', '/var/lib/heartbeat/trace_ra')
         self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10'])
         self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
 


### PR DESCRIPTION
By default all logs are stored in `/var/lib/heartbeat/trace_ra`
This patch adds a new resource attribute trace_dir to the `cib.file`
The `trace_dir` should come alongside the `trace_ra`,
whereas `trace_ra` signals that the resource is traced,
the `trace_dir` defines the path.