### PR TITLE
Dev: bootstrap: Support replacing sbd device via sbd stage

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -210,8 +210,8 @@ class Context(object):
         if self.stage == "sbd":
             if not self.sbd_devices and not self.diskless_sbd and self.yes_to_all:
                 utils.fatal("Stage sbd should specify sbd device by -s or diskless sbd by -S option")
-            if utils.service_is_active("sbd.service"):
-                utils.fatal("Cannot configure stage sbd: sbd.service already running!")
+            if utils.service_is_active("sbd.service") and not config.core.force:
+                utils.fatal("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")
             if self.cluster_is_running:
                 utils.check_all_nodes_reachable()
 
@@ -1492,6 +1492,9 @@ def init_sbd():
     SBD can also run in diskless mode if no device
     is configured.
     """
+    import crmsh.sbd
+    if _context.stage == "sbd":
+        crmsh.sbd.clean_up_existing_sbd_resource()
     _context.sbd_manager.sbd_init()
 
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -620,3 +620,12 @@ class SBDManager(object):
         cmd = "sbd -d {} dump".format(dev)
         rc, _, _ = utils.get_stdout_stderr(cmd)
         return rc == 0
+
+
+def clean_up_existing_sbd_resource():
+    if xmlutil.CrmMonXmlParser.is_resource_configured(SBDManager.SBD_RA):
+        sbd_id_list = xmlutil.CrmMonXmlParser.get_resource_id_list_via_type(SBDManager.SBD_RA)
+        if xmlutil.CrmMonXmlParser.is_resource_started(SBDManager.SBD_RA):
+            for sbd_id in sbd_id_list:
+                utils.ext_cmd("crm resource stop {}".format(sbd_id))
+        utils.ext_cmd("crm configure delete {}".format(' '.join(sbd_id_list)))

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -271,6 +271,12 @@ Examples:
   # Add SBD on a running cluster
   crm cluster init sbd -s <share disk> -y
 
+  # Replace SBD device on a running cluster which already configured SBD
+  crm -F cluster init sbd -s <share disk> -y
+
+  # Add diskless SBD on a running cluster
+  crm cluster init sbd -S -y
+
   # Add QDevice on a running cluster
   crm cluster init qdevice --qnetd-hostname <qnetd addr> -y
 

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1579,4 +1579,17 @@ class CrmMonXmlParser(object):
             return False
         # Starting will return False
         return all([True if elem.get('role') == 'Started' else False for elem in elem_list])
+
+    @classmethod
+    def get_resource_id_list_via_type(cls, ra_type, peer=None):
+        """
+        Given configured ra type, get the ra id list
+        """
+        id_list = []
+        cls_inst = cls(peer=peer)
+        cls_inst._load()
+        elem_list = cls_inst.xml_elem.xpath('//resource[@resource_agent="{ra_type}"]'.format(ra_type=ra_type))
+        if not elem_list:
+            return id_list
+        return [elem.get('id') for elem in elem_list]
 # vim:ts=4:sw=4:et:

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -191,6 +191,12 @@ Examples:
   # Add SBD on a running cluster
   crm cluster init sbd -s <share disk> -y
 
+  # Replace SBD device on a running cluster which already configured SBD
+  crm -F cluster init sbd -s <share disk> -y
+
+  # Add diskless SBD on a running cluster
+  crm cluster init sbd -S -y
+
   # Add QDevice on a running cluster
   crm cluster init qdevice --qnetd-hostname <qnetd addr> -y
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -110,7 +110,7 @@ class TestContext(unittest.TestCase):
         mock_active.return_value = True
         with self.assertRaises(SystemExit):
             ctx._validate_sbd_option()
-        mock_error.assert_called_once_with("Cannot configure stage sbd: sbd.service already running!")
+        mock_error.assert_called_once_with("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")
         mock_active.assert_called_once_with("sbd.service")
 
     @mock.patch('crmsh.utils.check_all_nodes_reachable')

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -84,3 +84,9 @@ class TestCrmMonXmlParser(unittest.TestCase):
         assert xmlutil.CrmMonXmlParser.is_resource_started("test") is False
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocfs2-clusterfs") is True
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocf::pacemaker:controld") is True
+
+    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    def test_get_resource_id_list_via_type(self, mock_run):
+        mock_run.return_value = self.resources_xml
+        assert xmlutil.CrmMonXmlParser.get_resource_id_list_via_type("test") == []
+        assert xmlutil.CrmMonXmlParser.get_resource_id_list_via_type("ocf::pacemaker:controld")[0] == "ocfs2-dlm"


### PR DESCRIPTION
- Originally, `crm cluster init sbd -s <device> -y` can add sbd configuration and sbd service into a running cluster
- Then, if want to re-deploy sbd or replace sbd device, `crm cluster init sbd -s <device> -y` will get error:
```
# crm cluster init sbd -s /dev/sda2 -y
ERROR: cluster.init: Cannot configure stage sbd: sbd.service already running!
```
#### After changed
```
 # crm cluster init sbd -s /dev/sda2 -y
ERROR: cluster.init: Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy
```
Change disk-based SBD as disk-less SBD
```
# crm -F cluster init sbd -S -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
WARNING: Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice.
INFO: Configuring diskless SBD
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
...........                                                                                                                                                                                   INFO: END Waiting for cluster
INFO: BEGIN Adjusting sbd related timeout values
WARNING: "stonith-timeout" in crm_config is set to 71, it was 60
INFO: END Adjusting sbd related timeout values
INFO: Done (log saved to /var/log/crmsh/crmsh.log)
```
Change disk-less SBD as disk-based SBD
```
# ps -ef|grep sbd
root     23093     1  0 17:44 ?        00:00:00 sbd: inquisitor
root     23094 23093  0 17:44 ?        00:00:00 sbd: watcher: Pacemaker
root     23095 23093  0 17:44 ?        00:00:00 sbd: watcher: Cluster

15sp4-1:/opt/features # crm -F cluster init sbd -s /dev/sda1 -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Initializing SBD
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
..........                                                                                                                                                                                    INFO: END Waiting for cluster
INFO: BEGIN Adjusting sbd related timeout values
WARNING: "stonith-timeout" in crm_config is set to 83, it was 71
INFO: END Adjusting sbd related timeout values
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp4-1:/opt/features # ps -ef|grep sbd
root     23305     1  0 17:49 ?        00:00:00 sbd: inquisitor
root     23306 23305  0 17:49 ?        00:00:00 sbd: watcher: /dev/sda1 - slot: 0 - uuid: b567a68f-c044-4d70-871b-9e47a08dfd04
root     23307 23305  0 17:49 ?        00:00:00 sbd: watcher: Pacemaker
root     23308 23305  0 17:49 ?        00:00:00 sbd: watcher: Cluster

15sp4-1:/opt/features # crm_mon -1
Cluster Summary:
  * Stack: corosync
  * Current DC: 15sp4-1 (version 2.1.2+20211124.ada5c3b36-150400.4.6.1-2.1.2+20211124.ada5c3b36) - partition with quorum
  * Last updated: Thu Dec 15 17:50:14 2022
  * Last change:  Thu Dec 15 17:50:02 2022 by root via cibadmin on 15sp4-1
  * 2 nodes configured
  * 1 resource instance configured

Node List:
  * Online: [ 15sp4-1 15sp4-2 ]

Active Resources:
  * stonith-sbd	(stonith:external/sbd):	 Started 15sp4-1
```
Replace sbd device
```
 # ps -ef|grep sbd
root     23305     1  0 17:49 ?        00:00:00 sbd: inquisitor
root     23306 23305  0 17:49 ?        00:00:00 sbd: watcher: /dev/sda1 - slot: 0 - uuid: b567a68f-c044-4d70-871b-9e47a08dfd04
root     23307 23305  0 17:49 ?        00:00:00 sbd: watcher: Pacemaker
root     23308 23305  0 17:49 ?        00:00:00 sbd: watcher: Cluster

15sp4-1:/opt/features # crm -F cluster init sbd -s /dev/sda2 -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Initializing SBD
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
..........                                                                                                                                                                                    INFO: END Waiting for cluster
INFO: BEGIN Adjusting sbd related timeout values
INFO: END Adjusting sbd related timeout values
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp4-1:/opt/features # ps -ef|grep sbd
root     23611     1  0 17:51 ?        00:00:00 sbd: inquisitor
root     23612 23611  0 17:51 ?        00:00:00 sbd: watcher: /dev/sda2 - slot: 0 - uuid: 9a3030de-c9ad-44d3-960a-24c3a05de687
root     23613 23611  0 17:51 ?        00:00:00 sbd: watcher: Pacemaker
root     23614 23611  0 17:51 ?        00:00:00 sbd: watcher: Cluster
```