### PR TITLE
Fix: bootstrap: Unset SBD_DELAY_START when running 'crm cluster start'

### DIFF
--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -290,21 +290,32 @@ class TestBootstrap(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.log.LoggerUtils.status_long')
+    @mock.patch('crmsh.parallax.parallax_call')
     @mock.patch('crmsh.utils.start_service')
-    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_delay_start_sec_from_sysconfig')
     @mock.patch('crmsh.sbd.SBDTimeout.is_sbd_delay_start')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_start_pacemaker(self, mock_installed, mock_enabled, mock_delay_start, mock_timeout, mock_start, mock_long):
+    def test_start_pacemaker(self, mock_installed, mock_enabled, mock_delay_start, mock_start, mock_parallax_call):
         bootstrap._context = None
         mock_installed.return_value = True
         mock_enabled.return_value = True
         mock_delay_start.return_value = True
-        mock_timeout.return_value = 60
-        bootstrap.start_pacemaker()
-        mock_long.assert_called_once_with('Starting pacemaker(delaying start of sbd for 60s)')
-        mock_start.assert_called_once_with('pacemaker.service', enable=False, node_list=[])
+        node_list = ["node1", "node2", "node3", "node4", "node5", "node6"]
+        bootstrap.start_pacemaker(node_list)
+        mock_start.assert_has_calls([
+            mock.call("corosync.service", remote_addr="node1"),
+            mock.call("corosync.service", remote_addr="node2"),
+            mock.call("corosync.service", remote_addr="node3"),
+            mock.call("corosync.service", remote_addr="node4"),
+            mock.call("corosync.service", remote_addr="node5"),
+            mock.call("corosync.service", remote_addr="node6"),
+            mock.call("pacemaker.service", enable=False, node_list=node_list)
+            ])
+        mock_parallax_call.assert_has_calls([
+            mock.call(node_list, 'mkdir -p /run/systemd/system/sbd.service.d/'),
+            mock.call(node_list, "echo -e '[Service]\nUnsetEnvironment=SBD_DELAY_START' > /run/systemd/system/sbd.service.d/sbd_delay_start_disabled.conf"),
+            mock.call(node_list, "systemctl daemon-reload"),
+            ])
 
     @mock.patch('crmsh.bootstrap.configure_ssh_key')
     @mock.patch('crmsh.utils.start_service')


### PR DESCRIPTION
## Problem 
On a 2-node cluster with sbd configured, start the cluster using "crm cluster start" on the first node and get a fence action for the second which was planned to enter the cluster a bit later

## Solution 
Just drop-in a volatile sbd service snippet to unset SBD_DELAY_START, when running "crm cluster start"
```
mkdir /run/systemd/system/sbd.service.d/

cat << EOF > /run/systemd/system/sbd.service.d/sbd_delay_start_disabled.conf
[Service]
UnsetEnvironment=SBD_DELAY_START
EOF

systemctl daemon-reload
```