### PR TITLE
[crmsh-4.4] Fix: healthcheck: do not run automatic upgrade when crmsh is called by a non-root user (bsc#1208936)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -774,7 +774,7 @@ def change_user_shell(user):
     """
     message = "The user '{}' will have the login shell configuration changed to /bin/bash"
     if user != "root" and is_nologin(user):
-        if not _context.yes_to_all:
+        if _context is not None and not _context.yes_to_all:
             logger.info(message.format(user))
             if not confirm("Continue?"):
                 _context.with_other_user = False

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -105,19 +105,18 @@ def _get_minimal_seq_in_cluster(nodes) -> typing.Tuple[int, int]:
 
 def _upgrade(nodes, seq):
     def ask(msg: str):
-        if not crmsh.utils.ask('Upgrade of crmsh configuration: ' + msg, background_wait=False):
-            raise crmsh.healthcheck.AskDeniedByUser()
+        pass
     try:
         for key in VERSION_FEATURES.keys():
             if seq < key <= CURRENT_UPGRADE_SEQ:
                 for feature_class in VERSION_FEATURES[key]:
                     feature = feature_class()
                     if crmsh.healthcheck.feature_full_check(feature, nodes):
-                        logger.info("Upgrade: feature %s is already functional.")
+                        logger.debug("upgradeutil: feature %s is already functional.")
                     else:
-                        logger.debug("Upgrade: fixing feature %s...")
+                        logger.debug("upgradeutil: fixing feature %s...")
                         crmsh.healthcheck.feature_fix(feature, nodes, ask)
-        logger.info("Upgrade of crmsh configuration succeeded.")
+        logger.debug("upgradeutil: upgrade succeeded.")
     except crmsh.healthcheck.AskDeniedByUser:
         raise _SkipUpgrade() from None
 
@@ -125,32 +124,36 @@ def _upgrade(nodes, seq):
 def upgrade_if_needed():
     if os.geteuid() != 0:
         return
+    if not crmsh.utils.can_ask(background_wait=False):
+        return
     nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
     if nodes and _is_upgrade_needed(nodes):
-        logger.info("crmsh version is newer than its configuration. Configuration upgrade is needed.")
+        logger.debug("upgradeutil: configuration upgrade needed")
         try:
             if not _is_cluster_target_seq_consistent(nodes):
                 logger.warning("crmsh version is inconsistent in cluster.")
                 raise _SkipUpgrade()
             seq = _get_minimal_seq_in_cluster(nodes)
             logger.debug(
-                "Upgrading crmsh configuration from seq %s to %s.",
+                "Upgrading crmsh from seq %s to %s.",
                 seq, _format_upgrade_seq(CURRENT_UPGRADE_SEQ),
             )
             _upgrade(nodes, seq)
         except _SkipUpgrade:
-            logger.warning("Upgrade of crmsh configuration skipped.")
+            logger.debug("upgradeutil: upgrade skipped")
             return
-        crmsh.parallax.parallax_call(
-            nodes,
-            "mkdir -p '{}' && echo '{}' > '{}'".format(
-                DATA_DIR,
-                _format_upgrade_seq(CURRENT_UPGRADE_SEQ),
-                SEQ_FILE_PATH,
-            ),
-        )
+        # TODO: replace with parallax_copy when it is ready
+        for node in nodes:
+            crmsh.utils.get_stdout_or_raise_error(
+                "mkdir -p '{}' && echo '{}' > '{}'".format(
+                    DATA_DIR,
+                    _format_upgrade_seq(CURRENT_UPGRADE_SEQ),
+                    SEQ_FILE_PATH,
+                ),
+                node,
+            )
         crmsh.parallax.parallax_call(nodes, 'rm -f {}'.format(FORCE_UPGRADE_FILE_PATH))
-        logger.debug("Upgrade of crmsh configuration finished.", seq)
+        logger.debug("upgrade finished")
 
 
 def force_set_local_upgrade_seq():

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -123,6 +123,8 @@ def _upgrade(nodes, seq):
 
 
 def upgrade_if_needed():
+    if os.geteuid() != 0:
+        return
     nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
     if nodes and _is_upgrade_needed(nodes):
         logger.info("crmsh version is newer than its configuration. Configuration upgrade is needed.")


### PR DESCRIPTION
And also backport 082e9b8fbfb86bc5b3c03c0a9c5853e4cd581ec4(Dev: upgradeutil: do upgrade silently (bsc#1208327)) from master.