### PR TITLE
Fix: parallax: Use 'sudo bash -c' when executing commands via sudoer (bsc#1209192)

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -273,8 +273,12 @@ class LoggerUtils(object):
             self.logger.addHandler(console_handler)
 
     def log_only_to_file(self, msg, level=logging.INFO):
-        with self.only_file():
-            self.logger.log(level, msg)
+        from .config import core
+        if core.debug:
+            self.logger.log(logging.DEBUG, msg)
+        else:
+            with self.only_file():
+                self.logger.log(level, msg)
 
     @contextmanager
     def buffer(self):

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -67,7 +67,9 @@ class Parallax(object):
         for host in self.nodes:
             host_port_user.append([host, None, crmsh.utils.user_of(host)])
         # FIXME: this is really unreliable
-        results = parallax.call(host_port_user, 'sudo {}'.format(self.cmd), self.opts)
+        sudoer = userdir.get_sudoer()
+        cmd = f'sudo bash -c "{self.cmd}"' if sudoer else self.cmd
+        results = parallax.call(host_port_user, cmd, self.opts)
         return self.handle(list(results.items()))
 
     def slurp(self):
@@ -79,9 +81,11 @@ class Parallax(object):
         results = parallax.copy(self.nodes, self.src, self.dst, self.opts)
         return self.handle(list(results.items()))
     def run(self):
+        sudoer = userdir.get_sudoer()
+        cmd = f'sudo bash -c "{self.cmd}"' if sudoer else self.cmd
         return parallax.run(
             [[node, None, crmsh.utils.user_of(node)] for node in self.nodes],
-            'sudo {}'.format(self.cmd),
+            cmd,
             self.opts,
         )
 

--- a/test/unittests/test_parallax.py
+++ b/test/unittests/test_parallax.py
@@ -51,7 +51,7 @@ class TestParallax(unittest.TestCase):
         self.assertEqual(result, mock_handle.return_value)
 
         mock_userof.assert_called_once_with("node1")
-        mock_call.assert_called_once_with([["node1", None, "alice"]], "sudo ls", self.parallax_call_instance.opts)
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
     @mock.patch("parallax.Error")
@@ -69,7 +69,7 @@ class TestParallax(unittest.TestCase):
         self.assertEqual("error happen", str(err.exception))
 
         mock_userof.assert_called_once_with("node1")
-        mock_call.assert_called_once_with([["node1", None, "alice"]], "sudo ls", self.parallax_call_instance.opts)
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
     @mock.patch("crmsh.parallax.Parallax.handle")


### PR DESCRIPTION
Or, some commands like `rm -rf /etc/corosync/qdevice/net/*` might fail.

Also add more debug messages when configuring qdevice.