### PR TITLE
Dev: bootstrap: Add option -x to skip csync2 initialization stage during the whole cluster bootstrap

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -525,8 +525,8 @@ DC_DEADTIME_DEFAULT = 20
 ADVISED_ACTION_LIST = ['monitor', 'start', 'stop', 'promote', 'demote']
 ADVISED_KEY_LIST = ['timeout', 'interval', 'role']
 DEFAULT_INTERVAL_IN_ACTION = "20s"
-
 WAIT_TIMEOUT_MS_DEFAULT = 120000
+CSYNC2_SERVICE = "csync2.socket"
 
 RSC_ROLE_PROMOTED = "Promoted"
 RSC_ROLE_UNPROMOTED = "Unpromoted"

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -212,7 +212,7 @@ class SBDTimeout(object):
         utils.mkdirp(SBD_SYSTEMD_DELAY_START_DIR)
         sbd_delay_start_file = "{}/sbd_delay_start.conf".format(SBD_SYSTEMD_DELAY_START_DIR)
         utils.str2file("[Service]\nTimeoutSec={}".format(int(1.2*int(sbd_delay_start_value))), sbd_delay_start_file)
-        bootstrap.csync2_update(SBD_SYSTEMD_DELAY_START_DIR)
+        bootstrap.sync_file(SBD_SYSTEMD_DELAY_START_DIR)
         utils.cluster_run_cmd("systemctl daemon-reload")
 
     def adjust_stonith_timeout(self):
@@ -428,7 +428,7 @@ class SBDManager(object):
         Update /etc/sysconfig/sbd
         """
         if self.no_update_config:
-            bootstrap.csync2_update(SYSCONFIG_SBD)
+            bootstrap.sync_file(SYSCONFIG_SBD)
             return
 
         shutil.copyfile(self.SYSCONFIG_SBD_TEMPLATE, SYSCONFIG_SBD)
@@ -439,7 +439,7 @@ class SBDManager(object):
         if self._sbd_devices:
             sbd_config_dict["SBD_DEVICE"] = ';'.join(self._sbd_devices)
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
-        bootstrap.csync2_update(SYSCONFIG_SBD)
+        bootstrap.sync_file(SYSCONFIG_SBD)
 
     def _get_sbd_device_from_config(self):
         """
@@ -601,7 +601,7 @@ class SBDManager(object):
         Update and sync sbd configuration
         """
         utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
-        bootstrap.csync2_update(SYSCONFIG_SBD)
+        bootstrap.sync_file(SYSCONFIG_SBD)
 
     @staticmethod
     def get_sbd_value_from_config(key):

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -347,6 +347,8 @@ Examples:
                             help="Enable SBD even if no SBD device is configured (diskless mode)")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG",
                             help="Use the given watchdog device or driver name")
+        parser.add_argument("-x", "--skip-csync2-sync", dest="skip_csync2", action="store_true",
+                            help="Skip csync2 initialization (an experimental option)")
         parser.add_argument("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
                             help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default; Deprecated)')
 

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -137,3 +137,17 @@ Feature: crmsh bootstrap process - options
     When    Run "crm cluster init -N hanode1 -N hanode2 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
+
+  @clean
+  Scenario: Skip using csync2 by -x option
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y -x" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "csync2.socket" is "stopped" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "csync2.socket" is "stopped" on "hanode2"
+    When    Run "crm cluster init csync2 -y" on "hanode1"
+    Then    Service "csync2.socket" is "started" on "hanode1"
+    And     Service "csync2.socket" is "started" on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -77,6 +77,8 @@ optional arguments:
                         (diskless mode)
   -w WATCHDOG, --watchdog WATCHDOG
                         Use the given watchdog device or driver name
+  -x, --skip-csync2-sync
+                        Skip csync2 initialization (an experimental option)
   --no-overwrite-sshkey
                         Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is
                         used (False by default; Deprecated)

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -255,7 +255,7 @@ class TestSBDTimeout(unittest.TestCase):
         mock_mkdirp.assert_not_called()
 
     @mock.patch('crmsh.utils.cluster_run_cmd')
-    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.utils.str2file')
     @mock.patch('crmsh.utils.mkdirp')
     @mock.patch('crmsh.utils.get_systemd_timeout_start_in_sec')
@@ -505,7 +505,7 @@ class TestSBDManager(unittest.TestCase):
             ])
         mock_error.assert_called_once_with("Failed to initialize SBD device /dev/sdc1: error")
 
-    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.utils.sysconfig_set')
     @mock.patch('shutil.copyfile')
     def test_update_configuration(self, mock_copy, mock_sysconfig, mock_update):
@@ -882,7 +882,7 @@ class TestSBDManager(unittest.TestCase):
         mock_context.assert_called_once_with()
         mock_get_sbd.assert_called_once_with()
 
-    @mock.patch('crmsh.bootstrap.csync2_update')
+    @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.utils.sysconfig_set')
     def test_update_configuration_static(self, mock_config_set, mock_csync2):
         sbd_config_dict = {


### PR DESCRIPTION
## Motivation

On some environments, the csync2 initialization process consumes too much time comparing to the whole cluster bootstrap process, and could be blamed as too slow. csync2 is not the critical component for the cluster stack. Adding an option to skip that could make it flexible to give users a choice, and users can initialize csyn2 for the cluster later on if need

Another bad situations did happen in the past, csync2 was broken because of its dependency, eg. gnutls bsc#1172695. This functionality gives the flexibility to provide the workaround to setup the cluster without csync2.

## Solution
- On init side, add `-x` option to skip csync2 configure and sync; Or, can set environment variable 'SKIP_CSYNC2_SYNC=true' on init node:
```
# csync2 will not be configured and csync2.socket will not started
crm cluster init -x -y
```
- Based on above, use scp to retrieve all related config files when node joining; use parallax.copy to sync files when files changed
- Based on above, give a hint for user, run `crm cluster init csync2 -y' on any one node, before using csync2 for the first time, then csync2 will be configured:
```
# a hint when joining and detect not using csync2
csync2 is not initiated yet. Before using csync2 for the first time, please run "crm cluster init csync2 -y" on any one node. Note, this may take a while.
```
```
# on any node of a running cluster
crm cluster init csync2 -y
INFO: Configuring csync2
INFO: Starting csync2.socket service on 15sp4-1
INFO: Starting csync2.socket service on 15sp4-2
INFO: Starting csync2.socket service on 15sp4-3
INFO: BEGIN csync2 syncing files
INFO: END csync2 syncing files
INFO: Done (log saved to /var/log/crmsh/crmsh.log)
```
- Consider the scenarios for adding sbd via stage, adding qdevice via stage, and remove node, which all need to sync the configure files
- Some log info changed for csync2
-  Keep original behavior unchanged when '-x' or 'SKIP_CSYNC2_SYNC' not set
## Test
```
  @clean
  Scenario: Skip using csync2 by -x option
    Given   Cluster service is "stopped" on "hanode1"
    Given   Cluster service is "stopped" on "hanode2"
    When    Run "crm cluster init -y -x" on "hanode1"
    Then    Cluster service is "started" on "hanode1"
    And     Service "csync2.socket" is "stopped" on "hanode1"
    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
    Then    Cluster service is "started" on "hanode2"
    And     Service "csync2.socket" is "stopped" on "hanode2"
    When    Run "crm cluster init csync2 -y" on "hanode1"
    Then    Service "csync2.socket" is "started" on "hanode1"
    And     Service "csync2.socket" is "started" on "hanode2"
```