### PR TITLE
Dev: utils: add auto_convert_role flag for handle_role_for_ocf_1_1 function

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -858,9 +858,11 @@ def parse_cli_to_xml(cli, oldnode=None):
     complete = False
     comments = []
     if isinstance(cli, str):
+        utils.auto_convert_role = False
         for s in lines2cli(cli):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
+        utils.auto_convert_role = True
         complete = True
         node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete)
     if node is False:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3399,6 +3399,9 @@ def compatible_role(role1, role2):
     return res1 or res2
 
 
+auto_convert_role = True
+
+
 def handle_role_for_ocf_1_1(value, name='role'):
     """
     * Convert role from Promoted/Unpromoted to Master/Slave if schema doesn't support OCF 1.1
@@ -3416,7 +3419,7 @@ def handle_role_for_ocf_1_1(value, name='role'):
     if value in downgrade_dict and not is_ocf_1_1_cib_schema_detected():
         logger.warning('Convert "%s" to "%s" since the current schema version is old and not upgraded yet. Please consider "%s"', value, downgrade_dict[value], constants.CIB_UPGRADE)
         return downgrade_dict[value]
-    if value in upgrade_dict and is_ocf_1_1_cib_schema_detected() and config.core.OCF_1_1_SUPPORT:
+    if value in upgrade_dict and is_ocf_1_1_cib_schema_detected() and config.core.OCF_1_1_SUPPORT and auto_convert_role:
         logger.info('Convert deprecated "%s" to "%s"', value, upgrade_dict[value])
         return upgrade_dict[value]
 


### PR DESCRIPTION
## Problem
When cib schema version support OCF 1.1 and set `OCF_1_1_SUPPORT = yes` in /etc/crm/crm.conf, if origin cib configuration contain original Master/Slave for role, command `crm configure show` will be messy:
```
crm(live/15sp4-1)configure# show
INFO: Convert deprecated "Master" to "Promoted"
node 1: 15sp4-1
node 2: 15sp4-2
xml <primitive id="st" class="ocf" provider="pacemaker" type="Stateful"> \
  <operations> \
    <op name="monitor" role="Master" interval="10s" timeout="20s" id="st-monitor-10s"/> \
    <op name="start" timeout="20s" interval="0s" id="st-start-0s"/> \
    <op name="stop" timeout="20s" interval="0s" id="st-stop-0s"/> \
    <op name="promote" timeout="10s" interval="0s" id="st-promote-0s"/> \
    <op name="demote" timeout="10s" interval="0s" id="st-demote-0s"/> \
  </operations> \
</primitive>
```

## Solution
Add `utils.auto_convert_role` flag to control role convert, when doing configuring from cli, this flag value is True, otherwise, it's False.
Then, `crm configure show` will keep origin cib configuration unchanged