### PR TITLE
[ALP] Dev: ui_cluster: Drop deprecated options

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -39,6 +39,7 @@ jobs:
         python-version: ['3.6', '3.8', '3.10']
       fail-fast: false
     timeout-minutes: 5
+    if: ${{ false }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -351,6 +352,7 @@ jobs:
       original_regression_test]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
+    if: ${{ false }}
     steps:
     - uses: actions/checkout@v3
     - name: delivery process
@@ -370,6 +372,7 @@ jobs:
     needs: delivery
     runs-on: ubuntu-20.04
     timeout-minutes: 10
+    if: ${{ false }}
     steps:
     - uses: actions/checkout@v3
     - name: submit process

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -92,7 +92,6 @@ class Context(object):
         self.yes_to_all = None
         self.cluster_name = None
         self.watchdog = None
-        self.no_overwrite_sshkey = None
         self.nic_list = []
         self.node_list = []
         self.node_list_in_cluster = []
@@ -294,10 +293,6 @@ class Context(object):
                 utils.fatal("Maximum number of interface is 2")
             if utils.has_dup_value(self.nic_list):
                 utils.fatal("Duplicated input for -i/--interface option")
-        if self.no_overwrite_sshkey:
-            logger.warning("--no-overwrite-sshkey option is deprecated since crmsh does not overwrite ssh keys by default anymore and will be removed in future versions")
-        if self.type == "join" and self.watchdog:
-            logger.warning("-w option is deprecated and will be removed in future versions")
         if self.ocfs2_devices or self.stage == "ocfs2":
             ocfs2.OCFS2Manager.verify_ocfs2(self)
         if not self.skip_csync2 and self.type == "init":

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -299,20 +299,12 @@ Examples:
                             help="Use the given watchdog device or driver name")
         parser.add_argument("-x", "--skip-csync2-sync", dest="skip_csync2", action="store_true",
                             help="Skip csync2 initialization (an experimental option)")
-        parser.add_argument("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
-                            help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default; Deprecated)')
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(), default=[],
                                    help="Bind to IP address on interface IF. Use -i second time for second interface")
-        network_group.add_argument("-u", "--unicast", action="store_true", dest="unicast",
-                                   help="Configure corosync to communicate over unicast(udpu). This is the default transport type")
-        network_group.add_argument("-U", "--multicast", action="store_true", dest="multicast",
-                                   help="Configure corosync to communicate over multicast. Default is unicast")
         network_group.add_argument("-A", "--admin-ip", dest="admin_ip", metavar="IP",
                                    help="Configure IP address as an administration virtual IP")
-        network_group.add_argument("-M", "--multi-heartbeats", action="store_true", dest="second_heartbeat",
-                                   help="Configure corosync with second heartbeat line")
         network_group.add_argument("-I", "--ipv6", action="store_true", dest="ipv6",
                                    help="Configure corosync use IPv6")
 
@@ -410,7 +402,6 @@ Examples:
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
-        parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG", help="Use the given watchdog device")
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -44,7 +44,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Setup cluster with crossed network(udpu only)
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -u -i eth0 -y" on "hanode1"
+    When    Run "crm cluster init -i eth0 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "stopped" on "hanode2"
@@ -56,7 +56,7 @@ Feature: Regression test for bootstrap bugs
   Scenario: Remove correspond nodelist in corosync.conf while remove(bsc#1165644)
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -u -i eth1 -y" on "hanode1"
+    When    Run "crm cluster init -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -4,11 +4,8 @@ Feature: crmsh bootstrap process - options
   Test crmsh bootstrap options:
       "--node": Additional nodes to add to the created cluster
       "-i":      Bind to IP address on interface IF
-      "-M":      Configure corosync with second heartbeat line
       "-n":      Set the name of the configured cluster
       "-A":      Configure IP address as an administration virtual IP
-      "-u":      Configure corosync to communicate over unicast
-      "-U":      Configure corosync to communicate over multicast
   Tag @clean means need to stop cluster service if the service is available
   Need nodes: hanode1 hanode2
 
@@ -49,18 +46,6 @@ Feature: crmsh bootstrap process - options
     And     Show corosync ring status
 
   @clean
-  Scenario: Using multiple network interface using "-M" option
-    Given   Cluster service is "stopped" on "hanode1"
-    And     IP "@hanode1.ip.default" is belong to "eth0"
-    And     IP "@hanode1.ip.0" is belong to "eth1"
-    When    Run "crm cluster init -M -y" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip.default" is used by corosync on "hanode1"
-    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
-    And     Show corosync ring status
-    And     Corosync working on "unicast" mode
-
-  @clean
   Scenario: Using multiple network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "@hanode1.ip.default" is belong to "eth0"
@@ -85,16 +70,6 @@ Feature: crmsh bootstrap process - options
     And     Show cluster status on "hanode1"
 
   @clean
-  Scenario: Init cluster service with udpu using "-u" option
-    Given   Cluster service is "stopped" on "hanode1"
-    When    Run "crm cluster init -u -y -i eth0" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
-    And     Cluster is using udpu transport mode
-    And     IP "@hanode1.ip.default" is used by corosync on "hanode1"
-    And     Show corosync ring status
-    And     Corosync working on "unicast" mode
-
-  @clean
   Scenario: Init cluster service with ipv6 using "-I" option
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
@@ -105,30 +80,6 @@ Feature: crmsh bootstrap process - options
     Then    Cluster service is "started" on "hanode2"
     And     IP "@hanode2.ip6.default" is used by corosync on "hanode2"
     And     Corosync working on "unicast" mode
-
-  @clean
-  Scenario: Init cluster service with ipv6 unicast using "-I" and "-u" option
-    Given   Cluster service is "stopped" on "hanode1"
-    Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -I -i eth1 -u -y" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip6.default" is used by corosync on "hanode1"
-    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
-    Then    Cluster service is "started" on "hanode2"
-    And     IP "@hanode2.ip6.default" is used by corosync on "hanode2"
-    And     Show cluster status on "hanode1"
-    And     Corosync working on "unicast" mode
-
-  @clean
-  Scenario: Init cluster service with multicast using "-U" option (bsc#1132375)
-    Given   Cluster service is "stopped" on "hanode1"
-    Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -U -i eth1 -y" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
-    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
-    Then    Cluster service is "started" on "hanode2"
-    And     Show cluster status on "hanode1"
-    And     Corosync working on "multicast" mode
 
   @clean
   Scenario: Init cluster with -N option (bsc#1175863)

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -88,7 +88,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice on multi nodes existing cluster
-    When    Run "crm cluster init -u -y" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
@@ -111,7 +111,7 @@ Feature: corosync qdevice/qnetd setup/remove process
 
   @clean
   Scenario: Setup qdevice using IPv6
-    When    Run "crm cluster init -u -y" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -79,9 +79,6 @@ optional arguments:
                         Use the given watchdog device or driver name
   -x, --skip-csync2-sync
                         Skip csync2 initialization (an experimental option)
-  --no-overwrite-sshkey
-                        Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is
-                        used (False by default; Deprecated)
 
 Network configuration:
   Options for configuring the network and messaging layer.
@@ -89,13 +86,7 @@ Network configuration:
   -i IF, --interface IF
                         Bind to IP address on interface IF. Use -i second time
                         for second interface
-  -u, --unicast         Configure corosync to communicate over unicast(udpu).
-                        This is the default transport type
-  -U, --multicast       Configure corosync to communicate over multicast.
-                        Default is unicast
   -A IP, --admin-ip IP  Configure IP address as an administration virtual IP
-  -M, --multi-heartbeats
-                        Configure corosync with second heartbeat line
   -I, --ipv6            Configure corosync use IPv6
 
 QDevice configuration:
@@ -217,8 +208,6 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution)
-  -w WATCHDOG, --watchdog WATCHDOG
-                        Use the given watchdog device
 
 Network configuration:
   Options for configuring the network and messaging layer.


### PR DESCRIPTION
Includes:
      --no-overwrite-sshkey on init side;
      -u/--unicast on init side;
      -U/--multicast on init side;
      -M/--multi-heartbeats on init side;
      -w/--watchdog on join side
      
      
The other commit: 
`Dev: workflows: Temporarily disabled unit_test, delivery and submit job`, until corosync3 is ready on opensuse:TW