### PR TITLE
Dev: utils: Check current user's privilege and give hints to user

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -62,8 +62,7 @@ jobs:
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
-        index=`$GET_INDEX_OF crm_report_bugs`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $DOCKER_SCRIPT `$GET_INDEX_OF crm_report_bugs`
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-20.04
@@ -220,6 +219,17 @@ jobs:
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
 
+  functional_test_user_access:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for user access
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
+
   original_regression_test:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
@@ -246,6 +256,7 @@ jobs:
       functional_test_geo_cluster,
       functional_test_healthcheck,
       functional_test_cluster_api,
+      functional_test_user_access,
       original_regression_test]
     runs-on: ubuntu-20.04
     timeout-minutes: 10

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -82,6 +82,7 @@ class Context(object):
                     cmd = True
                     break
             if cmd:
+                utils.check_user_access(self.current_level().name)
                 rv = self.execute_command() is not False
         except (ValueError, IOError) as msg:
             if config.core.debug or options.regression_tests:

--- a/data-manifest
+++ b/data-manifest
@@ -88,6 +88,7 @@ test/features/steps/const.py
 test/features/steps/__init__.py
 test/features/steps/step_implementation.py
 test/features/steps/utils.py
+test/features/user_access.feature
 test/history-test.tar.bz2
 test/list-undocumented-commands.py
 test/profile-history.sh

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -129,7 +129,7 @@ Feature: Regression test for bootstrap bugs
     When    Run "crm cluster stop --all" on "hanode1"
     Then    Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster start --all;crm cluster stop --all" on "hanode1"
+    When    Run "crm cluster start --all;sudo crm cluster stop --all" on "hanode1"
     Then    Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
     When    Run "systemctl start corosync" on "hanode1"

--- a/test/features/user_access.feature
+++ b/test/features/user_access.feature
@@ -1,0 +1,110 @@
+@user
+Feature: Functional test for user access
+
+  Need nodes: hanode1
+
+  Scenario: User in haclient group
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "useradd -m -s /bin/bash -N -g 90 xin1" on "hanode1"
+    When    Try "su xin1 -c 'crm cluster init -y'"
+    Then    Except multiple lines
+      """
+      ERROR: Please run this command starting with "sudo".
+      Currently, this command needs to use sudo to escalate itself as root.
+      Please consider to add "xin1" as sudoer. For example:
+        echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1
+      """
+    When    Run "echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1" on "hanode1"
+    When    Try "su xin1 -c 'crm cluster init -y'"
+    Then    Except multiple lines
+      """
+      ERROR: Please run this command starting with "sudo"
+      """
+    When    Run "su xin1 -c 'sudo crm cluster init -y'" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+
+    When    Run "useradd -m -s /bin/bash -N -g 90 xin2" on "hanode1"
+    When    Run "su xin2 -c 'crm node standby hanode1'" on "hanode1"
+    Then    Node "hanode1" is standby
+
+  @clean
+  Scenario: User in sudoer
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "useradd -m -s /bin/bash xin3" on "hanode1"
+    And     Run "echo "xin3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin3" on "hanode1"
+    When    Try "su xin3 -c 'crm cluster init -y'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: Please run this command starting with "sudo"
+      """
+    When    Run "su xin3 -c 'sudo crm cluster init -y'" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+
+    When    Try "su xin3 -c 'crm node standby hanode1'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: Please run this command starting with "sudo"
+      """
+    When    Run "su xin3 -c 'sudo crm node standby hanode1'" on "hanode1"
+    Then    Node "hanode1" is standby
+
+  @clean
+  Scenario: Normal user access
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "useradd -m -s /bin/bash user1" on "hanode1"
+    When    Try "su user1 -c 'crm cluster init -y'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: Please run this command starting with "sudo".
+      Currently, this command needs to use sudo to escalate itself as root.
+      Please consider to add "user1" as sudoer. For example:
+        echo "user1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user1
+      """
+    When    Run "echo "user1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user1" on "hanode1"
+    When    Try "su user1 -c 'crm cluster init -y'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: Please run this command starting with "sudo"
+      """
+    When    Run "su user1 -c 'sudo crm cluster init -y'" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+
+    When    Run "useradd -m -s /bin/bash user2" on "hanode1"
+    When    Try "su user2 -c 'crm node standby hanode1'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: This command needs higher privilege.
+      Option 1) Please consider to add "user2" as sudoer. For example:
+        echo "user2 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user2
+      Option 2) Add "user2" to the haclient group. For example:
+        usermod -g haclient user2
+      """
+    When    Run "usermod -g haclient user2" on "hanode1"
+    When    Run "su user2 -c 'crm node standby hanode1'" on "hanode1"
+    Then    Node "hanode1" is standby
+
+    When    Run "useradd -m -s /bin/bash user3" on "hanode1"
+    When    Try "su user3 -c 'crm node online hanode1'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: This command needs higher privilege.
+      Option 1) Please consider to add "user3" as sudoer. For example:
+        echo "user3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user3
+      Option 2) Add "user3" to the haclient group. For example:
+        usermod -g haclient user3
+      """
+    When    Run "echo "user3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user3" on "hanode1"
+    When    Try "su user3 -c 'crm node online hanode1'"
+    Then    Except multiple lines
+      """
+      WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
+      ERROR: Please run this command starting with "sudo"
+      """
+    When    Run "su user3 -c 'sudo crm node online hanode1'" on "hanode1"
+    Then    Node "hanode1" is online

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -241,7 +241,6 @@ create_node() {
 		docker network create --ipv6 --subnet ${HA_NETWORK_V6_ARRAY[$index]} $network &> /dev/null
 	done
 
-	info "Setup cluster..."
 	for node in $*;do
 		deploy_ha_node $node &
 	done


### PR DESCRIPTION
## Restrictions for different types of users:
#### hacluster and other user who is in the haclient group
-  When running bootstrap interface
```
hanode1:/ # useradd -m -s /bin/bash -N -g 90 xin1
 
hanode1:/ # su xin1 -c 'crm cluster init -y'
ERROR: Please run this command starting with "sudo".
Currently, this command needs to use sudo to escalate itself as root.
Please consider to add "xin1" as sudoer. For example:
  echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1
 
hanode1:/ # echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1
 
hanode1:/ # su xin1 -c 'crm cluster init -y'
ERROR: Please run this command starting with "sudo"
```
- When running ACL(pacemaker cib related) interface
```
hanode1:/ #id xin1
uid=1003(xin1) gid=90(haclient) groups=90(haclient)
 
hanode1:/ # su xin1 -c 'crm node standby'
INFO: standby node hanode1
```
#### User who is configured in sudoer 
- When running bootstrap interface
```
hanode1:/ # useradd -m -s /bin/bash xin2
 
hanode1:/ # echo "xin2 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin2
 
hanode1:/ # su xin2 -c 'sudo -l'
Matching Defaults entries for xin2 on hanode1:
    always_set_home, secure_path=/usr/sbin\:/usr/bin\:/sbin\:/bin\:/usr/local/bin\:/usr/local/sbin, env_reset, env_keep="LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT
    LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE", !insults, targetpw
 
User xin2 may run the following commands on hanode1:
    (ALL) ALL
    (ALL) NOPASSWD: ALL
 
hanode1:/ # su xin2 -c 'crm cluster init -y'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: Please run this command starting with "sudo"
```
- When running ACL interface
```
hanode1:/ # su xin2 -c 'crm node standby hanode1'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: Please run this command starting with "sudo"
```
#### Normal user
- When running bootstrap interface
```
hanode1:/ # useradd -m -s /bin/bash xin3
 
hanode1:/ # su xin3 -c 'crm cluster init -y'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: Please run this command starting with "sudo".
Currently, this command needs to use sudo to escalate itself as root.
Please consider to add "xin3" as sudoer. For example:
  echo "xin3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin3
 
hanode1:/ # echo "xin3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin3
 
hanode1:/ # su xin3 -c 'crm cluster init -y'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: Please run this command starting with "sudo"
```
- When running ACL interface
```
hanode1:/ # useradd -m -s /bin/bash xin4
 
hanode1:/ # su xin4 -c 'crm node standby hanode1'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: This command needs higher privilege.
Option 1) Please consider to add "xin4" as sudoer. For example:
  echo "xin4 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin4
Option 2) Add "xin4 "to the haclient group. For example:
  usermod -g haclient xin4
 
hanode1:/ # echo "xin4 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin4
 
hanode1:/ # su xin4 -c 'crm node standby hanode1'
WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
ERROR: Please run this command starting with "sudo"
 
hanode1:/ # su xin4 -c 'sudo crm node standby hanode1'
INFO: standby node hanode1
```