### PR TITLE
Dev: bootstrap: Generate public key from private key if not exist

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -828,10 +828,14 @@ def configure_ssh_key(user="root", remote=None):
     """
     change_user_shell(user)
 
+    cmd = ""
     private_key, public_key, authorized_file = key_files(user).values()
     if not utils.detect_file(private_key, remote=remote):
         logger.info("SSH key for {} does not exist, hence generate it now".format(user))
         cmd = "ssh-keygen -q -f {} -C 'Cluster Internal on {}' -N ''".format(private_key, remote if remote else utils.this_node())
+    elif not utils.detect_file(public_key, remote=remote):
+        cmd = "ssh-keygen -y -f {} > {}".format(private_key, public_key)
+    if cmd:
         cmd = utils.add_su(cmd, user)
         utils.get_stdout_or_raise_error(cmd, remote=remote)
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -362,7 +362,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.change_user_shell')
     def test_configure_ssh_key(self, mock_change_shell, mock_key_files, mock_detect, mock_run, mock_append_unique):
         mock_key_files.return_value = {"private": "/test/.ssh/id_rsa", "public": "/test/.ssh/id_rsa.pub", "authorized": "/test/.ssh/authorized_keys"}
-        mock_detect.side_effect = [True, False]
+        mock_detect.side_effect = [True, True, False]
 
         bootstrap.configure_ssh_key("test")
 
@@ -370,6 +370,7 @@ class TestBootstrap(unittest.TestCase):
         mock_key_files.assert_called_once_with("test")
         mock_detect.assert_has_calls([
             mock.call("/test/.ssh/id_rsa", remote=None),
+            mock.call("/test/.ssh/id_rsa.pub", remote=None),
             mock.call("/test/.ssh/authorized_keys", remote=None)
             ])
         mock_append_unique.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys", remote=None)


### PR DESCRIPTION
## Problem
The ssh public key might not exist, which could impact on later steps for configuring passwordless between nodes.
## Solution
Generate public key from private key if not exist
## Verified cases
- No .ssh directory
- Already configured passwordless, without public key
- Only private key exists
- `-N` option