### PR TITLE
Dev: report: collect ra trace files from specified directories

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2688,7 +2688,7 @@ def get_stdout_or_raise_error(cmd, remote=None, success_val_list=[0], no_raise=F
     """
     Common function to get stdout from cmd or raise exception
     """
-    if remote:
+    if remote and remote != this_node():
         cmd = "ssh {} root@{} \"{}\"".format(SSH_OPTION, remote, cmd)
     rc, out, err = get_stdout_stderr(cmd, no_reg=True)
     if rc not in success_val_list and not no_raise:

--- a/test/features/crm_report_bugs.feature
+++ b/test/features/crm_report_bugs.feature
@@ -103,3 +103,22 @@ Feature: crm report functional test for verifying bugs
     # found password
     Then    Expected return code is "0"
     When    Run "rm -rf report.tar.bz2 report" on "hanode1"
+
+  @clean
+  Scenario: crm report collect trace ra log
+    When    Run "crm configure primitive d Dummy" on "hanode1"
+    And     Run "crm configure primitive d2 Dummy" on "hanode1"
+    Then    Resource "d" is started on "hanode1"
+    And     Resource "d2" is started on "hanode2"
+    When    Run "crm resource trace d monitor" on "hanode1"
+    Then    Expected "Trace for d:monitor is written to /var/lib/heartbeat/trace_ra/Dummy" in stdout
+    When    Wait "10" seconds
+    And     Run "crm resource untrace d" on "hanode1"
+    And     Run "crm resource trace d2 monitor /trace_d" on "hanode1"
+    Then    Expected "Trace for d2:monitor is written to /trace_d/Dummy" in stdout
+    When    Wait "10" seconds
+    And     Run "crm resource untrace d2" on "hanode1"
+    And     Run "crm report report" on "hanode1"
+    Then    Directory "trace_ra" in "report.tar.bz2"
+    And     Directory "trace_d" in "report.tar.bz2"
+    When    Run "rm -rf report.tar.bz2 report" on "hanode1"

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -314,6 +314,11 @@ def step_impl(context, f, archive):
     assert file_in_archive(f, archive) is True
 
 
+@then('Directory "{f}" in "{archive}"')
+def step_impl(context, f, archive):
+    assert file_in_archive(f, archive) is True
+
+
 @then('File "{f}" not in "{archive}"')
 def step_impl(context, f, archive):
     assert file_in_archive(f, archive) is False


### PR DESCRIPTION
## Problem
After #939 , if user specify other directory to trace ra log, crm report can't collect the log

## Solution
Since the "trace_dir" attribute will be removed from cib after untrace, crm report need to parse crmsh.log to extract custom trace ra log directory on each node

## Functional test
```
  @clean
  Scenario: crm report collect trace ra log
    When    Run "crm configure primitive d Dummy" on "hanode1"
    And     Run "crm configure primitive d2 Dummy" on "hanode1"
    Then    Resource "d" is started on "hanode1"
    And     Resource "d2" is started on "hanode2"
    When    Run "crm resource trace d monitor" on "hanode1"
    Then    Expected "Trace for d:monitor is written to /var/lib/heartbeat/trace_ra/Dummy" in stdout
    When    Wait "10" seconds
    And     Run "crm resource untrace d" on "hanode1"
    And     Run "crm resource trace d2 monitor /trace_d" on "hanode1"
    Then    Expected "Trace for d2:monitor is written to /trace_d/Dummy" in stdout
    When    Wait "10" seconds
    And     Run "crm resource untrace d2" on "hanode1"
    And     Run "crm report report" on "hanode1"
    Then    Directory "trace_ra" in "report.tar.bz2"
    And     Directory "trace_d" in "report.tar.bz2"
    When    Run "rm -rf report.tar.bz2 report" on "hanode1"
```
