### PR TITLE
[crmsh-4.4] fix: fail to open log file even if user is in haclient group (bsc#1204670)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN zypper -n install systemd
 RUN zypper -n install make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables
 RUN zypper -n install python3 python3-lxml python3-python-dateutil python3-parallax python3-setuptools python3-PyYAML python3-curses python3-behave
 RUN zypper -n install csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
+RUN zypper --non-interactive up zypper
+RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf
+RUN zypper --non-interactive refresh
+RUN zypper --non-interactive up --allow-vendor-change -y python3-parallax
 
 RUN mkdir -p /var/log/crmsh
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN zypper -n install make autoconf automake vim which libxslt-tools mailx iprou
 RUN zypper -n install python3 python3-lxml python3-python-dateutil python3-parallax python3-setuptools python3-PyYAML python3-curses python3-behave
 RUN zypper -n install csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
 
+RUN mkdir -p /var/log/crmsh
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
 RUN echo "$ssh_prv_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
 RUN echo "$ssh_pub_key" > /root/.ssh/id_rsa.pub && chmod 600 /root/.ssh/id_rsa.pub

--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -40,6 +40,7 @@ Version:        @VERSION@
 Release:        0
 Url:            http://crmsh.github.io
 Source0:        %{name}-%{version}.tar.bz2
+Source1:        %{name}.tmpfiles.d.conf
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?suse_version}
@@ -174,9 +175,14 @@ if [ -f %{buildroot}%{_bindir}/crm ]; then
 	install -Dm0755 %{buildroot}%{_bindir}/crm %{buildroot}%{_sbindir}/crm
 	rm %{buildroot}%{_bindir}/crm
 fi
+install -d -m 0755 %{buildroot}%{_tmpfilesdir}
+install -m 0644 %{SOURCE1} %{buildroot}%{_tmpfilesdir}/%{name}.conf
 %if 0%{?suse_version}
 %fdupes %{buildroot}
 %endif
+
+%post
+%tmpfiles_create %{_tmpfilesdir}/%{name}.conf
 
 %if %{with regression_tests}
 # Run regression tests after installing the package
@@ -211,6 +217,8 @@ result2=$?
 %{_datadir}/%{name}
 %exclude %{_datadir}/%{name}/tests
 %exclude %{_datadir}/%{name}/scripts
+
+%{_tmpfilesdir}/%{name}.conf
 
 %doc %{_mandir}/man8/*
 %{crmsh_docdir}/COPYING

--- a/crmsh.tmpfiles.d.conf
+++ b/crmsh.tmpfiles.d.conf
@@ -1,0 +1,1 @@
+d   /var/log/crmsh  0775    hacluster   haclient    -

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -102,6 +102,18 @@ class DebugCustomFilter(logging.Filter):
             return True
 
 
+class GroupWriteRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """
+    A custom rotating file handler which keeps log files group wirtable after rotating
+    Source: https://stackoverflow.com/a/6779307
+    """
+    def _open(self):
+        prevumask=os.umask(0o002)
+        rtv=logging.handlers.RotatingFileHandler._open(self)
+        os.umask(prevumask)
+        return rtv
+
+
 LOGGING_CFG = {
     "version": 1,
     "disable_existing_loggers": "False",
@@ -141,7 +153,7 @@ LOGGING_CFG = {
             "flushLevel": logging.CRITICAL,
         },
         "file": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "()": GroupWriteRotatingFileHandler,
             "filename": CRMSH_LOG_FILE,
             "formatter": "file",
             "filters": ["filter"],

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -76,6 +76,8 @@ pcmk_host_map (string): A mapping of host names to ports numbers for devices tha
     Eg. node1:1;node2:2,3 would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2
 
 pcmk_host_list (string): A list of machines controlled by this device (Optional unless pcmk_host_check=static-list).
+    Eg. node1,node2,node3
+
 pcmk_host_check (string, [dynamic-list]): How to determine which machines are controlled by the device.
     Allowed values: dynamic-list (query the device via the 'list' command), static-list (check the pcmk_host_list attribute), status (query the device via the 'status' command), none (assume every device can fence every machine)
 


### PR DESCRIPTION
The file had been created with umask 0022 in usual so that it was not
group-writable.

Call chown and chmod explicitly to fix it.