### PR TITLE
[crmsh-4.4] Fix: bootstrap: Unset SBD_DELAY_START when running 'crm cluster start'

### DIFF
--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -261,21 +261,23 @@ class TestBootstrap(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.log.LoggerUtils.status_long')
+    @mock.patch('crmsh.parallax.parallax_call')
     @mock.patch('crmsh.utils.start_service')
-    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_delay_start_sec_from_sysconfig')
     @mock.patch('crmsh.sbd.SBDTimeout.is_sbd_delay_start')
     @mock.patch('crmsh.utils.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_start_pacemaker(self, mock_installed, mock_enabled, mock_delay_start, mock_timeout, mock_start, mock_long):
+    def test_start_pacemaker(self, mock_installed, mock_enabled, mock_delay_start, mock_start_service, mock_call):
         bootstrap._context = None
         mock_installed.return_value = True
         mock_enabled.return_value = True
         mock_delay_start.return_value = True
-        mock_timeout.return_value = 60
         bootstrap.start_pacemaker()
-        mock_long.assert_called_once_with('Starting pacemaker(delaying start of sbd for 60s)')
-        mock_start.assert_called_once_with('pacemaker.service', enable=False, node_list=[])
+        mock_start_service.assert_called_once_with('pacemaker.service', enable=False, node_list=[])
+        mock_call.assert_has_calls([
+            mock.call([], 'mkdir -p /run/systemd/system/sbd.service.d/'),
+            mock.call([], "echo -e '[Service]\nUnsetEnvironment=SBD_DELAY_START' > /run/systemd/system/sbd.service.d/sbd_delay_start_disabled.conf"),
+            mock.call([], 'systemctl daemon-reload')
+            ])
 
     @mock.patch('crmsh.bootstrap.configure_local_ssh_key')
     @mock.patch('crmsh.utils.start_service')


### PR DESCRIPTION
backport #1092 