### PR TITLE
Dev: cibconfig: "crm config show related:xxx" provides partial search among class, provider, type fields

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3135,30 +3135,37 @@ class CibFactory(object):
         return [x for x in self.cib_objects
                 if x.updated or x.origin == "user"]
 
-    def get_elems_on_ra_type(self, spec):
+    def get_elems_of_ra_partial_search(self, spec):
         """
-        Get elements by given ra class:provider:type or class:type or only type
+        Get elements by given ra class:provider:type or class:type or only class/provider/type
         return [] if no results
         """
+        def match_type(obj, tp):
+            type_res = obj.node.get("type")
+            return type_res and tp.lower() in type_res.lower()
+
         content_list = spec.split(':')[1:]
         if len(content_list) > 3:
             return []
         if len(content_list) == 3:
             cls, provider, tp = content_list
             return [x for x in self.cib_objects 
-                    if x.node.get("type") == tp
+                    if match_type(x, tp)
                     and x.node.get("provider") == provider
                     and x.node.get("class") == cls]
         if len(content_list) == 2:
             cls, tp = content_list
             return [x for x in self.cib_objects 
-                    if x.node.get("type") == tp
+                    if match_type(x, tp)
                     and x.node.get("class") == cls]
         if len(content_list) == 1:
             tp = content_list[0]
             if not tp:
                 return []
-            return [x for x in self.cib_objects if x.node.get("type") == tp]
+            return [x for x in self.cib_objects
+                    if match_type(x, tp) or
+                    x.node.get("class") == tp or
+                    x.node.get("provider") == tp]
 
     def get_elems_on_type(self, spec):
         if not spec.startswith("type:"):
@@ -3223,7 +3230,7 @@ class CibFactory(object):
                 obj = self.find_object(name)
                 if obj is not None:
                     obj_set |= orderedset.oset(self.related_elements(obj))
-                obj_set |= orderedset.oset(self.get_elems_on_ra_type(spec))
+                obj_set |= orderedset.oset(self.get_elems_of_ra_partial_search(spec))
             else:
                 objs = self.find_objects(spec) or []
                 for obj in objs:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3913,7 +3913,14 @@ show type:primitive
 show xml tag:db tag:fs
 show related:webapp
 show related:IPaddr2
+show related:ipad
 show related:ocf:heartbeat:Dummy
+show related:ocf:heartbeat:dum
+show related:ocf
+show related:heartbeat
+show related:pacemaker
+show related:suse
+show related:stonith
 show type:primitive obscure:passwd
 ...............
 


### PR DESCRIPTION
```
crm(live/15sp4-1)configure# show related:ocf
primitive d Dummy
primitive vip IPaddr2 \
	params ip=10.10.10.125

crm(live/15sp4-1)configure# show related:stonith
primitive stonith-sbd stonith:external/sbd \
	params
primitive ttt stonith:rps10 \
	params pcmk_delay_max=30 serial_to_targets=sf
primitive xxx stonith:fence_eps \
	params pcmk_delay_base=10

crm(live/15sp4-1)configure# show related:ip
primitive vip IPaddr2 \
        params ip=10.10.10.125
```