### PR TITLE
[crmsh-4.4] Fix: corosync: show corosync ring status if has fault

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -62,7 +62,7 @@ def query_ring_status():
     rc, out, err = utils.get_stdout_stderr("corosync-cfgtool -s")
     if rc != 0 and err:
         raise ValueError(err)
-    if rc == 0 and out:
+    if out:
         print(out)
 
 


### PR DESCRIPTION
backport #1058 