### PR TITLE
[ALP] Update Dockerfile and run-functional-tests for corosync3 and knet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ MAINTAINER Xin Liang <XLiang@suse.com>
 
 ARG ssh_prv_key
 ARG ssh_pub_key
-# docker build -t haleap --build-arg ssh_prv_key="$(cat /root/.ssh/id_rsa)" --build-arg ssh_pub_key="$(cat /root/.ssh/id_rsa.pub)" .
+# docker build -t alpha --build-arg ssh_prv_key="$(cat /root/.ssh/id_rsa)" --build-arg ssh_pub_key="$(cat /root/.ssh/id_rsa.pub)" .
 # docker login
-# docker tag haleap liangxin1300/haleap:15.5
-# docker push liangxin1300/haleap:15.5
+# docker tag alpha liangxin1300/alpha
+# docker push liangxin1300/alpha
 
 RUN zypper ref
 RUN zypper -n install systemd
@@ -17,6 +17,10 @@ RUN zypper --non-interactive up zypper
 RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf
 RUN zypper --non-interactive refresh
 RUN zypper --non-interactive up --allow-vendor-change -y python3-parallax resource-agents libqb100 pacemaker
+RUN zypper ar -f -G https://download.opensuse.org/repositories/home:/XinLiang:/corosync/15.4/ repo_corosync3
+RUN zypper --non-interactive refresh
+RUN zypper --non-interactive up --allow-vendor-change -y corosync corosync-qdevice corosync-qnetd
+RUN zypper --non-interactive in libknet1-*
 
 RUN mkdir -p /var/log/crmsh
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"liangxin1300/haleap:15.5"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"liangxin1300/alpha"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
 DOCKER_SERVICE="docker.service"
@@ -18,47 +18,25 @@ BEHAVE_CASE_EXCLUDE="sbd|ocfs2"
 
 read -r -d '' COROSYNC_CONF_TEMPLATE << EOM
 totem {
-        version: 2
-        cluster_name: hacluster
-        clear_node_high_bit: yes
-        interface {
-                ringnumber: 0
-                mcastport: 5405
-                ttl: 1
-        }
-
-        transport: udpu
-        crypto_hash: sha1
-        crypto_cipher: aes256
-        token: 5000
-        join: 60
-        max_messages: 20
-        token_retransmits_before_loss_const: 10
-}
-
-logging {
-        fileline: off
-        to_stderr: no
-        to_logfile: no
-        logfile: /var/log/cluster/corosync.log
-        to_syslog: yes
-        debug: off
-        timestamp: on
-        logger_subsys {
-                subsys: QUORUM
-                debug: off
-        }
-
+    version: 2
+    cluster_name: cluster1
+    transport: knet
+    crypto_cipher: aes256
+    crypto_hash: sha256
 }
 
 nodelist {
 }
 
 quorum {
+    provider: corosync_votequorum
+}
 
-        # Enable and configure quorum subsystem (default: off)
-        # see also corosync.conf.5 and votequorum.5
-        provider: corosync_votequorum
+logging {
+    to_logfile: yes
+    logfile: /var/log/cluster/corosync.log
+    to_syslog: yes
+    timestamp: on
 }
 EOM
 


### PR DESCRIPTION
```
# ./test/run-functional-tests -n 2
INFO: Loading docker image liangxin1300/alpha...
INFO: Create ha specific docker network "ha_network_first"...
INFO: Create ha specific docker network "ha_network_second"...
INFO: Deploying "hanode1"...
INFO: Deploying "hanode2"...
INFO: Building crmsh on "hanode1"...
INFO: Building crmsh on "hanode2"...
INFO: Copy corosync.conf to hanode1 hanode2
INFO: Cluster service started on "hanode1"
INFO: Cluster service started on "hanode2"
```

```
hanode1:/ # crm_mon -1
Cluster Summary:
  * Stack: corosync (Pacemaker is running)
  * Current DC: hanode2 (version 2.1.5+20230314.692147cd3-150400.385.2-2.1.5+20230314.692147cd3) - partition with quorum
  * Last updated: Thu Apr  6 02:41:31 2023 on hanode1
  * Last change:  Thu Apr  6 02:41:21 2023 by hacluster via crmd on hanode2
  * 2 nodes configured
  * 0 resource instances configured

Node List:
  * Online: [ hanode1 hanode2 ]

Active Resources:
  * No active resources
  

hanode1:/ # corosync-cfgtool -s
Local node ID 1, transport knet
LINK ID 0 udp
        addr    = 192.168.64.2
        status:
                nodeid:          1:     localhost
                nodeid:          2:     connected
```