### PR TITLE
Feature: replace root by a custom user with root privileges

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -8,6 +8,7 @@ import os
 import re
 import configparser
 from contextlib import contextmanager
+from typing import List
 from . import userdir
 
 
@@ -237,6 +238,7 @@ DEFAULTS = {
         'editor': opt_program('EDITOR', ('vim', 'vi', 'emacs', 'nano')),
         'pager': opt_program('PAGER', ('less', 'more', 'pg')),
         'user': opt_string(''),
+        'hosts': opt_list([]), # 'alice@host1, bob@host2'
         'skill_level': opt_choice('expert', ('operator', 'administrator', 'expert')),
         'sort_elements': opt_boolean('yes'),
         'check_frequency': opt_choice('always', ('always', 'on-verify', 'never')),
@@ -432,7 +434,18 @@ def save():
 
 
 def set_option(section, option, value):
-    _configuration.set(section, option, value)
+    if not isinstance(value, List):
+        _configuration.set(section, option, value)
+        return
+    string = ""
+    first = True
+    for item in value:
+        if first:
+            first = False
+        else:
+            string += ", "
+        string += str(item)
+    _configuration.set(section, option, string)
 
 
 def get_option(section, option, raw=False):

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -107,9 +107,10 @@ def query_qnetd_status():
         raise ValueError("host for qnetd not configured!")
 
     # Configure ssh passwordless to qnetd if detect password is needed
-    if utils.check_ssh_passwd_need(qnetd_addr):
+    local_user = utils.getuser()
+    if utils.check_ssh_passwd_need(utils.getuser(), utils.user_of(qnetd_addr), qnetd_addr):
         print("Copy ssh key to qnetd node({})".format(qnetd_addr))
-        rc, _, err = utils.get_stdout_stderr("ssh-copy-id -i /root/.ssh/id_rsa.pub root@{}".format(qnetd_addr))
+        rc, _, err = utils.get_stdout_stderr("ssh-copy-id -i ~{}/.ssh/id_rsa.pub root@{}".format(local_user, qnetd_addr))
         if rc != 0:
             raise ValueError(err)
 

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -31,7 +31,7 @@ class Lock(object):
     A base class define a lock mechanism used to exclude other nodes
     """
 
-    LOCK_DIR_DEFAULT = "/run/.crmsh_lock_directory"
+    LOCK_DIR_NON_PRIVILEGED = "/tmp/.crmsh_lock_directory"
 
     def __init__(self, lock_dir=None):
         """
@@ -39,7 +39,7 @@ class Lock(object):
         """
         # only the lock owner can unlock
         self.lock_owner = False
-        self.lock_dir = lock_dir or self.LOCK_DIR_DEFAULT
+        self.lock_dir = lock_dir or self.LOCK_DIR_NON_PRIVILEGED
 
     def _run(self, cmd):
         """
@@ -100,10 +100,11 @@ class RemoteLock(Lock):
     MIN_LOCK_TIMEOUT = 120
     WAIT_INTERVAL = 10
 
-    def __init__(self, remote_node, for_join=True, lock_dir=None, wait=True, no_warn=False):
+    def __init__(self, remote_user, remote_node, for_join=True, lock_dir=None, wait=True, no_warn=False):
         """
         Init function
         """
+        self.remote_user = remote_user
         self.remote_node = remote_node
         self.for_join = for_join
         self.wait = wait
@@ -114,7 +115,7 @@ class RemoteLock(Lock):
         """
         Run command on remote node
         """
-        cmd = "ssh {} root@{} \"{}\"".format(self.SSH_OPTION, self.remote_node, cmd)
+        cmd = "ssh {} {}@{} \"{}\"".format(self.SSH_OPTION, self.remote_user, self.remote_node, cmd)
         rc, out, err = utils.get_stdout_stderr(cmd)
         if rc == self.SSH_EXIT_ERR:
             raise SSHError(err)

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -55,7 +55,11 @@ class Parallax(object):
         return results
 
     def call(self):
-        results = parallax.call(self.nodes, self.cmd, self.opts)
+        from crmsh.utils import user_of
+        host_port_user = []
+        for host in self.nodes:
+            host_port_user.append([host, None, user_of(host)])
+        results = parallax.call(host_port_user, self.cmd, self.opts)
         return self.handle(list(results.items()))
 
     def slurp(self):

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -63,7 +63,8 @@ def qnetd_lock_for_same_cluster_name(func):
     def wrapper(*args, **kwargs):
         cluster_name = args[0].cluster_name
         lock_dir = "/run/.crmsh_qdevice_lock_for_{}".format(cluster_name)
-        lock_inst = lock.RemoteLock(args[0].qnetd_addr, for_join=False, lock_dir=lock_dir, wait=False)
+        lock_inst = lock.RemoteLock(utils.user_of(args[0].qnetd_addr), args[0].qnetd_addr
+            , for_join=False, lock_dir=lock_dir, wait=False)
         try:
             with lock_inst.lock():
                 func(*args, **kwargs)
@@ -80,7 +81,8 @@ def qnetd_lock_for_multi_cluster(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        lock_inst = lock.RemoteLock(args[0].qnetd_addr, for_join=False, no_warn=True)
+        lock_inst = lock.RemoteLock(utils.user_of(args[0].qnetd_addr)
+            , args[0].qnetd_addr, for_join=False, no_warn=True)
         try:
             with lock_inst.lock():
                 func(*args, **kwargs)
@@ -285,10 +287,10 @@ class QDevice(object):
         exception_msg = ""
         suggest = ""
         duplicated_cluster_name = False
-        if not utils.package_is_installed("corosync-qnetd", self.qnetd_addr):
+        if not utils.package_is_installed("corosync-qnetd", remote_addr=self.qnetd_addr):
             exception_msg = "Package \"corosync-qnetd\" not installed on {}!".format(self.qnetd_addr)
             suggest = "install \"corosync-qnetd\" on {}".format(self.qnetd_addr)
-        elif utils.service_is_active("corosync-qnetd", self.qnetd_addr):
+        elif utils.service_is_active("corosync-qnetd", remote_addr=self.qnetd_addr):
             cmd = "corosync-qnetd-tool -l -c {}".format(self.cluster_name)
             if utils.get_stdout_or_raise_error(cmd, remote=self.qnetd_addr):
                 duplicated_cluster_name = True

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -135,7 +135,7 @@ class Cluster(command.UI):
         if not node_list:
             return
 
-        dc_deadtime = utils.get_property("dc-deadtime") or constants.DC_DEADTIME_DEFAULT
+        dc_deadtime = utils.get_property("dc-deadtime") or str(constants.DC_DEADTIME_DEFAULT)
         dc_timeout = int(dc_deadtime.strip('s')) + 5
         try:
             utils.check_function_with_timeout(utils.get_dc, wait_timeout=dc_timeout)
@@ -719,11 +719,16 @@ to get the geo cluster configuration.""",
         opts = parallax.Options()
         opts.ssh_options = ['StrictHostKeyChecking=no']
         for host in hosts:
-            res = utils.check_ssh_passwd_need(host)
+            res = utils.check_ssh_passwd_need(utils.getuser(), utils.user_of(host), host)
             if res:
                 opts.askpass = True
                 break
-        for host, result in parallax.call(hosts, cmd, opts).items():
+
+        host_port_user = []
+        for host in hosts:
+            host_port_user.append([host, None, utils.user_of(host)])
+
+        for host, result in parallax.call(host_port_user, cmd, opts).items():
             if isinstance(result, parallax.Error):
                 logger.error("[%s]: %s" % (host, result))
             else:

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -155,12 +155,10 @@ def force_set_local_upgrade_seq():
     """Create the upgrade sequence file and set it to CURRENT_UPGRADE_SEQ.
 
     It should only be used when initializing new cluster nodes."""
-    try:
-        os.mkdir(DATA_DIR)
-    except FileExistsError:
-        pass
-    with open(SEQ_FILE_PATH, 'w', encoding='ascii') as f:
-        print(_format_upgrade_seq(CURRENT_UPGRADE_SEQ), file=f)
+    if not os.path.exists(DATA_DIR):
+        crmsh.utils.mkdirs_owned(DATA_DIR, mode=0o755)
+    up_seq = _format_upgrade_seq(CURRENT_UPGRADE_SEQ)
+    crmsh.utils.str2file(up_seq, SEQ_FILE_PATH)
 
 
 def main():

--- a/crmsh/watchdog.py
+++ b/crmsh/watchdog.py
@@ -8,14 +8,15 @@ class Watchdog(object):
     """
     Class to find valid watchdog device name
     """
-    QUERY_CMD = "sbd query-watchdog"
+    QUERY_CMD = "sudo sbd query-watchdog"
     DEVICE_FIND_REGREX = "\[[0-9]+\] (/dev/.*)\n.*\nDriver: (.*)"
 
-    def __init__(self, _input=None, peer_host=None):
+    def __init__(self, _input=None, remote_user=None, peer_host=None):
         """
         Init function
         """
         self._input = _input
+        self._remote_user = remote_user
         self._peer_host = peer_host
         self._watchdog_info_dict = {}
         self._watchdog_device_name = None
@@ -29,7 +30,7 @@ class Watchdog(object):
         """
         Use wdctl to verify watchdog device
         """
-        rc, _, err = utils.get_stdout_stderr("wdctl {}".format(dev))
+        rc, _, err = utils.get_stdout_stderr("sudo wdctl {}".format(dev))
         if rc != 0:
             if ignore_error:
                 return False
@@ -87,7 +88,7 @@ class Watchdog(object):
         """
         Given watchdog device name, get driver name on remote node
         """
-        cmd = "ssh {} root@{} {}".format(SSH_OPTION, self._peer_host, self.QUERY_CMD)
+        cmd = "ssh {} {}@{} {}".format(SSH_OPTION, self._remote_user, self._peer_host, self.QUERY_CMD)
         rc, out, err = utils.get_stdout_stderr(cmd)
         if rc == 0 and out:
             # output format might like:

--- a/data-manifest
+++ b/data-manifest
@@ -66,6 +66,7 @@ test/defaults
 test/descriptions
 test/evaltest.sh
 test/features/bootstrap_bugs.feature
+test/features/bootstrap_init_join_remove_alice.feature
 test/features/bootstrap_init_join_remove.feature
 test/features/bootstrap_options.feature
 test/features/bootstrap_sbd_delay.feature

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -98,10 +98,10 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode2"
     # Try to simulate the join process hanging on hanode2 or hanode2 died
     # Just leave the lock directory unremoved
-    When    Run "mkdir /run/.crmsh_lock_directory" on "hanode1"
+    When    Run "mkdir /tmp/.crmsh_lock_directory" on "hanode1"
     When    Try "crm cluster join -c hanode1 -y" on "hanode3"
-    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/run/.crmsh_lock_directory)"
-    When    Run "rm -rf /run/.crmsh_lock_directory" on "hanode1"
+    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/tmp/.crmsh_lock_directory)"
+    When    Run "rm -rf /tmp/.crmsh_lock_directory" on "hanode1"
 
   @clean
   Scenario: Change host name in /etc/hosts as alias(bsc#1183654)

--- a/test/features/bootstrap_init_join_remove_alice.feature
+++ b/test/features/bootstrap_init_join_remove_alice.feature
@@ -1,0 +1,17 @@
+@bootstrap
+Feature: crmsh bootstrap process - init, join and remove
+
+  Test crmsh bootstrap init/join/remove process
+  Need nodes: hanode1 hanode2
+
+  Scenario: Setup a two nodes cluster as alice and bob
+    Given   Nodes ["hanode1", "hanode2"] are cleaned up
+    And     Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "su alice -c 'crm cluster init -y'" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Show cluster status on "hanode1"
+    When    Run "su bob -c 'crm cluster join -c alice@hanode1 -y'" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    And     Show cluster status on "hanode1"

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -179,6 +179,31 @@ docker_exec() {
 	docker exec -t $name /bin/sh -c "$cmd"
 }
 
+create_custom_user() {
+	user_name=$1
+	user_id=$2
+	docker_exec $node_name "useradd -m -s /bin/bash -N -u ${user_id} -g 90 ${user_name} 2>/dev/null"
+	docker_exec $node_name "chmod u+w /etc/sudoers"
+	docker_exec $node_name "echo \"${user_name} ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers"
+	docker_exec $node_name "chmod u-w /etc/sudoers"
+	docker_exec $node_name "echo 'export PATH=\$PATH:/usr/sbin/' >> ~${user_name}/.bashrc"
+	docker_exec $node_name "echo -e \"linux\\nlinux\" | passwd ${user_name} 2>/dev/null"
+	docker_exec $node_name "cp -r /root/.ssh ~${user_name}/ && chown ${user_name}:haclient -R ~${user_name}/.ssh"
+}
+
+create_alice_bob_carol() {
+	# Custom users are alice, bob and carol and they are as important as the root
+	# and eventually they should be already in the docker image
+	# However now, let's create them here
+	create_custom_user "alice" "1000"
+	create_custom_user "bob" "1001"
+	create_custom_user "carol" "1002"
+
+	# I think /var/log/crmsh used to be hacluster:haclient
+	# Let's make it here again anyway. (This is a workarout, please FIXME!)
+	docker_exec $node_name "chown hacluster:haclient -R /var/log/crmsh"
+	docker_exec $node_name "chmod g+w -R /var/log/crmsh"
+}
 
 deploy_ha_node() {
 	node_name=$1
@@ -201,6 +226,8 @@ deploy_ha_node() {
 	info "Building crmsh on \"$node_name\"..."
 	docker_exec $node_name "$make_cmd" 1> /dev/null || \
 		fatal "Building failed on $node_name!"
+
+	create_alice_bob_carol
 }
 
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -309,12 +309,11 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.configure_ssh_key')
     @mock.patch('crmsh.utils.start_service')
     def test_init_ssh(self, mock_start_service, mock_config_ssh):
-        bootstrap._context = mock.Mock(node_list=[])
+        bootstrap._context = mock.Mock(current_user="alice", node_list=[])
         bootstrap.init_ssh()
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
         mock_config_ssh.assert_has_calls([
-            mock.call("root"),
-            mock.call("hacluster")
+            mock.call("alice")
             ])
 
     @mock.patch('crmsh.userdir.gethomedir')
@@ -357,30 +356,26 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.bootstrap.append_unique')
     @mock.patch('crmsh.utils.get_stdout_or_raise_error')
-    @mock.patch('crmsh.utils.add_su')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.detect_file')
-    @mock.patch('crmsh.bootstrap.key_files')
     @mock.patch('crmsh.bootstrap.change_user_shell')
-    def test_configure_ssh_key_remote(self, mock_change_shell, mock_key_files, mock_detect, mock_info, mock_su, mock_run, mock_append):
-        mock_key_files.return_value = {"private": "/test/.ssh/id_rsa", "public": "/test/.ssh/id_rsa.pub", "authorized": "/test/.ssh/authorized_keys"}
+    def test_configure_ssh_key_remote(self, mock_change_shell, mock_detect, mock_info,  mock_run, mock_append):
+        mock_run.side_effect = ["/home/alice", None]
         mock_detect.side_effect = [False, True]
-        mock_su.return_value = "cmd with su"
 
-        bootstrap.configure_ssh_key("test", remote="node1")
+        bootstrap.configure_ssh_key("alice", remote="node1")
 
-        mock_change_shell.assert_called_once_with("test")
-        mock_key_files.assert_called_once_with("test")
+        mock_change_shell.assert_called_once_with("alice")
         mock_detect.assert_has_calls([
-            mock.call("/test/.ssh/id_rsa", remote="node1"),
-            mock.call("/test/.ssh/authorized_keys", remote="node1")
+            mock.call("/home/alice/.ssh/id_rsa", remote="node1"),
+            mock.call("/home/alice/.ssh/authorized_keys", remote="node1")
             ])
-        mock_info.assert_called_once_with("SSH key for test does not exist, hence generate it now")
-        mock_su.assert_called_once_with("ssh-keygen -q -f /test/.ssh/id_rsa -C 'Cluster Internal on node1' -N ''", "test")
+        mock_info.assert_called_once_with("SSH key for alice does not exist, hence generate it now")
         mock_run.assert_has_calls([
-            mock.call("cmd with su", remote="node1")
+            mock.call("pwd", user="alice", remote="node1"),
+            mock.call("ssh-keygen -q -f /home/alice/.ssh/id_rsa -C 'Cluster Internal on node1' -N ''", user="alice", remote="node1")
             ])
-        mock_append.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys", remote="node1")
+        mock_append.assert_called_once_with("/home/alice/.ssh/id_rsa.pub", "/home/alice/.ssh/authorized_keys", "alice", remote="node1")
 
     @mock.patch('crmsh.bootstrap.append_unique')
     @mock.patch('crmsh.utils.get_stdout_or_raise_error')
@@ -400,16 +395,16 @@ class TestBootstrap(unittest.TestCase):
             mock.call("/test/.ssh/id_rsa.pub", remote=None),
             mock.call("/test/.ssh/authorized_keys", remote=None)
             ])
-        mock_append_unique.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys", remote=None)
-        mock_run.assert_called_once_with('touch /test/.ssh/authorized_keys', remote=None)
+        mock_append_unique.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys", "test", remote=None)
+        mock_run.assert_called_once_with('touch /test/.ssh/authorized_keys', user="test", remote=None)
 
     @mock.patch('crmsh.bootstrap.append_to_remote_file')
     @mock.patch('crmsh.utils.check_file_content_included')
     def test_append_unique_remote(self, mock_check, mock_append):
         mock_check.return_value = False
-        bootstrap.append_unique("fromfile", "tofile", remote="node1", from_local=True)
+        bootstrap.append_unique("fromfile", "tofile", user="root", remote="node1", from_local=True)
         mock_check.assert_called_once_with("fromfile", "tofile", remote="node1", source_local=True)
-        mock_append.assert_called_once_with("fromfile", "node1", "tofile")
+        mock_append.assert_called_once_with("fromfile", "root", "node1", "tofile")
 
     @mock.patch('crmsh.bootstrap.append')
     @mock.patch('crmsh.utils.check_file_content_included')
@@ -421,7 +416,7 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.utils.get_stdout_or_raise_error')
     def test_append_to_remote_file(self, mock_run):
-        bootstrap.append_to_remote_file("fromfile", "node1", "tofile")
+        bootstrap.append_to_remote_file("fromfile", "root", "node1", "tofile")
         cmd = "cat fromfile | ssh {} root@node1 'cat >> tofile'".format(constants.SSH_OPTION)
         mock_run.assert_called_once_with(cmd)
 
@@ -464,67 +459,64 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.swap_public_ssh_key')
     @mock.patch('crmsh.bootstrap.configure_ssh_key')
     @mock.patch('crmsh.utils.start_service')
-    def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_swap, mock_invoke, mock_error):
-        bootstrap._context = mock.Mock(default_nic_list=["eth1"])
+    def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_swap, mock_run, mock_invoke, mock_error):
+        bootstrap._context = mock.Mock(current_user="bob", user_list=["alice"], default_nic_list=["eth1"])
         mock_invoke.return_value = (False, None, "error")
+        mock_swap.return_value = None
 
         bootstrap.join_ssh("node1")
 
+        mock_run.assert_called_once_with("/usr/bin/env python3 -m crmsh.healthcheck fix-cluster PasswordlessHaclusterAuthenticationFeature"
+            , user="alice", remote="node1")
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
         mock_config_ssh.assert_has_calls([
-            mock.call("root"),
-            mock.call("hacluster")
+                mock.call("bob"),
+                mock.call("hacluster"),
             ])
         mock_swap.assert_has_calls([
-            mock.call("node1", "root"),
-            mock.call("node1", "hacluster")
+                mock.call("bob", "alice", "alice", "node1", add=True),
+                mock.call("bob", "alice", "hacluster", "node1"),
+                mock.call("hacluster", "alice", "hacluster", "node1")
             ])
-        mock_invoke.assert_called_once_with("ssh {} root@node1 crm cluster init -i eth1 ssh_remote".format(constants.SSH_OPTION))
+        mock_invoke.assert_called_once_with("ssh {} alice@node1 crm cluster init -i eth1 ssh_remote".format(constants.SSH_OPTION))
         mock_error.assert_called_once_with("Can't invoke crm cluster init -i eth1 ssh_remote on node1: error")
 
     def test_swap_public_ssh_key_return(self):
         bootstrap._context = mock.Mock(with_other_user=False)
-        bootstrap.swap_public_ssh_key("node1", "hacluster")
+        bootstrap.swap_public_ssh_key("bob", "alice", "alice", "node1")
 
+    @mock.patch('crmsh.bootstrap.import_ssh_key')
     @mock.patch('logging.Logger.warning')
-    @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    @mock.patch('crmsh.bootstrap.key_files')
-    def test_swap_public_ssh_key_exception(self, mock_key_files, mock_check_passwd, mock_fetch, mock_warn):
-        mock_key_files.return_value = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
+    def test_swap_public_ssh_key_exception(self, mock_check_passwd, mock_warn, mock_import_ssh):
         mock_check_passwd.return_value = False
-        mock_fetch.side_effect = ValueError("No key exist")
+        bootstrap._context = mock.Mock(with_other_user=True)
+        mock_import_ssh.side_effect = ValueError("No key exist")
 
-        bootstrap.swap_public_ssh_key("node1")
+        bootstrap.swap_public_ssh_key("bob", "alice", "alice", "node1")
 
-        mock_key_files.assert_called_once_with("root")
-        mock_warn.assert_called_once_with(mock_fetch.side_effect)
-        mock_check_passwd.assert_called_once_with("node1", "root")
-        mock_fetch.assert_called_once_with("node1", "root")
+        mock_warn.assert_called_once_with(mock_import_ssh.side_effect)
+        mock_check_passwd.assert_called_once_with("bob", "alice", "node1")
+        mock_import_ssh.assert_called_once_with("bob", "alice", "node1")
 
-    @mock.patch('crmsh.bootstrap.append_unique')
-    @mock.patch('crmsh.bootstrap.fetch_public_key_from_remote_node')
-    @mock.patch('crmsh.bootstrap.append_to_remote_file')
+    @mock.patch('crmsh.bootstrap.import_ssh_key')
+    @mock.patch('crmsh.bootstrap.export_ssh_key')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    @mock.patch('crmsh.bootstrap.key_files')
-    def test_swap_public_ssh_key(self, mock_key_files, mock_check_passwd, mock_status, mock_append_remote, mock_fetch, mock_append_unique):
-        mock_key_files.return_value = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
+    def test_swap_public_ssh_key(self, mock_check_passwd, mock_status, mock_export_ssh, mock_import_ssh):
         mock_check_passwd.return_value = True
-        mock_fetch.return_value = "file1"
         bootstrap._context = mock.Mock(with_other_user=True)
 
-        bootstrap.swap_public_ssh_key("node1", user="other")
+        bootstrap.swap_public_ssh_key("bob", "alice", "alice", "node1")
 
-        mock_key_files.assert_called_once_with("other")
-        mock_check_passwd.assert_called_once_with("node1", "other")
-        mock_status.assert_called_once_with("Configuring SSH passwordless with other@node1")
-        mock_append_remote.assert_called_once_with("/root/.ssh/id_rsa.pub", "node1", "/root/.ssh/authorized_keys")
-        mock_fetch.assert_called_once_with("node1", "other")
-        mock_append_unique.assert_called_once_with("file1", "/root/.ssh/authorized_keys")
+        mock_check_passwd.assert_called_once_with("bob", "alice", "node1")
+        mock_status.assert_called_once_with("Configuring SSH passwordless with alice@node1")
+        mock_export_ssh.assert_called_once_with("bob", "alice", "alice", "node1")
+        mock_import_ssh.assert_called_once_with("bob", "alice", "node1")
 
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add_return(self, mock_this_node):
@@ -536,36 +528,86 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add(self, mock_this_node, mock_info, mock_ext):
-        ctx = mock.Mock(node_list=["node2", "node3"], nic_list=["eth1"])
+        ctx = mock.Mock(current_user="alice", user_list=["bob", "carol"], node_list=["node2", "node3"], nic_list=["eth1"])
         mock_this_node.return_value = "node1"
         bootstrap.bootstrap_add(ctx)
         mock_info.assert_has_calls([
             mock.call("Adding node node2 to cluster"),
-            mock.call("Running command on node2: crm cluster join -y -c node1 -i eth1"),
+            mock.call("Running command on node2: crm cluster join -y -c alice@node1 -i eth1"),
             mock.call("Adding node node3 to cluster"),
-            mock.call("Running command on node3: crm cluster join -y -c node1 -i eth1")
+            mock.call("Running command on node3: crm cluster join -y -c alice@node1 -i eth1")
             ])
 
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
+        bootstrap._context = mock.Mock(user_list=["alice"])
+        mock_run.return_value = (1, None, None)
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.setup_passwordless_with_other_nodes("node1")
+
+        mock_run.assert_called_once_with("ssh {} alice@node1 crm_node -l".format(constants.SSH_OPTION))
+        mock_error.assert_called_once_with("Can't fetch cluster nodes list from node1: None")
+
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_setup_passwordless_with_other_nodes_failed_fetch_hostname(self, mock_run, mock_error):
+        bootstrap._context = mock.Mock(user_list=["alice"])
+        out_node_list = """1 node1 member
+        2 node2 member"""
+        mock_run.side_effect = [
+                (0, out_node_list, None),
+                (1, None, None)
+                ]
+        mock_error.side_effect = SystemExit
+
+        with self.assertRaises(SystemExit):
+            bootstrap.setup_passwordless_with_other_nodes("node1")
+
+        mock_run.assert_has_calls([
+            mock.call("ssh {} alice@node1 crm_node -l".format(constants.SSH_OPTION)),
+            mock.call("ssh {} alice@node1 hostname".format(constants.SSH_OPTION))
+        ])
+        mock_error.assert_called_once_with("Can't fetch hostname of node1: None")
+
+    @mock.patch('crmsh.utils.user_of')
     @mock.patch('crmsh.bootstrap.swap_public_ssh_key')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
-    def test_setup_passwordless_with_other_nodes(self, mock_run, mock_swap):
-        bootstrap._context = mock.Mock(node_list_in_cluster=["node1", "node2"])
-        mock_run.return_value = "node1"
-        bootstrap.setup_passwordless_with_other_nodes("node1")
-        mock_swap.assert_has_calls([
-            mock.call("node2", u) for u in bootstrap.USER_LIST
-            ])
+    @mock.patch('crmsh.utils.get_stdout_stderr')
+    def test_setup_passwordless_with_other_nodes(self, mock_run, mock_swap, mock_userof):
+        bootstrap._context = mock.Mock(current_user="carol", user_list=["alice", "bob"])
+        mock_userof.return_value = "bob"
+        out_node_list = """1 node1 member
+        2 node2 member"""
+        mock_run.side_effect = [
+                (0, out_node_list, None),
+                (0, "node1", None)
+                ]
 
+        bootstrap.setup_passwordless_with_other_nodes("node1")
+
+        mock_run.assert_has_calls([
+            mock.call("ssh {} alice@node1 crm_node -l".format(constants.SSH_OPTION)),
+            mock.call("ssh {} alice@node1 hostname".format(constants.SSH_OPTION))
+            ])
+        mock_userof.assert_called_once_with("node2")
+        mock_swap.assert_called_once_with("carol", "bob", "bob", "node2")
+
+    @mock.patch('crmsh.userdir.getuser')
+    @mock.patch('crmsh.bootstrap.key_files')
     @mock.patch('builtins.open')
     @mock.patch('crmsh.bootstrap.append')
     @mock.patch('os.path.join')
     @mock.patch('os.path.exists')
-    def test_init_ssh_remote_no_sshkey(self, mock_exists, mock_join, mock_append, mock_open_file):
+    def test_init_ssh_remote_no_sshkey(self, mock_exists, mock_join, mock_append, mock_open_file, mock_key_files, mock_getuser):
+        mock_getuser.return_value = "alice"
+        mock_key_files.return_value = {"private": "/home/alice/.ssh/id_rsa", "public": "/home/alice/.ssh/id_rsa.pub", "authorized": "/home/alice/.ssh/authorized_keys"}
         mock_exists.side_effect = [False, True, False, False, False]
-        mock_join.side_effect = ["/root/.ssh/id_rsa",
-                                 "/root/.ssh/id_dsa",
-                                 "/root/.ssh/id_ecdsa",
-                                 "/root/.ssh/id_ed25519"]
+        mock_join.side_effect = ["/home/alice/.ssh/id_rsa",
+                                 "/home/alice/.ssh/id_dsa",
+                                 "/home/alice/.ssh/id_ecdsa",
+                                 "/home/alice/.ssh/id_ed25519"]
         mock_open_file.side_effect = [
             mock.mock_open().return_value,
             mock.mock_open(read_data="data1 data2").return_value,
@@ -574,41 +616,50 @@ class TestBootstrap(unittest.TestCase):
 
         bootstrap.init_ssh_remote()
 
+        mock_getuser.assert_called_once_with()
+        mock_key_files.assert_called_once_with("alice")
+
         mock_open_file.assert_has_calls([
-            mock.call("/root/.ssh/authorized_keys", 'w'),
-            mock.call("/root/.ssh/authorized_keys", "r+"),
-            mock.call("/root/.ssh/id_rsa.pub")
+            mock.call("/home/alice/.ssh/authorized_keys", 'w'),
+            mock.call("/home/alice/.ssh/authorized_keys", "r+"),
+            mock.call("/home/alice/.ssh/id_rsa.pub")
         ])
         mock_exists.assert_has_calls([
-            mock.call("/root/.ssh/authorized_keys"),
-            mock.call("/root/.ssh/id_rsa"),
-            mock.call("/root/.ssh/id_dsa"),
-            mock.call("/root/.ssh/id_ecdsa"),
-            mock.call("/root/.ssh/id_ed25519"),
+            mock.call("/home/alice/.ssh/authorized_keys"),
+            mock.call("/home/alice/.ssh/id_rsa"),
+            mock.call("/home/alice/.ssh/id_dsa"),
+            mock.call("/home/alice/.ssh/id_ecdsa"),
+            mock.call("/home/alice/.ssh/id_ed25519"),
         ])
-        mock_append.assert_called_once_with("/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+        mock_append.assert_called_once_with("/home/alice/.ssh/id_rsa.pub", "/home/alice/.ssh/authorized_keys")
 
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_cluster_node_hostname(self, mock_stdout_stderr):
+    @mock.patch('crmsh.utils.user_of')
+    def test_get_cluster_node_hostname(self, mock_userof, mock_stdout_stderr):
         bootstrap._context = mock.Mock(cluster_node="node1")
         mock_stdout_stderr.return_value = (0, "Node1", None)
+        mock_userof.return_value = "alice"
 
         peer_node = bootstrap.get_cluster_node_hostname()
         assert peer_node == "Node1"
 
-        mock_stdout_stderr.assert_called_once_with("ssh {} node1 crm_node --name".format(constants.SSH_OPTION))
+        mock_userof.assert_called_once_with("node1")
+        mock_stdout_stderr.assert_called_once_with("ssh {} alice@node1 crm_node --name".format(constants.SSH_OPTION))
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.get_stdout_stderr')
-    def test_get_cluster_node_hostname_error(self, mock_stdout_stderr, mock_error):
-        bootstrap._context = mock.Mock(cluster_node="node2")
+    @mock.patch('crmsh.utils.user_of')
+    def test_get_cluster_node_hostname_error(self, mock_userof, mock_stdout_stderr, mock_error):
+        bootstrap._context = mock.Mock(cluster_node="node1")
         mock_stdout_stderr.return_value = (1, None, "error")
+        mock_userof.return_value = "alice"
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
             bootstrap.get_cluster_node_hostname()
 
-        mock_stdout_stderr.assert_called_once_with("ssh {} node2 crm_node --name".format(constants.SSH_OPTION))
+        mock_userof.assert_called_once_with("node1")
+        mock_stdout_stderr.assert_called_once_with("ssh {} alice@node1 crm_node --name".format(constants.SSH_OPTION))
         mock_error.assert_called_once_with("error")
 
     @mock.patch('crmsh.utils.this_node')
@@ -697,8 +748,8 @@ class TestBootstrap(unittest.TestCase):
     def test_csync2_update_no_conflicts(self, mock_invoke, mock_invokerc):
         mock_invokerc.return_value = True
         bootstrap.csync2_update("/etc/corosync.conf")
-        mock_invoke.assert_called_once_with("csync2 -rm /etc/corosync.conf")
-        mock_invokerc.assert_called_once_with("csync2 -rxv /etc/corosync.conf")
+        mock_invoke.assert_called_once_with("sudo csync2 -rm /etc/corosync.conf")
+        mock_invokerc.assert_called_once_with("sudo csync2 -rxv /etc/corosync.conf")
 
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.bootstrap.invokerc')
@@ -707,12 +758,12 @@ class TestBootstrap(unittest.TestCase):
         mock_invokerc.side_effect = [False, False]
         bootstrap.csync2_update("/etc/corosync.conf")
         mock_invoke.assert_has_calls([
-            mock.call("csync2 -rm /etc/corosync.conf"),
-            mock.call("csync2 -rf /etc/corosync.conf")
+            mock.call("sudo csync2 -rm /etc/corosync.conf"),
+            mock.call("sudo csync2 -rf /etc/corosync.conf")
             ])
         mock_invokerc.assert_has_calls([
-            mock.call("csync2 -rxv /etc/corosync.conf"),
-            mock.call("csync2 -rxv /etc/corosync.conf")
+            mock.call("sudo csync2 -rxv /etc/corosync.conf"),
+            mock.call("sudo csync2 -rxv /etc/corosync.conf")
             ])
         mock_warn.assert_called_once_with("/etc/corosync.conf was not synced")
 
@@ -738,15 +789,18 @@ class TestBootstrap(unittest.TestCase):
         mock_status.assert_not_called()
         mock_disable.assert_called_once_with("corosync-qdevice.service")
 
+    @mock.patch('crmsh.utils.user_of')
     @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
     @mock.patch('logging.Logger.info')
-    def test_init_qdevice_copy_ssh_key_failed(self, mock_status, mock_ssh, mock_invoke, mock_error, mock_list_nodes):
+    def test_init_qdevice_copy_ssh_key_failed(self, mock_status, mock_ssh,
+            mock_invoke, mock_error, mock_list_nodes, mock_userof):
         mock_list_nodes.return_value = []
-        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip, current_user="bob", user_list=["alice"])
         mock_ssh.return_value = True
+        mock_userof.return_value = "alice"
         mock_invoke.return_value = (False, None, "error")
         mock_error.side_effect = SystemExit
 
@@ -757,19 +811,22 @@ class TestBootstrap(unittest.TestCase):
             mock.call("Configure Qdevice/Qnetd:"),
             mock.call("Copy ssh key to qnetd node(10.10.10.123)")
             ])
-        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_ssh.assert_called_once_with("bob", "alice", "10.10.10.123")
         mock_invoke.assert_called_once_with("ssh-copy-id -i /root/.ssh/id_rsa.pub root@10.10.10.123")
         mock_error.assert_called_once_with("Failed to copy ssh key: error")
 
+    @mock.patch('crmsh.utils.user_of')
     @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
     @mock.patch('logging.Logger.info')
-    def test_init_qdevice_already_configured(self, mock_status, mock_ssh, mock_qdevice_configured, mock_confirm, mock_list_nodes):
+    def test_init_qdevice_already_configured(self, mock_status, mock_ssh,
+            mock_qdevice_configured, mock_confirm, mock_list_nodes, mock_userof):
         mock_list_nodes.return_value = []
-        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip, current_user="bob", user_list=["alice"])
         mock_ssh.return_value = False
+        mock_userof.return_value = "alice"
         mock_qdevice_configured.return_value = True
         mock_confirm.return_value = False
         self.qdevice_with_ip.start_qdevice_service = mock.Mock()
@@ -777,21 +834,24 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.init_qdevice()
 
         mock_status.assert_called_once_with("Configure Qdevice/Qnetd:")
-        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_ssh.assert_called_once_with("bob", "alice", "10.10.10.123")
         mock_qdevice_configured.assert_called_once_with()
         mock_confirm.assert_called_once_with("Qdevice is already configured - overwrite?")
         self.qdevice_with_ip.start_qdevice_service.assert_called_once_with()
 
+    @mock.patch('crmsh.utils.user_of')
     @mock.patch('crmsh.bootstrap.adjust_priority_fencing_delay')
     @mock.patch('crmsh.bootstrap.adjust_priority_in_rsc_defaults')
     @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
     @mock.patch('logging.Logger.info')
-    def test_init_qdevice(self, mock_info, mock_ssh, mock_qdevice_configured, mock_list_nodes, mock_adjust_priority, mock_adjust_fence_delay):
-        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip)
+    def test_init_qdevice(self, mock_info, mock_ssh, mock_qdevice_configured, mock_list_nodes,
+            mock_adjust_priority, mock_adjust_fence_delay, mock_userof):
+        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip, current_user="bob", user_list=["alice"])
         mock_list_nodes.return_value = []
         mock_ssh.return_value = False
+        mock_userof.return_value = "alice"
         mock_qdevice_configured.return_value = False
         self.qdevice_with_ip.set_cluster_name = mock.Mock()
         self.qdevice_with_ip.valid_qnetd = mock.Mock()
@@ -800,7 +860,7 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.init_qdevice()
 
         mock_info.assert_called_once_with("Configure Qdevice/Qnetd:")
-        mock_ssh.assert_called_once_with("10.10.10.123")
+        mock_ssh.assert_called_once_with("bob", "alice", "10.10.10.123")
         mock_qdevice_configured.assert_called_once_with()
         self.qdevice_with_ip.set_cluster_name.assert_called_once_with()
         self.qdevice_with_ip.valid_qnetd.assert_called_once_with()
@@ -1587,9 +1647,7 @@ class TestValidation(unittest.TestCase):
         mock_invoke.assert_has_calls([
             mock.call("corosync-cfgtool -R")
             ])
-        mock_invokerc.assert_has_calls([
-            mock.call("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
-            ])
+        mock_invokerc.assert_called_once_with("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
         mock_error.assert_not_called()
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
         mock_del.assert_called_once_with("node1")

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -177,11 +177,16 @@ def test_query_qnetd_status_no_host(mock_qdevice_configured, mock_get_value):
         ])
 
 
+@mock.patch('crmsh.utils.user_of')
+@mock.patch('crmsh.utils.getuser')
 @mock.patch("crmsh.utils.get_stdout_stderr")
 @mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
-def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured, mock_get_value, mock_check_passwd, mock_run):
+def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
+        mock_get_value, mock_check_passwd, mock_run, mock_getuser, mock_userof):
+    mock_getuser.return_value = "bob"
+    mock_userof.return_value = "alice"
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
     mock_check_passwd.return_value = True
@@ -194,17 +199,23 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured, mock_get_val
         mock.call("totem.cluster_name"),
         mock.call("quorum.device.net.host")
         ])
-    mock_check_passwd.assert_called_once_with("10.10.10.123")
-    mock_run.assert_called_once_with("ssh-copy-id -i /root/.ssh/id_rsa.pub root@10.10.10.123")
+    mock_check_passwd.assert_called_once_with("bob", "alice", "10.10.10.123")
+    mock_run.assert_called_once_with("ssh-copy-id -i ~bob/.ssh/id_rsa.pub root@10.10.10.123")
 
 
+@mock.patch('crmsh.utils.user_of')
+@mock.patch('crmsh.utils.getuser')
 @mock.patch("crmsh.utils.print_cluster_nodes")
 @mock.patch("crmsh.parallax.parallax_call")
 @mock.patch("crmsh.utils.get_stdout_stderr")
 @mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
-def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value, mock_check_passwd, mock_run, mock_parallax_call, mock_print_nodes):
+def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
+        mock_check_passwd, mock_run, mock_parallax_call, mock_print_nodes,
+        mock_getuser, mock_userof):
+    mock_getuser.return_value = "bob"
+    mock_userof.return_value = "alice"
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
     mock_check_passwd.return_value = True
@@ -218,8 +229,8 @@ def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value, mock_c
         mock.call("totem.cluster_name"),
         mock.call("quorum.device.net.host")
         ])
-    mock_check_passwd.assert_called_once_with("10.10.10.123")
-    mock_run.assert_called_once_with("ssh-copy-id -i /root/.ssh/id_rsa.pub root@10.10.10.123")
+    mock_check_passwd.assert_called_once_with("bob", "alice", "10.10.10.123")
+    mock_run.assert_called_once_with("ssh-copy-id -i ~bob/.ssh/id_rsa.pub root@10.10.10.123")
     mock_parallax_call.assert_called_once_with(["10.10.10.123"], "corosync-qnetd-tool -lv -c hacluster")
     mock_print_nodes.assert_called_once_with()
 

--- a/test/unittests/test_parallax.py
+++ b/test/unittests/test_parallax.py
@@ -39,31 +39,37 @@ class TestParallax(unittest.TestCase):
         Global tearDown.
         """
 
+    @mock.patch("crmsh.utils.user_of")
     @mock.patch("parallax.call")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_call(self, mock_handle, mock_call):
+    def test_call(self, mock_handle, mock_call, mock_userof):
         mock_call.return_value = {"node1": (0, None, None)}
+        mock_userof.return_value = "alice"
         mock_handle.return_value = [("node1", (0, None, None))]
 
         result = self.parallax_call_instance.call()
         self.assertEqual(result, mock_handle.return_value)
 
-        mock_call.assert_called_once_with(["node1"], "ls", self.parallax_call_instance.opts)
+        mock_userof.assert_called_once_with("node1")
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
     @mock.patch("parallax.Error")
+    @mock.patch("crmsh.utils.user_of")
     @mock.patch("parallax.call")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_call_exception(self, mock_handle, mock_call, mock_error):
+    def test_call_exception(self, mock_handle, mock_call, mock_userof, mock_error):
         mock_error = mock.Mock()
         mock_call.return_value = {"node1": mock_error}
+        mock_userof.return_value = "alice"
         mock_handle.side_effect = ValueError("error happen")
 
         with self.assertRaises(ValueError) as err:
             self.parallax_call_instance.call()
         self.assertEqual("error happen", str(err.exception))
 
-        mock_call.assert_called_once_with(["node1"], "ls", self.parallax_call_instance.opts)
+        mock_userof.assert_called_once_with("node1")
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
     @mock.patch("crmsh.parallax.Parallax.handle")

--- a/test/unittests/test_watchdog.py
+++ b/test/unittests/test_watchdog.py
@@ -26,7 +26,7 @@ class TestWatchdog(unittest.TestCase):
         Test setUp.
         """
         self.watchdog_inst = watchdog.Watchdog()
-        self.watchdog_join_inst = watchdog.Watchdog(peer_host="node1")
+        self.watchdog_join_inst = watchdog.Watchdog(remote_user="alice", peer_host="node1")
 
     def tearDown(self):
         """
@@ -48,7 +48,7 @@ class TestWatchdog(unittest.TestCase):
         mock_run.return_value = (1, None, "error")
         res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog", True)
         self.assertEqual(res, False)
-        mock_run.assert_called_once_with("wdctl /dev/watchdog")
+        mock_run.assert_called_once_with("sudo wdctl /dev/watchdog")
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.get_stdout_stderr')
@@ -58,7 +58,7 @@ class TestWatchdog(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
         mock_error.assert_called_once_with("Invalid watchdog device /dev/watchdog: error")
-        mock_run.assert_called_once_with("wdctl /dev/watchdog")
+        mock_run.assert_called_once_with("sudo wdctl /dev/watchdog")
 
     @mock.patch('crmsh.utils.get_stdout_stderr')
     def test_verify_watchdog_device(self, mock_run):
@@ -149,15 +149,15 @@ Driver: iTCO_wdt
     def test_get_driver_through_device_remotely_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         self.watchdog_join_inst._get_driver_through_device_remotely("test")
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
-        mock_error.assert_called_once_with("Failed to run sbd query-watchdog remotely: error")
+        mock_run.assert_called_once_with("ssh {} alice@node1 sudo sbd query-watchdog".format(constants.SSH_OPTION))
+        mock_error.assert_called_once_with("Failed to run sudo sbd query-watchdog remotely: error")
 
     @mock.patch('crmsh.utils.get_stdout_stderr')
     def test_get_driver_through_device_remotely_none(self, mock_run):
         mock_run.return_value = (0, "data", None)
         res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
         self.assertEqual(res, None)
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
+        mock_run.assert_called_once_with("ssh {} alice@node1 sudo sbd query-watchdog".format(constants.SSH_OPTION))
 
     @mock.patch('crmsh.utils.get_stdout_stderr')
     def test_get_driver_through_device_remotely(self, mock_run):
@@ -181,7 +181,7 @@ Driver: iTCO_wdt
         mock_run.return_value = (0, output, None)
         res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
         self.assertEqual(res, "softdog")
-        mock_run.assert_called_once_with("ssh {} root@node1 sbd query-watchdog".format(constants.SSH_OPTION))
+        mock_run.assert_called_once_with("ssh {} alice@node1 sudo sbd query-watchdog".format(constants.SSH_OPTION))
 
     def test_get_first_unused_device_none(self):
         res = self.watchdog_inst._get_first_unused_device()


### PR DESCRIPTION
It enables creating the cluster under a custom user
Assume the users are alice@node1 and non@node2.

1) Bring the alice into sudoers file on the node1
and bob on the node2
for example
`$ sudo echo "alice ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers`
(use `visudo` rather than echo)

2) add /usr/sbin to the PATH for alice and bob (writ it in the ~/.bashrc)
`$ export PATH=$PATH:/usr/sbin`

And now you can do the usual routines under alice

```
alice@node1$ crm cluster init -y
bob@node2$ crm cluster join -c alice@node1 -y
or
alice@node1$ crm cluster init -N bob@node2 -y
```

The crm will start as a usual process with the same context as the
current user (alice/bob). However when it would lack permissions
for example to read/write file it would try again as the super-user.