### PR TITLE
Dev: qdevice: Refactor qdevice validation code

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -201,52 +201,82 @@ class QDevice(object):
         """
         return "{}/{}/{}".format(self.qdevice_path, self.cluster_node, self.qdevice_p12_filename)
 
-    def valid_qdevice_options(self):
-        """
-        Validate qdevice related options
-        """
+    @staticmethod
+    def check_qnetd_addr(qnetd_addr):
         qnetd_ip = None
-
-        if not utils.package_is_installed("corosync-qdevice"):
-            raise ValueError("Package \"corosync-qdevice\" not installed on this node")
-
         try:
             # socket.getaddrinfo works for both ipv4 and ipv6 address
             # The function returns a list of 5-tuples with the following structure:
             # (family, type, proto, canonname, sockaddr)
             # sockaddr is a tuple describing a socket address, whose format depends on the returned family
             # (a (address, port) 2-tuple for AF_INET, a (address, port, flow info, scope id) 4-tuple for AF_INET6)
-            res = socket.getaddrinfo(self.qnetd_addr, None)
+            res = socket.getaddrinfo(qnetd_addr, None)
             qnetd_ip = res[0][-1][0]
         except socket.error:
-            raise ValueError("host \"{}\" is unreachable".format(self.qnetd_addr))
+            raise ValueError("host \"{}\" is unreachable".format(qnetd_addr))
 
-        utils.ping_node(self.qnetd_addr)
+        utils.ping_node(qnetd_addr)
 
         if utils.InterfacesInfo.ip_in_local(qnetd_ip):
             raise ValueError("host for qnetd must be a remote one")
 
         if not utils.check_port_open(qnetd_ip, 22):
-            raise ValueError("ssh service on \"{}\" not available".format(self.qnetd_addr))
+            raise ValueError("ssh service on \"{}\" not available".format(qnetd_addr))
 
-        if not utils.valid_port(self.port):
+    @staticmethod
+    def check_qdevice_port(qdevice_port):
+        if not utils.valid_port(qdevice_port):
             raise ValueError("invalid qdevice port range(1024 - 65535)")
 
-        if self.algo not in ("ffsplit", "lms"):
-            raise ValueError("invalid ALGORITHM choice: '{}' (choose from 'ffsplit', 'lms')".format(self.algo))
+    @staticmethod
+    def check_qdevice_algo(qdevice_algo):
+        if qdevice_algo not in ("ffsplit", "lms"):
+            raise ValueError("invalid ALGORITHM choice: '{}' (choose from 'ffsplit', 'lms')".format(qdevice_algo))
 
-        if self.tie_breaker not in ("lowest", "highest") and not utils.valid_nodeid(self.tie_breaker):
+    @staticmethod
+    def check_qdevice_tie_breaker(qdevice_tie_breaker):
+        if qdevice_tie_breaker not in ("lowest", "highest") and not utils.valid_nodeid(qdevice_tie_breaker):
             raise ValueError("invalid qdevice tie_breaker(lowest/highest/valid_node_id)")
 
-        if self.tls not in ("on", "off", "required"):
-            raise ValueError("invalid TLS choice: '{}' (choose from 'on', 'off', 'required')".format(self.tls))
+    @staticmethod
+    def check_qdevice_tls(qdevice_tls):
+        if qdevice_tls not in ("on", "off", "required"):
+            raise ValueError("invalid TLS choice: '{}' (choose from 'on', 'off', 'required')".format(qdevice_tls))
 
-        if self.cmds:
-            for cmd in self.cmds.strip(';').split(';'):
-                if not cmd.startswith('/'):
-                    raise ValueError("commands for heuristics should be absolute path")
-                if not os.path.exists(cmd.split()[0]):
-                    raise ValueError("command {} not exist".format(cmd.split()[0]))
+    @staticmethod
+    def check_qdevice_heuristics_mode(mode):
+        if not mode:
+            return
+        if mode not in ("on", "sync", "off"):
+            raise ValueError("invalid MODE choice: '{}' (choose from 'on', 'sync', 'off')".format(mode))
+
+    @staticmethod
+    def check_qdevice_heuristics(cmds):
+        if not cmds:
+            return
+        for cmd in cmds.strip(';').split(';'):
+            if not cmd.startswith('/'):
+                raise ValueError("commands for heuristics should be absolute path")
+            if not os.path.exists(cmd.split()[0]):
+                raise ValueError("command {} not exist".format(cmd.split()[0]))
+
+    @staticmethod
+    def check_package_installed(pkg, remote=None):
+        if not utils.package_is_installed(pkg, remote_addr=remote):
+            raise ValueError("Package \"{}\" not installed on {}".format(pkg, remote if remote else "this node"))
+
+    def valid_qdevice_options(self):
+        """
+        Validate qdevice related options
+        """
+        self.check_package_installed("corosync-qdevice")
+        self.check_qnetd_addr(self.qnetd_addr)
+        self.check_qdevice_port(self.port)
+        self.check_qdevice_algo(self.algo)
+        self.check_qdevice_tie_breaker(self.tie_breaker)
+        self.check_qdevice_tls(self.tls)
+        self.check_qdevice_heuristics(self.cmds)
+        self.check_qdevice_heuristics_mode(self.mode)
 
     def valid_qnetd(self):
         """

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -352,8 +352,6 @@ class SBDManager(object):
         dev_looks_sane = False
         while not dev_looks_sane:
             dev = bootstrap.prompt_for_string('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', r'none|\/.*')
-            if not dev:
-                continue
             if dev == "none":
                 self.diskless_sbd = True
                 return

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -845,26 +845,34 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.configure_qdevice_interactive()
         mock_prompt.assert_not_called()
 
-    @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.confirm')
-    def test_configure_qdevice_interactive_error(self, mock_confirm, mock_prompt, mock_error):
+    def test_configure_qdevice_interactive_not_confirm(self, mock_confirm, mock_info):
         bootstrap._context = mock.Mock(yes_to_all=False)
-        mock_confirm.return_value = True
-        mock_prompt.return_value = None
-        mock_error.side_effect = SystemExit
-
-        with self.assertRaises(SystemExit):
-            bootstrap.configure_qdevice_interactive()
-
-        mock_error.assert_called_once_with("Address of QNetd is required")
+        mock_confirm.return_value = False
+        bootstrap.configure_qdevice_interactive()
         mock_confirm.assert_called_once_with("Do you want to configure QDevice?")
-        mock_prompt.assert_called_once_with("HOST or IP of the QNetd server to be used")
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch('crmsh.qdevice.QDevice.check_package_installed')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.bootstrap.confirm')
+    def test_configure_qdevice_interactive_not_installed(self, mock_confirm, mock_info, mock_installed, mock_error):
+        bootstrap._context = mock.Mock(yes_to_all=False)
+        mock_confirm.side_effect = [True, False]
+        mock_installed.side_effect = ValueError("corosync-qdevice not installed")
+        bootstrap.configure_qdevice_interactive()
+        mock_confirm.assert_has_calls([
+            mock.call("Do you want to configure QDevice?"),
+            mock.call("Please install the package manually and press 'y' to continue")
+            ])
 
     @mock.patch('crmsh.qdevice.QDevice')
     @mock.patch('crmsh.bootstrap.prompt_for_string')
+    @mock.patch('crmsh.qdevice.QDevice.check_package_installed')
+    @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.confirm')
-    def test_configure_qdevice_interactive(self, mock_confirm, mock_prompt, mock_qdevice):
+    def test_configure_qdevice_interactive(self, mock_confirm, mock_info, mock_installed, mock_prompt, mock_qdevice):
         bootstrap._context = mock.Mock(yes_to_all=False)
         mock_confirm.return_value = True
         mock_prompt.side_effect = ["qnetd-node", 5403, "ffsplit", "lowest", "on", None]
@@ -874,15 +882,21 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.configure_qdevice_interactive()
         mock_confirm.assert_called_once_with("Do you want to configure QDevice?")
         mock_prompt.assert_has_calls([
-            mock.call("HOST or IP of the QNetd server to be used"),
-            mock.call("TCP PORT of QNetd server", default=5403),
-            mock.call("QNetd decision ALGORITHM (ffsplit/lms)", default="ffsplit"),
-            mock.call("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest"),
-            mock.call("Whether using TLS on QDevice/QNetd (on/off/required)", default="on"),
-            mock.call("Heuristics COMMAND to run with absolute path; For multiple commands, use \";\" to separate")
+            mock.call("HOST or IP of the QNetd server to be used",
+                valid_func=qdevice.QDevice.check_qnetd_addr),
+            mock.call("TCP PORT of QNetd server", default=5403,
+                valid_func=qdevice.QDevice.check_qdevice_port),
+            mock.call("QNetd decision ALGORITHM (ffsplit/lms)", default="ffsplit",
+                valid_func=qdevice.QDevice.check_qdevice_algo),
+            mock.call("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest",
+                valid_func=qdevice.QDevice.check_qdevice_tie_breaker),
+            mock.call("Whether using TLS on QDevice/QNetd (on/off/required)", default="on",
+                valid_func=qdevice.QDevice.check_qdevice_tls),
+            mock.call("Heuristics COMMAND to run with absolute path; For multiple commands, use \";\" to separate",
+                valid_func=qdevice.QDevice.check_qdevice_heuristics,
+                allow_empty=True)
             ])
         mock_qdevice.assert_called_once_with('qnetd-node', port=5403, algo='ffsplit', tie_breaker='lowest', tls='on', cmds=None, mode=None, is_stage=False)
-        mock_qdevice_inst.valid_qdevice_options.assert_called_once_with()
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.is_qdevice_configured')

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -383,7 +383,7 @@ class TestSBDManager(unittest.TestCase):
         mock_confirm.return_value = True
         mock_no_overwrite.return_value = False
         mock_from_config.return_value = []
-        mock_prompt.side_effect = [None, "none"]
+        mock_prompt.return_value = "none"
 
         self.sbd_inst._get_sbd_device_interactive()
 
@@ -391,7 +391,7 @@ class TestSBDManager(unittest.TestCase):
         mock_confirm.assert_called_once_with("Do you wish to use SBD?")
         mock_from_config.assert_called_once_with()
         mock_prompt.assert_has_calls([
-            mock.call('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', 'none|\\/.*') for x in range(2)
+            mock.call('Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path', 'none|\\/.*')
             ])
 
     @mock.patch('crmsh.utils.re_split_string')


### PR DESCRIPTION
On interactive mode, when configuring qdevice with mistake, crmsh exit immediately.
crmsh ui should let user input again, until get the right input
So, the method `qdevice.QDevice.valid_qdevice_options` should be refactored