### PR TITLE
Fix: bootstrap: -N option setup the current node and peers all together 

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -87,7 +87,7 @@ class Context(object):
         self.watchdog = None
         self.no_overwrite_sshkey = None
         self.nic_list = []
-        self.nodes = []
+        self.node_list = []
         self.unicast = None
         self.multicast = None
         self.admin_ip = None
@@ -172,15 +172,15 @@ class Context(object):
         """
         Validate -N/--nodes option
         """
-        self.nodes = utils.parse_append_action_argument(self.nodes)
+        self.node_list = utils.parse_append_action_argument(self.node_list)
         me = utils.this_node()
-        if me in self.nodes:
-            self.nodes.remove(me)
-        if self.nodes and self.stage:
+        if me in self.node_list:
+            self.node_list.remove(me)
+        if self.node_list and self.stage:
             utils.fatal("Can't use -N/--nodes option and stage({}) together".format(self.stage))
-        if utils.has_dup_value(self.nodes):
+        if utils.has_dup_value(self.node_list):
             utils.fatal("Duplicated input for -N/--nodes option")
-        for node in self.nodes:
+        for node in self.node_list:
             utils.ping_node(node)
 
     def validate_option(self):
@@ -763,11 +763,11 @@ def init_ssh():
         configure_ssh_key(user)
 
     # If not use -N/--nodes option
-    if not _context.nodes:
+    if not _context.node_list:
         return
 
     print()
-    node_list = _context.nodes
+    node_list = _context.node_list
     # Swap public ssh key between remote node and local
     for node in node_list:
         swap_public_ssh_key(node, add=True)
@@ -2023,7 +2023,7 @@ def bootstrap_add(context):
     """
     Adds the given node to the cluster.
     """
-    if not context.nodes:
+    if not context.node_list:
         return
 
     global _context
@@ -2034,7 +2034,7 @@ def bootstrap_add(context):
         options += '-i {} '.format(nic)
     options = " {}".format(options.strip()) if options else ""
 
-    for node in _context.nodes:
+    for node in _context.node_list:
         print()
         logger.info("Adding node {} to cluster".format(node))
         cmd = "crm cluster join{} -c {}{}".format(" -y" if _context.yes_to_all else "", utils.this_node(), options)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -301,7 +301,7 @@ Note:
                             help='Answer "yes" to all prompts (use with caution, this is destructive, especially those storage related configurations and stages. The /root/.ssh/id_rsa key will be overwritten unless the option "--no-overwrite-sshkey" is used)')
         parser.add_argument("-n", "--name", metavar="NAME", dest="cluster_name", default="hacluster",
                             help='Set the name of the configured cluster.')
-        parser.add_argument("-N", "--nodes", metavar="NODES", dest="nodes", action="append", default=[],
+        parser.add_argument("-N", "--node", metavar="NODENAME", dest="node_list", action="append", default=[],
                             help='The member node of the cluster. Note: the current node is always get initialized during bootstrap in the beginning.')
         parser.add_argument("-S", "--enable-sbd", dest="diskless_sbd", action="store_true",
                             help="Enable SBD even if no SBD device is configured (diskless mode)")

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -302,7 +302,7 @@ Note:
         parser.add_argument("-n", "--name", metavar="NAME", dest="cluster_name", default="hacluster",
                             help='Set the name of the configured cluster.')
         parser.add_argument("-N", "--nodes", metavar="NODES", dest="nodes", action="append", default=[],
-                            help='Additional nodes to add to the created cluster. May include the current node, which will always be the initial cluster node.')
+                            help='The member node of the cluster. Note: the current node is always get initialized during bootstrap in the beginning.')
         parser.add_argument("-S", "--enable-sbd", dest="diskless_sbd", action="store_true",
                             help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -301,9 +301,8 @@ Note:
                             help='Answer "yes" to all prompts (use with caution, this is destructive, especially those storage related configurations and stages. The /root/.ssh/id_rsa key will be overwritten unless the option "--no-overwrite-sshkey" is used)')
         parser.add_argument("-n", "--name", metavar="NAME", dest="cluster_name", default="hacluster",
                             help='Set the name of the configured cluster.')
-        parser.add_argument("-N", "--nodes", metavar="NODES", dest="nodes",
+        parser.add_argument("-N", "--nodes", metavar="NODES", dest="nodes", action="append", default=[],
                             help='Additional nodes to add to the created cluster. May include the current node, which will always be the initial cluster node.')
-        # parser.add_argument("--quick-start", dest="quickstart", action="store_true", help="Perform basic system configuration (NTP, watchdog, /etc/hosts)")
         parser.add_argument("-S", "--enable-sbd", dest="diskless_sbd", action="store_true",
                             help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",
@@ -312,7 +311,7 @@ Note:
                             help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
-        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
+        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(), default=[],
                                    help="Bind to IP address on interface IF. Use -i second time for second interface")
         network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
                                    help="Configure corosync to communicate over unicast(udpu). This is the default transport type")
@@ -342,7 +341,7 @@ Note:
                                    help="MODE of operation of heuristics (on/sync/off, default:sync)")
 
         storage_group = parser.add_argument_group("Storage configuration", "Options for configuring shared storage.")
-        storage_group.add_argument("-s", "--sbd-device", dest="sbd_devices", metavar="DEVICE", action="append",
+        storage_group.add_argument("-s", "--sbd-device", dest="sbd_devices", metavar="DEVICE", action="append", default=[],
                                    help="Block device to use for SBD fencing, use \";\" as separator or -s multiple times for multi path (up to 3 devices)")
         storage_group.add_argument("-o", "--ocfs2-device", dest="ocfs2_devices", metavar="DEVICE", action="append", default=[],
                 help="Block device to use for OCFS2; When using Cluster LVM2 to manage the shared storage, user can specify one or multiple raw disks, use \";\" as separator or -o multiple times for multi path (must specify -C option) NOTE: this is a Technical Preview")
@@ -379,20 +378,11 @@ Note:
         boot_context.args = args
         boot_context.cluster_is_running = utils.service_is_active("pacemaker.service")
         boot_context.type = "init"
+        boot_context.initialize_qdevice()
+        boot_context.validate_option()
 
         bootstrap.bootstrap_init(boot_context)
-
-        # if options.geo:
-        #    bootstrap.bootstrap_init_geo()
-
-        if options.nodes is not None:
-            nodelist = [n for n in re.split('[ ,;]+', options.nodes)]
-            for node in nodelist:
-                if node == utils.this_node():
-                    continue
-                logger.info("\n\nAdd node {} (may prompt for root password):".format(node))
-                if not self._add_node(node, yes_to_all=options.yes_to_all):
-                    return False
+        bootstrap.bootstrap_add(boot_context)
 
         return True
 
@@ -423,7 +413,7 @@ If stage is not specified, each stage will be invoked in sequence.
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
-        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
+        network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(), default=[],
                 help="Bind to IP address on interface IF. Use -i second time for second interface")
         options, args = parse_options(parser, args)
         if options is None or args is None:
@@ -444,15 +434,6 @@ If stage is not specified, each stage will be invoked in sequence.
 
         return True
 
-    def _add_node(self, node, yes_to_all=False):
-        '''
-        Adds the given node to the cluster.
-        '''
-        me = utils.this_node()
-        cmd = "crm cluster join{} -c {}".format(" -y" if yes_to_all else "", me)
-        rc = utils.ext_cmd_nosudo("ssh{} root@{} -o StrictHostKeyChecking=no '{}'".format("" if yes_to_all else " -t", node, cmd))
-        return rc == 0
-
     @command.completers_repeating(compl.call(scripts.param_completion_list, 'add'))
     @command.skill_level('administrator')
     def do_add(self, context, *args):
@@ -466,14 +447,18 @@ Add a new node to the cluster. The new node will be
 configured as a cluster member.""",
                 usage="add [options] [node ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
+        parser.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
+                help="Bind to IP address on interface IF. Use -i second time for second interface")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         options, args = parse_options(parser, args)
         if options is None or args is None:
             return
 
-        for node in args:
-            if not self._add_node(node, yes_to_all=options.yes_to_all):
-                return False
+        add_context = bootstrap.Context.set_context(options)
+        add_context.nodes = args
+        bootstrap.bootstrap_add(add_context)
+
+        return True
 
     @command.alias("delete")
     @command.completers_repeating(_remove_completer)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -434,32 +434,6 @@ If stage is not specified, each stage will be invoked in sequence.
 
         return True
 
-    @command.completers_repeating(compl.call(scripts.param_completion_list, 'add'))
-    @command.skill_level('administrator')
-    def do_add(self, context, *args):
-        '''
-        Add the given node(s) to the cluster.
-        Installs packages, sets up corosync and pacemaker, etc.
-        Must be executed from a node in the existing cluster.
-        '''
-        parser = ArgParser(description="""
-Add a new node to the cluster. The new node will be
-configured as a cluster member.""",
-                usage="add [options] [node ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
-        parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
-        parser.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(),
-                help="Bind to IP address on interface IF. Use -i second time for second interface")
-        parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
-        options, args = parse_options(parser, args)
-        if options is None or args is None:
-            return
-
-        add_context = bootstrap.Context.set_context(options)
-        add_context.nodes = args
-        bootstrap.bootstrap_add(add_context)
-
-        return True
-
     @command.alias("delete")
     @command.completers_repeating(_remove_completer)
     @command.skill_level('administrator')

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2491,19 +2491,19 @@ class InterfacesInfo(object):
         return False
 
 
-def check_file_content_included(source_file, target_file):
+def check_file_content_included(source_file, target_file, remote=None, source_local=False):
     """
     Check whether target_file includes contents of source_file
     """
-    if not os.path.exists(source_file):
+    if not detect_file(source_file, remote=None if source_local else remote):
         raise ValueError("File {} not exist".format(source_file))
-    if not os.path.exists(target_file):
+    if not detect_file(target_file, remote=remote):
         return False
 
-    with open(target_file, 'r') as target_fd:
-        target_data = target_fd.read()
-    with open(source_file, 'r') as source_fd:
-        source_data = source_fd.read()
+    cmd = "cat {}".format(target_file)
+    target_data = get_stdout_or_raise_error(cmd, remote=remote)
+    cmd = "cat {}".format(source_file)
+    source_data = get_stdout_or_raise_error(cmd, remote=None if source_local else remote)
     return source_data in target_data
 
 
@@ -3105,4 +3105,22 @@ def read_from_file(infile):
     with open(infile, 'rt', encoding='utf-8', errors='replace') as f:
         data = f.read()
     return to_ascii(data)
+
+
+def has_dup_value(_list):
+    return _list and len(_list) != len(set(_list))
+
+
+def detect_file(_file, remote=None):
+    """
+    Detect if file exists, support both local and remote
+    """
+    rc = False
+    if not remote:
+        rc = os.path.exists(_file)
+    else:
+        cmd = "ssh {} root@{} 'test -f {}'".format(SSH_OPTION, remote, _file)
+        code, _, _ = get_stdout_stderr(cmd)
+        rc = code == 0
+    return rc
 # vim:ts=4:sw=4:et:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -946,10 +946,6 @@ These commands enable easy installation and maintenance of a HA
 cluster, by providing support for package installation, configuration
 of the cluster messaging layer, file system setup and more.
 
-[[cmdhelp_cluster_add,Add a new node to the cluster,From Code]]
-==== `add`
-See "crm cluster help add" or "crm cluster add --help"
-
 [[cmdhelp_cluster_copy,Copy file to other cluster nodes]]
 ==== `copy`
 

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -2,7 +2,7 @@
 Feature: crmsh bootstrap process - options
 
   Test crmsh bootstrap options:
-      "--nodes": Additional nodes to add to the created cluster
+      "--node": Additional nodes to add to the created cluster
       "-i":      Bind to IP address on interface IF
       "-M":      Configure corosync with second heartbeat line
       "-n":      Set the name of the configured cluster
@@ -20,8 +20,6 @@ Feature: crmsh bootstrap process - options
     Then    Output is the same with expected "crm cluster init" help output
     When    Run "crm cluster join -h" on "hanode1"
     Then    Output is the same with expected "crm cluster join" help output
-    When    Run "crm cluster add -h" on "hanode1"
-    Then    Output is the same with expected "crm cluster add" help output
     When    Run "crm cluster remove -h" on "hanode1"
     Then    Output is the same with expected "crm cluster remove" help output
     When    Run "crm cluster geo_init -h" on "hanode1"
@@ -32,10 +30,10 @@ Feature: crmsh bootstrap process - options
     Then    Output is the same with expected "crm cluster geo-init-arbitrator" help output
 
   @clean
-  Scenario: Init whole cluster service on node "hanode1" using "--nodes" option
+  Scenario: Init whole cluster service on node "hanode1" using "--node" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --nodes \"hanode1 hanode2\"" on "hanode1"
+    When    Run "crm cluster init -y --node \"hanode1 hanode2\"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
@@ -131,3 +129,11 @@ Feature: crmsh bootstrap process - options
     Then    Cluster service is "started" on "hanode2"
     And     Show cluster status on "hanode1"
     And     Corosync working on "multicast" mode
+
+  @clean
+  Scenario: Init cluster with -N option (bsc#1175863)
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -N hanode1 -N hanode2 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster service is "started" on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -69,10 +69,10 @@ optional arguments:
                         will be overwritten unless the option "--no-overwrite-
                         sshkey" is used)
   -n NAME, --name NAME  Set the name of the configured cluster.
-  -N NODES, --nodes NODES
-                        Additional nodes to add to the created cluster. May
-                        include the current node, which will always be the
-                        initial cluster node.
+  -N NODENAME, --node NODENAME
+                        The member node of the cluster. Note: the current node
+                        is always get initialized during bootstrap in the
+                        beginning.
   -S, --enable-sbd      Enable SBD even if no SBD device is configured
                         (diskless mode)
   -w WATCHDOG, --watchdog WATCHDOG
@@ -192,16 +192,6 @@ Stage can be one of:
     cluster     Start the cluster on this node
 
 If stage is not specified, each stage will be invoked in sequence.'''
-
-
-CRM_CLUSTER_ADD_H_OUTPUT = '''usage: add [options] [node ...]
-
-Add a new node to the cluster. The new node will be
-configured as a cluster member.
-
-optional arguments:
-  -h, --help  Show this help message
-  -y, --yes   Answer "yes" to all prompts (use with caution)'''
 
 
 CRM_CLUSTER_REMOVE_H_OUTPUT = '''usage: remove [options] [<node> ...]

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -276,7 +276,6 @@ def step_impl(context, cmd):
     cmd_help["crm"] = const.CRM_H_OUTPUT
     cmd_help["crm_cluster_init"] = const.CRM_CLUSTER_INIT_H_OUTPUT
     cmd_help["crm_cluster_join"] = const.CRM_CLUSTER_JOIN_H_OUTPUT
-    cmd_help["crm_cluster_add"] = const.CRM_CLUSTER_ADD_H_OUTPUT
     cmd_help["crm_cluster_remove"] = const.CRM_CLUSTER_REMOVE_H_OUTPUT
     cmd_help["crm_cluster_geo-init"] = const.CRM_CLUSTER_GEO_INIT_H_OUTPUT
     cmd_help["crm_cluster_geo-join"] = const.CRM_CLUSTER_GEO_JOIN_H_OUTPUT


### PR DESCRIPTION
#### Enable -N option on init node
```
tbw-1:~ # crm cluster init -N tbw-1 -N tbw-2 -N tbw-3 -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: SSH key for root does not exist, hence generate it now
INFO: SSH key for hacluster does not exist, hence generate it now

INFO: Configuring SSH passwordless with root@tbw-2
root@tbw-2's password: 
INFO: SSH key for root does not exist, hence generate it now
INFO: Configuring SSH passwordless with root@tbw-3
root@tbw-3's password: 
INFO: SSH key for root does not exist, hence generate it now

INFO: Configuring csync2
INFO: Generating csync2 shared key (this may take a while)...done
INFO: csync2 checking files...done
INFO: Configuring corosync (unicast)
WARNING: Not configuring SBD - STONITH will be disabled.
WARNING: Hawk not installed - not configuring web management interface.
WARNING: You should change the hacluster password to something more secure!
INFO: Starting pacemaker...done
INFO: Waiting for cluster..............done
INFO: Loading initial cluster configuration
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

INFO: Adding node tbw-2 to cluster
INFO: Running command on tbw-2: crm cluster join -y -c tbw-1
INFO: SSH key for hacluster does not exist, hence generate it now
INFO: Configuring SSH passwordless with hacluster@tbw-1
INFO: Configuring csync2...done
INFO: Merging known_hosts
INFO: Probing for new partitions...done
WARNING: Hawk not installed - not configuring web management interface.
WARNING: You should change the hacluster password to something more secure!
INFO: Starting pacemaker...done
INFO: Waiting for cluster.....done
INFO: Reloading cluster configuration...done
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

INFO: Adding node tbw-3 to cluster
INFO: Running command on tbw-3: crm cluster join -y -c tbw-1
INFO: SSH key for hacluster does not exist, hence generate it now
INFO: Configuring SSH passwordless with hacluster@tbw-1
INFO: Configuring SSH passwordless with hacluster@tbw-2
INFO: Configuring csync2...
...
```
#### Remove crm cluster add sub-command

#### Validate -N option
```
# unreachable node
tbw-1:~ # crm cluster init -N tbw-1 -N tbw100 -y
ERROR: cluster.init: host "tbw100" is unreachable: ping: tbw100: Name or service not known
```
```
# duplicated input
tbw-1:~ # crm cluster init -N tbw-1 -N tbw-2 -N tbw-2 -y
ERROR: cluster.init: Duplicated input for -N/--nodes option
```
```
# one of node already started
tbw-1:~ # crm cluster init -N tbw-1 -N tbw-2 -N tbw-3 -y
INFO: Loading "default" profile from /etc/crm/profiles.yml

ERROR: cluster.init: Cluster is currently active on tbw-2 - can't run
```