### PR TITLE
Dev: workflows: Temporarily remove unit_test from needs list for delivery job

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -327,7 +327,6 @@ jobs:
 
   delivery:
     needs: [general_check,
-      unit_test,
       functional_test_crm_report_bugs,
       functional_test_bootstrap_bugs,
       functional_test_bootstrap_bugs_non_root,


### PR DESCRIPTION
Fix for #1185 , which unit_test was skipped, then delivery job wouldn't trigger.