### PR TITLE
Fix: hawk fails to parse the slash (bsc#1206217)

### DIFF
--- a/scripts/cryptctl/main.yml
+++ b/scripts/cryptctl/main.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Peter Varkoly
 # License: GNU General Public License (GPL)
 version: 2.2
-category: System/Management
+category: System Management
 shortdesc:  A utility for setting up LUKS-based disk encryption
 longdesc: |
   Configure a resource group containing a virtual IP address,

--- a/test/testcases/scripts.exp
+++ b/test/testcases/scripts.exp
@@ -63,7 +63,7 @@ libvirt          STONITH for libvirt (kvm / Xen)
 sbd              SBD, Shared storage based fencing
 vmware           Fencing using vCenter / ESX Server
 
-System/management:
+System management:
 
 cryptctl         A utility for setting up LUKS-based disk encryption
 
@@ -128,7 +128,7 @@ libvirt          STONITH for libvirt (kvm / Xen)
 sbd              SBD, Shared storage based fencing
 vmware           Fencing using vCenter / ESX Server
 
-System/management:
+System management:
 
 cryptctl         A utility for setting up LUKS-based disk encryption
 


### PR DESCRIPTION
as the result the dropdown wizards in the configuration menu (https://127.0.0.1:7630/cib/live/wizards) don't work.