### PR TITLE
Fix: ui_resource: Avoid adding multi meta attributes

### DIFF
--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -98,8 +98,8 @@ def set_deep_meta_attr_node(target_node, attr, value):
         for nvpair in nvpairs:
             nvpair.set("value", value)
     else:
-        for n in xmlutil.get_set_nodes(target_node, "meta_attributes", create=True):
-            xmlutil.set_attr(n, attr, value)
+        nodes = xmlutil.get_set_nodes(target_node, "meta_attributes", create=True)
+        xmlutil.set_attr(nodes[0], attr, value)
     return True
 
 


### PR DESCRIPTION
Like avoid adding multi target-role enties for each meta instance
To fix upstream issue https://github.com/ClusterLabs/crmsh/issues/720

backport #979 

Before change
```
# After run `resource stop d2` and `resource manage d2`
crm(live/15sp4-1)configure# show
node 1: 15sp4-1
node 2: 15sp4-2
primitive d2 Dummy \
        meta description=d2 target-role=Stopped is-managed=true \
        meta priority=3 target-role=Stopped is-managed=true \
```
After changed
```
# run `resource start d2` and `resource unmanage d2`, still can change existing multi attribute value
# For the newly added resource d3, only set one entry for meta attributes, after run `resource stop d3` and `resource manage d3`
crm(live/15sp4-1)configure# show
node 1: 15sp4-1
node 2: 15sp4-2
primitive d2 Dummy \
        meta description=d2 target-role=Started is-managed=false \
        meta priority=3 target-role=Started is-managed=false \
        op monitor timeout=20s interval=10s \
        op start timeout=20s interval=0s \
        op stop timeout=20s interval=0s
primitive d3 Dummy \
        meta description=d2 target-role=Stopped is-managed=true \
        meta priority=3
```