### PR TITLE
Fix: qdevice: Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice not using stage

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -636,18 +636,17 @@ class QDevice(object):
         """
         Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice and diskless SBD
         """
-        if self.is_stage:
-            from .sbd import SBDManager, SBDTimeout
-            utils.check_all_nodes_reachable()
-            using_diskless_sbd = SBDManager.is_using_diskless_sbd()
-            self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
-            # add qdevice after diskless sbd started
-            if using_diskless_sbd:
-                res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
-                if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
-                    sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
-                    SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
-                    utils.set_property("stonith-timeout", SBDTimeout.get_stonith_timeout())
+        from .sbd import SBDManager, SBDTimeout
+        utils.check_all_nodes_reachable()
+        using_diskless_sbd = SBDManager.is_using_diskless_sbd()
+        self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
+        # add qdevice after diskless sbd started
+        if using_diskless_sbd:
+            res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
+            if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
+                sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
+                SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
+                utils.set_property("stonith-timeout", SBDTimeout.get_stonith_timeout())
 
     @qnetd_lock_for_same_cluster_name
     def config_and_start_qdevice(self):


### PR DESCRIPTION
## Problem
When using `crm cluster init` to configure diskless-sbd + qdevice, on interactive mode, `SBD_WATCHDOG_TIMEOUT` in /etc/sysconfig/sbd is not as expected as `SBD_WATCHDOG_TIMEOUT = quorum.device.sync_timeout  + 5`, will lead to situation where pacemaker fails to start
## Reason
When running `crm cluster init` to configure diskless-sbd and qdevice,the sequence will be:
    - configure diskless-sbd
    - cluster service started
    - configure qdevice; On this time, qdevice is not in the 'qdevice' stage,
    so this piece of code (function adjust_sbd_watchdog_timeout_with_qdevice) will not be executed to adjust SBD_WATCHDOG_TIMEOUT