### PR TITLE
Dev: log: Use original way for the prompt input

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -332,12 +332,11 @@ class LoggerUtils(object):
         """
         Wrap input function with recording prompt string and input result
         """
-        with self.suppress_new_line():
+        with self.only_file():
             self.logger.info(prompt_string)
-        value = input()
+        value = input(prompt_string)
         if not value:
             value = default
-            print()
         with self.only_file():
             self.logger.info("input result: %s", value)
         return value


### PR DESCRIPTION
As the workaround for remove the whole prompt line when delete characters; 
And the prompt line should be treated as an input action hints, not a info log; 
Related information still be recorded into the log file