### PR TITLE
[crmsh-4.4] Dev: bootstrap: Show remote node name when stopping service remotely

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1808,7 +1808,7 @@ def stop_services(stop_list, remote_addr=None):
     """
     for service in stop_list:
         if utils.service_is_active(service, remote_addr=remote_addr):
-            logger.info("Stopping the {}".format(service))
+            logger.info("Stopping the %s%s", service, " on {}".format(remote_addr) if remote_addr else "")
             utils.stop_service(service, disable=True, remote_addr=remote_addr)
 
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1339,10 +1339,10 @@ class TestValidation(unittest.TestCase):
             mock.call("csync2.socket", remote_addr=None)
             ])
         mock_status.assert_has_calls([
-            mock.call("Stopping the corosync-qdevice.service"),
-            mock.call("Stopping the corosync.service"),
-            mock.call("Stopping the hawk.service"),
-            mock.call("Stopping the csync2.socket")
+            mock.call('Stopping the %s%s', 'corosync-qdevice.service', ''),
+            mock.call('Stopping the %s%s', 'corosync.service', ''),
+            mock.call('Stopping the %s%s', 'hawk.service', ''),
+            mock.call('Stopping the %s%s', 'csync2.socket', '')
             ])
         mock_stop.assert_has_calls([
             mock.call("corosync-qdevice.service", disable=True, remote_addr=None),


### PR DESCRIPTION
backport #1010 