### PR TITLE
Dev: bootstrap: Adjust sbd related timeout when add/remove qdevice

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1375,6 +1375,10 @@ def init_qdevice():
 
     qdevice_inst.config_and_start_qdevice()
 
+    if _context.stage == "qdevice" and utils.service_is_active("sbd.service"):
+        from .sbd import SBDTimeout
+        SBDTimeout.adjust_sbd_timeout_related_cluster_configuration()
+
 
 def init():
     """
@@ -2173,6 +2177,10 @@ def remove_qdevice():
         wait_for_cluster()
     else:
         logger.warning("To remove qdevice service, need to restart cluster service manually on each node")
+
+    if utils.service_is_active("sbd.service"):
+        from .sbd import SBDTimeout
+        SBDTimeout.adjust_sbd_timeout_related_cluster_configuration()
 
 
 def bootstrap_remove(context):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -258,7 +258,7 @@ class SBDTimeout(object):
         cls_inst = cls(removing=removing)
         cls_inst._load_configurations()
 
-        message = "Adjusting sbd related timeout values for 2-node cluster"
+        message = "Adjusting sbd related timeout values"
         with logger_utils.status_long(message):
             cls_inst.adjust_sbd_delay_start()
             cls_inst.adjust_pcmk_delay_max()


### PR DESCRIPTION
* After adding qdevice via stage on a running cluster with sbd running, the parameter `pcmk_delay_max` is useless and should be removed
* After removing qdevice from a two-node cluster with sbd running, the parameter `pcmk_delay_max` should be added