### PR TITLE
Dev: log: Redirect debug messages into stderr

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -19,12 +19,12 @@ class ConsoleCustomHandler(logging.StreamHandler):
     """
     A custom handler for console
 
-    Redirect ERROR message to sys.stderr
-    Redirect INFO/WARNING/DEBUG message to sys.stdout
+    Redirect ERROR/WARNING/DEBUG message to sys.stderr
+    Redirect INFO message to sys.stdout
     """
 
     def emit(self, record):
-        if record.levelno < logging.ERROR:
+        if record.levelno == logging.INFO:
             stream = sys.stdout
         else:
             stream = sys.stderr

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -360,7 +360,7 @@ def run():
             options.batch = True
         user_args = parse_options()
         if config.core.debug:
-            print(utils.debug_timestamp())
+            logger.debug(utils.debug_timestamp())
         term.init()
         if options.profile:
             return profile_run(context, user_args)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3485,8 +3485,13 @@ class HostUserConfig:
     def save_local(self):
         value = [f'{user}@{host}' for host, user in sorted(self._hosts_users.items(), key=lambda x: x[0])]
         config.set_option('core', 'hosts', value)
+        debug_on = config.get_option('core', 'debug')
+        if debug_on:
+            config.set_option('core', 'debug', 'false')
         # TODO: it is saved in ~root/.config/crm/crm.conf, is it as suitable path?
         config.save()
+        if debug_on:
+            config.set_option('core', 'debug', 'true')
 
     def save_remote(self, remote_hosts: typing.Iterable[str]):
         self.save_local()

--- a/data-manifest
+++ b/data-manifest
@@ -111,6 +111,7 @@ test/testcases/confbasic
 test/testcases/confbasic.exp
 test/testcases/confbasic-xml
 test/testcases/confbasic-xml.exp
+test/testcases/confbasic-xml.filter
 test/testcases/delete
 test/testcases/delete.exp
 test/testcases/edit

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -131,7 +131,7 @@ Feature: corosync qdevice/qnetd options validate
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode1"
-    Then    Expected "WARNING: To use qdevice service, need to restart cluster service manually on each node" in stdout
+    Then    Expected "WARNING: To use qdevice service, need to restart cluster service manually on each node" in stderr
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm cluster restart" on "hanode1"
     Then    Service "corosync-qdevice" is "started" on "hanode1"
@@ -153,7 +153,7 @@ Feature: corosync qdevice/qnetd options validate
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     When    Run "crm cluster remove --qdevice -y" on "hanode1"
-    Then    Expected "WARNING: To remove qdevice service, need to restart cluster service manually on each node" in stdout
+    Then    Expected "WARNING: To remove qdevice service, need to restart cluster service manually on each node" in stderr
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster restart" on "hanode1"

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -107,13 +107,13 @@ Feature: Use "crm configure set" to update attributes and operations
   @clean
   Scenario: operation warning
     When    Run "crm configure primitive id=d2 Dummy op start interval=5s" on "hanode1"
-    Then    Expected "WARNING: d2: Specified interval for start is 5s, it must be 0" in stdout
+    Then    Expected "WARNING: d2: Specified interval for start is 5s, it must be 0" in stderr
     When    Run "crm configure primitive id=d3 Dummy op monitor interval=0" on "hanode1"
-    Then    Expected "WARNING: d3: interval in monitor should be larger than 0, advised is 10s" in stdout
+    Then    Expected "WARNING: d3: interval in monitor should be larger than 0, advised is 10s" in stderr
     When    Run "crm configure primitive s2 ocf:pacemaker:Stateful op monitor role=Promoted interval=3s op monitor role=Unpromoted interval=3s" on "hanode1"
-    Then    Expected "WARNING: s2: interval in monitor must be unique, advised is 11s" in stdout
+    Then    Expected "WARNING: s2: interval in monitor must be unique, advised is 11s" in stderr
     When    Run "crm configure primitive id=d4 Dummy op start timeout=10s" on "hanode1"
-    Then    Expected "WARNING: d4: specified timeout 10s for start is smaller than the advised 20s" in stdout
+    Then    Expected "WARNING: d4: specified timeout 10s for start is smaller than the advised 20s" in stderr
 
   @clean
   Scenario: trace ra with specific directory

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -58,7 +58,7 @@ def step_impl(context, name, state, addr):
 
 @given('Has disk "{disk}" on "{addr}"')
 def step_impl(context, disk, addr):
-    out = run_command_local_or_remote(context, "fdisk -l", addr)
+    _, out, _ = run_command_local_or_remote(context, "fdisk -l", addr)
     assert re.search(r'{} '.format(disk), out) is not None
 
 
@@ -69,19 +69,19 @@ def step_impl(context, nodelist):
 
 @given('Run "{cmd}" OK')
 def step_impl(context, cmd):
-    rc, _, = run_command(context, cmd)
+    rc, _, _ = run_command(context, cmd)
     assert rc == 0
 
 
 @then('Run "{cmd}" OK')
 def step_impl(context, cmd):
-    rc, _, = run_command(context, cmd)
+    rc, _, _ = run_command(context, cmd)
     assert rc == 0
 
 
 @when('Run "{cmd}" OK')
 def step_impl(context, cmd):
-    rc, _, = run_command(context, cmd)
+    rc, _, _ = run_command(context, cmd)
     assert rc == 0
 
 
@@ -94,8 +94,7 @@ def step_impl(context, addr, iface):
 
 @when('Run "{cmd}" on "{addr}"')
 def step_impl(context, cmd, addr):
-    out = run_command_local_or_remote(context, cmd, addr)
-    context.stdout = out
+    _, out, _ = run_command_local_or_remote(context, cmd, addr)
 
 
 @then('Print stdout')
@@ -105,18 +104,17 @@ def step_impl(context):
 
 @then('Print stderr')
 def step_impl(context):
-    context.logger.info("\n{}".format(context.command_error_output))
+    context.logger.info("\n{}".format(context.stderr))
 
 
 @when('Try "{cmd}" on "{addr}"')
 def step_impl(context, cmd, addr):
-    run_command_local_or_remote(context, cmd, addr, err_record=True)
+    run_command_local_or_remote(context, cmd, addr, exit_on_fail=False)
 
 
 @when('Try "{cmd}"')
 def step_impl(context, cmd):
-    rc, out = run_command(context, cmd, err_record=True)
-    context.return_code = rc
+    _, out, _ = run_command(context, cmd, exit_on_fail=False)
 
 
 @when('Wait "{second}" seconds')
@@ -142,6 +140,12 @@ def step_impl(context, msg):
     context.stdout = None
 
 
+@then('Expected "{msg}" in stderr')
+def step_impl(context, msg):
+    assert msg in context.stderr
+    context.stderr = None
+
+
 @then('Expected regrex "{reg_str}" in stdout')
 def step_impl(context, reg_str):
     res = re.search(reg_str, context.stdout)
@@ -162,14 +166,14 @@ def step_impl(context, msg):
 
 @then('Except "{msg}"')
 def step_impl(context, msg):
-    assert msg in context.command_error_output
-    context.command_error_output = None
+    assert msg in context.stderr
+    context.stderr = None
 
 
 @then('Except multiple lines')
 def step_impl(context):
-    assert context.command_error_output.split('\n') == context.text.split('\n')
-    context.command_error_output = None
+    assert context.text in context.stderr
+    context.stderr = None
 
 
 @then('Expected multiple lines in output')
@@ -180,8 +184,8 @@ def step_impl(context):
 
 @then('Except "{msg}" in stderr')
 def step_impl(context, msg):
-    assert msg in context.command_error_output
-    context.command_error_output = None
+    assert msg in context.stderr
+    context.stderr = None
 
 
 @then('Cluster service is "{state}" on "{addr}"')
@@ -211,20 +215,20 @@ def step_impl(context, node):
 
 @then('IP "{addr}" is used by corosync on "{node}"')
 def step_impl(context, addr, node):
-    out = run_command_local_or_remote(context, 'corosync-cfgtool -s', node)
+    _, out, _ = run_command_local_or_remote(context, 'corosync-cfgtool -s', node)
     res = re.search(r' {}\n'.format(addr), out)
     assert bool(res) is True
 
 
 @then('Cluster name is "{name}"')
 def step_impl(context, name):
-    _, out = run_command(context, 'corosync-cmapctl -b totem.cluster_name')
+    _, out, _ = run_command(context, 'corosync-cmapctl -b totem.cluster_name')
     assert out.split()[-1] == name
 
 
 @then('Cluster virtual IP is "{addr}"')
 def step_impl(context, addr):
-    _, out = run_command(context, 'crm configure show|grep -A1 IPaddr2')
+    _, out, _ = run_command(context, 'crm configure show|grep -A1 IPaddr2')
     res = re.search(r' ip={}'.format(addr), out)
     assert bool(res) is True
 
@@ -236,35 +240,35 @@ def step_impl(context):
 
 @then('Show cluster status on "{addr}"')
 def step_impl(context, addr):
-    out = run_command_local_or_remote(context, 'crm_mon -1', addr)
+    _, out, _ = run_command_local_or_remote(context, 'crm_mon -1', addr)
     if out:
         context.logger.info("\n{}".format(out))
 
 
 @then('Show corosync ring status')
 def step_impl(context):
-    _, out = run_command(context, 'crm corosync status ring')
+    _, out, _ = run_command(context, 'crm corosync status ring')
     if out:
         context.logger.info("\n{}".format(out))
 
 
 @then('Show crm configure')
 def step_impl(context):
-    _, out = run_command(context, 'crm configure show')
+    _, out, _ = run_command(context, 'crm configure show')
     if out:
         context.logger.info("\n{}".format(out))
 
 
 @then('Show status from qnetd')
 def step_impl(context):
-    _, out = run_command(context, 'crm corosync status qnetd')
+    _, out, _ = run_command(context, 'crm corosync status qnetd')
     if out:
         context.logger.info("\n{}".format(out))
 
 
 @then('Show corosync qdevice configuration')
 def step_impl(context):
-    _, out = run_command(context, "sed -n -e '/quorum/,/^}/ p' /etc/corosync/corosync.conf")
+    _, out, _ = run_command(context, "sed -n -e '/quorum/,/^}/ p' /etc/corosync/corosync.conf")
     if out:
         context.logger.info("\n{}".format(out))
 
@@ -275,7 +279,7 @@ def step_impl(context, res, res_type, state):
     result = None
     while try_count < 20:
         time.sleep(1)
-        _, out = run_command(context, "crm_mon -1rR")
+        _, out, _ = run_command(context, "crm_mon -1rR")
         if out:
             result = re.search(r'\s{}\s+.*:+{}\):\s+{} '.format(res, res_type, state), out)
             if not result:
@@ -288,7 +292,7 @@ def step_impl(context, res, res_type, state):
 @then('Resource "{res}" failcount on "{node}" is "{number}"')
 def step_impl(context, res, node, number):
     cmd = "crm resource failcount {} show {}".format(res, node)
-    _, out = run_command(context, cmd)
+    _, out, _ = run_command(context, cmd)
     if out:
         result = re.search(r'name=fail-count-{} value={}'.format(res, number), out)
         assert result is not None
@@ -296,7 +300,7 @@ def step_impl(context, res, node, number):
 
 @then('Resource "{res_type}" not configured')
 def step_impl(context, res_type):
-    _, out = run_command(context, "crm configure show")
+    _, out, _ = run_command(context, "crm configure show")
     result = re.search(r' {} '.format(res_type), out)
     assert result is None
 
@@ -358,7 +362,7 @@ def step_impl(context, f, archive):
 @then('File "{f}" was synced in cluster')
 def step_impl(context, f):
     cmd = "crm cluster diff {}".format(f)
-    rc, out = run_command(context, cmd)
+    rc, out, _ = run_command(context, cmd)
     assert_eq("", out)
 
 
@@ -402,14 +406,14 @@ def step_impl(context, key, type, value):
 
 @then('Parameter "{param_name}" not configured in "{res_id}"')
 def step_impl(context, param_name, res_id):
-    _, out = run_command(context, "crm configure show {}".format(res_id))
+    _, out, _ = run_command(context, "crm configure show {}".format(res_id))
     result = re.search("params {}=".format(param_name), out)
     assert result is None
 
 
 @then('Parameter "{param_name}" configured in "{res_id}"')
 def step_impl(context, param_name, res_id):
-    _, out = run_command(context, "crm configure show {}".format(res_id))
+    _, out, _ = run_command(context, "crm configure show {}".format(res_id))
     result = re.search("params {}=".format(param_name), out)
     assert result is not None
 

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -7,6 +7,9 @@ import socket
 from crmsh import utils, bootstrap, parallax
 
 
+COLOR_MODE = r'\x1b\[[0-9]+m'
+
+
 def get_file_type(file_path):
     rc, out, _ = utils.get_stdout_stderr("file {}".format(file_path))
     if re.search(r'{}: bzip2'.format(file_path), out):
@@ -43,38 +46,41 @@ def add_sudo(cmd):
     return cmd
 
 
-def run_command(context, cmd, err_record=False):
+def run_command(context, cmd, exit_on_fail=True):
     rc, out, err = utils.get_stdout_stderr(add_sudo(cmd))
-    if rc != 0 and err:
-        if err_record:
-            res = re.sub(r'\x1b\[[0-9]+m', '', err)
-            context.command_error_output = res
-            return rc, re.sub(r'\x1b\[[0-9]+m', '', out)
+    context.return_code = rc
+    if out:
+        out = re.sub(COLOR_MODE, '', out)
+        context.stdout = out
+    if err:
+        err = re.sub(COLOR_MODE, '', err)
+        context.stderr = err
+    if rc != 0 and exit_on_fail:
         if out:
             context.logger.info("\n{}\n".format(out))
         context.logger.error("\n{}\n".format(err))
         context.failed = True
-    return rc, re.sub(r'\x1b\[[0-9]+m', '', out)
+    return rc, out, err
 
 
-def run_command_local_or_remote(context, cmd, addr, err_record=False):
+def run_command_local_or_remote(context, cmd, addr, exit_on_fail=True):
     cmd = add_sudo(cmd)
     if addr == me():
-        rc, out = run_command(context, cmd, err_record)
-        context.return_code = rc
-        return out
+        return run_command(context, cmd, exit_on_fail)
     else:
         try:
             results = parallax.parallax_call(addr.split(','), cmd)
         except ValueError as err:
-            if err_record:
-                context.command_error_output = re.sub(r'\x1b\[[0-9]+m', '', str(err))
-                return
-            context.logger.error("\n{}\n".format(err))
-            context.failed = True
+            err = re.sub(COLOR_MODE, '', str(err))
+            context.stderr = err
+            if exit_on_fail:
+                context.logger.error("\n{}\n".format(err))
+                context.failed = True
         else:
+            out = utils.to_ascii(results[0][1][1])
+            context.stdout = out
             context.return_code = 0
-            return utils.to_ascii(results[0][1][1])
+            return 0, out, None
 
 
 def check_service_state(context, service_name, state, addr):

--- a/test/testcases/confbasic-xml.filter
+++ b/test/testcases/confbasic-xml.filter
@@ -1,0 +1,2 @@
+#!/bin/bash
+grep -v "WARNING"


### PR DESCRIPTION
- Dev: log: Redirect debug messages into stderr
If keep debug and info messages all in stdout, then some scripts that need to handle or analyze the output of the crm command might be messy.


- Dev: bootstrap: Don't save core.debug when saving core.hosts 