### PR TITLE
[crmsh-4.4]  Fix: bootstrap: Use crmsh.parallax instead of parallax module directly

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -35,6 +35,7 @@ from . import userdir
 from .constants import SSH_OPTION, QDEVICE_HELP_INFO, STONITH_TIMEOUT_DEFAULT, REJOIN_COUNT, REJOIN_INTERVAL
 from . import ocfs2
 from . import qdevice
+from . import parallax
 from . import log
 
 
@@ -1434,6 +1435,9 @@ def join_csync2(seed_host):
 
 
 def join_ssh_merge(_cluster_node):
+    """
+    Ensure known_hosts is the same in all nodes
+    """
     logger.info("Merging known_hosts")
 
     hosts = [m.group(1)
@@ -1442,22 +1446,14 @@ def join_ssh_merge(_cluster_node):
         hosts = [_cluster_node]
         logger.warning("Unable to extract host list from %s" % (CSYNC2_CFG))
 
-    try:
-        import parallax
-    except ImportError:
-        utils.fatal("parallax python library is missing")
+    # To create local entry in known_hosts
+    utils.get_stdout_or_raise_error("ssh {} {} true".format(SSH_OPTION, utils.this_node()))
 
-    opts = parallax.Options()
-    opts.ssh_options = ['StrictHostKeyChecking=no']
-
-    # The act of using pssh to connect to every host (without strict host key
-    # checking) ensures that at least *this* host has every other host in its
-    # known_hosts
     known_hosts_new = set()
     cat_cmd = "[ -e /root/.ssh/known_hosts ] && cat /root/.ssh/known_hosts || true"
     logger_utils.log_only_to_file("parallax.call {} : {}".format(hosts, cat_cmd))
-    results = parallax.call(hosts, cat_cmd, opts)
-    for host, result in results.items():
+    results = parallax.parallax_call(hosts, cat_cmd, strict=False)
+    for host, result in results:
         if isinstance(result, parallax.Error):
             logger.warning("Failed to get known_hosts from {}: {}".format(host, str(result)))
         else:
@@ -1467,8 +1463,8 @@ def join_ssh_merge(_cluster_node):
         hoststxt = "\n".join(sorted(known_hosts_new))
         tmpf = utils.str2tmp(hoststxt)
         logger_utils.log_only_to_file("parallax.copy {} : {}".format(hosts, hoststxt))
-        results = parallax.copy(hosts, tmpf, "/root/.ssh/known_hosts")
-        for host, result in results.items():
+        results = parallax.parallax_copy(hosts, tmpf, "/root/.ssh/known_hosts", strict=False)
+        for host, result in results:
             if isinstance(result, parallax.Error):
                 logger.warning("scp to {} failed ({}), known_hosts update may be incomplete".format(host, str(result)))
 

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -14,10 +14,11 @@ class Parallax(object):
     # slurp: Copies files from a set of remote hosts to local folders
     """
     def __init__(self, nodes, cmd=None, localdir=None, filename=None,
-                 src=None, dst=None, askpass=False, ssh_options=None):
+            src=None, dst=None, askpass=False, ssh_options=None, strict=True):
         self.nodes = nodes
         self.askpass = askpass
         self.ssh_options = ssh_options
+        self.strict = strict
 
         # used for call
         self.cmd = cmd
@@ -45,7 +46,9 @@ class Parallax(object):
     def handle(self, results):
         for host, result in results:
             if isinstance(result, parallax.Error):
-                raise ValueError("Failed on {}: {}".format(host, result))
+                exception_str = "Failed on {}: {}".format(host, result)
+                if self.strict:
+                    raise ValueError(exception_str)
         return results
 
     def call(self):
@@ -62,7 +65,7 @@ class Parallax(object):
         return self.handle(list(results.items()))
 
 
-def parallax_call(nodes, cmd, askpass=False, ssh_options=None):
+def parallax_call(nodes, cmd, askpass=False, ssh_options=None, strict=True):
     """
     Executes the given command on a set of hosts, collecting the output
     nodes:       a set of hosts
@@ -71,11 +74,11 @@ def parallax_call(nodes, cmd, askpass=False, ssh_options=None):
     ssh_options: Extra options to pass to SSH
     Returns [(host, (rc, stdout, stdin)), ...] or ValueError exception
     """
-    p = Parallax(nodes, cmd=cmd, askpass=askpass, ssh_options=ssh_options)
+    p = Parallax(nodes, cmd=cmd, askpass=askpass, ssh_options=ssh_options, strict=strict)
     return p.call()
 
 
-def parallax_slurp(nodes, localdir, filename, askpass=False, ssh_options=None):
+def parallax_slurp(nodes, localdir, filename, askpass=False, ssh_options=None, strict=True):
     """
     Copies from the remote node to the local node
     nodes:       a set of hosts
@@ -86,11 +89,11 @@ def parallax_slurp(nodes, localdir, filename, askpass=False, ssh_options=None):
     Returns [(host, (rc, stdout, stdin, localpath)), ...] or ValueError exception
     """
     p = Parallax(nodes, localdir=localdir, filename=filename,
-                 askpass=askpass, ssh_options=ssh_options)
+            askpass=askpass, ssh_options=ssh_options, strict=strict)
     return p.slurp()
 
 
-def parallax_copy(nodes, src, dst, askpass=False, ssh_options=None):
+def parallax_copy(nodes, src, dst, askpass=False, ssh_options=None, strict=True):
     """
     Copies from the local node to a set of remote hosts
     nodes:       a set of hosts
@@ -100,5 +103,5 @@ def parallax_copy(nodes, src, dst, askpass=False, ssh_options=None):
     ssh_options: Extra options to pass to SSH
     Returns [(host, (rc, stdout, stdin)), ...] or ValueError exception
     """
-    p = Parallax(nodes, src=src, dst=dst, askpass=askpass, ssh_options=ssh_options)
+    p = Parallax(nodes, src=src, dst=dst, askpass=askpass, ssh_options=ssh_options, strict=strict)
     return p.copy()

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -6,6 +6,9 @@ import os
 import parallax
 
 
+Error = parallax.Error
+
+
 class Parallax(object):
     """
     # Parallax SSH API
@@ -45,10 +48,8 @@ class Parallax(object):
 
     def handle(self, results):
         for host, result in results:
-            if isinstance(result, parallax.Error):
-                exception_str = "Failed on {}: {}".format(host, result)
-                if self.strict:
-                    raise ValueError(exception_str)
+            if isinstance(result, parallax.Error) and self.strict:
+                raise ValueError("Failed on {}: {}".format(host, result))
         return results
 
     def call(self):


### PR DESCRIPTION
backport #994 and #965 