### PR TITLE
[crmsh-4.4] Fix: crm report: sustain if there are offline nodes (bsc#1209480)

### DIFF
--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -1383,6 +1383,9 @@ def start_slave_collector(node, arg_str):
         if err:
             print(err)
 
+    if out == '': # if we couldn't get anything
+        return
+
     compress_data = ""
     for data in out.split('\n'):
         if data.startswith(constants.COMPRESS_DATA_FLAG):


### PR DESCRIPTION
Without this patch, the hb_report will crash trying to reach out to the offline nodes. (backport)