### PR TITLE
[crmsh-4.1] Fix: parse: Should still be able to show the empty property if already exists

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -833,7 +833,7 @@ def parse_cli_to_xml(cli, oldnode=None):
         for s in lines2cli(cli):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
-        node = parse.parse(cli, comments=comments)
+        node = parse.parse(cli, comments=comments, ignore_empty=False)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -164,11 +164,12 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd):
+    def do_parse(self, cmd, ignore_empty):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
+        self.ignore_empty = ignore_empty
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -1098,7 +1099,11 @@ def property_parser(self, cmd):
         attrs.set(idkey, idval)
     for rule in self.match_rules():
         attrs.append(rule)
-    for nvp in self.match_nvpairs(terminator=[], minpairs=0, allow_empty=False):
+    if self.ignore_empty:
+        res_list = self.match_nvpairs(minpairs=0)
+    else:
+        res_list = self.match_nvpairs(terminator=[], minpairs=0, allow_empty=False)
+    for nvp in res_list:
         attrs.append(nvp)
     return root
 
@@ -1687,7 +1692,7 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None):
+def parse(s, comments=None, ignore_empty=True):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1733,7 +1738,7 @@ def parse(s, comments=None):
         return False
 
     try:
-        ret = parser.do_parse(s)
+        ret = parser.do_parse(s, ignore_empty)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)


### PR DESCRIPTION
backport #845 