### PR TITLE
Improve for "one qnetd for multi cluster" scenario

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2160,9 +2160,11 @@ def remove_qdevice():
 
     with logger_utils.status_long("Removing QDevice configuration from cluster"):
         qnetd_host = corosync.get_value('quorum.device.net.host')
-        qdevice_inst = qdevice.QDevice(qnetd_host)
+        cluster_name = corosync.get_value('totem.cluster_name')
+        qdevice_inst = qdevice.QDevice(qnetd_host, cluster_name=cluster_name)
         qdevice_inst.remove_qdevice_config()
         qdevice_inst.remove_qdevice_db()
+        qdevice_inst.remove_certification_files_on_qnetd()
         update_expected_votes()
     if _context.qdevice_reload_policy == QdevicePolicy.QDEVICE_RELOAD:
         invoke("crm cluster run 'crm corosync reload'")

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1295,7 +1295,7 @@ def init_qdevice():
     if utils.is_qdevice_configured() and not confirm("Qdevice is already configured - overwrite?"):
         qdevice_inst.start_qdevice_service()
         return
-
+    qdevice_inst.set_cluster_name()
     # Validate qnetd node
     qdevice_inst.valid_qnetd()
 

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -31,16 +31,15 @@ class Lock(object):
     A base class define a lock mechanism used to exclude other nodes
     """
 
-    LOCK_DIR = "/run/.crmsh_lock_directory"
-    MKDIR_CMD = "mkdir {}".format(LOCK_DIR)
-    RM_CMD = "rm -rf {}".format(LOCK_DIR)
+    LOCK_DIR_DEFAULT = "/run/.crmsh_lock_directory"
 
-    def __init__(self):
+    def __init__(self, lock_dir=None):
         """
         Init function
         """
         # only the lock owner can unlock
         self.lock_owner = False
+        self.lock_dir = lock_dir or self.LOCK_DIR_DEFAULT
 
     def _run(self, cmd):
         """
@@ -52,7 +51,8 @@ class Lock(object):
         """
         Create lock directory, mkdir command was atomic
         """
-        rc, _, _ = self._run(self.MKDIR_CMD)
+        cmd = "mkdir {}".format(self.lock_dir)
+        rc, _, _ = self._run(cmd)
         if rc == 0:
             self.lock_owner = True
             return True
@@ -63,14 +63,15 @@ class Lock(object):
         Raise ClaimLockError if claiming lock failed
         """
         if not self._create_lock_dir():
-            raise ClaimLockError("Failed to claim lock (the lock directory exists at {})".format(self.LOCK_DIR))
+            raise ClaimLockError("Failed to claim lock (the lock directory exists at {})".format(self.lock_dir))
 
     def _unlock(self):
         """
         Remove the lock directory
         """
         if self.lock_owner:
-            self._run(self.RM_CMD)
+            cmd = "rm -rf {}".format(self.lock_dir)
+            self._run(cmd)
 
     @contextmanager
     def lock(self):
@@ -99,12 +100,14 @@ class RemoteLock(Lock):
     MIN_LOCK_TIMEOUT = 120
     WAIT_INTERVAL = 10
 
-    def __init__(self, remote_node):
+    def __init__(self, remote_node, for_join=True, lock_dir=None, wait=True):
         """
         Init function
         """
         self.remote_node = remote_node
-        super(__class__, self).__init__()
+        self.for_join = for_join
+        self.wait = wait
+        super(__class__, self).__init__(lock_dir=lock_dir)
 
     def _run(self, cmd):
         """
@@ -146,7 +149,7 @@ class RemoteLock(Lock):
         warned_once = False
         online_list = []
         pre_online_list = []
-        expired_error_str = "Cannot continue since the lock directory exists at the node ({}:{})".format(self.remote_node, self.LOCK_DIR)
+        expired_error_str = "Cannot continue since the lock directory exists at the node ({}:{})".format(self.remote_node, self.lock_dir)
 
         current_time = int(time.time())
         timeout = current_time + self.lock_timeout
@@ -157,11 +160,12 @@ class RemoteLock(Lock):
                 # Success
                 break
 
-            # Might lose claiming lock again, start to wait again
-            online_list = self._get_online_nodelist()
-            if pre_online_list and pre_online_list != online_list:
-                timeout = current_time + self.lock_timeout
-            pre_online_list = online_list
+            if self.for_join:
+                # Might lose claiming lock again, start to wait again
+                online_list = self._get_online_nodelist()
+                if pre_online_list and pre_online_list != online_list:
+                    timeout = current_time + self.lock_timeout
+                pre_online_list = online_list
 
             if not warned_once:
                 warned_once = True
@@ -180,7 +184,10 @@ class RemoteLock(Lock):
         Might raise SSHError, ClaimLockError and ValueError
         """
         try:
-            self._lock_or_wait()
+            if self.wait:
+                self._lock_or_wait()
+            else:
+                self._lock_or_fail()
             yield
         except:
             raise

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -100,13 +100,14 @@ class RemoteLock(Lock):
     MIN_LOCK_TIMEOUT = 120
     WAIT_INTERVAL = 10
 
-    def __init__(self, remote_node, for_join=True, lock_dir=None, wait=True):
+    def __init__(self, remote_node, for_join=True, lock_dir=None, wait=True, no_warn=False):
         """
         Init function
         """
         self.remote_node = remote_node
         self.for_join = for_join
         self.wait = wait
+        self.no_warn = no_warn
         super(__class__, self).__init__(lock_dir=lock_dir)
 
     def _run(self, cmd):
@@ -167,7 +168,7 @@ class RemoteLock(Lock):
                     timeout = current_time + self.lock_timeout
                 pre_online_list = online_list
 
-            if not warned_once:
+            if not self.no_warn and not warned_once:
                 warned_once = True
                 logger.warning("Might have unfinished process on other nodes, wait %ss...", self.lock_timeout)
 

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -663,3 +663,14 @@ class QDevice(object):
         self.adjust_sbd_watchdog_timeout_with_qdevice()
         self.config_qdevice()
         self.start_qdevice_service()
+
+    @staticmethod
+    def check_qdevice_vote():
+        """
+        Check if qdevice can contribute vote
+        """
+        out = utils.get_stdout_or_raise_error("corosync-quorumtool -s", success_val_list=[0, 2])
+        res = re.search(r'\s+0\s+0\s+Qdevice', out)
+        if res:
+            qnetd_host = corosync.get_value('quorum.device.net.host')
+            logger.warning("Qdevice's vote is 0, which simply means Qdevice can't talk to Qnetd({}) for various reasons.".format(qnetd_host))

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -11,6 +11,7 @@ from . import scripts
 from . import completers as compl
 from . import bootstrap
 from . import corosync
+from . import qdevice
 from .cibconfig import cib_factory
 from . import constants
 
@@ -166,6 +167,8 @@ class Cluster(command.UI):
         if start_qdevice:
             utils.start_service("corosync-qdevice", node_list=node_list)
         bootstrap.start_pacemaker(node_list)
+        if start_qdevice:
+            qdevice.QDevice.check_qdevice_vote()
         for node in node_list:
             logger.info("Cluster services started on {}".format(node))
 

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -120,3 +120,14 @@ Feature: corosync qdevice/qnetd setup/remove process
     And     Service "corosync-qdevice" is "started" on "hanode2"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     And     Show status from qnetd
+
+  @clean
+  Scenario: One qnetd for multi cluster, add in parallel
+    When    Run "crm cluster init -n cluster1 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster init -n cluster2 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    When    Run "crm cluster init qdevice --qnetd-hostname qnetd-node -y" on "hanode1,hanode2"
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -59,28 +59,28 @@ class TestLock(unittest.TestCase):
         mock_run.return_value = (1, None, None)
         rc = self.local_inst._create_lock_dir()
         self.assertEqual(rc, False)
-        mock_run.assert_called_once_with(lock.Lock.MKDIR_CMD)
+        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._run')
     def test_create_lock_dir(self, mock_run):
         mock_run.return_value = (0, None, None)
         rc = self.local_inst._create_lock_dir()
         self.assertEqual(rc, True)
-        mock_run.assert_called_once_with(lock.Lock.MKDIR_CMD)
+        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._create_lock_dir')
     def test_lock_or_fail(self, mock_create):
         mock_create.return_value = False
         with self.assertRaises(lock.ClaimLockError) as err:
             self.local_inst._lock_or_fail()
-        self.assertEqual("Failed to claim lock (the lock directory exists at {})".format(lock.Lock.LOCK_DIR), str(err.exception))
+        self.assertEqual("Failed to claim lock (the lock directory exists at {})".format(lock.Lock.LOCK_DIR_DEFAULT), str(err.exception))
         mock_create.assert_called_once_with()
 
     @mock.patch('crmsh.lock.Lock._run')
     def test_unlock(self, mock_run):
         self.local_inst.lock_owner = True
         self.local_inst._unlock()
-        mock_run.assert_called_once_with(lock.Lock.RM_CMD)
+        mock_run.assert_called_once_with("rm -rf {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._unlock')
     @mock.patch('crmsh.lock.Lock._lock_or_fail')
@@ -119,6 +119,7 @@ class TestRemoteLock(unittest.TestCase):
         Test setUp.
         """
         self.lock_inst = lock.RemoteLock("node1")
+        self.lock_inst_no_wait = lock.RemoteLock("node1", wait=False)
 
     def tearDown(self):
         """
@@ -210,7 +211,7 @@ class TestRemoteLock(unittest.TestCase):
 
         with self.assertRaises(lock.ClaimLockError) as err:
             self.lock_inst._lock_or_wait()
-        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:{})".format(lock.Lock.LOCK_DIR), str(err.exception))
+        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:{})".format(lock.Lock.LOCK_DIR_DEFAULT), str(err.exception))
 
         mock_time.assert_has_calls([ mock.call(), mock.call()])
         mock_time_out.assert_has_calls([mock.call(), mock.call(), mock.call()])
@@ -257,6 +258,14 @@ class TestRemoteLock(unittest.TestCase):
     @mock.patch('crmsh.lock.RemoteLock._lock_or_wait')
     def test_lock(self, mock_lock, mock_unlock):
         with self.lock_inst.lock():
+            pass
+        mock_lock.assert_called_once_with()
+        mock_unlock.assert_called_once_with()
+
+    @mock.patch('crmsh.lock.Lock._unlock')
+    @mock.patch('crmsh.lock.RemoteLock._lock_or_fail')
+    def test_lock_no_wait(self, mock_lock, mock_unlock):
+        with self.lock_inst_no_wait.lock():
             pass
         mock_lock.assert_called_once_with()
         mock_unlock.assert_called_once_with()

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -56,13 +56,14 @@ class TestCluster(unittest.TestCase):
             mock.call("Cluster services already started on node2")
             ])
 
+    @mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
     @mock.patch('crmsh.bootstrap.start_pacemaker')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     @mock.patch('crmsh.utils.start_service')
     @mock.patch('crmsh.utils.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
-    def test_do_start(self, mock_parse_nodes, mock_active, mock_start, mock_qdevice_configured, mock_info, mock_start_pacemaker):
+    def test_do_start(self, mock_parse_nodes, mock_active, mock_start, mock_qdevice_configured, mock_info, mock_start_pacemaker, mock_check_qdevice):
         context_inst = mock.Mock()
         mock_parse_nodes.return_value = ["node1"]
         mock_active.side_effect = [False, False]


### PR DESCRIPTION
## Problems
* Race condition might happen when multi cluster setup qdevice at the same time, include:
  - init database on qnetd
  ```
  Certificate database (/etc/corosync/qnetd/nssdb) already exists. Delete it to initialize new db
  ```
  - qnetd sign the crq file while other cluster copy the new same name crq
* Not allow multi cluster with the same cluster name
* The crq and crt files on qnetd should be removed while removing qdevice

## Solutions
**Not allow multi cluster with the same cluster name:**
- During configuring qdevice process on this cluster, after setup passwordless between qnetd, special lock directory with cluster name should be created (like "/run/.crmsh_qdevice_lock_for_<cluster_name>")
- Raise error when finding cluster name directory exists on qnetd (like "/run/.crmsh_qdevice_lock_for_<cluster_name>")
```
ERROR: cluster.init: Duplicated cluster name "cluster1"!
```

- Raise error when the same cluster-name exists on qnetd, at the beginning fo configuring qdevice (using "corosync-qnetd-tool -l -c <cluster name>" to check)
```
ERROR: cluster.init: This cluster's name "cluster1" already exists on qnetd server!
```
- During configuring qdevice process on this cluster, after setup passwordless between qnetd, special lock directory with cluster name should be created (like "/run/.crmsh_qdevice_lock_for_<cluster_name>")



**Allow multi cluster with different cluster name:**

- On step "Initialize database on QNetd server", add lock to protect init database failed when in parallel, other clusters who failed to claim the lock should wait
- On step "sing crq on qnetd", to avoid possible race condition, the crq file should add suffix with cluster name
- Remember to clean up cluster name specific crq and crt file on qnetd node when remove qdevice from cluster

## Changes
* Dev: qdevice: Add cluster name suffix to qdevice-net-node.crq on qnet
  And remove crt and crq files on qnetd when remove qdevice
* Dev: lock: Make lock.py more generic
* Dev: qdevice: Consolidate qdevice related separate functions into qdevice.QDevice class
* Dev: qdevice: Add lock to protect init_db_on_qnetd function
* Dev: qdevice: Add lock to protect for the same cluster name
* Dev: qdevice: remove askpass since it's unnecessary after passwordless configured on qnetd
* Dev: qdevice: Improve remove qdevice process
