### PR TITLE
Dev: report: make sure 'crm -d report' could increase the verbosity

### DIFF
--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -473,19 +473,21 @@ class Report(object):
             nodes_option = "'-n %s'" % ' '.join(self.setnodes)
         utils.mkdirp(os.path.dirname(d))
         logger.info("Retrieving information from cluster nodes, please wait...")
-        rc = utils.pipe_cmd_nosudo("%s -Z -Q -f '%s' %s %s %s %s" %
-                                   (extcmd,
-                                    self.from_dt.ctime(),
-                                    to_option,
-                                    nodes_option,
-                                    str(config.core.report_tool_options),
-                                    d))
+        cmd = "{} {} -Z -Q -f '{}' {} {} {} {}".format(extcmd,
+                "-v" if config.core.debug else "", self.from_dt.ctime(),
+                to_option, nodes_option, str(config.core.report_tool_options), d)
+        logger.debug("Running command: {}".format(cmd))
+        rc, out, err = utils.get_stdout_stderr(cmd)
         if rc != 0:
+            if err:
+                print(err)
             if os.path.isfile(tarball):
                 self.warn("report thinks it failed, proceeding anyway")
             else:
                 self.error("report failed")
                 return None
+        if out:
+            print(out)
         self.last_live_update = time.time()
         return self.unpack_report(tarball)
 

--- a/crmsh/report/constants.py
+++ b/crmsh/report/constants.py
@@ -60,7 +60,6 @@ TRY_SSH = "root hacluster"
 # UNIQUE_MSG = "Mark:HB_REPORT:%d" % now_second
 USER_CLUSTER_TYPE = "Corosync/Pacemaker"
 USER_NODES = ""
-VERBOSITY = 0
 WE = socket.gethostname()
 WORKDIR = None
 

--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -52,7 +52,7 @@ def dump_env():
     env_dict["SKIP_LVL"] = constants.SKIP_LVL
     env_dict["EXTRA_LOGS"] = constants.EXTRA_LOGS
     env_dict["PCMK_LOG"] = constants.PCMK_LOG
-    env_dict["VERBOSITY"] = int(constants.VERBOSITY)
+    env_dict["VERBOSITY"] = int(config.report.verbosity) or (1 if config.core.debug else 0)
 
     res_str = ""
     for k, v in env_dict.items():
@@ -133,8 +133,7 @@ def load_env(env_str):
     constants.SKIP_LVL = utillib.str_to_bool(env_dict["SKIP_LVL"])
     constants.EXTRA_LOGS = env_dict["EXTRA_LOGS"]
     constants.PCMK_LOG = env_dict["PCMK_LOG"]
-    constants.VERBOSITY = int(env_dict["VERBOSITY"])
-    config.report.verbosity = constants.VERBOSITY
+    config.report.verbosity = env_dict["VERBOSITY"]
 
 
 def parse_argument(argv):
@@ -151,6 +150,7 @@ def parse_argument(argv):
     else:
         usage("short")
 
+    verbosity = 0
     for args, option in opt:
         if args == '-h':
             usage()
@@ -191,10 +191,11 @@ def parse_argument(argv):
         if args == "-E":
             constants.EXTRA_LOGS += " %s" % option
         if args == "-v":
-            constants.VERBOSITY += 1
-            config.report.verbosity = constants.VERBOSITY
+            verbosity += 1
         if args == '-d':
             constants.COMPRESS = False
+
+    config.report.verbosity = verbosity
 
     if config.report.sanitize_rule:
         constants.DO_SANITIZE = True


### PR DESCRIPTION
## Problem
`crm -d report` and `crm -d history peinputs` cannot print report debug messages

## Changes:
- Dev: report: make sure 'crm -d report' could increase the verbosity
  (equal to `crm report -v`)
- Dev: history: print necessary log messages when collecting report