### PR TITLE
Fix: crash_test: do not use firewalld to isolate a cluster node

### DIFF
--- a/crmsh/crash_test/main.py
+++ b/crmsh/crash_test/main.py
@@ -155,7 +155,7 @@ For each --kill-* testcase, report directory: {}'''.format(context.logfile,
     group_mutual.add_argument('--fence-node', dest='fence_node', metavar='NODE',
                               help='Fence specific node')
     group_mutual.add_argument('--split-brain-iptables', dest='sp_iptables', action='store_true',
-                              help='Make split brain by blocking corosync ports')
+                              help='Make split brain by blocking traffic between cluster nodes')
     parser.add_argument('-l', '--kill-loop', dest='loop', action='store_true',
                         help='Kill process in loop')
 

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -437,14 +437,14 @@ Expected State:    {}
 
 class TaskSplitBrain(Task):
     """
-    Class to define how to simulate split brain by blocking corosync ports
+    Class to define how to simulate split brain by blocking traffic between cluster nodes
     """
 
     def  __init__(self, force=False):
         """
         Init function
         """
-        self.description = "Simulate split brain by blocking corosync ports"
+        self.description = "Simulate split brain by blocking traffic between cluster nodes"
         self.expected = "One of nodes get fenced"
         self.ports = []
         self.peer_nodelist = []
@@ -493,26 +493,11 @@ Fence timeout:     {}
         """
         Context manager to block and unblock ip/ports
         """
-        self.firewalld_enabled = crmshutils.service_is_active("firewalld.service")
-        if self.firewalld_enabled:
-            self.do_block_firewalld()
-        else:
-            self.do_block_iptables()
+        self.do_block_iptables()
         try:
             yield
         finally:
             self.un_block()
-
-    def do_block_firewalld(self):
-        """
-        Block corosync ports
-        """
-        self.ports = utils.corosync_port_list()
-        if not self.ports:
-            raise TaskError("Can not get corosync's port")
-        self.info("Trying to temporarily block port {}".format(','.join(self.ports)))
-        for p in self.ports:
-            crmshutils.get_stdout_stderr(config.REMOVE_PORT.format(port=p))
 
     def do_block_iptables(self):
         """
@@ -528,18 +513,7 @@ Fence timeout:     {}
         """
         Unblock corosync ip/ports
         """
-        if self.firewalld_enabled:
-            self.un_block_firewalld()
-        else:
-            self.un_block_iptables()
-
-    def un_block_firewalld(self):
-        """
-        Unblock corosync ports
-        """
-        self.info("Trying to add port {}".format(','.join(self.ports)))
-        for p in self.ports:
-            crmshutils.get_stdout_stderr(config.ADD_PORT.format(port=p))
+        self.un_block_iptables()
 
     def un_block_iptables(self):
         """


### PR DESCRIPTION
Removing ports from firewalld zone will not break established connections.