### PR TITLE
Fix: bootstrap: Use crmsh.parallax instead of parallax module directly

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -35,6 +35,7 @@ from . import userdir
 from .constants import SSH_OPTION, QDEVICE_HELP_INFO, STONITH_TIMEOUT_DEFAULT, REJOIN_COUNT, REJOIN_INTERVAL
 from . import ocfs2
 from . import qdevice
+from . import parallax
 from . import log
 
 
@@ -1496,6 +1497,9 @@ def join_csync2(seed_host):
 
 
 def join_ssh_merge(_cluster_node):
+    """
+    Ensure known_hosts is the same in all nodes
+    """
     logger.info("Merging known_hosts")
 
     hosts = [m.group(1)
@@ -1504,22 +1508,14 @@ def join_ssh_merge(_cluster_node):
         hosts = [_cluster_node]
         logger.warning("Unable to extract host list from %s" % (CSYNC2_CFG))
 
-    try:
-        import parallax
-    except ImportError:
-        utils.fatal("parallax python library is missing")
+    # To create local entry in known_hosts
+    utils.get_stdout_or_raise_error("ssh {} {} true".format(SSH_OPTION, utils.this_node()))
 
-    opts = parallax.Options()
-    opts.ssh_options = ['StrictHostKeyChecking=no']
-
-    # The act of using pssh to connect to every host (without strict host key
-    # checking) ensures that at least *this* host has every other host in its
-    # known_hosts
     known_hosts_new = set()
     cat_cmd = "[ -e /root/.ssh/known_hosts ] && cat /root/.ssh/known_hosts || true"
     logger_utils.log_only_to_file("parallax.call {} : {}".format(hosts, cat_cmd))
-    results = parallax.call(hosts, cat_cmd, opts)
-    for host, result in results.items():
+    results = parallax.parallax_call(hosts, cat_cmd, strict=False)
+    for host, result in results:
         if isinstance(result, parallax.Error):
             logger.warning("Failed to get known_hosts from {}: {}".format(host, str(result)))
         else:
@@ -1529,8 +1525,8 @@ def join_ssh_merge(_cluster_node):
         hoststxt = "\n".join(sorted(known_hosts_new))
         tmpf = utils.str2tmp(hoststxt)
         logger_utils.log_only_to_file("parallax.copy {} : {}".format(hosts, hoststxt))
-        results = parallax.copy(hosts, tmpf, "/root/.ssh/known_hosts")
-        for host, result in results.items():
+        results = parallax.parallax_copy(hosts, tmpf, "/root/.ssh/known_hosts", strict=False)
+        for host, result in results:
             if isinstance(result, parallax.Error):
                 logger.warning("scp to {} failed ({}), known_hosts update may be incomplete".format(host, str(result)))
 

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -6,6 +6,9 @@ import os
 import parallax
 
 
+Error = parallax.Error
+
+
 class Parallax(object):
     """
     # Parallax SSH API
@@ -45,10 +48,8 @@ class Parallax(object):
 
     def handle(self, results):
         for host, result in results:
-            if isinstance(result, parallax.Error):
-                exception_str = "Failed on {}: {}".format(host, result)
-                if self.strict:
-                    raise ValueError(exception_str)
+            if isinstance(result, parallax.Error) and self.strict:
+                raise ValueError("Failed on {}: {}".format(host, result))
         return results
 
     def call(self):


### PR DESCRIPTION
crmsh.parallax will add StrictHostKeyChecking=no internally, can suppress the warning mentioned in bug 1202006