### PR TITLE
Fix: ha-cluster-join fails to add nodes to a existing cluster after the version update (bsc#1201785)

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -185,6 +185,17 @@ jobs:
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF geo_setup`
 
+  functional_test_healthcheck:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for healthcheck
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        $DOCKER_SCRIPT `$GET_INDEX_OF healthcheck`
+
   original_regression_test:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
@@ -209,6 +220,7 @@ jobs:
       functional_test_configure_sublevel,
       functional_test_constraints_bugs,
       functional_test_geo_cluster,
+      functional_test_healthcheck,
       original_regression_test]
     runs-on: ubuntu-20.04
     timeout-minutes: 10

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -25,6 +25,7 @@ from lxml import etree
 from pathlib import Path
 from contextlib import contextmanager
 from . import config
+from . import upgradeutil
 from . import utils
 from . import xmlutil
 from .cibconfig import mkset_obj, cib_factory
@@ -1251,6 +1252,10 @@ def init_sbd():
     _context.sbd_manager.sbd_init()
 
 
+def init_upgradeutil():
+    upgradeutil.force_set_local_upgrade_seq()
+
+
 def init_ocfs2():
     """
     OCFS2 configure process
@@ -2049,6 +2054,7 @@ def bootstrap_init(context):
         init_corosync()
         init_remote_auth()
         init_sbd()
+        init_upgradeutil()
 
         lock_inst = lock.Lock()
         try:
@@ -2120,6 +2126,7 @@ def bootstrap_join(context):
             cluster_node = prompt_for_string("IP address or hostname of existing node (e.g.: 192.168.1.1)", ".+")
             _context.cluster_node = cluster_node
 
+        init_upgradeutil()
         utils.ping_node(cluster_node)
 
         join_ssh(cluster_node)

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1431,7 +1431,14 @@ def swap_public_ssh_key(remote_node, user="root", add=False):
         if user == "root":
             copy_ssh_key(public_key, user, remote_node)
         else:
-            append_to_remote_file(public_key, remote_node, authorized_file)
+            try:
+                append_to_remote_file(public_key, remote_node, authorized_file)
+            except ValueError:
+                utils.get_stdout_or_raise_error(
+                    '/usr/bin/env python3 -m crmsh.healthcheck fix-cluster PasswordlessHaclusterAuthenticationFeature',
+                    remote_node,
+                )
+                append_to_remote_file(public_key, remote_node, authorized_file)
 
     if add:
         configure_ssh_key(remote=remote_node)

--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -1,0 +1,181 @@
+import logging
+import argparse
+import os
+import os.path
+import parallax
+import subprocess
+import sys
+import typing
+
+import crmsh.parallax
+import crmsh.utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class Feature:
+    _feature_registry = dict()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        Feature._feature_registry[cls.__name__.rsplit('.', 1)[-1]] = cls
+
+    @staticmethod
+    def get_feature_by_name(name: str):
+        return Feature._feature_registry[name]
+
+    def check_quick(self) -> bool:
+        raise NotImplementedError
+
+    def check_local(self, nodes: typing.Iterable[str]) -> bool:
+        raise NotImplementedError
+
+    def check_cluster(self, nodes: typing.Iterable[str]) -> bool:
+        raise NotImplementedError
+
+    def fix_local(self, nodes: typing.Iterable[str], ask: typing.Callable[[str], None]) -> None:
+        raise NotImplementedError
+
+    def fix_cluster(self, nodes: typing.Iterable[str], ask: typing.Callable[[str], None]) -> None:
+        raise NotImplementedError
+
+
+class FixFailure(Exception):
+    pass
+
+
+class AskDeniedByUser(Exception):
+    pass
+
+
+def feature_quick_check(feature: Feature):
+    return feature.check_quick()
+
+
+def feature_full_check(feature: Feature, nodes: typing.Iterable[str]) -> bool:
+    try:
+        if not feature.check_local(nodes):
+            return False
+    except NotImplementedError:
+        pass
+    try:
+        return feature.check_cluster(nodes)
+    except NotImplementedError:
+        results = _parallax_run(
+            nodes,
+            '/usr/bin/env python3 -m crmsh.healthcheck --check-local {}'.format(
+                feature.__class__.__name__.rsplit('.', 1)[-1],
+            )
+        )
+        return all(rc == 0 for rc, _, _ in results.values())
+
+
+def feature_fix(feature: Feature, nodes: typing.Iterable[str], ask: typing.Callable[[str], None]) -> None:
+    try:
+        return feature.fix_cluster(nodes, ask)
+    except NotImplementedError:
+        for node in nodes:
+            raise NotImplementedError
+            _parallax_run(node, _)
+
+
+class PasswordlessHaclusterAuthenticationFeature(Feature):
+    SSH_DIR = os.path.expanduser('~hacluster/.ssh')
+    KEY_TYPES = ['ed25519', 'ecdsa', 'rsa']
+
+    def check_quick(self) -> bool:
+        for key_type in self.KEY_TYPES:
+            try:
+                os.stat('{}/{}'.format(self.SSH_DIR, key_type))
+                os.stat('{}/{}.pub'.format(self.SSH_DIR, key_type))
+                return True
+            except FileNotFoundError:
+                pass
+        return False
+
+    def check_local(self, nodes: typing.Iterable[str]) -> bool:
+        try:
+            for node in nodes:
+                subprocess.check_call(['sudo', 'su', '-', 'hacluster', '-c', 'ssh hacluster@{} true'.format(node)])
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    def fix_cluster(self, nodes: typing.Iterable[str], ask: typing.Callable[[str], None]) -> None:
+        logger.debug("setup passwordless ssh authentication for user hacluster")
+        try:
+            nodes_without_keys = [
+                node for node, result in
+                _parallax_run(
+                    nodes,
+                    '[ -f ~hacluster/.ssh/id_rsa ] || [ -f ~hacluster/.ssh/id_ecdsa ] || [ -f ~hacluster/.ssh/id_ed25519 ]'
+                ).items()
+                if result[0] != 0
+            ]
+        except parallax.Error:
+            raise FixFailure()
+        if nodes_without_keys:
+            ask("Setup passwordless ssh authentication for user hacluster?")
+            if len(nodes_without_keys) == len(nodes):
+                # pick one node to run init ssh on it
+                init_node = nodes_without_keys[0]
+                # and run join ssh on other nodes
+                join_nodes = list()
+                join_nodes.extend(nodes)
+                join_nodes.remove(init_node)
+                join_target_node = init_node
+            else:
+                nodes_with_keys = set(nodes) - set(nodes_without_keys)
+                # no need to init ssh
+                init_node = None
+                join_nodes = nodes_without_keys
+                # pick one node as join target
+                join_target_node = next(iter(nodes_with_keys))
+            if init_node is not None:
+                try:
+                    crmsh.parallax.parallax_call([init_node], 'crm cluster init ssh -y')
+                except ValueError as e:
+                    logger.error('Failed to initialize passwordless ssh authentication on node %s.', init_node, exc_info=e)
+                    raise FixFailure from None
+            try:
+                for node in join_nodes:
+                    crmsh.parallax.parallax_call([node], 'crm cluster join ssh -c {} -y'.format(join_target_node))
+            except ValueError as e:
+                logger.error('Failed to initialize passwordless ssh authentication.', exc_info=e)
+                raise FixFailure from None
+
+
+def _parallax_run(nodes: str, cmd: str) -> typing.Dict[str, typing.Tuple[int, bytes, bytes]]:
+    parallax_options = parallax.Options()
+    parallax_options.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
+    ret = dict()
+    for node, result in parallax.run(nodes, cmd, parallax_options).items():
+        if isinstance(result, parallax.Error):
+            logger.warning("SSH connection to remote node %s failed.", node, exc_info=result)
+            raise result
+        ret[node] = result
+    return ret
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--check-local')
+    parser.add_argument('feature')
+    args = parser.parse_args()
+    try:
+        feature = Feature.get_feature_by_name(args.feature)
+        if args.check_local:
+            nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
+            if nodes:
+                if feature.check_local(nodes):
+                    return 0
+                else:
+                    return 1
+    except KeyError:
+        logger.error('No such feature: %s.', args.feature)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -11,6 +11,7 @@ from . import options
 from . import constants
 from . import clidisplay
 from . import term
+from . import upgradeutil
 from . import utils
 from . import userdir
 
@@ -371,6 +372,7 @@ def run():
         if options.profile:
             return profile_run(context, user_args)
         else:
+            upgradeutil.upgrade_if_needed()
             return main_input_loop(context, user_args)
     except KeyboardInterrupt:
         print("Ctrl-C, leaving")

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -1,0 +1,180 @@
+import logging
+import os.path
+import typing
+
+import parallax
+import sys
+
+import crmsh.parallax
+import crmsh.utils
+
+
+# pump this seq when upgrade check need to be run
+CURRENT_UPGRADE_SEQ = 1
+DATA_DIR = os.path.expanduser('~hacluster/crmsh')
+SEQ_FILE_PATH = DATA_DIR + '/upgrade_seq'
+# touch this file to force a upgrade process
+FORCE_UPGRADE_FILE_PATH = DATA_DIR + '/upgrade_forced'
+
+
+logger = logging.getLogger(__name__)
+
+
+class _SkipUpgrade(Exception):
+    pass
+
+
+def _get_file_content(path, default=None):
+    try:
+        with open(path, 'rb') as f:
+            return f.read()
+    except FileNotFoundError:
+        return default
+
+
+def _parallax_run(nodes: str, cmd: str) -> typing.Dict[str, typing.Tuple[int, bytes, bytes]]:
+    parallax_options = parallax.Options()
+    parallax_options.ssh_options = ['StrictHostKeyChecking=no', 'ConnectTimeout=10']
+    ret = dict()
+    for node, result in parallax.run(nodes, cmd, parallax_options).items():
+        if isinstance(result, parallax.Error):
+            logger.warning("SSH connection to remote node %s failed.", node, exc_info=result)
+            raise result
+        ret[node] = result
+    return ret
+
+
+def _is_upgrade_needed(nodes):
+    """decide whether upgrading is needed by checking local sequence file"""
+    needed = False
+    try:
+        os.stat(FORCE_UPGRADE_FILE_PATH)
+        needed = True
+    except FileNotFoundError:
+        pass
+    if not needed:
+        try:
+            local_seq = int(_get_file_content(SEQ_FILE_PATH, b'').strip())
+        except ValueError:
+            local_seq = 0
+        needed = CURRENT_UPGRADE_SEQ > local_seq
+    return needed
+
+
+def _is_cluster_target_seq_consistent(nodes):
+    cmd = '/usr/bin/env python3 -m crmsh.upgradeutil get-seq'
+    try:
+        results = list(_parallax_run(nodes, cmd).values())
+    except parallax.Error as e:
+        raise _SkipUpgrade() from None
+    try:
+        return all(CURRENT_UPGRADE_SEQ == int(stdout.strip()) if rc == 0 else False for rc, stdout, stderr in results)
+    except ValueError as e:
+        logger.warning("Remote command '%s' returns unexpected output: %s", cmd, results, exc_info=e)
+        return False
+
+
+def _get_minimal_seq_in_cluster(nodes):
+    try:
+        return min(
+            int(stdout.strip()) if rc == 0 else 0
+            for rc, stdout, stderr in _parallax_run(nodes, 'cat {}'.format(SEQ_FILE_PATH)).values()
+        )
+    except ValueError:
+        return 0
+
+
+def _upgrade(nodes, seq):
+    logger.info("Upgrading cluster...")
+    if seq <= 0:
+        seq_0_setup_hacluster_passwordless(nodes)
+
+
+def upgrade_if_needed():
+    nodes = crmsh.utils.list_cluster_nodes()
+    if nodes and _is_upgrade_needed(nodes):
+        logger.info("crmsh version is newer than its configuration. Configuration upgrade is needed.")
+        try:
+            if not _is_cluster_target_seq_consistent(nodes):
+                logger.warning("crmsh version is inconsistent in cluster.")
+                raise _SkipUpgrade()
+            seq = _get_minimal_seq_in_cluster(nodes)
+            logger.debug("Upgrading crmsh configuration from seq %s to %s.", seq, CURRENT_UPGRADE_SEQ)
+            _upgrade(nodes, seq)
+        except _SkipUpgrade:
+            logger.warning("Configuration upgrade skipped.")
+            return
+        crmsh.parallax.parallax_call(
+            nodes,
+            "mkdir -p '{}' && echo '{}' > '{}'".format(DATA_DIR, CURRENT_UPGRADE_SEQ, SEQ_FILE_PATH),
+        )
+        crmsh.parallax.parallax_call(nodes, 'rm -f {}'.format(FORCE_UPGRADE_FILE_PATH))
+        logger.debug("Configuration upgrade finished.", seq, CURRENT_UPGRADE_SEQ)
+
+
+def force_set_local_upgrade_seq():
+    """Create the upgrade sequence file and set it to CURRENT_UPGRADE_SEQ.
+
+    It should only be used when initializing new cluster nodes."""
+    try:
+        os.mkdir(DATA_DIR)
+    except FileExistsError:
+        pass
+    with open(SEQ_FILE_PATH, 'w', encoding='ascii') as f:
+        print(CURRENT_UPGRADE_SEQ, file=f)
+
+
+def seq_0_setup_hacluster_passwordless(nodes):
+    """setup passwordless ssh authentication by running crm cluster ssh init/join on appreciated nodes."""
+    # https://bugzilla.suse.com/show_bug.cgi?id=1201785
+    logger.debug("upgradeutil: setup passwordless ssh authentication for user hacluster")
+    try:
+        nodes_without_keys = [
+            node for node, result in
+            _parallax_run(
+                nodes,
+                '[ -f ~hacluster/.ssh/id_rsa ] || [ -f ~hacluster/.ssh/id_ecdsa ] || [ -f ~hacluster/.ssh/id_ed25519 ]'
+            ).items()
+            if result[0] != 0
+        ]
+    except parallax.Error:
+        raise _SkipUpgrade() from None
+    if nodes_without_keys:
+        if not crmsh.utils.ask("Configuration upgrade: setup passwordless ssh authentication for user hacluster?"):
+            raise _SkipUpgrade()
+        if len(nodes_without_keys) == len(nodes):
+            # pick one node to run init ssh on it
+            init_node = nodes_without_keys[0]
+            # and run join ssh on other nodes
+            join_nodes = list()
+            join_nodes.extend(nodes)
+            join_nodes.remove(init_node)
+            join_target_node = init_node
+        else:
+            nodes_with_keys = set(nodes) - set(nodes_without_keys)
+            # no need to init ssh
+            init_node = None
+            join_nodes = nodes_without_keys
+            # pick one node as join target
+            join_target_node = next(iter(nodes_with_keys))
+        if init_node is not None:
+            try:
+                crmsh.parallax.parallax_call([init_node], 'crm cluster init ssh -y')
+            except ValueError as e:
+                logger.error('Failed to initialize passwordless ssh authentication on node %s.', init_node, exc_info=e)
+                raise _SkipUpgrade from None
+        try:
+            for node in join_nodes:
+                crmsh.parallax.parallax_call([node], 'crm cluster join ssh -c {} -y'.format(join_target_node))
+        except ValueError as e:
+            logger.error('Failed to initialize passwordless ssh authentication.', exc_info=e)
+            raise _SkipUpgrade from None
+
+
+def main():
+    if sys.argv[1] == 'get-seq':
+        print(CURRENT_UPGRADE_SEQ)
+
+
+if __name__ == '__main__':
+    main()

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -91,7 +91,7 @@ def _upgrade(nodes, seq):
 
 
 def upgrade_if_needed():
-    nodes = crmsh.utils.list_cluster_nodes()
+    nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
     if nodes and _is_upgrade_needed(nodes):
         logger.info("crmsh version is newer than its configuration. Configuration upgrade is needed.")
         try:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1703,13 +1703,13 @@ def print_cluster_nodes():
         print("{}\n".format(out))
 
 
-def list_cluster_nodes():
+def list_cluster_nodes(no_reg=False):
     '''
     Returns a list of nodes in the cluster.
     '''
     from . import xmlutil
     cib = None
-    rc, out, err = get_stdout_stderr(constants.CIB_QUERY)
+    rc, out, err = get_stdout_stderr(constants.CIB_QUERY, no_reg=no_reg)
     # When cluster service running
     if rc == 0:
         cib = etree.fromstring(out)

--- a/data-manifest
+++ b/data-manifest
@@ -197,6 +197,7 @@ test/unittests/test_sbd.py
 test/unittests/test_scripts.py
 test/unittests/test_time.py
 test/unittests/test_ui_cluster.py
+test/unittests/test_upgradeuitl.py
 test/unittests/test_utils.py
 test/unittests/test_watchdog.py
 test/unittests/test_xmlutil.py

--- a/data-manifest
+++ b/data-manifest
@@ -75,6 +75,7 @@ test/features/constraints_bugs.feature
 test/features/crm_report_bugs.feature
 test/features/environment.py
 test/features/geo_setup.feature
+test/features/healthcheck.feature
 test/features/ocfs2.feature
 test/features/qdevice_options.feature
 test/features/qdevice_setup_remove.feature

--- a/data-manifest
+++ b/data-manifest
@@ -186,6 +186,7 @@ test/unittests/test_crashtest_task.py
 test/unittests/test_crashtest_utils.py
 test/unittests/test_gv.py
 test/unittests/test_handles.py
+test/unittests/test_healthcheck.py
 test/unittests/test_lock.py
 test/unittests/test_objset.py
 test/unittests/test_ocfs2.py

--- a/test/crm-interface
+++ b/test/crm-interface
@@ -67,6 +67,10 @@ EOF
 }
 crm_filesession() {
 	local _file=`mktemp`
+        $CRM_NO_REG -c $CIB<<EOF
+configure
+delete node1
+EOF
 	$CRM -c $CIB configure save xml $_file
 	CIB_file=$_file $CRM <<EOF
 `cat`

--- a/test/features/healthcheck.feature
+++ b/test/features/healthcheck.feature
@@ -1,0 +1,27 @@
+@healthcheck
+Feature: healthcheck detect and fix problems in a crmsh deployment
+
+  Tag @clean means need to stop cluster service if the service is available
+  Need nodes: hanode1 hanode2 hanode3
+
+  Background: Setup a two nodes cluster
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Cluster service is "stopped" on "hanode3"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Show cluster status on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    And     Show cluster status on "hanode1"
+
+  @clean
+  Scenario: a new node joins when directory ~hacluster/.ssh is removed from cluster
+    When    Run "rm -rf ~hacluster/.ssh" on "hanode1"
+    And     Run "rm -rf ~hacluster/.ssh" on "hanode2"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode3"
+    Then    Cluster service is "started" on "hanode3"
+    And     File "~hacluster/.ssh/id_rsa" exists on "hanode1"
+    And     File "~hacluster/.ssh/id_rsa" exists on "hanode2"
+    And     File "~hacluster/.ssh/id_rsa" exists on "hanode3"

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -404,3 +404,8 @@ def step_impl(context, node):
     resource.setrlimit(resource.RLIMIT_NOFILE, (50, 50))
     for i in range(51):
         parallax.parallax_call([node], "true")
+
+
+@then('File "{path}" exists on "{node}"')
+def step_impl(context, path, node):
+    parallax.parallax_call([node], '[ -f {} ]'.format(path))

--- a/test/unittests/test_healthcheck.py
+++ b/test/unittests/test_healthcheck.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest import mock
+import sys
+
+from crmsh import healthcheck
+
+
+class _Py37MockCallShim:
+    def __init__(self, mock_call):
+        self._mock_call = mock_call
+
+    def __getattr__(self, item):
+        f = getattr(self._mock_call, item)
+
+        def g(*args, **kwargs):
+            return f(*((self._mock_call, ) + args[1:]), **kwargs)
+        return g
+
+    @property
+    def args(self):
+        if sys.version_info.major == 3 and sys.version_info.major < 8:
+            return self._mock_call[0]
+        else:
+            return self._mock_call.args
+
+    @property
+    def kwargs(self):
+        def args(self):
+            if sys.version_info.major == 3 and sys.version_info.major < 8:
+                return self._mock_call[1]
+            else:
+                return self._mock_call.kwargs
+
+
+class TestPasswordlessHaclusterAuthenticationFeature(unittest.TestCase):
+    @mock.patch('crmsh.parallax.parallax_call')
+    @mock.patch('crmsh.utils.ask')
+    @mock.patch('crmsh.healthcheck._parallax_run')
+    def test_upgrade_partially_initialized(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
+        nodes = ['node-{}'.format(i) for i in range(1, 6)]
+        return_value = {'node-{}'.format(i): (0, b'', b'') for i in range(1, 4)}
+        return_value.update({'node-{}'.format(i): (1, b'', b'') for i in range(4, 6)})
+        mock_parallax_run.return_value = return_value
+        mock_ask.return_value = True
+        healthcheck.feature_fix(healthcheck.PasswordlessHaclusterAuthenticationFeature(), nodes, mock_ask)
+        self.assertFalse(any(_Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh') for call_args in mock_parallax_call.call_args_list))
+        self.assertEqual(
+            {'node-{}'.format(i) for i in range(4, 6)},
+            set(
+                _Py37MockCallShim(call_args).args[0][0] for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
+            ),
+        )
+
+    @mock.patch('crmsh.parallax.parallax_call')
+    @mock.patch('crmsh.utils.ask')
+    @mock.patch('crmsh.healthcheck._parallax_run')
+    def test_upgrade_clean(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
+        nodes = ['node-{}'.format(i) for i in range(1, 6)]
+        mock_parallax_run.return_value = {node: (1, b'', b'') for node in nodes}
+        mock_ask.return_value = True
+        healthcheck.feature_fix(healthcheck.PasswordlessHaclusterAuthenticationFeature(), nodes, mock_ask)
+        self.assertEqual(
+            1, len([
+                True for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh')
+            ])
+        )
+        self.assertEqual(
+            len(nodes) - 1,
+            len([
+                True for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
+            ]),
+            )

--- a/test/unittests/test_upgradeuitl.py
+++ b/test/unittests/test_upgradeuitl.py
@@ -35,7 +35,7 @@ class TestUpgradeCondition(unittest.TestCase):
             mock_current_upgrade_seq: mock.MagicMock,
     ):
         mock_stat.side_effect = FileNotFoundError()
-        mock_get_file_content.return_value = b'0\n'
+        mock_get_file_content.return_value = b'0.1\n'
         mock_current_upgrade_seq.__gt__.return_value = True
         self.assertTrue(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
 
@@ -49,6 +49,6 @@ class TestUpgradeCondition(unittest.TestCase):
             mock_current_upgrade_seq: mock.MagicMock,
     ):
         mock_stat.side_effect = FileNotFoundError()
-        mock_get_file_content.return_value = b'1\n'
+        mock_get_file_content.return_value = b'1.0\n'
         mock_current_upgrade_seq.__gt__.return_value = False
         self.assertFalse(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))

--- a/test/unittests/test_upgradeuitl.py
+++ b/test/unittests/test_upgradeuitl.py
@@ -1,0 +1,124 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+from crmsh import upgradeutil
+
+
+class _Py37MockCallShim:
+    def __init__(self, mock_call):
+        self._mock_call = mock_call
+
+    def __getattr__(self, item):
+        f = getattr(self._mock_call, item)
+
+        def g(*args, **kwargs):
+            return f(*((self._mock_call, ) + args[1:]), **kwargs)
+        return g
+
+    @property
+    def args(self):
+        if sys.version_info.major == 3 and sys.version_info.major < 8:
+            return self._mock_call[0]
+        else:
+            return self._mock_call.args
+
+    @property
+    def kwargs(self):
+        def args(self):
+            if sys.version_info.major == 3 and sys.version_info.major < 8:
+                return self._mock_call[1]
+            else:
+                return self._mock_call.kwargs
+
+
+class TestUpgradeCondition(unittest.TestCase):
+    @mock.patch('crmsh.upgradeutil._get_file_content')
+    @mock.patch('os.stat')
+    def test_is_upgrade_needed_by_force_upgrade(self, mock_stat: mock.MagicMock, mock_get_file_content):
+        mock_stat.return_value = mock.Mock(os.stat_result)
+        mock_get_file_content.return_value = b''
+        self.assertTrue(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
+
+    @mock.patch('crmsh.upgradeutil._get_file_content')
+    @mock.patch('os.stat')
+    def test_is_upgrade_needed_by_non_existent_seq(
+            self,
+            mock_stat: mock.MagicMock,
+            mock_get_file_content: mock.MagicMock,
+    ):
+        mock_stat.side_effect = FileNotFoundError()
+        mock_get_file_content.return_value = b''
+        self.assertTrue(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
+
+    @mock.patch('crmsh.upgradeutil.CURRENT_UPGRADE_SEQ')
+    @mock.patch('crmsh.upgradeutil._get_file_content')
+    @mock.patch('os.stat')
+    def test_is_upgrade_needed_by_seq_less_than_expected(
+            self,
+            mock_stat,
+            mock_get_file_content,
+            mock_current_upgrade_seq: mock.MagicMock,
+    ):
+        mock_stat.side_effect = FileNotFoundError()
+        mock_get_file_content.return_value = b'0\n'
+        mock_current_upgrade_seq.__gt__.return_value = True
+        self.assertTrue(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
+
+    @mock.patch('crmsh.upgradeutil.CURRENT_UPGRADE_SEQ')
+    @mock.patch('crmsh.upgradeutil._get_file_content')
+    @mock.patch('os.stat')
+    def test_is_upgrade_needed_by_seq_not_less_than_expected(
+            self,
+            mock_stat,
+            mock_get_file_content,
+            mock_current_upgrade_seq: mock.MagicMock,
+    ):
+        mock_stat.side_effect = FileNotFoundError()
+        mock_get_file_content.return_value = b'1\n'
+        mock_current_upgrade_seq.__gt__.return_value = False
+        self.assertFalse(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
+
+
+class TestSeq0UpgradeHaclusterPasswordless(unittest.TestCase):
+    @mock.patch('crmsh.parallax.parallax_call')
+    @mock.patch('crmsh.utils.ask')
+    @mock.patch('crmsh.upgradeutil._parallax_run')
+    def test_upgrade_partially_initialized(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
+        nodes = ['node-{}'.format(i) for i in range(1, 6)]
+        return_value = {'node-{}'.format(i): (0, b'', b'') for i in range(1, 4)}
+        return_value.update({'node-{}'.format(i): (1, b'', b'') for i in range(4, 6)})
+        mock_parallax_run.return_value = return_value
+        mock_ask.return_value = True
+        upgradeutil.seq_0_setup_hacluster_passwordless(nodes)
+        self.assertFalse(any(_Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh') for call_args in mock_parallax_call.call_args_list))
+        self.assertEqual(
+            {'node-{}'.format(i) for i in range(4, 6)},
+            set(
+                _Py37MockCallShim(call_args).args[0][0] for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
+            ),
+        )
+
+    @mock.patch('crmsh.parallax.parallax_call')
+    @mock.patch('crmsh.utils.ask')
+    @mock.patch('crmsh.upgradeutil._parallax_run')
+    def test_upgrade_clean(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
+        nodes = ['node-{}'.format(i) for i in range(1, 6)]
+        mock_parallax_run.return_value = {node: (1, b'', b'') for node in nodes}
+        mock_ask.return_value = True
+        upgradeutil.seq_0_setup_hacluster_passwordless(nodes)
+        self.assertEqual(
+            1, len([
+                True for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh')
+            ])
+        )
+        self.assertEqual(
+            len(nodes) - 1,
+            len([
+                True for call_args in mock_parallax_call.call_args_list
+                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
+            ]),
+        )

--- a/test/unittests/test_upgradeuitl.py
+++ b/test/unittests/test_upgradeuitl.py
@@ -6,33 +6,6 @@ from unittest import mock
 from crmsh import upgradeutil
 
 
-class _Py37MockCallShim:
-    def __init__(self, mock_call):
-        self._mock_call = mock_call
-
-    def __getattr__(self, item):
-        f = getattr(self._mock_call, item)
-
-        def g(*args, **kwargs):
-            return f(*((self._mock_call, ) + args[1:]), **kwargs)
-        return g
-
-    @property
-    def args(self):
-        if sys.version_info.major == 3 and sys.version_info.major < 8:
-            return self._mock_call[0]
-        else:
-            return self._mock_call.args
-
-    @property
-    def kwargs(self):
-        def args(self):
-            if sys.version_info.major == 3 and sys.version_info.major < 8:
-                return self._mock_call[1]
-            else:
-                return self._mock_call.kwargs
-
-
 class TestUpgradeCondition(unittest.TestCase):
     @mock.patch('crmsh.upgradeutil._get_file_content')
     @mock.patch('os.stat')
@@ -79,46 +52,3 @@ class TestUpgradeCondition(unittest.TestCase):
         mock_get_file_content.return_value = b'1\n'
         mock_current_upgrade_seq.__gt__.return_value = False
         self.assertFalse(upgradeutil._is_upgrade_needed(['node-1', 'node-2']))
-
-
-class TestSeq0UpgradeHaclusterPasswordless(unittest.TestCase):
-    @mock.patch('crmsh.parallax.parallax_call')
-    @mock.patch('crmsh.utils.ask')
-    @mock.patch('crmsh.upgradeutil._parallax_run')
-    def test_upgrade_partially_initialized(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
-        nodes = ['node-{}'.format(i) for i in range(1, 6)]
-        return_value = {'node-{}'.format(i): (0, b'', b'') for i in range(1, 4)}
-        return_value.update({'node-{}'.format(i): (1, b'', b'') for i in range(4, 6)})
-        mock_parallax_run.return_value = return_value
-        mock_ask.return_value = True
-        upgradeutil.seq_0_setup_hacluster_passwordless(nodes)
-        self.assertFalse(any(_Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh') for call_args in mock_parallax_call.call_args_list))
-        self.assertEqual(
-            {'node-{}'.format(i) for i in range(4, 6)},
-            set(
-                _Py37MockCallShim(call_args).args[0][0] for call_args in mock_parallax_call.call_args_list
-                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
-            ),
-        )
-
-    @mock.patch('crmsh.parallax.parallax_call')
-    @mock.patch('crmsh.utils.ask')
-    @mock.patch('crmsh.upgradeutil._parallax_run')
-    def test_upgrade_clean(self, mock_parallax_run, mock_ask, mock_parallax_call: mock.MagicMock):
-        nodes = ['node-{}'.format(i) for i in range(1, 6)]
-        mock_parallax_run.return_value = {node: (1, b'', b'') for node in nodes}
-        mock_ask.return_value = True
-        upgradeutil.seq_0_setup_hacluster_passwordless(nodes)
-        self.assertEqual(
-            1, len([
-                True for call_args in mock_parallax_call.call_args_list
-                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster init ssh')
-            ])
-        )
-        self.assertEqual(
-            len(nodes) - 1,
-            len([
-                True for call_args in mock_parallax_call.call_args_list
-                if _Py37MockCallShim(call_args).args[1].startswith('crm cluster join ssh')
-            ]),
-        )

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1560,7 +1560,18 @@ def test_list_cluster_nodes_none(mock_run, mock_etree):
     mock_etree.return_value = None
     res = utils.list_cluster_nodes()
     assert res is None
-    mock_run.assert_called_once_with(constants.CIB_QUERY)
+    mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=False)
+    mock_etree.assert_called_once_with("data")
+
+
+@mock.patch('crmsh.utils.etree.fromstring')
+@mock.patch('crmsh.utils.get_stdout_stderr')
+def test_list_cluster_nodes_none_no_reg(mock_run, mock_etree):
+    mock_run.return_value = (0, "data", None)
+    mock_etree.return_value = None
+    res = utils.list_cluster_nodes(no_reg=True)
+    assert res is None
+    mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=True)
     mock_etree.assert_called_once_with("data")
 
 
@@ -1573,7 +1584,7 @@ def test_list_cluster_nodes_cib_not_exist(mock_run, mock_env, mock_isfile):
     mock_isfile.return_value = False
     res = utils.list_cluster_nodes()
     assert res is None
-    mock_run.assert_called_once_with(constants.CIB_QUERY)
+    mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=False)
     mock_env.assert_called_once_with("CIB_file", constants.CIB_RAW_FILE)
     mock_isfile.assert_called_once_with(constants.CIB_RAW_FILE)
 
@@ -1597,7 +1608,7 @@ def test_list_cluster_nodes(mock_run, mock_env, mock_isfile, mock_file2elem):
     res = utils.list_cluster_nodes()
     assert res == ["node2"]
 
-    mock_run.assert_called_once_with(constants.CIB_QUERY)
+    mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=False)
     mock_env.assert_called_once_with("CIB_file", constants.CIB_RAW_FILE)
     mock_isfile.assert_called_once_with(constants.CIB_RAW_FILE)
     mock_file2elem.assert_called_once_with(constants.CIB_RAW_FILE)


### PR DESCRIPTION
# Mechanism

* add a mechanism for updating cluster config after version update:
  - A sequence is written to `~hacluster/crmsh/upgrade_seq` and crmsh checks it to determine whether upgrade is needed whenever it runs.
  - Upgrade is performed only when all nodes in cluster are running compatible version of crmsh. It is determined by comparing `CURRENT_UPGRADE_SEQ` in upgradeutil.py.
  - Upgrade needs user confirm and is only performed in interactive mode.
* add health check and fix for passwordless ssh authentication for hacluster
* run health fix for passwordless ssh authentication for hacluster when with that upgrade mechanism
* run health fix for passwordless ssh authentication for hacluster when a node fails to join the cluster because of it

# Use Cases

Upgrade is performed in the following scenarios:

1. Running any crmsh command in interactive mode when crmsh on all nodes of a cluster have been upgraded to a same version.
2. Joining a cluster: crmsh is running on the joining node, which is not a member of the cluster, so it cannot perform upgrade on existing nodes.
2. When a new node is joining the cluster, and fails because of the lack of hacluster's keys,.

A warning is printed in the following scenarios:

1. Nodes of a cluster are running different version of crmsh.
2. Upgraded is needed and crmsh is not running in interactive mode.
