### PR TITLE
Fix: cibconfig: use any existing rsc_defaults set rather than create another one

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1527,13 +1527,10 @@ def init_cluster():
 
     logger.info("Loading initial cluster configuration")
 
-    rsc_defaults_str = "rsc_defaults rsc-options: migration-threshold=3"
-    if not xmlutil.RscState().has_rsc_stickiness():
-        rsc_defaults_str += " resource-stickiness=1"
     crm_configure_load("update", """property cib-bootstrap-options: stonith-enabled=false
 op_defaults op-options: timeout=600 record-pending=true
-{}
-""".format(rsc_defaults_str))
+rsc_defaults rsc-options: resource-stickiness=1 migration-threshold=3
+""")
 
     _context.sbd_manager.configure_sbd_resource_and_properties()
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -451,17 +451,15 @@ def invokerc(*args):
 
 
 def crm_configure_load(action, configuration):
+    action_types = ("update", "replace", "push")
+    if action not in action_types:
+        utils.fatal(f"Action type should be: {action_types}")
     logger_utils.log_only_to_file("Loading crm config (%s), content is:" % (action))
     logger_utils.log_only_to_file(configuration)
-    if not cib_factory.initialize():
-        utils.fatal("Failed to load cluster configuration")
-    set_obj = mkset_obj()
-    if action == 'replace':
-        cib_factory.erase()
-    if not set_obj.save(configuration, remove=False, method=action):
-        utils.fatal("Failed to load cluster configuration")
-    if not cib_factory.commit():
-        utils.fatal("Failed to commit cluster configuration")
+
+    configuration_tmpfile = utils.str2tmp(configuration)
+    tmpfiles.add(configuration_tmpfile)
+    utils.get_stdout_or_raise_error(f"crm -F configure load {action} {configuration_tmpfile}")
 
 
 def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT):

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3411,6 +3411,11 @@ class CibFactory(object):
     def set_property_cli(self, obj_type, node):
         pset_id = node.get('id') or default_id_for_obj(obj_type)
         obj = self.find_object(pset_id)
+        # If id is the default, use any existing set rather create another one.
+        if not obj and pset_id == default_id_for_obj(obj_type):
+            objs = self.get_elems_on_type("type:%s" %obj_type)
+            if objs and len(objs) > 0:
+                obj = objs[-1]
         if not obj:
             if not is_id_valid(pset_id):
                 logger_utils.invalid_id_err(pset_id)

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -234,16 +234,6 @@ class RscState(object):
         except (IndexError, AttributeError):
             return None
 
-    def has_rsc_stickiness(self):
-        """
-        Check if resource-stickiness already set
-        """
-        self._init_cib()
-        if self.rsc_dflt_elem is None:
-            return False
-        attr = get_attr_in_set(self.rsc_dflt_elem, "resource-stickiness")
-        return attr is not None
-
     def is_ms_or_promotable_clone(self, ident):
         '''
         Test if the resource is master-slave.


### PR DESCRIPTION
## Problem
This is the cib configuration after crmsh setup a cluster:

```
# crm configure show
node 1: 15sp4-1
node 2: 15sp4-2
property cib-bootstrap-options: \
        have-watchdog=false \
        dc-version="2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=false
rsc_defaults build-resource-defaults: \
        resource-stickiness=1
rsc_defaults rsc-options: \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

The id "build-resource-defaults" was introduced from pacemaker.

This is the text configuration:
```
# cat crmsh.txt 
property \
        stonith-enabled="true" \
        stonith-action="reboot" \
        stonith-timeout="150s"
rsc_defaults \
        resource-stickiness="1000" \
        migration-threshold="5000"
op_defaults \
        timeout="600"
```

Now load it
```
crm configure load  update crmsh.txt
```

Now the cib configuration is:
```
# crm configure show
node 1: 15sp4-1
node 2: 15sp4-2
property cib-bootstrap-options: \
        have-watchdog=false \
        dc-version="2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=true \
        stonith-action=reboot \
        stonith-timeout=150s
rsc_defaults build-resource-defaults: \
        resource-stickiness=1
rsc_defaults rsc-options: \
        migration-threshold=5000 \
        resource-stickiness=1000
op_defaults op-options: \
        timeout=600 \
        record-pending=true
```

Result of crm_attribute:
```
# crm_attribute -t rsc_defaults -n resource-stickiness -G
Multiple attributes match name=resource-stickiness
  Value: 1      (id=build-resource-stickiness)
  Value: 1000   (id=rsc-options-resource-stickiness)
```

It looks confused that crmsh has two entries of resource-stickiness

## After changed
```
# For the new setup cluster:

# crm configure show
node 1: 15sp4-1
property cib-bootstrap-options: \
        have-watchdog=false \
        dc-version="2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=false
rsc_defaults build-resource-defaults: \
        resource-stickiness=1 \
        migration-threshold=3
op_defaults op-options: \
        timeout=600 \
        record-pending=true

# After load crmsh.txt

15sp4-1:/opt # cat crmsh.txt 
property \
        stonith-enabled="true" \
        stonith-action="reboot" \
        stonith-timeout="150s"
rsc_defaults \
        resource-stickiness="1000" \
        migration-threshold="5000"
op_defaults \
        timeout="600"
15sp4-1:/opt # crm configure load update crmsh.txt
15sp4-1:/opt # crm configure show
node 1: 15sp4-1
node 2: 15sp4-2
primitive stonith-sbd stonith:external/sbd \
        op monitor timeout=20 interval=3600 \
        op start timeout=20 interval=0s \
        op stop timeout=15 interval=0s \
        params pcmk_delay_max=30s
property cib-bootstrap-options: \
        have-watchdog=true \
        dc-version="2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36" \
        cluster-infrastructure=corosync \
        cluster-name=hacluster \
        stonith-enabled=true \
        stonith-timeout=150s \
        priority-fencing-delay=60 \
        stonith-action=reboot
rsc_defaults build-resource-defaults: \
        resource-stickiness=1000 \
        migration-threshold=5000 \
        priority=1
op_defaults op-options: \
        timeout=600 \
        record-pending=true

```