### PR TITLE
Fix: validate ssh session when the users is determined by guessing (bsc#1209193)

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -107,11 +107,7 @@ def query_qnetd_status():
         raise ValueError("host for qnetd not configured!")
 
     # Configure ssh passwordless to qnetd if detect password is needed
-    local_user = utils.user_of(utils.this_node())
-    try:
-        remote_user = utils.user_of(qnetd_addr)
-    except ValueError:
-        remote_user = 'root'
+    local_user, remote_user = utils.user_pair_for_ssh(qnetd_addr)
     if utils.check_ssh_passwd_need(local_user, remote_user, qnetd_addr):
         utils.ssh_copy_id(local_user, remote_user, qnetd_addr)
 

--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -145,8 +145,8 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
         remote_nodes = set(nodes)
         remote_nodes.remove(local_node)
         remote_nodes = list(remote_nodes)
-        local_user = crmsh.utils.user_of(local_node)
-        remote_users = [crmsh.utils.user_of(node) for node in remote_nodes]
+        local_user = crmsh.utils.user_pair_for_ssh(remote_nodes[0])[0]
+        remote_users = [crmsh.utils.user_pair_for_ssh(node)[1] for node in remote_nodes]
         crmsh.bootstrap.init_ssh_impl(local_user, remote_nodes, remote_users)
 
 

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -390,14 +390,14 @@ class QDevice(object):
 
     @classmethod
     def _copy_file_to_remote_host(cls, local_file, remote_host: str, remote_path):
-        remote_user = utils.user_of(remote_host)
+        local_user, remote_user = utils.user_pair_for_ssh(remote_host)
         with tempfile.NamedTemporaryFile('w', encoding='utf-8') as tmp:
             tmp.write("put -pr '{}' '{}'\n".format(local_file, remote_path))
             tmp.flush()
             # we can not su to a non-root user, since reading the source file may need privilege.
             cmd = "sftp {} -o IdentityFile=~{}/.ssh/id_rsa -o BatchMode=yes -s 'sudo PATH=/usr/lib/ssh:/usr/libexec/ssh /bin/sh -c \"exec sftp-server\"' -b {} {}@{}".format(
                 constants.SSH_OPTION,
-                utils.user_of(utils.this_node()),
+                local_user,
                 # FIXME: sftp-server is not always in /usr/lib/ssh
                 tmp.name,
                 remote_user, cls._enclose_inet6_addr(remote_host),

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -177,18 +177,15 @@ def test_query_qnetd_status_no_host(mock_qdevice_configured, mock_get_value):
         ])
 
 
-@mock.patch('crmsh.utils.user_of')
+@mock.patch('crmsh.utils.user_pair_for_ssh')
 @mock.patch("crmsh.parallax.parallax_call")
 @mock.patch("crmsh.utils.ssh_copy_id")
 @mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
 def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
-        mock_get_value, mock_check_passwd, mock_ssh_copy_id, mock_parallax_call, mock_userof):
-    mock_userof.side_effect = [
-        "alice",
-        "root",
-    ]
+        mock_get_value, mock_check_passwd, mock_ssh_copy_id, mock_parallax_call, mock_user_pair_for_ssh):
+    mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_parallax_call.side_effect = ValueError("Failed on 10.10.10.123: foo")
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
@@ -205,7 +202,7 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
     mock_ssh_copy_id.assert_called_once_with('alice', 'root', '10.10.10.123')
 
 
-@mock.patch('crmsh.utils.user_of')
+@mock.patch('crmsh.utils.user_pair_for_ssh')
 @mock.patch("crmsh.utils.print_cluster_nodes")
 @mock.patch("crmsh.parallax.parallax_call")
 @mock.patch("crmsh.utils.ssh_copy_id")
@@ -214,11 +211,8 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
 @mock.patch("crmsh.utils.is_qdevice_configured")
 def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
         mock_check_passwd, mock_ssh_copy_id, mock_parallax_call, mock_print_nodes,
-        mock_userof):
-    mock_userof.side_effect = [
-        "alice",
-        "root",
-    ]
+        mock_user_pair_for_ssh):
+    mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
     mock_check_passwd.return_value = True

--- a/test/unittests/test_parallax.py
+++ b/test/unittests/test_parallax.py
@@ -13,121 +13,124 @@ from crmsh import parallax as cparallax
 
 
 class TestParallax(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """
-        Global setUp.
-        """
-
     def setUp(self):
         """
         Test setUp.
         """
         # Use the setup to create a fresh instance for each test
-        self.parallax_call_instance = cparallax.Parallax(["node1"], cmd="ls")
-        self.parallax_slurp_instance = cparallax.Parallax(["node1"], localdir="/opt", filename="/opt/file.c")
-        self.parallax_copy_instance = cparallax.Parallax(["node1", "node2"], src="/opt/file.c", dst="/tmp")
-
-    def tearDown(self):
-        """
-        Test tearDown.
-        """
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Global tearDown.
-        """
-
-    @mock.patch("crmsh.utils.user_of")
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("parallax.call")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_call(self, mock_handle, mock_call, mock_userof):
+    def test_call(self, mock_handle, mock_call, mock_user_pair_for_ssh):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_call_instance = cparallax.Parallax(["node1"], cmd="ls")
         mock_call.return_value = {"node1": (0, None, None)}
-        mock_userof.return_value = "alice"
         mock_handle.return_value = [("node1", (0, None, None))]
 
-        result = self.parallax_call_instance.call()
+        result = parallax_call_instance.call()
         self.assertEqual(result, mock_handle.return_value)
 
-        mock_userof.assert_called_once_with("node1")
-        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
+        mock_user_pair_for_ssh.assert_has_calls([
+            mock.call("node1"),
+            mock.call("node1"),
+        ])
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
     @mock.patch("parallax.Error")
-    @mock.patch("crmsh.utils.user_of")
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("parallax.call")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_call_exception(self, mock_handle, mock_call, mock_userof, mock_error):
+    def test_call_exception(self, mock_handle, mock_call, mock_user_pair_for_ssh, mock_error):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_call_instance = cparallax.Parallax(["node1"], cmd="ls")
         mock_error = mock.Mock()
         mock_call.return_value = {"node1": mock_error}
-        mock_userof.return_value = "alice"
         mock_handle.side_effect = ValueError("error happen")
 
         with self.assertRaises(ValueError) as err:
-            self.parallax_call_instance.call()
+            parallax_call_instance.call()
         self.assertEqual("error happen", str(err.exception))
 
-        mock_userof.assert_called_once_with("node1")
-        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", self.parallax_call_instance.opts)
+        mock_user_pair_for_ssh.assert_has_calls([
+            mock.call("node1"),
+            mock.call("node1"),
+        ])
+        mock_call.assert_called_once_with([["node1", None, "alice"]], "ls", parallax_call_instance.opts)
         mock_handle.assert_called_once_with(list(mock_call.return_value.items()))
 
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("crmsh.parallax.Parallax.handle")
     @mock.patch("parallax.slurp")
     @mock.patch("os.path.basename")
-    def test_slurp(self, mock_basename, mock_slurp, mock_handle):
+    def test_slurp(self, mock_basename, mock_slurp, mock_handle, mock_user_pair_for_ssh):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_slurp_instance = cparallax.Parallax(["node1"], localdir="/opt", filename="/opt/file.c")
         mock_basename.return_value = "file.c"
         mock_slurp.return_value = {"node1": (0, None, None, "/opt")}
         mock_handle.return_value = [("node1", (0, None, None, "/opt"))]
 
-        result = self.parallax_slurp_instance.slurp()
+        result = parallax_slurp_instance.slurp()
         self.assertEqual(result, mock_handle.return_value)
 
         mock_basename.assert_called_once_with("/opt/file.c")
-        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", self.parallax_slurp_instance.opts)
+        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", parallax_slurp_instance.opts)
         mock_handle.assert_called_once_with(list(mock_slurp.return_value.items()))
+        mock_user_pair_for_ssh.assert_called_once_with("node1")
 
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("parallax.Error")
     @mock.patch("crmsh.parallax.Parallax.handle")
     @mock.patch("parallax.slurp")
     @mock.patch("os.path.basename")
-    def test_slurp_exception(self, mock_basename, mock_slurp, mock_handle, mock_error):
+    def test_slurp_exception(self, mock_basename, mock_slurp, mock_handle, mock_error, mock_user_pair_for_ssh):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_slurp_instance = cparallax.Parallax(["node1"], localdir="/opt", filename="/opt/file.c")
         mock_basename.return_value = "file.c"
         mock_error = mock.Mock()
         mock_slurp.return_value = {"node1": mock_error}
         mock_handle.side_effect = ValueError("error happen")
 
         with self.assertRaises(ValueError) as err:
-            self.parallax_slurp_instance.slurp()
+            parallax_slurp_instance.slurp()
         self.assertEqual("error happen", str(err.exception))
 
         mock_basename.assert_called_once_with("/opt/file.c")
-        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", self.parallax_slurp_instance.opts)
+        mock_slurp.assert_called_once_with(["node1"], "/opt/file.c", "file.c", parallax_slurp_instance.opts)
         mock_handle.assert_called_once_with(list(mock_slurp.return_value.items()))
+        mock_user_pair_for_ssh.assert_called_once_with("node1")
 
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("parallax.copy")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_copy(self, mock_handle, mock_copy):
+    def test_copy(self, mock_handle, mock_copy, mock_user_pair_for_ssh):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_copy_instance = cparallax.Parallax(["node1", "node2"], src="/opt/file.c", dst="/tmp")
         mock_copy.return_value = {"node1": (0, None, None), "node2": (0, None, None)}
         mock_handle.return_value = [("node1", (0, None, None)), ("node2", (0, None, None))]
 
-        result = self.parallax_copy_instance.copy()
+        result = parallax_copy_instance.copy()
         self.assertEqual(result, mock_handle.return_value)
 
-        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", self.parallax_copy_instance.opts)
+        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", parallax_copy_instance.opts)
         mock_handle.assert_called_once_with(list(mock_copy.return_value.items()))
+        mock_user_pair_for_ssh.assert_called_once_with("node1")
 
+    @mock.patch("crmsh.utils.user_pair_for_ssh")
     @mock.patch("parallax.Error")
     @mock.patch("parallax.copy")
     @mock.patch("crmsh.parallax.Parallax.handle")
-    def test_copy_exception(self, mock_handle, mock_copy, mock_error):
+    def test_copy_exception(self, mock_handle, mock_copy, mock_error, mock_user_pair_for_ssh):
+        mock_user_pair_for_ssh.return_value = "alice", "alice"
+        parallax_copy_instance = cparallax.Parallax(["node1", "node2"], src="/opt/file.c", dst="/tmp")
         mock_error = mock.Mock()
         mock_copy.return_value = {"node1": mock_error, "node2": (0, None, None)}
         mock_handle.side_effect = ValueError("error happen")
 
         with self.assertRaises(ValueError) as err:
-            self.parallax_copy_instance.copy()
+            parallax_copy_instance.copy()
         self.assertEqual("error happen", str(err.exception))
 
-        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", self.parallax_copy_instance.opts)
+        mock_copy.assert_called_once_with(["node1", "node2"], "/opt/file.c", "/tmp", parallax_copy_instance.opts)
         mock_handle.assert_called_once_with(list(mock_copy.return_value.items()))
+        mock_user_pair_for_ssh.assert_called_once_with("node1")

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1227,28 +1227,25 @@ class TestSubprocessRunUtils(unittest.TestCase):
         self.assertEqual(b'bar', result.stdout)
 
     @mock.patch("crmsh.utils.this_node")
-    @mock.patch("crmsh.utils.user_of")
+    @mock.patch('crmsh.utils.user_pair_for_ssh')
     @mock.patch("crmsh.utils.su_subprocess_run")
     @mock.patch("subprocess.run")
     def test_subprocess_run_auto_ssh_no_input_remote_no_user(
             self,
             mock_subprocess_run: mock.MagicMock,
             mock_su_subprocess_run: mock.MagicMock,
-            mock_user_of: mock.MagicMock,
+            mock_user_pair_for_ssh: mock.MagicMock,
             mock_this_node: mock.MagicMock,
     ):
         mock_this_node.return_value = 'node1'
-        mock_user_of.return_value = 'alice'
+        mock_user_pair_for_ssh.return_value = "alice", "bob"
         mock_su_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
         result = utils.subprocess_run_auto_ssh_no_input("foo", "node2", stderr=subprocess.DEVNULL)
-        mock_user_of.assert_has_calls([
-            mock.call('node1'),
-            mock.call('node2'),
-        ], any_order=True)
+        mock_user_pair_for_ssh.assert_called_once_with('node2')
         mock_subprocess_run.assert_not_called()
         mock_su_subprocess_run.assert_called_once_with(
             'alice',
-            'ssh -o StrictHostKeyChecking=no alice@node2 sudo -H -u root /bin/sh',
+            'ssh -o StrictHostKeyChecking=no bob@node2 sudo -H -u root /bin/sh',
             input=b'foo',
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
In the following scenario, `user_of()` is not able to get a user from
`core.hosts`:

1. In the early stage of cluster node initialization
2. When a cluster is upgraded from a previous version
3. Called by external code, for example, the behave test

`user_of()` uses to return `$SUDO_USER` if it exists, or return the
current user if it doesn't. However, this breaks the following use case:

* A cluster is upgraded from a previous version and users operate it
  with sudo

In this case, `user_of()` returns `$SUDO_USER`, but `root` is expected.

This commit consists of the following changes:

1. `user_of()` returns `None` when it is not able to get a user from
   `core.hosts`. It is expected to be used only in early stage of
   initialization.

2. After the early stage of intialization, when an SSH session is
   needed, `user_pair_for_ssh()` is called to get both the local user
   and remote user that can be used for creating it. This function is
   implemented as follow:

    1. If `user_of()` returns valid users for both local and remote host,
       return them.
    2. Try create an ssh session with `root` as both local and remote
       user. If succeeds, return them.
    3. Try create an ssh session with `$SUDO_USER` as both local and remote
       user. If succeeds, return them.
