### PR TITLE
[crmsh-4.3] Fix: utils: Only raise exception when return code of systemctl command overssh larger than 4

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2543,10 +2543,13 @@ class ServiceManager(object):
         if self.remote_addr:
             prompt_msg = "Run \"{}\" on {}".format(cmd, self.remote_addr)
             rc, output, err = run_cmd_on_remote(cmd, self.remote_addr, prompt_msg)
+            # see "EXIT STATUS" in man systemctl
+            if rc > 4:
+                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         else:
             rc, output, err = get_stdout_stderr(cmd)
-        if rc != 0 and err:
-            raise ValueError("Run \"{}\" error: {}".format(cmd, err))
+            if rc != 0 and err:
+                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         return rc == 0, output
 
     @property


### PR DESCRIPTION
backport #949 