### PR TITLE
Fix spelling errors.

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -254,7 +254,7 @@ For example, instead of typing `crm status`, you can type `crm st` or
 `crm cf`. `crm resource` can be shorted as `crm rsc`, and so on.
 
 The exact list of accepted aliases is too long to print in full, but
-experimentation and typoes should help in discovering more of them.
+experimentation and typos should help in discovering more of them.
 
 [[topics_Features,Features]]
 == Features

--- a/doc/website-v1/man-2.0.adoc
+++ b/doc/website-v1/man-2.0.adoc
@@ -255,7 +255,7 @@ For example, instead of typing `crm status`, you can type `crm st` or
 `crm cf`. `crm resource` can be shorted as `crm rsc`, and so on.
 
 The exact list of accepted aliases is too long to print in full, but
-experimentation and typoes should help in discovering more of them.
+experimentation and typos should help in discovering more of them.
 
 [[topics_Features,Features]]
 == Features

--- a/doc/website-v1/man-3.adoc
+++ b/doc/website-v1/man-3.adoc
@@ -255,7 +255,7 @@ For example, instead of typing `crm status`, you can type `crm st` or
 `crm cf`. `crm resource` can be shorted as `crm rsc`, and so on.
 
 The exact list of accepted aliases is too long to print in full, but
-experimentation and typoes should help in discovering more of them.
+experimentation and typos should help in discovering more of them.
 
 [[topics_Features,Features]]
 == Features

--- a/doc/website-v1/man-4.3.adoc
+++ b/doc/website-v1/man-4.3.adoc
@@ -254,7 +254,7 @@ For example, instead of typing `crm status`, you can type `crm st` or
 `crm cf`. `crm resource` can be shorted as `crm rsc`, and so on.
 
 The exact list of accepted aliases is too long to print in full, but
-experimentation and typoes should help in discovering more of them.
+experimentation and typos should help in discovering more of them.
 
 [[topics_Features,Features]]
 == Features


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * typoes -> typos