### PR TITLE
Dev: upgradeutil: do not ask when running in a background process group

### DIFF
--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -216,7 +216,7 @@ def main_fix_local(args) -> int:
             if args.yes:
                 def ask(msg): return True
             else:
-                def ask(msg): return crmsh.utils.ask('Healthcheck: fix: ' + msg)
+                def ask(msg): return crmsh.utils.ask('Healthcheck: fix: ' + msg, background_wait=False)
             if args.without_check or not feature_local_check(feature, nodes):
                 feature.fix_local(nodes, ask)
             return 0
@@ -233,7 +233,7 @@ def main_fix_cluster(args) -> int:
             if args.yes:
                 def ask(msg): return True
             else:
-                def ask(msg): return crmsh.utils.ask('Healthcheck: fix: ' + msg)
+                def ask(msg): return crmsh.utils.ask('Healthcheck: fix: ' + msg, background_wait=False)
             if args.without_check or not feature_full_check(feature, nodes):
                 feature_fix(feature, nodes, ask)
             return 0

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -105,7 +105,7 @@ def _get_minimal_seq_in_cluster(nodes) -> typing.Tuple[int, int]:
 
 def _upgrade(nodes, seq):
     def ask(msg: str):
-        if not crmsh.utils.ask('Upgrade of crmsh configuration: ' + msg):
+        if not crmsh.utils.ask('Upgrade of crmsh configuration: ' + msg, background_wait=False):
             raise crmsh.healthcheck.AskDeniedByUser()
     try:
         for key in VERSION_FEATURES.keys():

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -211,16 +211,24 @@ def can_ask():
     return (not options.ask_no) and sys.stdin.isatty()
 
 
-def ask(msg):
-    """
-    Ask for user confirmation.
-    If core.force is true, always return true.
-    If not interactive and core.force is false, always return false.
+def ask(msg, background_wait=True):
+    """Ask for user confirmation.
+
+    Parameters:
+    * background_wait: When set to False, return False without asking if current process is in background. Otherwise,
+    block until the process is brought to foreground.
+
+    Global Options:
+    * core.force: always return true without asking
+    * options.ask_no: do not ask and return false
     """
     if config.core.force:
         logger.info("%s [YES]", msg)
         return True
     if not can_ask():
+        return False
+    if sys.stdin.isatty() and os.tcgetpgrp(sys.stdin.fileno()) != os.getpgrp() and not background_wait:
+        logger.info("%s [NO]", msg)
         return False
 
     msg += ' '


### PR DESCRIPTION
# Problem

When crmsh is running in a background process group, for example,

```
crm status &
```

and upgradeutil tries to ask for user confirm, it will block until crmsh is brought to foreground (with fg).

However, configuration upgrading is not a critical operation, and it is better not to block when running in background.

# Solution

When current process is not in the foreground process group, do not ask and skip the upgrade.

Close #1102.