### PR TITLE
Dev: ui_corosync: Remove add-node and del-node subcommands

### DIFF
--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -142,24 +142,6 @@ class Corosync(command.UI):
             context.fatal_error("No corosync log file configured")
         utils.page_file(logfile)
 
-    @command.name('add-node')
-    @command.alias('add_node')
-    @command.skill_level('administrator')
-    def do_addnode(self, context, addr, name=None):
-        "Add a node to the corosync nodelist"
-        corosync.add_node(addr, name)
-
-    @command.name('del-node')
-    @command.alias('del_node')
-    @command.skill_level('administrator')
-    @command.completers(_push_completer)
-    def do_delnode(self, context, name):
-        "Remove a node from the corosync nodelist"
-        transport = corosync.get_value('totem.transport')
-        if not transport or transport != "udpu":
-            context.fatal_error("Only support udpu transport now")
-        corosync.del_node(name)
-
     @command.skill_level('administrator')
     @command.completers(completers.call(corosync.get_all_paths))
     def do_get(self, context, path):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1949,44 +1949,6 @@ def resolve_hostnames(hostnames):
     return True, None
 
 
-def list_corosync_node_names():
-    '''
-    Returns list of nodes configured
-    in corosync.conf
-    '''
-    try:
-        cfg = os.getenv('COROSYNC_MAIN_CONFIG_FILE', '/etc/corosync/corosync.conf')
-        lines = open(cfg).read().split('\n')
-        name_re = re.compile(r'\s*name:\s+(.*)')
-        names = []
-        for line in lines:
-            name = name_re.match(line)
-            if name:
-                names.append(name.group(1))
-        return names
-    except Exception:
-        return []
-
-
-def list_corosync_nodes():
-    '''
-    Returns list of nodes configured
-    in corosync.conf
-    '''
-    try:
-        cfg = os.getenv('COROSYNC_MAIN_CONFIG_FILE', '/etc/corosync/corosync.conf')
-        lines = open(cfg).read().split('\n')
-        addr_re = re.compile(r'\s*ring0_addr:\s+(.*)')
-        nodes = []
-        for line in lines:
-            addr = addr_re.match(line)
-            if addr:
-                nodes.append(addr.group(1))
-        return nodes
-    except Exception:
-        return []
-
-
 def print_cluster_nodes():
     """
     Print the output of crm_node -l

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1246,33 +1246,6 @@ Corosync is the underlying messaging layer for most HA clusters.
 This level provides commands for editing and managing the corosync
 configuration.
 
-[[cmdhelp_corosync_add-node,Add a corosync node]]
-==== `add-node`
-
-Adds a node to the corosync configuration. This is used with the `udpu`
-type configuration in corosync.
-
-A nodeid for the added node is generated automatically.
-
-Note that this command assumes that only a single ring is used, and
-sets only the address for ring0.
-
-Usage:
-.........
-add-node <addr> [name]
-.........
-
-[[cmdhelp_corosync_del-node,Remove a corosync node]]
-==== `del-node`
-
-Removes a node from the corosync configuration. The argument given is
-the `ring0_addr` address set in the configuration file.
-
-Usage:
-.........
-del-node <addr>
-.........
-
 [[cmdhelp_corosync_diff,Diffs the corosync configuration]]
 ==== `diff`
 


### PR DESCRIPTION
Remove `corosync add-node` and `corosync del-node` because:
- `corosync add-node` and `corosync del-node` will make corosync.conf inconsistent if forget to sync manually, 
- And should be useless under knet case since it only supports one link
