### PR TITLE
Fix: utils: qdevice initialization should user_pair_for_ssh() to get appreciated users (crmsh#1157)

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -8,6 +8,7 @@ configuration file, and also the corosync-* utilities.
 import os
 import re
 import socket
+
 from . import utils
 from . import tmpfiles
 from . import parallax
@@ -97,6 +98,7 @@ def query_qnetd_status():
     """
     Query qnetd status
     """
+    import crmsh.bootstrap  # workaround for circular dependencies
     if not utils.is_qdevice_configured():
         raise ValueError("QDevice/QNetd not configured!")
     cluster_name = get_value('totem.cluster_name')
@@ -109,6 +111,7 @@ def query_qnetd_status():
     # Configure ssh passwordless to qnetd if detect password is needed
     local_user, remote_user = utils.user_pair_for_ssh(qnetd_addr)
     if utils.check_ssh_passwd_need(local_user, remote_user, qnetd_addr):
+        crmsh.bootstrap.configure_ssh_key(local_user)
         utils.ssh_copy_id(local_user, remote_user, qnetd_addr)
 
     cmd = "corosync-qnetd-tool -lv -c {}".format(cluster_name)

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -100,11 +100,10 @@ class RemoteLock(Lock):
     MIN_LOCK_TIMEOUT = 120
     WAIT_INTERVAL = 10
 
-    def __init__(self, remote_user, remote_node, for_join=True, lock_dir=None, wait=True, no_warn=False):
+    def __init__(self, remote_node, for_join=True, lock_dir=None, wait=True, no_warn=False):
         """
         Init function
         """
-        self.remote_user = remote_user
         self.remote_node = remote_node
         self.for_join = for_join
         self.wait = wait

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -69,8 +69,7 @@ def qnetd_lock_for_same_cluster_name(func):
     def wrapper(*args, **kwargs):
         cluster_name = args[0].cluster_name
         lock_dir = "/run/.crmsh_qdevice_lock_for_{}".format(cluster_name)
-        lock_inst = lock.RemoteLock(utils.user_of(args[0].qnetd_addr), args[0].qnetd_addr
-            , for_join=False, lock_dir=lock_dir, wait=False)
+        lock_inst = lock.RemoteLock(args[0].qnetd_addr, for_join=False, lock_dir=lock_dir, wait=False)
         try:
             with lock_inst.lock():
                 func(*args, **kwargs)
@@ -87,8 +86,7 @@ def qnetd_lock_for_multi_cluster(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        lock_inst = lock.RemoteLock(utils.user_of(args[0].qnetd_addr)
-            , args[0].qnetd_addr, for_join=False, no_warn=True)
+        lock_inst = lock.RemoteLock(args[0].qnetd_addr, for_join=False, no_warn=True)
         try:
             with lock_inst.lock():
                 func(*args, **kwargs)

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -180,11 +180,12 @@ def test_query_qnetd_status_no_host(mock_qdevice_configured, mock_get_value):
 @mock.patch('crmsh.utils.user_pair_for_ssh')
 @mock.patch("crmsh.parallax.parallax_call")
 @mock.patch("crmsh.utils.ssh_copy_id")
+@mock.patch('crmsh.bootstrap.configure_ssh_key')
 @mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
 def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
-        mock_get_value, mock_check_passwd, mock_ssh_copy_id, mock_parallax_call, mock_user_pair_for_ssh):
+        mock_get_value, mock_check_passwd, mock_config_ssh_key, mock_ssh_copy_id, mock_parallax_call, mock_user_pair_for_ssh):
     mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_parallax_call.side_effect = ValueError("Failed on 10.10.10.123: foo")
     mock_qdevice_configured.return_value = True
@@ -199,6 +200,7 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
         mock.call("quorum.device.net.host")
         ])
     mock_check_passwd.assert_called_once_with("alice", "root", "10.10.10.123")
+    mock_config_ssh_key.assert_called_once_with('alice')
     mock_ssh_copy_id.assert_called_once_with('alice', 'root', '10.10.10.123')
 
 
@@ -206,11 +208,12 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
 @mock.patch("crmsh.utils.print_cluster_nodes")
 @mock.patch("crmsh.parallax.parallax_call")
 @mock.patch("crmsh.utils.ssh_copy_id")
+@mock.patch('crmsh.bootstrap.configure_ssh_key')
 @mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.utils.is_qdevice_configured")
 def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
-        mock_check_passwd, mock_ssh_copy_id, mock_parallax_call, mock_print_nodes,
+        mock_check_passwd, mock_config_ssh_key, mock_ssh_copy_id, mock_parallax_call, mock_print_nodes,
         mock_user_pair_for_ssh):
     mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_qdevice_configured.return_value = True
@@ -226,6 +229,7 @@ def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
         mock.call("quorum.device.net.host")
         ])
     mock_check_passwd.assert_called_once_with("alice", "root", "10.10.10.123")
+    mock_config_ssh_key.assert_called_once_with('alice')
     mock_ssh_copy_id.assert_called_once_with('alice', 'root', '10.10.10.123')
     mock_parallax_call.assert_called_once_with(["10.10.10.123"], "corosync-qnetd-tool -lv -c hacluster")
     mock_print_nodes.assert_called_once_with()

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -118,8 +118,8 @@ class TestRemoteLock(unittest.TestCase):
         """
         Test setUp.
         """
-        self.lock_inst = lock.RemoteLock("alice", "node1")
-        self.lock_inst_no_wait = lock.RemoteLock("alice", "node1", wait=False)
+        self.lock_inst = lock.RemoteLock("node1")
+        self.lock_inst_no_wait = lock.RemoteLock("node1", wait=False)
 
     def tearDown(self):
         """

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -67,66 +67,55 @@ def test_evaluate_qdevice_quorum_effect(mock_get_dict, mock_quorate, mock_ra_run
 
 
 @mock.patch('crmsh.lock.RemoteLock')
-@mock.patch('crmsh.utils.user_of')
-def test_qnetd_lock_for_same_cluster_name(mock_userof, mock_remote_lock):
+def test_qnetd_lock_for_same_cluster_name(mock_remote_lock):
     _context = mock.Mock(qnetd_addr="qnetd-node", cluster_name="cluster1")
     remote_lock_inst = mock.Mock()
     mock_remote_lock.return_value = remote_lock_inst
-    mock_userof.return_value = "alice"
     remote_lock_inst.lock.return_value.__enter__ = mock.Mock()
     remote_lock_inst.lock.return_value.__exit__ = mock.Mock()
     @qdevice.qnetd_lock_for_same_cluster_name
     def decorated(ctx):
         return
     decorated(_context)
-    mock_userof.assert_called_once_with("qnetd-node")
-    mock_remote_lock.assert_called_once_with("alice", "qnetd-node", for_join=False, 
+    mock_remote_lock.assert_called_once_with("qnetd-node", for_join=False,
             lock_dir="/run/.crmsh_qdevice_lock_for_cluster1", wait=False)
 
 
 @mock.patch('crmsh.utils.fatal')
 @mock.patch('crmsh.lock.RemoteLock')
-@mock.patch('crmsh.utils.user_of')
-def test_qnetd_lock_for_same_cluster_name_claim_error(mock_userof, mock_remote_lock, mock_fatal):
+def test_qnetd_lock_for_same_cluster_name_claim_error(mock_remote_lock, mock_fatal):
     _context = mock.Mock(qnetd_addr="qnetd-node", cluster_name="cluster1")
     remote_lock_inst = mock.Mock()
     mock_remote_lock.return_value = remote_lock_inst
-    mock_userof.return_value = "alice"
     remote_lock_inst.lock.side_effect = lock.ClaimLockError
     @qdevice.qnetd_lock_for_same_cluster_name
     def decorated(ctx):
         return
     decorated(_context)
-    mock_userof.assert_called_once_with("qnetd-node")
     mock_fatal.assert_called_once_with("Duplicated cluster name \"cluster1\"!")
-    mock_remote_lock.assert_called_once_with("alice", "qnetd-node", for_join=False, 
+    mock_remote_lock.assert_called_once_with("qnetd-node", for_join=False,
             lock_dir="/run/.crmsh_qdevice_lock_for_cluster1", wait=False)
 
 
 @mock.patch('crmsh.utils.fatal')
 @mock.patch('crmsh.lock.RemoteLock')
-@mock.patch('crmsh.utils.user_of')
-def test_qnetd_lock_for_same_cluster_name_ssh_error(mock_userof, mock_remote_lock, mock_fatal):
+def test_qnetd_lock_for_same_cluster_name_ssh_error(mock_remote_lock, mock_fatal):
     _context = mock.Mock(qnetd_addr="qnetd-node", cluster_name="cluster1")
     remote_lock_inst = mock.Mock()
     mock_remote_lock.return_value = remote_lock_inst
-    mock_userof.return_value = "alice"
     remote_lock_inst.lock.side_effect = lock.SSHError("ssh error!")
     @qdevice.qnetd_lock_for_same_cluster_name
     def decorated(ctx):
         return
     decorated(_context)
-    mock_userof.assert_called_once_with("qnetd-node")
-    mock_remote_lock.assert_called_once_with("alice", "qnetd-node", for_join=False, 
+    mock_remote_lock.assert_called_once_with("qnetd-node", for_join=False,
             lock_dir="/run/.crmsh_qdevice_lock_for_cluster1", wait=False) 
 
 
 @mock.patch('crmsh.lock.RemoteLock')
-@mock.patch('crmsh.utils.user_of')
-def test_qnetd_lock_for_multi_cluster(mock_userof, mock_remote_lock):
+def test_qnetd_lock_for_multi_cluster(mock_remote_lock):
     _context = mock.Mock(qnetd_addr="qnetd-node")
     remote_lock_inst = mock.Mock()
-    mock_userof.return_value = "alice"
     mock_remote_lock.return_value = remote_lock_inst
     remote_lock_inst.lock.return_value.__enter__ = mock.Mock()
     remote_lock_inst.lock.return_value.__exit__ = mock.Mock()
@@ -134,24 +123,21 @@ def test_qnetd_lock_for_multi_cluster(mock_userof, mock_remote_lock):
     def decorated(ctx):
         return
     decorated(_context)
-    mock_remote_lock.assert_called_once_with("alice", "qnetd-node", for_join=False, no_warn=True)
+    mock_remote_lock.assert_called_once_with("qnetd-node", for_join=False, no_warn=True)
 
 
 @mock.patch('crmsh.utils.fatal')
 @mock.patch('crmsh.lock.RemoteLock')
-@mock.patch('crmsh.utils.user_of')
-def test_qnetd_lock_for_multi_cluster_error(mock_userof, mock_remote_lock, mock_fatal):
+def test_qnetd_lock_for_multi_cluster_error(mock_remote_lock, mock_fatal):
     _context = mock.Mock(qnetd_addr="qnetd-node")
     remote_lock_inst = mock.Mock()
-    mock_userof.return_value = "alice"
     mock_remote_lock.return_value = remote_lock_inst
     remote_lock_inst.lock.side_effect = lock.SSHError("ssh error!")
     @qdevice.qnetd_lock_for_multi_cluster
     def decorated(ctx):
         return
     decorated(_context)
-    mock_userof.assert_called_once_with("qnetd-node")
-    mock_remote_lock.assert_called_once_with("alice", "qnetd-node", for_join=False, no_warn=True)
+    mock_remote_lock.assert_called_once_with("qnetd-node", for_join=False, no_warn=True)
 
 
 class TestQDevice(unittest.TestCase):


### PR DESCRIPTION
And `configure_ssh_key()` should be called prior to `ssh_copy_id()` to ensure there exists a key pair to be copy.