### PR TITLE
Fix: qdevice: Unable to setup qdevice under non-root user (bsc#1208770)

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -113,7 +113,6 @@ def query_qnetd_status():
     except ValueError:
         remote_user = 'root'
     if utils.check_ssh_passwd_need(local_user, remote_user, qnetd_addr):
-        print("Copy ssh key to qnetd node({})".format(qnetd_addr))
         utils.ssh_copy_id(local_user, remote_user, qnetd_addr)
 
     cmd = "corosync-qnetd-tool -lv -c {}".format(cluster_name)

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -422,10 +422,10 @@ class TestQDevice(unittest.TestCase):
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("os.path.exists")
-    @mock.patch("crmsh.parallax.parallax_slurp")
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     def test_fetch_qnetd_crt_from_qnetd_exist(self, mock_qnetd_cacert_local,
-                                              mock_slurp, mock_exists, mock_log):
+                                              mock_fetch, mock_exists, mock_log):
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_exists.return_value = True
 
@@ -433,31 +433,29 @@ class TestQDevice(unittest.TestCase):
 
         mock_exists.assert_called_once_with(mock_qnetd_cacert_local.return_value)
         mock_qnetd_cacert_local.assert_called_once_with()
-        mock_slurp.assert_not_called()
+        mock_fetch.assert_not_called()
         mock_log.assert_not_called()
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("os.path.exists")
-    @mock.patch("crmsh.parallax.parallax_slurp")
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     def test_fetch_qnetd_crt_from_qnetd(self, mock_qnetd_cacert_local,
-                                        mock_slurp, mock_exists, mock_log):
+                                        mock_fetch, mock_exists, mock_log):
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_exists.return_value = False
-        mock_slurp.return_value = [("10.10.10.123", (0, None, None, "test"))]
 
         self.qdevice_with_ip.fetch_qnetd_crt_from_qnetd()
 
         mock_exists.assert_called_once_with(mock_qnetd_cacert_local.return_value)
         mock_qnetd_cacert_local.assert_called_once_with()
         mock_log.assert_called_once_with("Step 2: Fetch qnetd-cacert.crt from 10.10.10.123")
-        mock_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net",
-                                           "/etc/corosync/qnetd/nssdb/qnetd-cacert.crt")
+        mock_fetch.assert_called_once_with("10.10.10.123", "/etc/corosync/qnetd/nssdb/qnetd-cacert.crt", "/etc/corosync/qdevice/net/10.10.10.123")
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
-    @mock.patch("crmsh.parallax.parallax_copy")
+    @mock.patch("crmsh.qdevice.QDevice._copy_file_to_remote_host")
     def test_copy_qnetd_crt_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes, mock_log):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com"]
@@ -472,7 +470,7 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
-    @mock.patch("crmsh.parallax.parallax_copy")
+    @mock.patch("crmsh.qdevice.QDevice._copy_file_to_remote_host")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     @mock.patch("os.path.dirname")
     def test_copy_qnetd_crt_to_cluster(self, mock_dirname, mock_qnetd_cacert_local,
@@ -481,14 +479,13 @@ class TestQDevice(unittest.TestCase):
         mock_dirname.return_value = "/etc/corosync/qdevice/net/10.10.10.123"
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com", "node2.com"]
-        mock_copy.return_value = [("node1.com", (0, None, None)), ("node2.com", (0, None, None))]
 
         self.qdevice_with_ip.copy_qnetd_crt_to_cluster()
 
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
         mock_log.assert_called_once_with("Step 3: Copy exported qnetd-cacert.crt to ['node2.com']")
-        mock_copy.assert_called_once_with(["node2.com"], mock_dirname.return_value,
+        mock_copy.assert_called_once_with(mock_dirname.return_value, "node2.com",
                                           "/etc/corosync/qdevice/net")
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
@@ -521,17 +518,16 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_crq_on_qnetd", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qdevice_crq_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_copy")
+    @mock.patch("crmsh.qdevice.QDevice._copy_file_to_remote_host")
     def test_copy_crq_to_qnetd(self, mock_copy, mock_qdevice_crq_local,
                                mock_qdevice_crq_qnetd, mock_log):
-        mock_copy.return_value = [("10.10.10.123", (0, None, None))]
         mock_qdevice_crq_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.crq"
         mock_qdevice_crq_qnetd.return_value = "/etc/corosync/qnetd/nssdb/qdevice-net-node.crq"
 
         self.qdevice_with_ip.copy_crq_to_qnetd()
 
         mock_log.assert_called_once_with("Step 6: Copy qdevice-net-node.crq to 10.10.10.123")
-        mock_copy.assert_called_once_with(["10.10.10.123"], mock_qdevice_crq_local.return_value,
+        mock_copy.assert_called_once_with(mock_qdevice_crq_local.return_value, "10.10.10.123",
                                           mock_qdevice_crq_qnetd.return_value)
         mock_qdevice_crq_local.assert_called_once_with()
         mock_qdevice_crq_qnetd.assert_called_once_with()
@@ -553,18 +549,16 @@ class TestQDevice(unittest.TestCase):
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cluster_crt_on_qnetd", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_cluster_crt_from_qnetd(self, mock_slurp, mock_crt_on_qnetd, mock_log):
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
+    def test_fetch_cluster_crt_from_qnetd(self, mock_fetch, mock_crt_on_qnetd, mock_log):
         mock_crt_on_qnetd.return_value = "/etc/corosync/qnetd/nssdb/cluster-hacluster.crt"
-        mock_slurp.return_value = [("10.10.10.123", (0, None, None, "test"))]
 
         self.qdevice_with_ip.cluster_name = "hacluster"
         self.qdevice_with_ip.fetch_cluster_crt_from_qnetd()
 
         mock_log.assert_called_once_with("Step 8: Fetch cluster-hacluster.crt from 10.10.10.123")
         mock_crt_on_qnetd.assert_has_calls([mock.call(), mock.call()])
-        mock_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net",
-                                           mock_crt_on_qnetd.return_value)
+        mock_fetch.assert_called_once_with("10.10.10.123", mock_crt_on_qnetd.return_value, "/etc/corosync/qdevice/net/10.10.10.123",)
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.get_stdout_or_raise_error")
@@ -581,7 +575,7 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
-    @mock.patch("crmsh.parallax.parallax_copy")
+    @mock.patch("crmsh.qdevice.QDevice._copy_file_to_remote_host")
     def test_copy_p12_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes, mock_log):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com"]
@@ -596,25 +590,21 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
-    @mock.patch("crmsh.parallax.parallax_copy")
+    @mock.patch("crmsh.qdevice.QDevice._copy_file_to_remote_hosts")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("os.path.dirname")
-    def test_copy_p12_to_cluster(self, mock_dirname, mock_p12_on_local,
+    def test_copy_p12_to_cluster(self, mock_p12_on_local,
                                        mock_copy, mock_this_node, mock_list_nodes, mock_log):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com", "node2.com"]
         mock_p12_on_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12"
-        mock_dirname.return_value = "/etc/corosync/qdevice/net/nssdb"
-        mock_copy.return_value = [("node1.com", (0, None, None)), ("node2.com", (0, None, None))]
 
         self.qdevice_with_ip.copy_p12_to_cluster()
 
         mock_log.assert_called_once_with("Step 10: Copy qdevice-net-node.p12 to ['node2.com']")
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
-        mock_copy.assert_called_once_with(["node2.com"], mock_p12_on_local.return_value,
-                                          mock_dirname.return_value)
-        mock_dirname.assert_called_once_with(mock_p12_on_local.return_value)
+        mock_copy.assert_called_once_with(mock_p12_on_local.return_value, ["node2.com"],
+                                          mock_p12_on_local.return_value)
         mock_p12_on_local.assert_has_calls([mock.call(), mock.call()])
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
@@ -680,8 +670,8 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_cluster", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_qnetd_crt_from_cluster_exist(self, mock_slurp, mock_qnetd_cacert_local,
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
+    def test_fetch_qnetd_crt_from_cluster_exist(self, mock_fetch, mock_qnetd_cacert_local,
                                                 mock_qnetd_cacert_cluster, mock_exists, mock_log):
         mock_exists.return_value = True
         mock_qnetd_cacert_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qnetd-cacert.crt"
@@ -692,19 +682,18 @@ class TestQDevice(unittest.TestCase):
         mock_exists.assert_called_once_with(mock_qnetd_cacert_cluster.return_value)
         mock_qnetd_cacert_cluster.assert_called_once_with()
         mock_qnetd_cacert_local.assert_not_called()
-        mock_slurp.assert_not_called()
+        mock_fetch.assert_not_called()
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_cluster", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_qnetd_crt_from_cluster(self, mock_slurp, mock_qnetd_cacert_local,
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
+    def test_fetch_qnetd_crt_from_cluster(self, mock_fetch, mock_qnetd_cacert_local,
                                           mock_qnetd_cacert_cluster, mock_exists, mock_log):
         mock_exists.return_value = False
         mock_qnetd_cacert_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qnetd-cacert.crt"
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
-        mock_slurp.return_value = [("node1.com", (0, None, None, "test"))]
 
         self.qdevice_with_ip_cluster_node.fetch_qnetd_crt_from_cluster()
 
@@ -712,8 +701,7 @@ class TestQDevice(unittest.TestCase):
         mock_exists.assert_called_once_with(mock_qnetd_cacert_cluster.return_value)
         mock_qnetd_cacert_cluster.assert_called_once_with()
         mock_qnetd_cacert_local.assert_called_once_with()
-        mock_slurp.assert_called_once_with(["node1.com"], "/etc/corosync/qdevice/net",
-                                           mock_qnetd_cacert_local.return_value)
+        mock_fetch.assert_called_once_with("node1.com", mock_qnetd_cacert_local.return_value, '/etc/corosync/qdevice/net/node1.com')
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.get_stdout_or_raise_error")
@@ -732,8 +720,8 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_cluster", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_p12_from_cluster_exist(self, mock_slurp, mock_p12_on_local,
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
+    def test_fetch_p12_from_cluster_exist(self, mock_fetch, mock_p12_on_local,
                                           mock_p12_on_cluster, mock_exists, mock_log):
         mock_exists.return_value = True
         mock_p12_on_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qdevice-net-node.p12"
@@ -744,19 +732,18 @@ class TestQDevice(unittest.TestCase):
         mock_exists.assert_called_once_with(mock_p12_on_cluster.return_value)
         mock_p12_on_cluster.assert_called_once_with()
         mock_p12_on_local.assert_not_called()
-        mock_slurp.assert_not_called()
+        mock_fetch.assert_not_called()
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_cluster", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_local", new_callable=mock.PropertyMock)
-    @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_p12_from_cluster(self, mock_slurp, mock_p12_on_local,
+    @mock.patch("crmsh.qdevice.QDevice._fetch_file_to_local")
+    def test_fetch_p12_from_cluster(self, mock_fetch, mock_p12_on_local,
                                     mock_p12_on_cluster, mock_exists, mock_log):
         mock_exists.return_value = False
         mock_p12_on_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qdevice-net-node.p12"
         mock_p12_on_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12"
-        mock_slurp.return_value = [("node1.com", (0, None, None, "test"))]
 
         self.qdevice_with_ip_cluster_node.fetch_p12_from_cluster()
 
@@ -764,8 +751,7 @@ class TestQDevice(unittest.TestCase):
         mock_exists.assert_called_once_with(mock_p12_on_cluster.return_value)
         mock_p12_on_cluster.assert_called_once_with()
         mock_p12_on_local.assert_called_once_with()
-        mock_slurp.assert_called_once_with(["node1.com"], "/etc/corosync/qdevice/net",
-                                           mock_p12_on_local.return_value)
+        mock_fetch.assert_called_once_with("node1.com", mock_p12_on_local.return_value, "/etc/corosync/qdevice/net/node1.com")
 
     @mock.patch("crmsh.log.LoggerUtils.log_only_to_file")
     @mock.patch("crmsh.utils.get_stdout_or_raise_error")


### PR DESCRIPTION
* When --qnetd-hostname is provided as "user@host", use the specified user
* When --qnetd-hostname is provided as "host", use the same username as the local user