### PR TITLE
Fix: report: Catch read exception

### DIFF
--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -1541,7 +1541,11 @@ def read_from_file(infile):
     data = None
     _open = get_open_method(infile)
     with _open(infile, 'rt', encoding='utf-8', errors='replace') as f:
-        data = f.read()
+        try:
+            data = f.read()
+        except Exception as err:
+            logger.error("When reading file \"%s\": %s", infile, str(err))
+            return None
     return crmutils.to_ascii(data)
 
 


### PR DESCRIPTION
Fenced node could leave a zero byte length .xz file (which is not a file in xz format), which will raise EOFError while crm report trying to read it. So, it will be helpful to catch the exception while reading and make sure report process continues.