### PR TITLE
Dev: utils: Suppress the output of ssh-copy-id for non-root user case

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -154,13 +154,8 @@ def user_of(host):
 def ssh_copy_id(local_user, remote_user, remote_node):
     if check_ssh_passwd_need(local_user, remote_user, remote_node):
         logger.info("Configuring SSH passwordless with {}@{}".format(remote_user, remote_node))
-        cmd = "ssh-copy-id -i ~/.ssh/id_rsa.pub '{}@{}'".format(remote_user, remote_node)
-        result = su_subprocess_run(
-                local_user, 
-                cmd, 
-                tty=True, 
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE)
+        cmd = "ssh-copy-id -i ~/.ssh/id_rsa.pub '{}@{}' &> /dev/null".format(remote_user, remote_node)
+        result = su_subprocess_run(local_user, cmd, tty=True)
         if result.returncode != 0:
             fatal("Failed to login to remote host {}@{}".format(remote_user, remote_node))
 


### PR DESCRIPTION
After #1130 , the output of ssh-copy-id could be suppressed, but also the prompt `Password` under non-root user.
With this commit, both root and non-root case could have `Password` prompt message
```
# root case
15sp4-2:~ # crm cluster join -c 15sp4-1 -y
INFO: SSH key for root does not exist, hence generate it now
INFO: Configuring SSH passwordless with root@15sp4-1
Password:
```
```
# non-root case
xin@15sp4-2:~> sudo crm cluster join -c 15sp4-1 -y
INFO: SSH key for xin does not exist, hence generate it now
INFO: Configuring SSH passwordless with xin@15sp4-1
Password: 
INFO: SSH key for hacluster does not exist, hence generate it now
```