### PR TITLE
Add test case resource_failcount.feature back after upgrade pacemaker version

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -122,7 +122,19 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $DOCKER_SCRIPT $index
+
+  functional_test_bootstrap_options_non_root:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for bootstrap options, under non root user
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        index=`$GET_INDEX_OF bootstrap_options`
+        $DOCKER_SCRIPT $index -u
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-20.04
@@ -170,7 +182,19 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $DOCKER_SCRIPT $index
+
+  functional_test_qdevice_validate_non_root:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for qdevice validate, under non root user
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        index=`$GET_INDEX_OF qdevice_validate`
+        $DOCKER_SCRIPT $index -u
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-20.04
@@ -184,17 +208,41 @@ jobs:
         index=`$GET_INDEX_OF qdevice_usercase`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
 
-  functional_test_resource_subcommand:
+  functional_test_resource_failcount:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v3
-    - name: functional test for resource subcommand
+    - name: functional test for resource failcount
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
-        index=`$GET_INDEX_OF resource_failcount resource_set`
+        index=`$GET_INDEX_OF resource_failcount`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+
+  functional_test_resource_set:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for resource set
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        index=`$GET_INDEX_OF resource_set`
+        $DOCKER_SCRIPT $index
+
+  functional_test_resource_set_non_root:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for resource set, under non root user
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        index=`$GET_INDEX_OF resource_set`
+        $DOCKER_SCRIPT $index -u
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-20.04
@@ -284,12 +332,16 @@ jobs:
       functional_test_bootstrap_common,
       functional_test_bootstrap_common_non_root,
       functional_test_bootstrap_options,
+      functional_test_bootstrap_options_non_root,
       functional_test_qdevice_setup_remove,
       functional_test_qdevice_setup_remove_non_root,
       functional_test_qdevice_options,
       functional_test_qdevice_validate,
+      functional_test_qdevice_validate_non_root,
       functional_test_qdevice_user_case,
-      functional_test_resource_subcommand,
+      functional_test_resource_failcount,
+      functional_test_resource_set,
+      functional_test_resource_set_non_root,
       functional_test_configure_sublevel,
       functional_test_constraints_bugs,
       functional_test_geo_cluster,

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -193,7 +193,7 @@ jobs:
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
-        index=`$GET_INDEX_OF resource_set`
+        index=`$GET_INDEX_OF resource_failcount resource_set`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
 
   functional_test_configure_sublevel:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN zypper -n install csync2 libglue-devel corosync corosync-qdevice pacemaker b
 RUN zypper --non-interactive up zypper
 RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf
 RUN zypper --non-interactive refresh
-RUN zypper --non-interactive up --allow-vendor-change -y python3-parallax resource-agents
+RUN zypper --non-interactive up --allow-vendor-change -y python3-parallax resource-agents libqb100 pacemaker
 
 RUN mkdir -p /var/log/crmsh
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -163,7 +163,6 @@ scope=nodes  name=a1 value=1 2 3
 .TRY node attribute node1 delete a1
 .EXT crm_attribute -D -t nodes -N 'node1' -n 'a1'
 Deleted nodes attribute: id=nodes-node1-a1 name=a1
-
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -68,96 +68,76 @@ livedangerously (enum): Live Dangerously!!
     Viva la Vida Loca!
 
 pcmk_host_argument (string, [port]): Advanced use only: An alternate parameter to supply instead of 'port'
-    Some devices do not support the standard 'port' parameter or may provide additional ones.
-    Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced.
-    A value of 'none' can be used to tell the cluster not to supply any additional parameters.
+    some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of none can be used to tell the cluster not to supply any additional parameters.
 
 pcmk_host_map (string): A mapping of host names to ports numbers for devices that do not support host names.
     Eg. node1:1;node2:2,3 would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2
 
-pcmk_host_list (string): A list of machines controlled by this device (Optional unless pcmk_host_check=static-list).
-    Eg. node1,node2,node3
+pcmk_host_list (string): Eg. node1,node2,node3
+    A list of machines controlled by this device (Optional unless pcmk_host_list=static-list)
 
 pcmk_host_check (string, [dynamic-list]): How to determine which machines are controlled by the device.
     Allowed values: dynamic-list (query the device via the 'list' command), static-list (check the pcmk_host_list attribute), status (query the device via the 'status' command), none (assume every device can fence every machine)
 
-pcmk_delay_max (time, [0s]): Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.
-    This prevents double fencing when using slow devices such as sbd.
-    Use this to enable a random delay for fencing actions.
-    The overall delay is derived from this random delay value adding a static delay so that the sum is kept below the maximum delay.
+pcmk_delay_max (time, [0s]): Enable a base delay for fencing actions and specify base delay value.
+    Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.
 
-pcmk_delay_base (time, [0s]): Enable a base delay for fencing actions and specify base delay value.
-    This prevents double fencing when different delays are configured on the nodes.
-    Use this to enable a static delay for fencing actions.
-    The overall delay is derived from a random delay value adding this static delay so that the sum is kept below the maximum delay.
-    Set to eg. node1:1s;node2:5 to set different value per node.
+pcmk_delay_base (string, [0s]): Enable a base delay for fencing actions and specify base delay value.
+    This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max  is also used, a random delay will be added such that the total delay is kept below that value.This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value per target.
 
 pcmk_action_limit (integer, [1]): The maximum number of actions can be performed in parallel on this device
-    Cluster property concurrent-fencing=true needs to be configured first.
-    Then use this to specify the maximum number of actions can be performed in parallel on this device. -1 is unlimited.
+    Cluster property concurrent-fencing=true needs to be configured first.Then use this to specify the maximum number of actions can be performed in parallel on this device. -1 is unlimited.
 
 pcmk_reboot_action (string, [reboot]): Advanced use only: An alternate command to run instead of 'reboot'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'reboot' action.
+    Some devices do not support the standard commands or may provide additional ones.\nUse this to specify an alternate, device-specific, command that implements the 'reboot' action.
 
 pcmk_reboot_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for reboot actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'reboot' actions.
+    Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'reboot' actions.
 
 pcmk_reboot_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'reboot' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'reboot' actions before giving up.
 
 pcmk_off_action (string, [off]): Advanced use only: An alternate command to run instead of 'off'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'off' action.
+    Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'off' action.
 
 pcmk_off_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for off actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'off' actions.
+    Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'off' actions.
 
 pcmk_off_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'off' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'off' actions before giving up.
 
 pcmk_on_action (string, [on]): Advanced use only: An alternate command to run instead of 'on'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'on' action.
+    Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'on' action.
 
 pcmk_on_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for on actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'on' actions.
+    Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'on' actions.
 
 pcmk_on_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'on' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'on' actions before giving up.
 
 pcmk_list_action (string, [list]): Advanced use only: An alternate command to run instead of 'list'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'list' action.
+    Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'list' action.
 
 pcmk_list_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for list actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'list' actions.
+    Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'list' actions.
 
 pcmk_list_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'list' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'list' actions before giving up.
 
 pcmk_monitor_action (string, [monitor]): Advanced use only: An alternate command to run instead of 'monitor'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'monitor' action.
+    Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'monitor' action.
 
 pcmk_monitor_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for monitor actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'monitor' actions.
+    Some devices need much more/less time to complete than normal.\nUse this to specify an alternate, device-specific, timeout for 'monitor' actions.
 
 pcmk_monitor_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'monitor' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'monitor' actions before giving up.
 
 pcmk_status_action (string, [status]): Advanced use only: An alternate command to run instead of 'status'
-    Some devices do not support the standard commands or may provide additional ones.
-    Use this to specify an alternate, device-specific, command that implements the 'status' action.
+    Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'status' action.
 
 pcmk_status_timeout (time, [60s]): Advanced use only: Specify an alternate timeout to use for status actions instead of stonith-timeout
-    Some devices need much more/less time to complete than normal.
-    Use this to specify an alternate, device-specific, timeout for 'status' actions.
+    Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'status' actions.
 
 pcmk_status_retries (integer, [2]): Advanced use only: The maximum number of times to retry the 'status' command within the timeout period
     Some devices do not support multiple connections. Operations may 'fail' if the device is busy with another task so Pacemaker will automatically retry the operation, if there is time remaining. Use this option to alter the number of times Pacemaker retries 'status' actions before giving up.

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1176,24 +1176,24 @@ Node node1: UNCLEAN (offline)
      Stopped: [ node1 ]
 
 Original: node1 capacity:
-pcmk__native_allocate: st allocation score on node1: 0
+pcmk__primitive_assign: st allocation score on node1: 0
 pcmk__clone_allocate: c1 allocation score on node1: 0
 pcmk__clone_allocate: p1:0 allocation score on node1: 0
-pcmk__native_allocate: p1:0 allocation score on node1: -INFINITY
+pcmk__primitive_assign: p1:0 allocation score on node1: -INFINITY
 pcmk__clone_allocate: m1 allocation score on node1: 0
 pcmk__clone_allocate: p2:0 allocation score on node1: 0
-pcmk__native_allocate: p2:0 allocation score on node1: -INFINITY
+pcmk__primitive_assign: p2:0 allocation score on node1: -INFINITY
 p2:0 promotion score on none: 0
-pcmk__native_allocate: p3 allocation score on node1: -INFINITY
+pcmk__primitive_assign: p3 allocation score on node1: -INFINITY
 pcmk__clone_allocate: msg allocation score on node1: 0
 pcmk__clone_allocate: g:0 allocation score on node1: 0
 pcmk__clone_allocate: p0:0 allocation score on node1: 0
 pcmk__clone_allocate: p4:0 allocation score on node1: 0
-pcmk__group_allocate: g:0 allocation score on node1: -INFINITY
-pcmk__group_allocate: p0:0 allocation score on node1: -INFINITY
-pcmk__group_allocate: p4:0 allocation score on node1: -INFINITY
-pcmk__native_allocate: p0:0 allocation score on node1: -INFINITY
-pcmk__native_allocate: p4:0 allocation score on node1: -INFINITY
+pcmk__group_assign: g:0 allocation score on node1: -INFINITY
+pcmk__group_assign: p0:0 allocation score on node1: -INFINITY
+pcmk__group_assign: p4:0 allocation score on node1: -INFINITY
+pcmk__primitive_assign: p0:0 allocation score on node1: -INFINITY
+pcmk__primitive_assign: p4:0 allocation score on node1: -INFINITY
 g:0 promotion score on none: 0
 Remaining: node1 capacity:
 


### PR DESCRIPTION
## Problem
I found the resource failcount number is inconsistent, on pacemaker-2.1.2+20211124.ada5c3b36-150400.4.9.2.x86_64
Here is the trigger script:
```
crm cluster init -y &> /dev/null
echo "Info: Cluster is running..."
crm configure primitive d Dummy op monitor interval=3s &> /dev/null
echo "Info: Add resource d(Dummy)"
while :
do
  echo "Info: Remove /run/resource-agents/Dummy-d.state"
  rm -f /run/resource-agents/Dummy-d.state
  sleep 15
  echo "Info: Show failcount"
  echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  crm resource failcount d show `hostname`
  echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  echo "Info: Set failcount to 0"
  crm resource failcount d set `hostname` 0
  echo "Info: Restart resource d"
  crm resource stop d
  crm resource start d
  sleep 5
done
```
Here are the results:
```
Info: Cluster is running...
Info: Add resource d(Dummy)
Info: Remove /run/resource-agents/Dummy-d.state
Info: Show failcount
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
scope=status  name=fail-count-d value=1
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
Info: Set failcount to 0
Info: Restart resource d
Info: Remove /run/resource-agents/Dummy-d.state
Info: Show failcount
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
scope=status  name=fail-count-d value=1
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
Info: Set failcount to 0
Info: Restart resource d
Info: Remove /run/resource-agents/Dummy-d.state
Info: Show failcount
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
scope=status  name=fail-count-d value=2
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
Info: Set failcount to 0
Info: Restart resource d
Info: Remove /run/resource-agents/Dummy-d.state
Info: Show failcount
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
scope=status  name=fail-count-d value=1
xxxxxxxxxxxxxxxxxxxxxxxxxxxx
Info: Set failcount to 0
```
See, the value of failcount is not always 1
This is the different point that lead crmsh CI failed

## Solution

Update pacemaker and libqb version in docker image:
```
pacemaker-2.1.5+20230314.692147cd3-150400.385.1.x86_64
libqb100-2.0.6+20220323.758044b-150400.94.3.x86_64
```