### PR TITLE
[crmsh-4.3] Fix: bootstrap: Use crmsh.parallax instead of parallax module directly

### DIFF
--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -6,6 +6,9 @@ import os
 import parallax
 
 
+Error = parallax.Error
+
+
 class Parallax(object):
     """
     # Parallax SSH API


### PR DESCRIPTION
backport #994 