### PR TITLE
Dev: ui_cluster: Improve cluster start/stop INFO

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -90,7 +90,7 @@ class Cluster(command.UI):
     @command.skill_level('administrator')
     def do_start(self, context, *args):
         '''
-        Starts the cluster services on all nodes or specific node(s)
+        Starts the cluster stack on all nodes or specific node(s)
         '''
         service_check_list = ["pacemaker.service"]
         start_qdevice = False
@@ -101,7 +101,7 @@ class Cluster(command.UI):
         node_list = parse_option_for_nodes(context, *args)
         for node in node_list[:]:
             if all([utils.service_is_active(srv, remote_addr=node) for srv in service_check_list]):
-                logger.info("Cluster services already started on {}".format(node))
+                logger.info("The cluster stack already started on {}".format(node))
                 node_list.remove(node)
         if not node_list:
             return
@@ -112,25 +112,25 @@ class Cluster(command.UI):
         if start_qdevice:
             qdevice.QDevice.check_qdevice_vote()
         for node in node_list:
-            logger.info("Cluster services started on {}".format(node))
+            logger.info("The cluster stack started on {}".format(node))
 
     @command.skill_level('administrator')
     def do_stop(self, context, *args):
         '''
-        Stops the cluster services on all nodes or specific node(s)
+        Stops the cluster stack on all nodes or specific node(s)
         '''
         node_list = parse_option_for_nodes(context, *args)
         for node in node_list[:]:
             if not utils.service_is_active("corosync.service", remote_addr=node):
                 if utils.service_is_active("sbd.service", remote_addr=node):
                     utils.stop_service("corosync", remote_addr=node)
-                    logger.info("Cluster services stopped on {}".format(node))
+                    logger.info("The cluster stack stopped on {}".format(node))
                 else:
-                    logger.info("Cluster services already stopped on {}".format(node))
+                    logger.info("The cluster stack already stopped on {}".format(node))
                 node_list.remove(node)
             elif not utils.service_is_active("pacemaker.service", remote_addr=node):
                 utils.stop_service("corosync", remote_addr=node)
-                logger.info("Cluster services stopped on {}".format(node))
+                logger.info("The cluster stack stopped on {}".format(node))
                 node_list.remove(node)
         if not node_list:
             return
@@ -158,12 +158,12 @@ class Cluster(command.UI):
         node_list = utils.stop_service("corosync", node_list=node_list)
 
         for node in node_list:
-            logger.info("Cluster services stopped on {}".format(node))
+            logger.info("The cluster stack stopped on {}".format(node))
 
     @command.skill_level('administrator')
     def do_restart(self, context, *args):
         '''
-        Restarts the cluster services on all nodes or specific node(s)
+        Restarts the cluster stack on all nodes or specific node(s)
         '''
         parse_option_for_nodes(context, *args)
         self.do_stop(context, *args)

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -52,8 +52,8 @@ class TestCluster(unittest.TestCase):
             mock.call("pacemaker.service", remote_addr="node2")
             ])
         mock_info.assert_has_calls([
-            mock.call("Cluster services already started on node1"),
-            mock.call("Cluster services already started on node2")
+            mock.call("The cluster stack already started on node1"),
+            mock.call("The cluster stack already started on node2")
             ])
 
     @mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
@@ -78,7 +78,7 @@ class TestCluster(unittest.TestCase):
             ])
         mock_start.assert_called_once_with("corosync-qdevice", node_list=["node1"])
         mock_qdevice_configured.assert_called_once_with()
-        mock_info.assert_called_once_with("Cluster services started on node1")
+        mock_info.assert_called_once_with("The cluster stack started on node1")
 
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.service_is_active')
@@ -92,7 +92,7 @@ class TestCluster(unittest.TestCase):
             mock.call("corosync.service", remote_addr="node1"),
             mock.call("sbd.service", remote_addr="node1")
             ])
-        mock_info.assert_called_once_with("Cluster services already stopped on node1")
+        mock_info.assert_called_once_with("The cluster stack already stopped on node1")
 
     @mock.patch('logging.Logger.debug')
     @mock.patch('logging.Logger.info')
@@ -126,6 +126,6 @@ class TestCluster(unittest.TestCase):
             mock.call("corosync-qdevice.service", node_list=["node1"]),
             mock.call("corosync", node_list=["node1"])
             ])
-        mock_info.assert_called_once_with("Cluster services stopped on node1")
+        mock_info.assert_called_once_with("The cluster stack stopped on node1")
         mock_debug.assert_called_once_with("Quorum is lost; Set enable_quorum_fencing=0 and enable_quorum_lockspace=0 for dlm")
         mock_check.assert_called_once_with(mock_get_dc, wait_timeout=25)


### PR DESCRIPTION
 s/Cluster services/The cluster stack/
    
 To clarify that it starts/stops the whole stack, both resource agents and systemd pacemaker/corosync.service/services.

Related issue #413 