### PR TITLE
Dev: cinconfig: enable "related:" prefix to show the objects by given ra type

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3135,6 +3135,31 @@ class CibFactory(object):
         return [x for x in self.cib_objects
                 if x.updated or x.origin == "user"]
 
+    def get_elems_on_ra_type(self, spec):
+        """
+        Get elements by given ra class:provider:type or class:type or only type
+        return [] if no results
+        """
+        content_list = spec.split(':')[1:]
+        if len(content_list) > 3:
+            return []
+        if len(content_list) == 3:
+            cls, provider, tp = content_list
+            return [x for x in self.cib_objects 
+                    if x.node.get("type") == tp
+                    and x.node.get("provider") == provider
+                    and x.node.get("class") == cls]
+        if len(content_list) == 2:
+            cls, tp = content_list
+            return [x for x in self.cib_objects 
+                    if x.node.get("type") == tp
+                    and x.node.get("class") == cls]
+        if len(content_list) == 1:
+            tp = content_list[0]
+            if not tp:
+                return []
+            return [x for x in self.cib_objects if x.node.get("type") == tp]
+
     def get_elems_on_type(self, spec):
         if not spec.startswith("type:"):
             return []
@@ -3198,6 +3223,7 @@ class CibFactory(object):
                 obj = self.find_object(name)
                 if obj is not None:
                     obj_set |= orderedset.oset(self.related_elements(obj))
+                obj_set |= orderedset.oset(self.get_elems_on_ra_type(spec))
             else:
                 objs = self.find_objects(spec) or []
                 for obj in objs:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3853,7 +3853,8 @@ To show all objects of a certain type, use the +type:+ prefix.
 
 To show all objects in a tag, use the +tag:+ prefix.
 
-To show all constraints related to a primitive, use the +related:+ prefix.
+To show all constraints related to a primitive, or 
+to show all objects of a certain RA type, use the +related:+ prefix.
 
 To show all modified objects, pass the argument +changed+.
 
@@ -3915,6 +3916,8 @@ show webapp
 show type:primitive
 show xml tag:db tag:fs
 show related:webapp
+show related:IPaddr2
+show related:ocf:heartbeat:Dummy
 show type:primitive obscure:passwd
 ...............
 


### PR DESCRIPTION
```
crm(live/tbw-1)configure# show related:Dummy
primitive d1 Dummy
primitive d2 Dummy
primitive d3 ocf:pacemaker:Dummy
crm(live/tbw-1)configure# show related:IPaddr2
primitive vip1 IPaddr2 \
        params ip=10.10.10.123 \
        op monitor interval=10s
primitive vip2 IPaddr2 \
        params ip=10.10.10.124 \
        op monitor interval=10s
crm(live/tbw-1)configure# show related:ocf:heartbeat:Dummy
primitive d1 Dummy
primitive d2 Dummy
```

Should be part of requirements from #698 and #819 

Others:
- [x] Complete the help info