### PR TITLE
Fix: utils: raise exception when failed to run command remotely

### DIFF
--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -37,7 +37,9 @@ class Parallax(object):
     def prepare(self):
         opts = parallax.Options()
         if self.ssh_options is None:
-            self.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
+            self.ssh_options = ['StrictHostKeyChecking=no',
+                    'ConnectTimeout=10',
+                    'LogLevel=error']
         opts.ssh_options = self.ssh_options
         opts.askpass = self.askpass
         # warn_message will available from parallax-1.0.5

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -90,14 +90,7 @@ class Context(object):
                     break
             if cmd:
                 rv = self.execute_command() is not False
-        except ValueError as msg:
-            if config.core.debug or options.regression_tests:
-                import traceback
-                traceback.print_exc()
-                sys.stdout.flush()
-            logger.error("%s: %s", self.get_qualified_name(), msg)
-            rv = False
-        except IOError as msg:
+        except (ValueError, IOError) as msg:
             if config.core.debug or options.regression_tests:
                 import traceback
                 traceback.print_exc()

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2539,13 +2539,10 @@ class ServiceManager(object):
         elif self.remote_addr and self.remote_addr != this_node():
             prompt_msg = "Run \"{}\" on {}".format(cmd, self.remote_addr)
             rc, output, err = run_cmd_on_remote(cmd, self.remote_addr, prompt_msg)
-            # see "EXIT STATUS" in man systemctl
-            if rc > 4:
-                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         else:
             rc, output, err = get_stdout_stderr(cmd)
-            if rc != 0 and err:
-                raise ValueError("Run \"{}\" error: {}".format(cmd, err))
+        if rc != 0 and err:
+            raise ValueError("Run \"{}\" error: {}".format(cmd, err))
         return rc == 0, output
 
     @property


### PR DESCRIPTION
## Promblem
```
# ssh 15sp4-2 systemctl start corosync
Job for corosync.service failed because the control process exited with error code.
See "systemctl status corosync.service" and "journalctl -xeu corosync.service" for details.
```

But in crmsh, don't raise any exception
```
# python3
Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from crmsh import utils
>>> utils.start_service('corosync.service', remote_addr="15sp4-2")
```
## Solution
Revert 9cf075149412a757f7b1e527926922e34c9ce624.

Besides this,

- Dev: parallax: Add LogLevel=error ssh option to filter out warnings like ssh banner message
- Dev: ui_context: remove duplicated codes