### PR TITLE
 Fix: bootstrap: crm cluster join default behavior change in ssh key handling (bsc#1210693)

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -317,8 +317,8 @@ Examples:
                                    help="Configure corosync use IPv6")
 
         qdevice_group = parser.add_argument_group("QDevice configuration", re.sub('  ', '', constants.QDEVICE_HELP_INFO) + "\n\nOptions for configuring QDevice and QNetd.")
-        qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr", metavar="HOST",
-                                   help="HOST or IP of the QNetd server to be used")
+        qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr", metavar="[USER@]HOST",
+                                   help="User and host of the QNetd server. The host can be specified in either hostname or IP address.")
         qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int, default=5403,
                                    help="TCP PORT of QNetd server (default:5403)")
         qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", default="ffsplit", choices=['ffsplit', 'lms'],
@@ -413,7 +413,10 @@ Examples:
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG", help="Use the given watchdog device")
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
-        network_group.add_argument("-c", "--cluster-node", dest="cluster_node", help="IP address or hostname of existing cluster node", metavar="HOST")
+        network_group.add_argument(
+            "-c", "--cluster-node", dest="cluster_node", metavar="[USER@]HOST",
+            help="User and host to login to an existing cluster node. The host can be specified with either a hostname or an IP.",
+        )
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action="append", choices=utils.interface_choice(), default=[],
                 help="Bind to IP address on interface IF. Use -i second time for second interface")
         options, args = parse_options(parser, args)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -225,13 +225,19 @@ def user_pair_for_ssh(host):
         raise ValueError('Can not create ssh session from {} to {}.'.format(this_node(), host))
 
 
-def ssh_copy_id(local_user, remote_user, remote_node):
+def ssh_copy_id_no_raise(local_user, remote_user, remote_node):
     if check_ssh_passwd_need(local_user, remote_user, remote_node):
         logger.info("Configuring SSH passwordless with {}@{}".format(remote_user, remote_node))
         cmd = "ssh-copy-id -i ~/.ssh/id_rsa.pub '{}@{}' &> /dev/null".format(remote_user, remote_node)
         result = su_subprocess_run(local_user, cmd, tty=True)
-        if result.returncode != 0:
-            fatal("Failed to login to remote host {}@{}".format(remote_user, remote_node))
+        return result.returncode
+    else:
+        return 0
+
+
+def ssh_copy_id(local_user, remote_user, remote_node):
+    if 0 != ssh_copy_id_no_raise(local_user, remote_user, remote_node):
+        fatal("Failed to login to remote host {}@{}".format(remote_user, remote_node))
 
 
 @memoize

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -107,8 +107,9 @@ QDevice configuration:
   
   Options for configuring QDevice and QNetd.
 
-  --qnetd-hostname HOST
-                        HOST or IP of the QNetd server to be used
+  --qnetd-hostname [USER@]HOST
+                        User and host of the QNetd server. The host can be
+                        specified in either hostname or IP address.
   --qdevice-port PORT   TCP PORT of QNetd server (default:5403)
   --qdevice-algo ALGORITHM
                         QNetd decision ALGORITHM (ffsplit/lms,
@@ -223,8 +224,10 @@ optional arguments:
 Network configuration:
   Options for configuring the network and messaging layer.
 
-  -c HOST, --cluster-node HOST
-                        IP address or hostname of existing cluster node
+  -c [USER@]HOST, --cluster-node [USER@]HOST
+                        User and host to login to an existing cluster node.
+                        The host can be specified with either a hostname or an
+                        IP.
   -i IF, --interface IF
                         Bind to IP address on interface IF. Use -i second time
                         for second interface


### PR DESCRIPTION
Problem
=======

In previous versions, `sudo crm cluster join -c <host>` use user root
for ssh sessions. However, in crmsh 4.5.0, the sudoer user is used. This
change in default behavior may break existing scripts.

Solution
========

Keep the default behavior unchanged and require using `sudo crm cluster
join -c <user>@<host>` to authenticate as a non-root user.