### PR TITLE
Fix: cibconfig: Complete promotable=true and interleave=true for Promoted/Unpromoted resource

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -25,7 +25,7 @@ from . import cibstatus
 from . import crm_gv
 from . import ui_utils
 from . import userdir
-from .ra import get_ra, get_properties_list, get_pe_meta, get_properties_meta
+from .ra import get_ra, get_properties_list, get_pe_meta, get_properties_meta, RAInfo
 from .utils import ext_cmd, safe_open_w, pipe_string, safe_close_w, crm_msec
 from .utils import ask, lines2cli, olist
 from .utils import page_string, cibadmin_can_patch, str2tmp, ensure_sudo_readable
@@ -42,7 +42,7 @@ from .xmlutil import merge_attributes, is_cib_element, sanity_check_meta
 from .xmlutil import is_simpleconstraint, is_template, rmnode, is_defaults, is_live_cib
 from .xmlutil import get_rsc_operations, delete_rscref, xml_equals, lookup_node, RscState
 from .xmlutil import text2elem, is_related, check_id_ref, xml_tostring
-from .xmlutil import sanitize_cib_for_patching
+from .xmlutil import sanitize_cib_for_patching, is_attr_set, get_set_nodes, set_attr
 from .cliformat import get_score, nvpairs2list, abs_pos_score, cli_acl_roleref, nvpair_format
 from .cliformat import cli_nvpair, cli_acl_rule, rsc_set_constraint, get_kind, head_id_format
 from .cliformat import simple_rsc_constraint, cli_rule, cli_format
@@ -793,7 +793,7 @@ def id_for_node(node, id_hint=None):
     return obj_id
 
 
-def postprocess_cli(node, oldnode=None, id_hint=None):
+def postprocess_cli(node, oldnode=None, id_hint=None, complete_advised=False):
     """
     input: unprocessed but parsed XML
     output: XML, obj_type, obj_id
@@ -816,7 +816,37 @@ def postprocess_cli(node, oldnode=None, id_hint=None):
     resolve_references(node)
     if oldnode is not None:
         remove_id_used_attributes(oldnode)
+    if complete_advised:
+        complete_advised_meta(node)
     return node, obj_type, obj_id
+
+
+def complete_advised_meta(node):
+    """
+    Complete advised meta attributes
+    """
+    if node.tag != "clone":
+        return
+    primitive_list = node.xpath('primitive')
+    if not primitive_list:
+        return
+    set_list = []
+    for meta_item in ["promotable", "interleave"]:
+        if not is_attr_set(node, meta_item):
+            set_list.append(meta_item)
+    if not set_list:
+        return
+
+    meta_node = get_set_nodes(node, "meta_attributes", create=True)[0]
+    p = primitive_list[0]
+    ra_inst = RAInfo(p.get('class'), p.get('type'), p.get('provider'))
+    ra_actions_dict = ra_inst.actions()
+    if ra_actions_dict and "promote" in ra_actions_dict and "demote" in ra_actions_dict:
+        for item in set_list:
+            set_attr(meta_node, item, "true")
+    # Add interleave=true as long as it's not set, no matter if it's promotable clone or not
+    elif "interleave" in set_list:
+        set_attr(meta_node, "interleave", "true")
 
 
 def parse_cli_to_xml(cli, oldnode=None):
@@ -825,17 +855,19 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
+    complete = False
     comments = []
     if isinstance(cli, str):
         for s in lines2cli(cli):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
-        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_op_advised=True)
+        complete = True
+        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete)
     if node is False:
         return None, None, None
     elif node is None:
         return None, None, None
-    return postprocess_cli(node, oldnode)
+    return postprocess_cli(node, oldnode, complete_advised=complete)
 
 #
 # cib element classes (CibObject the parent class)

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,13 +170,13 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, complete_op_advised):
+    def do_parse(self, cmd, ignore_empty, complete_advised):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
         self.ignore_empty = ignore_empty
-        self.complete_op_advised = complete_op_advised
+        self.complete_advised = complete_advised
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -661,7 +661,7 @@ class BaseParser(object):
         """
         Complete operation actions advised values
         """
-        if not self.complete_op_advised or out.tag != "primitive":
+        if not self.complete_advised or out.tag != "primitive":
             return
         ra_inst = ra.RAInfo(out.get('class'), out.get('type'), out.get('provider'))
         ra_actions_dict = ra_inst.actions()
@@ -1774,7 +1774,7 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None, ignore_empty=True, complete_op_advised=False):
+def parse(s, comments=None, ignore_empty=True, complete_advised=False):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1820,7 +1820,7 @@ def parse(s, comments=None, ignore_empty=True, complete_op_advised=False):
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, complete_op_advised)
+        ret = parser.do_parse(s, ignore_empty, complete_advised)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -550,10 +550,14 @@ def is_group(node):
     return node.tag == "group"
 
 
+def is_attr_set(node, attr):
+    return get_attr_value(get_child_nvset_node(node), attr) is not None
+
+
 def is_ms_or_promotable_clone(node):
-    is_promotable = is_boolean_true(get_attr_value(get_child_nvset_node(node), "promotable"))
-    is_ms = node.tag in ("master", "ms")
-    return is_ms or is_promotable
+    is_promotable_type = is_boolean_true(is_attr_set(node, "promotable"))
+    is_ms_type = node.tag in ("master", "ms")
+    return is_ms_type or is_promotable_type
 
 
 def is_clone(node):

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -129,3 +129,15 @@ Feature: Use "crm configure set" to update attributes and operations
     Then    Run "ls /trace_log_d/Dummy/d.monitor.*" OK
     When    Run "crm resource untrace d" on "hanode1"
     Then    Expected "Stop tracing d" in stdout
+
+  @clean
+  Scenario: Add promotable=true and interleave=true automatically (bsc#1205522)
+    When    Run "crm configure primitive s2 ocf:pacemaker:Stateful" on "hanode1"
+    And     Run "crm configure clone p2 s2" on "hanode1"
+    Then    Run "sleep 2;crm configure show|grep -A1 'clone p2 s2'|grep 'promotable=true interleave=true'" OK
+    When    Run "crm configure primitive s3 ocf:pacemaker:Stateful" on "hanode1"
+    And     Run "crm configure clone p3 s3 meta promotable=false" on "hanode1"
+    Then    Run "sleep 2;crm configure show|grep -A1 'clone p3 s3'|grep 'promotable=false interleave=true'" OK
+    When    Run "crm configure primitive d2 Dummy" on "hanode1"
+    And     Run "crm configure clone p4 d2" on "hanode1"
+    Then    Run "sleep 2;crm configure show|grep -A1 'clone p4 d2'|grep 'interleave=true'" OK

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -58,7 +58,8 @@ primitive p6 Dummy \
         op monitor timeout=20s interval=10s \
         op start timeout=20s interval=0s \
         op stop timeout=20s interval=0s
-clone cl-p5 p5
+clone cl-p5 p5 \
+       meta interleave=true
 colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: commit
 .INP: _test
@@ -95,7 +96,8 @@ primitive p5 Dummy \
         op monitor timeout=20s interval=10s \
         op start timeout=20s interval=0s \
         op stop timeout=20s interval=0s
-clone cl-p5 p5
+clone cl-p5 p5 \
+       meta interleave=true
 colocation c2 inf: ( p1 p2 ) p3 p4
 .TRY Unordered load file
 .INP: options
@@ -141,7 +143,8 @@ primitive gr4 Dummy
 group g1 gr1 gr2
 group g2 gr3
 group g3 gr4
-clone cl-p5 p5
+clone cl-p5 p5 \
+       meta interleave=true
 colocation c2 inf: ( p1 p2 ) p3 p4
 location loc1 g1 \
 	rule 200: #uname eq node1

--- a/test/testcases/confbasic-xml.exp
+++ b/test/testcases/confbasic-xml.exp
@@ -75,6 +75,7 @@
       <clone id="c">
         <meta_attributes id="c-meta_attributes">
           <nvpair name="clone-max" value="1" id="c-meta_attributes-clone-max"/>
+          <nvpair name="interleave" value="true" id="c-meta_attributes-interleave"/>
         </meta_attributes>
         <primitive id="d3" class="ocf" provider="pacemaker" type="Dummy">
           <operations>

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -145,9 +145,9 @@ ms m d4
 ms m5 s5
 ms m6 s6
 clone c d3 \
-	meta clone-max=1
+	meta clone-max=1 interleave=true
 clone m7 d8 \
-	meta promotable=true \
+	meta promotable=true interleave=true \
 	meta promoted-max=1 \
 	meta promoted-node-max=1
 tag t1 m5 m6

--- a/test/testcases/file.exp
+++ b/test/testcases/file.exp
@@ -23,9 +23,10 @@ primitive st stonith:null \
         op monitor timeout=20 interval=3600 \
 	op start timeout=20 interval=0s \
 	op stop timeout=15 interval=0s
-clone c1 p1
+clone c1 p1 \
+       meta interleave=true
 clone m1 p2 \
-       meta promotable=true
+       meta promotable=true interleave=true
 rsc_defaults build-resource-defaults: \
        resource-stickiness=1
 op_defaults op-options: \

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -65,6 +65,7 @@ resource p0 is NOT running
     <resources>
       <clone id="c1">
         <meta_attributes id="c1-meta_attributes">
+          <nvpair id="c1-meta_attributes-interleave" name="interleave" value="true"/>
           <nvpair id="c1-meta_attributes-is-managed" name="is-managed" value="true"/>
         </meta_attributes>
         <primitive id="p1" class="ocf" provider="pacemaker" type="Dummy">
@@ -92,6 +93,7 @@ resource p0 is NOT running
     <resources>
       <clone id="c1">
         <meta_attributes id="c1-meta_attributes">
+          <nvpair id="c1-meta_attributes-interleave" name="interleave" value="true"/>
           <nvpair id="c1-meta_attributes-is-managed" name="is-managed" value="false"/>
         </meta_attributes>
         <primitive id="p1" class="ocf" provider="pacemaker" type="Dummy">
@@ -121,6 +123,7 @@ resource p0 is NOT running
       <clone id="m1">
         <meta_attributes id="m1-meta_attributes">
           <nvpair name="promotable" value="true" id="m1-meta_attributes-promotable"/>
+          <nvpair id="m1-meta_attributes-interleave" name="interleave" value="true"/>
           <nvpair id="m1-meta_attributes-maintenance" name="maintenance" value="true"/>
         </meta_attributes>
         <primitive id="p2" class="ocf" provider="heartbeat" type="Delay">
@@ -154,6 +157,7 @@ resource p0 is NOT running
       <clone id="m1">
         <meta_attributes id="m1-meta_attributes">
           <nvpair name="promotable" value="true" id="m1-meta_attributes-promotable"/>
+          <nvpair id="m1-meta_attributes-interleave" name="interleave" value="true"/>
           <nvpair id="m1-meta_attributes-maintenance" name="maintenance" value="false"/>
         </meta_attributes>
         <primitive id="p2" class="ocf" provider="heartbeat" type="Delay">


### PR DESCRIPTION
When configure Promoted/Unpromoted resource, "promotable=true" is required and "interleave=true" is often
preferred.
So the solution is to complete this meta attribute.
Possible cases:
- input like `clone <clone-id> <res-id>`
  If detected this primitive resource contain "promote" and "demote" actions,
  then "meta promotable=true interleave=true" will be completed
- if the input contain `promotable` or `interleave`
  then crmsh doesn't complete it

```
crm(live/15sp4-1)configure# primitive stateful-1 ocf:pacemaker:Stateful
crm(live/15sp4-1)configure# clone c1 stateful-1
crm(live/15sp4-1)configure# show
node 1: 15sp4-1
node 2: 15sp4-2
primitive stateful-1 ocf:pacemaker:Stateful \
	op monitor timeout=20s interval=10s role=Promoted \
	op monitor timeout=20s interval=11s role=Unpromoted \
	op start timeout=20s interval=0s \
	op stop timeout=20s interval=0s \
	op promote timeout=10s interval=0s \
	op demote timeout=10s interval=0s
clone c1 stateful-1 \
        meta promotable=true interleave=true
```