### PR TITLE
Fix: ha-cluster-join fails to add nodes to a existing cluster after the version update (bsc#1201785)

### DIFF
--- a/crmsh/remoteutil.py
+++ b/crmsh/remoteutil.py
@@ -6,25 +6,31 @@ import subprocess
 import sys
 import threading
 import typing
+# This script is intended to be run on a remote host. Only modules from standard library can be import here.
 
 
 class Error(Exception):
+    """base exception for this module"""
     pass
 
 
-class ProtocolError(Error):
+class ProtocolException(Error):
+    # failure to deserialize arguments or results
     pass
 
 
 class SshError(Error):
+    """ssh errors, such as authentication problems and connection problems"""
     pass
 
 
-class RemoteError(Error):
+class RemoteException(Error):
+    # remote agent is not working as expected
     pass
 
 
 class CalledProcessError(Error):
+    """remote calling finished successfully, but cmd exits with a non-zero code."""
     def __init__(self, returncode, cmd, stdout, stderr):
         self.returncode = returncode
         self.cmd = cmd
@@ -36,7 +42,8 @@ class CalledProcessError(Error):
         return self.stdout
 
 
-class RemoteCallParameter:
+class RemoteCallArguments:
+    # data structure to pass calling arguments to remote host, used only internally.
     def __init__(
             self,
             cmdline: str,
@@ -76,10 +83,14 @@ class RemoteCallParameter:
         cmdline = cmdline.decode('utf-8')
         cwd = None if len_cwd == 0 else cwd.decode('utf-8')
         stdin = None if len_stdin == 0 else stdin
-        return RemoteCallParameter(cmdline, cwd, stdin, use_shell, capture_stdout)
+        return RemoteCallArguments(cmdline, cwd, stdin, use_shell, capture_stdout)
 
 
 class RemoteCallResult:
+    """result of a remote call
+
+    stdout and stderr is returned as bytes.
+    """
     def __init__(self, rc: int, stdout: bytes = None, stderr: bytes = None):
         self.rc = rc
         self.stdout = stdout
@@ -99,20 +110,22 @@ class RemoteCallResult:
 
 
 def remote_agent(stdin: typing.BinaryIO, stdout: typing.BinaryIO, stderr: typing.TextIO):
+    # read calling arguments
     request = stdin.read()
     try:
-        parameters = RemoteCallParameter.deserialize(request)
+        arguments = RemoteCallArguments.deserialize(request)
     except (ValueError, struct.error) as e:
-        raise ProtocolError(e, request) from None
+        raise ProtocolException(e, request) from None
     process = subprocess.Popen(
-        parameters.cmdline if parameters.use_shell else shlex.split(parameters.cmdline),
-        shell=parameters.use_shell,
-        cwd=parameters.cwd,
+        arguments.cmdline if arguments.use_shell else shlex.split(arguments.cmdline),
+        shell=arguments.use_shell,
+        cwd=arguments.cwd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
     # TODO: implement not capturing outputs
+    # run the cmd and capture outputs
     with contextlib.closing(process.stdin), contextlib.closing(process.stdout), contextlib.closing(process.stderr):
         def reader(f, bb):
             bb.append(f.read())
@@ -122,29 +135,33 @@ def remote_agent(stdin: typing.BinaryIO, stdout: typing.BinaryIO, stderr: typing
         stderr_buf_box = []
         stderr_reader = threading.Thread(target=reader, args=(process.stderr, stderr_buf_box), daemon=True)
         stderr_reader.start()
-        if parameters.stdin is not None:
-            process.stdin.write(parameters.stdin)
+        if arguments.stdin is not None:
+            process.stdin.write(arguments.stdin)
         process.stdin.close()
         process.wait()
         stdout_reader.join()
         stderr_reader.join()
 
+    # write results
     result = RemoteCallResult(process.returncode, stdout_buf_box[0], stderr_buf_box[0])
     stdout.write(result.serialize())
     stdout.flush()
 
 
-def remote_client(ifile: typing.BinaryIO, ofile: typing.BinaryIO, parameters: RemoteCallParameter):
+def remote_client(ifile: typing.BinaryIO, ofile: typing.BinaryIO, parameters: RemoteCallArguments):
+    # write calling arguments to remote host
     ofile.write(parameters.serialize())
     ofile.flush()
     ofile.close()
+    # read calling result from remote host
     ret = ifile.read()
     try:
         return RemoteCallResult.deserialize(ret)
     except struct.error as e:
-        raise ProtocolError(e, ret) from None
+        raise ProtocolException(e, ret) from None
 
 
+# public API
 def run(
         host: typing.Union[str, typing.Tuple[str, int, str]],
         cmd: str,
@@ -154,7 +171,14 @@ def run(
         use_shell: bool = False,
         capture_output: bool = True,
         ssh_options: typing.List[str] = None
-):
+) -> RemoteCallResult:
+    """ Run a command on specified host.
+
+    By default, the cmd is not run with a shell, so redirections/substitutions will not work. Set `use_shell` to True to
+    enable these features.
+
+    Warning: enable `use_shell` make it vulnerable to shell injection, avoid using it if unnecessary.
+    """
     if ssh_options is None:
         ssh_options = ['-o', 'StrictHostKeyChecking=no']
     args = ['ssh']
@@ -166,35 +190,39 @@ def run(
     with open(__file__, 'rb') as f:
         script = f.read()
     args.extend(['/bin/sh', '-c', ';F=$(mktemp)&&head -c {} >"$F"&&chmod +x "$F"&&"$F";rm -f "$F"'.format(len(script))])
+    # run a shell oneliner on remote host with ssh, which load and execute a larger executable from stdin.
     process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     with contextlib.closing(process.stdin), contextlib.closing(process.stdout), contextlib.closing(process.stderr):
+        # fork a thread to consume stderr pipe so that the other end will not be blocked
         def reader(f, bb):
             bb.append(f.read())
         stderr_buf_box = []
         stderr_reader = threading.Thread(target=reader, args=(process.stderr, stderr_buf_box), daemon=True)
         stderr_reader.start()
+        # send this script to the oneliner, so remote_agent() is executed on remote host
         process.stdin.write(script)
-        parameters = RemoteCallParameter(cmd, cwd, stdin, use_shell, capture_output)
+        arguments = RemoteCallArguments(cmd, cwd, stdin, use_shell, capture_output)
         try:
-            result = remote_client(process.stdout, process.stdin, parameters)
-        except ProtocolError:
+            result = remote_client(process.stdout, process.stdin, arguments)
+        except ProtocolException:
             ssh_rc = process.wait()
             stderr_reader.join()
             if ssh_rc == 255:
                 raise SshError(stderr_buf_box[0].decode('utf-8', 'replace')) from None
             else:
-                raise RemoteError(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
+                raise RemoteException(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
         else:
             ssh_rc = process.wait()
             stderr_reader.join()
             if ssh_rc == 255:
                 raise SshError(stderr_buf_box[0].decode('utf-8', 'replace'))
             elif ssh_rc != 0:
-                raise RemoteError(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
+                raise RemoteException(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
             else:
                 return result
 
 
+# public API
 def check_call(
         host: typing.Union[str, typing.Tuple[str, int, str]],
         cmd: str,
@@ -205,10 +233,12 @@ def check_call(
         capture_output: bool = True,
         ssh_options: typing.List[str] = None
 ):
+    """Run a command on remote host and raise CalledProcessError when it exits with non-zero code."""
     result = run(host, cmd, cwd, stdin, use_shell, capture_output, ssh_options)
     if result.rc != 0:
         raise CalledProcessError(result.rc, cmd, result.stdout, result.stderr)
 
 
 if __name__ == '__main__':
+    # use BinaryIO instead of TextIO, since we are working with binary streams
     remote_agent(sys.stdin.buffer, sys.stdout.buffer, sys.stderr)

--- a/crmsh/remoteutil.py
+++ b/crmsh/remoteutil.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+import contextlib
+import shlex
+import struct
+import subprocess
+import sys
+import threading
+import typing
+
+
+class Error(Exception):
+    pass
+
+
+class ProtocolError(Error):
+    pass
+
+
+class SshError(Error):
+    pass
+
+
+class RemoteError(Error):
+    pass
+
+
+class CalledProcessError(Error):
+    def __init__(self, returncode, cmd, stdout, stderr):
+        self.returncode = returncode
+        self.cmd = cmd
+        self.stdout = stdout
+        self.stderr = stderr
+
+    @property
+    def output(self):
+        return self.stdout
+
+
+class RemoteCallParameter:
+    def __init__(
+            self,
+            cmdline: str,
+            cwd: str = None,
+            stdin: typing.Union[str, bytes] = None,
+            use_shell: bool = False,
+            capture_output: bool = False
+    ):
+        self.cmdline = cmdline
+        self.cwd = cwd
+        self.stdin = stdin
+        self.use_shell = use_shell
+        self.capture_output = capture_output
+
+    def serialize(self):
+        cmdline = self.cmdline.encode('utf-8')
+        cwd = b'' if self.cwd is None else self.cwd.encode('utf-8')
+        if self.stdin is None:
+            stdin = b''
+        elif isinstance(self.stdin, str):
+            stdin = self.stdin.encode('utf-8')
+        else:
+            stdin = self.stdin
+        return struct.pack(
+            '!III??',
+            len(cmdline),
+            len(cwd),
+            len(stdin),
+            self.use_shell,
+            self.capture_output,
+        ) + cmdline + cwd + stdin
+
+    @staticmethod
+    def deserialize(data):
+        len_cmdline, len_cwd, len_stdin, use_shell, capture_stdout = struct.unpack_from('!III??', data)
+        _, _, _, _, _, cmdline, cwd, stdin = struct.unpack('!III??{}s{}s{}s'.format(len_cmdline, len_cwd, len_stdin), data)
+        cmdline = cmdline.decode('utf-8')
+        cwd = None if len_cwd == 0 else cwd.decode('utf-8')
+        stdin = None if len_stdin == 0 else stdin
+        return RemoteCallParameter(cmdline, cwd, stdin, use_shell, capture_stdout)
+
+
+class RemoteCallResult:
+    def __init__(self, rc: int, stdout: bytes = None, stderr: bytes = None):
+        self.rc = rc
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def serialize(self):
+        stdout = b'' if self.stdout is None else self.stdout
+        stderr = b'' if self.stderr is None else self.stderr
+        data = struct.pack('!III', self.rc, len(stdout), len(stderr)) + stdout + stderr
+        return data
+
+    @staticmethod
+    def deserialize(data):
+        rc, len_stdout, len_stderr = struct.unpack_from('!III', data)
+        _, _, _, stdout, stderr = struct.unpack('!III{}s{}s'.format(len_stdout, len_stderr), data)
+        return RemoteCallResult(rc, stdout, stderr)
+
+
+def remote_agent(stdin: typing.BinaryIO, stdout: typing.BinaryIO, stderr: typing.TextIO):
+    request = stdin.read()
+    try:
+        parameters = RemoteCallParameter.deserialize(request)
+    except (ValueError, struct.error) as e:
+        raise ProtocolError(e, request) from None
+    process = subprocess.Popen(
+        parameters.cmdline if parameters.use_shell else shlex.split(parameters.cmdline),
+        shell=parameters.use_shell,
+        cwd=parameters.cwd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # TODO: implement not capturing outputs
+    with contextlib.closing(process.stdin), contextlib.closing(process.stdout), contextlib.closing(process.stderr):
+        def reader(f, bb):
+            bb.append(f.read())
+        stdout_buf_box = []
+        stdout_reader = threading.Thread(target=reader, args=(process.stdout, stdout_buf_box), daemon=True)
+        stdout_reader.start()
+        stderr_buf_box = []
+        stderr_reader = threading.Thread(target=reader, args=(process.stderr, stderr_buf_box), daemon=True)
+        stderr_reader.start()
+        if parameters.stdin is not None:
+            process.stdin.write(parameters.stdin)
+        process.stdin.close()
+        process.wait()
+        stdout_reader.join()
+        stderr_reader.join()
+
+    result = RemoteCallResult(process.returncode, stdout_buf_box[0], stderr_buf_box[0])
+    stdout.write(result.serialize())
+    stdout.flush()
+
+
+def remote_client(ifile: typing.BinaryIO, ofile: typing.BinaryIO, parameters: RemoteCallParameter):
+    ofile.write(parameters.serialize())
+    ofile.flush()
+    ofile.close()
+    ret = ifile.read()
+    try:
+        return RemoteCallResult.deserialize(ret)
+    except struct.error as e:
+        raise ProtocolError(e, ret) from None
+
+
+def run(
+        host: typing.Union[str, typing.Tuple[str, int, str]],
+        cmd: str,
+        cwd: str = None,
+        stdin: typing.Union[str, bytes] = None,
+        # TODO: implement sudo
+        use_shell: bool = False,
+        capture_output: bool = True,
+        ssh_options: typing.List[str] = None
+):
+    if ssh_options is None:
+        ssh_options = ['-o', 'StrictHostKeyChecking=no']
+    args = ['ssh']
+    args.extend(ssh_options)
+    if isinstance(host, str):
+        args.append(host)
+    else:
+        args.extend(['-p', str(host[1]), '{}@{}'.format(host[2], host[0])])
+    with open(__file__, 'rb') as f:
+        script = f.read()
+    args.extend(['/bin/sh', '-c', ';F=$(mktemp)&&head -c {} >"$F"&&chmod +x "$F"&&"$F";rm -f "$F"'.format(len(script))])
+    process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    with contextlib.closing(process.stdin), contextlib.closing(process.stdout), contextlib.closing(process.stderr):
+        def reader(f, bb):
+            bb.append(f.read())
+        stderr_buf_box = []
+        stderr_reader = threading.Thread(target=reader, args=(process.stderr, stderr_buf_box), daemon=True)
+        stderr_reader.start()
+        process.stdin.write(script)
+        parameters = RemoteCallParameter(cmd, cwd, stdin, use_shell, capture_output)
+        try:
+            result = remote_client(process.stdout, process.stdin, parameters)
+        except ProtocolError:
+            ssh_rc = process.wait()
+            stderr_reader.join()
+            if ssh_rc == 255:
+                raise SshError(stderr_buf_box[0].decode('utf-8', 'replace')) from None
+            else:
+                raise RemoteError(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
+        else:
+            ssh_rc = process.wait()
+            stderr_reader.join()
+            if ssh_rc == 255:
+                raise SshError(stderr_buf_box[0].decode('utf-8', 'replace'))
+            elif ssh_rc != 0:
+                raise RemoteError(ssh_rc, stderr_buf_box[0].decode('utf-8', 'replace'))
+            else:
+                return result
+
+
+def check_call(
+        host: typing.Union[str, typing.Tuple[str, int, str]],
+        cmd: str,
+        cwd: str = None,
+        stdin: typing.Union[str, bytes] = None,
+        # TODO: implement sudo
+        use_shell: bool = False,
+        capture_output: bool = True,
+        ssh_options: typing.List[str] = None
+):
+    result = run(host, cmd, cwd, stdin, use_shell, capture_output, ssh_options)
+    if result.rc != 0:
+        raise CalledProcessError(result.rc, cmd, result.stdout, result.stderr)
+
+
+if __name__ == '__main__':
+    remote_agent(sys.stdin.buffer, sys.stdout.buffer, sys.stderr)


### PR DESCRIPTION
# Problem

1. When directory `~hacluster/.ssh` does not exist, crm cluster join will failed
2. When file `~hacluster/.ssh/id_*.pub` does not exist, crm cluster join will succeed with a warning, but passwordless ssh is not set up.

# Fix

1. If the directory does not exists, failed with a suggestion to run crm cluster init ssh.
2. if public key does not exists, fail the join procedure.

A demo util for remote ssh calling is used here. Maybe it needs to be replaced with non-privileged remote utils from #1009 in the future.

# Work in Progress:

- [ ] checks should be added to `crm report -u user`
- [ ] unit tests