### PR TITLE
Dev: utils: Check passwordless between cluster nodes

### DIFF
--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -115,6 +115,9 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
     SSH_DIR = os.path.expanduser('~hacluster/.ssh')
     KEY_TYPES = ['ed25519', 'ecdsa', 'rsa']
 
+    def __str__(self):
+        return "Configure Passwordless for hacluster"
+
     def check_quick(self) -> bool:
         for key_type in self.KEY_TYPES:
             try:

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -124,7 +124,7 @@ def upgrade_if_needed():
     if not crmsh.utils.can_ask(background_wait=False):
         return
     nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
-    if nodes and _is_upgrade_needed(nodes):
+    if nodes and _is_upgrade_needed(nodes) and not crmsh.utils.check_passwordless_between_nodes(nodes):
         logger.debug("upgradeutil: configuration upgrade needed")
         try:
             if not _is_cluster_target_seq_consistent(nodes):

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -109,11 +109,11 @@ def _upgrade(nodes, seq):
                 for feature_class in VERSION_FEATURES[key]:
                     feature = feature_class()
                     if crmsh.healthcheck.feature_full_check(feature, nodes):
-                        logger.debug("upgradeutil: feature %s is already functional.")
+                        logger.debug("upgradeutil: feature '%s' is already functional.", str(feature))
                     else:
-                        logger.debug("upgradeutil: fixing feature %s...")
+                        logger.debug("upgradeutil: fixing feature '%s'...", str(feature))
                         crmsh.healthcheck.feature_fix(feature, nodes, ask)
-        logger.debug("upgradeutil: upgrade succeeded.")
+        logger.debug("upgradeutil: configuration fix succeeded.")
     except crmsh.healthcheck.AskDeniedByUser:
         raise _SkipUpgrade() from None
 
@@ -125,10 +125,10 @@ def upgrade_if_needed():
         return
     nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
     if nodes and _is_upgrade_needed(nodes) and not crmsh.utils.check_passwordless_between_nodes(nodes):
-        logger.debug("upgradeutil: configuration upgrade needed")
+        logger.debug("upgradeutil: configuration fix needed")
         try:
             if not _is_cluster_target_seq_consistent(nodes):
-                logger.warning("crmsh version is inconsistent in cluster.")
+                logger.warning("crmsh configuration is inconsistent in cluster.")
                 raise _SkipUpgrade()
             seq = _get_minimal_seq_in_cluster(nodes)
             logger.debug(
@@ -137,7 +137,7 @@ def upgrade_if_needed():
             )
             _upgrade(nodes, seq)
         except _SkipUpgrade:
-            logger.debug("upgradeutil: upgrade skipped")
+            logger.debug("upgradeutil: configuration fix skipped")
             return
         # TODO: replace with parallax_copy when it is ready
         for node in nodes:
@@ -150,7 +150,7 @@ def upgrade_if_needed():
                 node,
             )
         crmsh.parallax.parallax_call(nodes, 'rm -f {}'.format(FORCE_UPGRADE_FILE_PATH))
-        logger.debug("upgrade finished")
+        logger.debug("configuration fix finished")
 
 
 def force_set_local_upgrade_seq():

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2368,6 +2368,39 @@ def check_ssh_passwd_need(local_user, remote_user, host):
     return rc != 0
 
 
+def check_passwordless_between_nodes(node_list, user='root'):
+    """
+    Check passwordless between cluster nodes
+    Suppose each node has the same user
+    Return a list of hosts that require passwords between
+    """
+    need_pw_pair_list = []
+    me = this_node()
+    # check local node between remote node
+    for node in node_list:
+        if node == me:
+            continue
+        if check_ssh_passwd_need(user, user, node):
+            need_pw_pair_list.append((me, node))
+
+    if not need_pw_pair_list:
+        for node in node_list:
+            for n in node_list:
+                if node == n or node == me:
+                    continue
+                if user == 'root':
+                    cmd = f"ssh {node} \"ssh {SSH_OPTION} -T -o Batchmode=yes {user}@{n} true\""
+                else:
+                    cmd = f"ssh {node} \"su - {user} -c 'ssh {SSH_OPTION} -T -o Batchmode=yes {user}@{n} true'\""
+                rc, _, _ = get_stdout_stderr(cmd)
+                if rc != 0:
+                    need_pw_pair_list.append((node, n))
+
+    for m, n in need_pw_pair_list:
+        logger.debug("There is no passwordless configured from %s to %s under '%s'", m, n, user)
+    return need_pw_pair_list
+
+
 def check_port_open(ip, port):
     import socket
 

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -155,3 +155,17 @@ Feature: Regression test for bootstrap bugs
     When    Run "su xin -c "sudo crm cluster run 'touch /tmp/1209193'"" on "hanode1"
     And     Run "test -f /tmp/1209193" on "hanode1"
     And     Run "test -f /tmp/1209193" on "hanode2"
+
+  @clean
+  @skip_non_root
+  Scenario: Do upgrade job without root passwordless
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    When    Run "rm -f /var/lib/crmsh/upgrade_seq" on "hanode1"
+    And     Run "rm -f /root/.config/crm/crm.conf" on "hanode1"
+    And     Run "rm -rf /root/.ssh" on "hanode1"
+    And     Run "crm status" on "hanode1"

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -483,17 +483,11 @@ def step_impl(context, count, node):
 def step_impl(context, nodelist):
     if userdir.getuser() != 'root':
         return True
-    ssh_option = "-o StrictHostKeyChecking=no -T -o Batchmode=yes"
-    node_list = nodelist.split()
-    for node in node_list:
-        for n in node_list:
-            if node == n:
-                continue
-            cmd = f"su - hacluster -c 'ssh {ssh_option} hacluster@{n} true'"
-            if node != me():
-                cmd = f"ssh {node} \"{cmd}\""
-            context.logger.info(f"\nRun cmd: {cmd}")
-            run_command(context, cmd)
+    need_pw_list = crmutils.check_passwordless_between_nodes(nodelist.split(), 'hacluster')
+    for m, n in need_pw_list:
+        context.logger.error(f"There is no passwordless configured from {m} to {n} under 'hacluster'")
+    assert need_pw_list == []
+
 
 @then('Check user shell for hacluster between "{nodelist}"')
 def step_impl(context, nodelist):


### PR DESCRIPTION
## Problem
When cluster nodes not configured passwordless for both root and hacluster, crmsh will give a warning each time it runs any crm commands such as:
```
WARNING: SSH connection to remote node 15sp4-2 failed.
parallax.Error: Exited with error code 255, Error output: parallax error: SSH requested a password. Please create SSH keys or
use the -A option to provide a password.
parallax error: SSH requested a password. Please create SSH keys or
use the -A option to provide a password.
root@15sp4-2: Permission denied (publickey,password,keyboard-interactive).
```
## Solution

Add function crmsh.utils.check_passwordless_between_nodes.
Return a list of hosts that require passwords between.
Call it when detected the hacluster passwordless was not configured:
```
if nodes and _is_upgrade_needed(nodes) and not crmsh.utils.check_passwordless_between_nodes(nodes):
```
If there were nodes not configured passwordless for root, record it in debug messages `instead of warning message` like:
```
DEBUG: There is no passwordless configured from 15sp4-2 to 15sp4-1 under 'root'
DEBUG: There is no passwordless configured from 15sp4-2 to 15sp4-3 under 'root'
DEBUG: There is no passwordless configured from 15sp4-1 to 15sp4-2 under 'root'
DEBUG: There is no passwordless configured from 15sp4-1 to 15sp4-3 under 'root'
```
## Other changes
- Reuse function `crmsh.utils.check_passwordless_between_nodes` in behave test case
- To reduce confusions, change 'upgrade' terminology to 'configuration fix'
