### PR TITLE
Dev: utils: Change the way to get pacemaker's version

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -28,7 +28,7 @@ from . import userdir
 from .ra import get_ra, get_properties_list, get_pe_meta, get_properties_meta, RAInfo
 from .utils import ext_cmd, safe_open_w, pipe_string, safe_close_w, crm_msec
 from .utils import ask, lines2cli, olist
-from .utils import page_string, cibadmin_can_patch, str2tmp, ensure_sudo_readable
+from .utils import page_string, str2tmp, ensure_sudo_readable
 from .utils import run_ptest, is_id_valid, edit_file, get_boolean, filter_string
 from .xmlutil import is_child_rsc, rsc_constraint, sanitize_cib, rename_id, get_interesting_nodes
 from .xmlutil import is_pref_location, get_topnode, new_cib, get_rscop_defaults_meta_node
@@ -2619,7 +2619,7 @@ class CibFactory(object):
         'Commit the configuration to the CIB.'
         if not self.is_cib_sane():
             return False
-        if not replace and cibadmin_can_patch():
+        if not replace:
             rc = self._patch_cib(force)
         else:
             rc = self._replace_cib(force)
@@ -2783,9 +2783,8 @@ class CibFactory(object):
             cib = text2elem(cib)
         if not self._import_cib(cib):
             return False
-        if cibadmin_can_patch():
-            self.cib_orig = copy.deepcopy(self.cib_elem)
-            sanitize_cib_for_patching(self.cib_orig)
+        self.cib_orig = copy.deepcopy(self.cib_elem)
+        sanitize_cib_for_patching(self.cib_orig)
         sanitize_cib(self.cib_elem)
         show_unrecognized_elems(self.cib_elem)
         self._populate()

--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -555,7 +555,6 @@ class Report(object):
             i = (i+1) % len(self.nodecolors)
 
     def _report_setup_source(self):
-        constants.pcmk_version = None
         # is this an crm report or a crm_report?
         for descname in ("description.txt", "report.summary"):
             self.desc = os.path.join(self.loc, descname)

--- a/crmsh/log_patterns.py
+++ b/crmsh/log_patterns.py
@@ -142,7 +142,7 @@ _patterns_118 = {
 
 
 def patterns(cib_f=None):
-    is118 = utils.is_pcmk_118(cib_f=cib_f)
+    is118 = utils.is_larger_than_pcmk_118(cib_f=cib_f)
     if is118:
         return _patterns_118
     else:

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -158,12 +158,6 @@ def set_interactive():
         options.interactive = True
 
 
-def compatibility_setup():
-    if not utils.is_pcmk_118():
-        del constants.attr_defaults["node"]
-        constants.cib_no_section_rc = 22
-
-
 def add_quotes(args):
     '''
     Add quotes if there's whitespace in one of the
@@ -250,7 +244,6 @@ def main_input_loop(context, user_args):
     Main input loop for crmsh. Parses input
     line by line.
     """
-    compatibility_setup()
     rc = handle_noninteractive_use(context, user_args)
     if rc is not None:
         return rc

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -901,7 +901,6 @@ class CibConfig(command.UI):
             logger.info("apparently there is nothing to commit")
             logger.info("try changing something first")
             return True
-        replace = replace or not utils.cibadmin_can_patch()
         rc1 = True
         if replace and not force:
             rc1 = cib_factory.is_current_cib_equal()

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -476,7 +476,7 @@ class NodeMgmt(command.UI):
         if not config.core.force and \
                 not utils.ask("Do you really want to drop state for node %s?" % node):
             return False
-        if utils.is_pcmk_118():
+        if utils.is_larger_than_pcmk_118():
             cib_elem = xmlutil.cibdump2elem()
             if cib_elem is None:
                 return False

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -137,7 +137,7 @@ def cibdump2elem(section=None):
     rc, outp, errp = sudocall(cmd)
     if rc == 0:
         return text2elem(outp)
-    elif rc != constants.cib_no_section_rc:
+    else:
         logger.error("running %s: %s", cmd, errp)
     return None
 


### PR DESCRIPTION
- Use '/usr/sbin/pacemakerd --version'
- Raise fatal error if failed to get pacemaker's version
- Remove unused codes