### PR TITLE
[crmsh-4.4] Fix: qdevice: Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice not using stage

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -332,12 +332,11 @@ class LoggerUtils(object):
         """
         Wrap input function with recording prompt string and input result
         """
-        with self.suppress_new_line():
+        with self.only_file():
             self.logger.info(prompt_string)
-        value = input()
+        value = input(prompt_string)
         if not value:
             value = default
-            print()
         with self.only_file():
             self.logger.info("input result: %s", value)
         return value

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -635,18 +635,17 @@ class QDevice(object):
         """
         Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice and diskless SBD
         """
-        if self.is_stage:
-            from .sbd import SBDManager, SBDTimeout
-            utils.check_all_nodes_reachable()
-            using_diskless_sbd = SBDManager.is_using_diskless_sbd()
-            self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
-            # add qdevice after diskless sbd started
-            if using_diskless_sbd:
-                res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
-                if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
-                    sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
-                    SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
-                    utils.set_property(stonith_timeout=SBDTimeout.get_stonith_timeout())
+        from .sbd import SBDManager, SBDTimeout
+        utils.check_all_nodes_reachable()
+        using_diskless_sbd = SBDManager.is_using_diskless_sbd()
+        self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
+        # add qdevice after diskless sbd started
+        if using_diskless_sbd:
+            res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
+            if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
+                sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
+                SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
+                utils.set_property(stonith_timeout=SBDTimeout.get_stonith_timeout())
 
     @qnetd_lock_for_same_cluster_name
     def config_and_start_qdevice(self):


### PR DESCRIPTION
backport #1070 #1074 