### PR TITLE
Dev: qdevice: Adjust qdevice reload policy

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -27,7 +27,7 @@ class QdevicePolicy(Enum):
     QDEVICE_RESTART_LATER = 2
 
 
-def evaluate_qdevice_quorum_effect(mode, diskless_sbd=False):
+def evaluate_qdevice_quorum_effect(mode, diskless_sbd=False, is_stage=False):
     """
     While adding/removing qdevice, get current expected votes and actual total votes,
     to calculate after adding/removing qdevice, whether cluster has quorum
@@ -44,6 +44,9 @@ def evaluate_qdevice_quorum_effect(mode, diskless_sbd=False):
     if utils.calculate_quorate_status(expected_votes, actual_votes) and not diskless_sbd:
         # safe to use reload
         return QdevicePolicy.QDEVICE_RELOAD
+    elif mode == QDEVICE_ADD and not is_stage:
+        # Add qdevice from init process, safe to restart
+        return QdevicePolicy.QDEVICE_RESTART
     elif xmlutil.CrmMonXmlParser.is_any_resource_running():
         # will lose quorum, and with RA running
         # no reload, no restart cluster service
@@ -137,6 +140,7 @@ class QDevice(object):
         self.cluster_name = cluster_name
         self.qdevice_reload_policy = QdevicePolicy.QDEVICE_RESTART
         self.is_stage = is_stage
+        self.using_diskless_sbd = False
 
     @property
     def qnetd_cacert_on_qnetd(self):
@@ -668,10 +672,9 @@ class QDevice(object):
         """
         from .sbd import SBDManager, SBDTimeout
         utils.check_all_nodes_reachable()
-        using_diskless_sbd = SBDManager.is_using_diskless_sbd()
-        self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, using_diskless_sbd)
+        self.using_diskless_sbd = SBDManager.is_using_diskless_sbd()
         # add qdevice after diskless sbd started
-        if using_diskless_sbd:
+        if self.using_diskless_sbd:
             res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
             if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
                 sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
@@ -688,6 +691,7 @@ class QDevice(object):
             with logger_utils.status_long("Qdevice certification process"):
                 self.certificate_process_on_init()
         self.adjust_sbd_watchdog_timeout_with_qdevice()
+        self.qdevice_reload_policy = evaluate_qdevice_quorum_effect(QDEVICE_ADD, self.using_diskless_sbd, self.is_stage)
         self.config_qdevice()
         self.start_qdevice_service()
 

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -18,6 +18,17 @@ F4 = open(os.path.join(os.path.dirname(__file__), 'corosync.conf.3')).read()
 
 @mock.patch('crmsh.utils.calculate_quorate_status')
 @mock.patch('crmsh.utils.get_quorum_votes_dict')
+def test_evaluate_qdevice_quorum_effect_restart(mock_get_dict, mock_quorate):
+    mock_get_dict.return_value = {'Expected': '1', 'Total': '1'}
+    mock_quorate.return_value = False
+    res = qdevice.evaluate_qdevice_quorum_effect(qdevice.QDEVICE_ADD, False, False)
+    assert res == qdevice.QdevicePolicy.QDEVICE_RESTART
+    mock_get_dict.assert_called_once_with()
+    mock_quorate.assert_called_once_with(2, 1)
+
+
+@mock.patch('crmsh.utils.calculate_quorate_status')
+@mock.patch('crmsh.utils.get_quorum_votes_dict')
 def test_evaluate_qdevice_quorum_effect_reload(mock_get_dict, mock_quorate):
     mock_get_dict.return_value = {'Expected': '2', 'Total': '2'}
     mock_quorate.return_value = True
@@ -871,9 +882,10 @@ Membership information
         mock_get_value.assert_called_once_with("quorum.device.net.host")
         mock_warning.assert_called_once_with("Qdevice's vote is 0, which simply means Qdevice can't talk to Qnetd(qnetd-node) for various reasons.")
 
+    @mock.patch('crmsh.qdevice.evaluate_qdevice_quorum_effect')
     @mock.patch('crmsh.log.LoggerUtils.status_long')
     @mock.patch('crmsh.qdevice.QDevice.remove_qdevice_db')
-    def test_config_and_start_qdevice(self, mock_rm_db, mock_status_long):
+    def test_config_and_start_qdevice(self, mock_rm_db, mock_status_long, mock_evaluate):
         mock_status_long.return_value.__enter__ = mock.Mock()
         mock_status_long.return_value.__exit__ = mock.Mock()
         self.qdevice_with_ip.certificate_process_on_init = mock.Mock()
@@ -894,13 +906,10 @@ Membership information
     @mock.patch('crmsh.sbd.SBDTimeout.get_stonith_timeout')
     @mock.patch('crmsh.sbd.SBDManager.update_configuration')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
-    @mock.patch('crmsh.qdevice.evaluate_qdevice_quorum_effect')
     @mock.patch('crmsh.sbd.SBDManager.is_using_diskless_sbd')
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
-    def test_adjust_sbd_watchdog_timeout_with_qdevice(self, mock_check_reachable, mock_using_diskless_sbd, mock_evaluate,
-            mock_get_sbd_value, mock_update_config, mock_get_timeout, mock_set_property):
+    def test_adjust_sbd_watchdog_timeout_with_qdevice(self, mock_check_reachable, mock_using_diskless_sbd, mock_get_sbd_value, mock_update_config, mock_get_timeout, mock_set_property):
         mock_using_diskless_sbd.return_value = True
-        mock_evaluate.return_value = qdevice.QdevicePolicy.QDEVICE_RELOAD
         mock_get_sbd_value.return_value = ""
         mock_get_timeout.return_value = 100
 
@@ -908,7 +917,6 @@ Membership information
 
         mock_check_reachable.assert_called_once_with()
         mock_using_diskless_sbd.assert_called_once_with()
-        mock_evaluate.assert_called_once_with(qdevice.QDEVICE_ADD, True)
         mock_get_sbd_value.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
         mock_update_config.assert_called_once_with({"SBD_WATCHDOG_TIMEOUT": str(sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)})
         mock_set_property.assert_called_once_with("stonith-timeout", 100)


### PR DESCRIPTION
## Problem
When configuring sbd and qdevice together like `crm cluster init -s <sbd> --qnetd-hostname <qnetd> -y`, corosync-qdevice.service will not start
## Reason
According to the logic of `evaluate_qdevice_quorum_effect`, after configured sbd and cluster started, there is an RA(external/sbd) running, at this time, to use qdevice service, need to restart cluster later
## Solution
When adding qdevice and not in qdevice stage, this means that qdevice is added from the beginning at init node. It's safe to restart the cluster, regardless of whether there is RA running or not.