### PR TITLE
Fix: lock: Join node failed to wait init node finished (bsc#1210332)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2398,7 +2398,7 @@ def bootstrap_init(context):
         init_sbd()
         init_upgradeutil()
 
-        lock_inst = lock.Lock(mktemp(prefix="crmsh_lock_"))
+        lock_inst = lock.Lock()
         try:
             with lock_inst.lock():
                 init_cluster()

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -31,7 +31,7 @@ class Lock(object):
     A base class define a lock mechanism used to exclude other nodes
     """
 
-    LOCK_DIR_NON_PRIVILEGED = "/tmp/.crmsh_lock_directory"
+    LOCK_DIR_DEFAULT = "/run/.crmsh_lock_directory"
 
     def __init__(self, lock_dir=None):
         """
@@ -39,7 +39,7 @@ class Lock(object):
         """
         # only the lock owner can unlock
         self.lock_owner = False
-        self.lock_dir = lock_dir or self.LOCK_DIR_NON_PRIVILEGED
+        self.lock_dir = lock_dir or self.LOCK_DIR_DEFAULT
 
     def _run(self, cmd):
         """

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -98,10 +98,10 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode2"
     # Try to simulate the join process hanging on hanode2 or hanode2 died
     # Just leave the lock directory unremoved
-    When    Run "mkdir /tmp/.crmsh_lock_directory" on "hanode1"
+    When    Run "mkdir /run/.crmsh_lock_directory" on "hanode1"
     When    Try "crm cluster join -c hanode1 -y" on "hanode3"
-    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/tmp/.crmsh_lock_directory)"
-    When    Run "rm -rf /tmp/.crmsh_lock_directory" on "hanode1"
+    Then    Except "ERROR: cluster.join: Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (hanode1:/run/.crmsh_lock_directory)"
+    When    Run "rm -rf /run/.crmsh_lock_directory" on "hanode1"
 
   @clean
   Scenario: Change host name in /etc/hosts as alias(bsc#1183654)

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -59,28 +59,28 @@ class TestLock(unittest.TestCase):
         mock_run.return_value = (1, None, None)
         rc = self.local_inst._create_lock_dir()
         self.assertEqual(rc, False)
-        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_NON_PRIVILEGED))
+        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._run')
     def test_create_lock_dir(self, mock_run):
         mock_run.return_value = (0, None, None)
         rc = self.local_inst._create_lock_dir()
         self.assertEqual(rc, True)
-        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_NON_PRIVILEGED))
+        mock_run.assert_called_once_with("mkdir {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._create_lock_dir')
     def test_lock_or_fail(self, mock_create):
         mock_create.return_value = False
         with self.assertRaises(lock.ClaimLockError) as err:
             self.local_inst._lock_or_fail()
-        self.assertEqual("Failed to claim lock (the lock directory exists at {})".format(lock.Lock.LOCK_DIR_NON_PRIVILEGED), str(err.exception))
+        self.assertEqual("Failed to claim lock (the lock directory exists at {})".format(lock.Lock.LOCK_DIR_DEFAULT), str(err.exception))
         mock_create.assert_called_once_with()
 
     @mock.patch('crmsh.lock.Lock._run')
     def test_unlock(self, mock_run):
         self.local_inst.lock_owner = True
         self.local_inst._unlock()
-        mock_run.assert_called_once_with("rm -rf {}".format(lock.Lock.LOCK_DIR_NON_PRIVILEGED))
+        mock_run.assert_called_once_with("rm -rf {}".format(lock.Lock.LOCK_DIR_DEFAULT))
 
     @mock.patch('crmsh.lock.Lock._unlock')
     @mock.patch('crmsh.lock.Lock._lock_or_fail')
@@ -211,7 +211,7 @@ class TestRemoteLock(unittest.TestCase):
 
         with self.assertRaises(lock.ClaimLockError) as err:
             self.lock_inst._lock_or_wait()
-        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:{})".format(lock.Lock.LOCK_DIR_NON_PRIVILEGED), str(err.exception))
+        self.assertEqual("Timed out after 120 seconds. Cannot continue since the lock directory exists at the node (node1:{})".format(lock.Lock.LOCK_DIR_DEFAULT), str(err.exception))
 
         mock_time.assert_has_calls([ mock.call(), mock.call()])
         mock_time_out.assert_has_calls([mock.call(), mock.call(), mock.call()])


### PR DESCRIPTION
This issue was introduced since
69b18cdb7e37581c0e3173b86bb6dde5f16b6ab0.
The join node cannot be excluded because it uses a different lock directory.