### PR TITLE
Dev: bootstrap: Add sudo before crm_node under non-root user on remote node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1927,7 +1927,7 @@ def setup_passwordless_with_other_nodes(init_node):
     # Fetch cluster nodes list
     remote_user = _context.user_list[0]
     local_user = _context.current_user
-    cmd = 'ssh {} {}@{} PATH=\\"\\$PATH\\":/usr/sbin:/sbin crm_node -l'.format(SSH_OPTION, remote_user, init_node)
+    cmd = f'ssh {SSH_OPTION} {remote_user}@{init_node} sudo crm_node -l'
     rc, out, err = utils.su_get_stdout_stderr(local_user, cmd)
     if rc != 0:
         utils.fatal("Can't fetch cluster nodes list from {}: {}".format(init_node, err))

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -561,7 +561,7 @@ class TestBootstrap(unittest.TestCase):
         with self.assertRaises(SystemExit):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
-        mock_run.assert_called_once_with('carol', 'ssh {} alice@node1 PATH=\\"\\$PATH\\":/usr/sbin:/sbin crm_node -l'.format(constants.SSH_OPTION))
+        mock_run.assert_called_once_with('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION))
         mock_error.assert_called_once_with("Can't fetch cluster nodes list from node1: None")
 
     @mock.patch('crmsh.utils.fatal')
@@ -589,7 +589,7 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call('carol', 'ssh {} alice@node1 PATH=\\"\\$PATH\\":/usr/sbin:/sbin crm_node -l'.format(constants.SSH_OPTION)),
+            mock.call('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION)),
             mock.call('carol', 'ssh {} alice@node1 hostname'.format(constants.SSH_OPTION))
         ])
         mock_error.assert_called_once_with("Can't fetch hostname of node1: None")
@@ -623,7 +623,7 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.setup_passwordless_with_other_nodes("node1")
 
         mock_run.assert_has_calls([
-            mock.call('carol', 'ssh {} alice@node1 PATH=\\"\\$PATH\\":/usr/sbin:/sbin crm_node -l'.format(constants.SSH_OPTION)),
+            mock.call('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION)),
             mock.call('carol', 'ssh {} alice@node1 hostname'.format(constants.SSH_OPTION))
             ])
         mock_userof.assert_called_once_with("node2")


### PR DESCRIPTION
Or will got error:
```
xin@hanode2:~> sudo crm cluster join -c hanode1 -y
INFO: SSH key for xin does not exist, hence generate it now
INFO: Configuring SSH passwordless with xin@hanode1
Password: 
INFO: SSH key for hacluster does not exist, hence generate it now
ERROR: cluster.join: Can't fetch cluster nodes list from hanode1: error: Could not connect to controller: Permission denied
```