### PR TITLE
fix: fail to open log file even if user is in haclient group (bsc#1204670)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clust
 RUN zypper --non-interactive refresh
 RUN zypper --non-interactive up --allow-vendor-change -y python3-parallax
 
+RUN mkdir -p /var/log/crmsh
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
 RUN echo "$ssh_prv_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
 RUN echo "$ssh_pub_key" > /root/.ssh/id_rsa.pub && chmod 600 /root/.ssh/id_rsa.pub

--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -40,6 +40,7 @@ Version:        @VERSION@
 Release:        0
 Url:            http://crmsh.github.io
 Source0:        %{name}-%{version}.tar.bz2
+Source1:        %{name}.tmpfiles.d.conf
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?suse_version}
@@ -174,9 +175,14 @@ if [ -f %{buildroot}%{_bindir}/crm ]; then
 	install -Dm0755 %{buildroot}%{_bindir}/crm %{buildroot}%{_sbindir}/crm
 	rm %{buildroot}%{_bindir}/crm
 fi
+install -d -m 0755 %{buildroot}%{_tmpfilesdir}
+install -m 0644 %{SOURCE1} %{buildroot}%{_tmpfilesdir}/%{name}.conf
 %if 0%{?suse_version}
 %fdupes %{buildroot}
 %endif
+
+%post
+%tmpfiles_create %{_tmpfilesdir}/%{name}.conf
 
 %if %{with regression_tests}
 # Run regression tests after installing the package
@@ -211,6 +217,8 @@ result2=$?
 %{_datadir}/%{name}
 %exclude %{_datadir}/%{name}/tests
 %exclude %{_datadir}/%{name}/scripts
+
+%{_tmpfilesdir}/%{name}.conf
 
 %doc %{_mandir}/man8/*
 %{crmsh_docdir}/COPYING

--- a/crmsh.tmpfiles.d.conf
+++ b/crmsh.tmpfiles.d.conf
@@ -1,0 +1,1 @@
+d   /var/log/crmsh  0775    hacluster   haclient    -

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -102,6 +102,18 @@ class DebugCustomFilter(logging.Filter):
             return True
 
 
+class GroupWriteRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """
+    A custom rotating file handler which keeps log files group wirtable after rotating
+    Source: https://stackoverflow.com/a/6779307
+    """
+    def _open(self):
+        prevumask=os.umask(0o002)
+        rtv=logging.handlers.RotatingFileHandler._open(self)
+        os.umask(prevumask)
+        return rtv
+
+
 LOGGING_CFG = {
     "version": 1,
     "disable_existing_loggers": "False",
@@ -141,7 +153,7 @@ LOGGING_CFG = {
             "flushLevel": logging.CRITICAL,
         },
         "file": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "()": GroupWriteRotatingFileHandler,
             "filename": CRMSH_LOG_FILE,
             "formatter": "file",
             "filters": ["filter"],


### PR DESCRIPTION
The file had been created with umask 0022 in usual so that it was not group-writable.

Call chown and chmod explicitly to fix it.