### PR TITLE
Don't use inspect.getargspec, removed in Python 3.11.

### DIFF
--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -113,7 +113,7 @@ def pretty_arguments(f, nskip=0):
     Returns a prettified representation
     of the command arguments
     '''
-    specs = inspect.getargspec(f)
+    specs = inspect.getfullargspec(f)
     named_args = []
     if specs.defaults is None:
         named_args += specs.args
@@ -140,7 +140,7 @@ def validate_arguments(f, args, nskip=0):
 
     Note: Does not support keyword arguments.
     '''
-    specs = inspect.getargspec(f)
+    specs = inspect.getfullargspec(f)
     min_args = len(specs.args)
     if specs.defaults is not None:
         min_args -= len(specs.defaults)


### PR DESCRIPTION
crmsh fails with Python 3.11:
```
Traceback (most recent call last):
  File "/usr/sbin/crm", line 35, in <module>
    from crmsh import main
  File "/usr/lib/python3/dist-packages/crmsh/main.py", line 17, in <module>
    from . import ui_root
  File "/usr/lib/python3/dist-packages/crmsh/ui_root.py", line 201, in <module>
    Root.init_ui()
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 503, in init_ui
    prepare(children, child, aliases)
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 488, in prepare
    info = ChildInfo(child, cls)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 558, in __init__
    self.children = self.level.init_ui()
                    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 503, in init_ui
    prepare(children, child, aliases)
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 488, in prepare
    info = ChildInfo(child, cls)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 558, in __init__
    self.children = self.level.init_ui()
                    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 503, in init_ui
    prepare(children, child, aliases)
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 494, in prepare
    add_help(info)
  File "/usr/lib/python3/dist-packages/crmsh/command.py", line 476, in add_help
    ui_utils.pretty_arguments(info.function, nskip=2)),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/crmsh/ui_utils.py", line 116, in pretty_arguments
    specs = inspect.getargspec(f)
            ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

`inspect.getfullargspec` should be used instead like in [`crmsh/command.py`](https://github.com/ClusterLabs/crmsh/blob/master/crmsh/command.py#L569-L585)