### PR TITLE
Fix: utils: Only raise exception when return code of systemctl command over ssh larger than 4

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2540,10 +2540,13 @@ class ServiceManager(object):
         elif self.remote_addr and self.remote_addr != this_node():
             prompt_msg = "Run \"{}\" on {}".format(cmd, self.remote_addr)
             rc, output, err = run_cmd_on_remote(cmd, self.remote_addr, prompt_msg)
+            # see "EXIT STATUS" in man systemctl
+            if rc > 4:
+                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         else:
             rc, output, err = get_stdout_stderr(cmd)
-        if rc != 0 and err:
-            raise ValueError("Run \"{}\" error: {}".format(cmd, err))
+            if rc != 0 and err:
+                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         return rc == 0, output
 
     @property

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -84,11 +84,9 @@ pcmk_delay_max (time, [0s]): Enable a delay of no more than the time specified b
     Use this to enable a random delay for fencing actions.
     The overall delay is derived from this random delay value adding a static delay so that the sum is kept below the maximum delay.
 
-pcmk_delay_base (time, [0s]): Enable a base delay for fencing actions and specify base delay value.
-    This prevents double fencing when different delays are configured on the nodes.
-    Use this to enable a static delay for fencing actions.
-    The overall delay is derived from a random delay value adding this static delay so that the sum is kept below the maximum delay.
-    Set to eg. node1:1s;node2:5 to set different value per node.
+pcmk_delay_base (string, [0s]): Enable a base delay for fencing actions and specify base delay value.
+    This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value.
+    This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value per target.
 
 pcmk_action_limit (integer, [1]): The maximum number of actions can be performed in parallel on this device
     Cluster property concurrent-fencing=true needs to be configured first.


### PR DESCRIPTION
When using systemctl to check service status over ssh, such return codes  are normal:
```
0 | program is running or service is OK
1 | program is dead and /var/run pid file exists
2 | program is dead and /var/lock lock file exists
3 | program is not running
4 | program or service status is unknown
```
So non zero return code with some no harm stderr output from ssh(such as with ssh banner configured), will trigger the condition to raise exception

