### PR TITLE
 Dev: behave: use a standalone agent instead of crmsh.parallax to run commands

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2738,7 +2738,7 @@ def geo_fetch_config(node):
         try:
             local_user = utils.user_of(utils.this_node())
         except utils.UserOfHost.UserNotFoundError:
-            local_user = userdir.getuser()
+            local_user = user
         remote_user = user
     else:
         try:
@@ -2752,6 +2752,10 @@ def geo_fetch_config(node):
     configure_ssh_key(local_user)
     logger.info("Retrieving configuration - This may prompt for %s@%s:", remote_user, node)
     utils.ssh_copy_id(local_user, remote_user, node)
+    user_by_host = utils.HostUserConfig()
+    user_by_host.add(local_user, utils.this_node())
+    user_by_host.add(remote_user, node)
+    user_by_host.save_local()
     cmd = "tar -c -C '{}' .".format(BOOTH_DIR)
     with tempfile.TemporaryDirectory() as tmpdir:
         pipe_outlet, pipe_inlet = os.pipe()

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -877,7 +877,6 @@ def init_ssh_impl(local_user: str, node_list: typing.List[str], user_list: typin
         # After this, login to remote_node is passwordless
         public_key_list.append(swap_public_ssh_key(node, local_user, remote_user, local_user, remote_user, add=True))
         hacluster_public_key_list.append(swap_public_ssh_key(node, 'hacluster', 'hacluster', local_user, remote_user, add=True))
-        change_user_shell('hacluster', node)
     if len(node_list) > 1:
         shell_script = _merge_authorized_keys(public_key_list)
         hacluster_shell_script = _merge_authorized_keys(hacluster_public_key_list)
@@ -906,6 +905,8 @@ def init_ssh_impl(local_user: str, node_list: typing.List[str], user_list: typin
         user_by_host.add(user, node)
     user_by_host.add(local_user, utils.this_node())
     user_by_host.save_remote(node_list)
+    for node in node_list:
+        change_user_shell('hacluster', node)
 
 
 def _merge_authorized_keys(keys: typing.List[str]) -> bytes:
@@ -1713,7 +1714,6 @@ def join_ssh_impl(seed_host, seed_user):
     # After this, login to remote_node is passwordless
     swap_public_ssh_key(seed_host, local_user, seed_user, local_user, seed_user, add=True)
     configure_ssh_key('hacluster')
-    change_user_shell('hacluster', seed_host)
     swap_public_ssh_key(seed_host, 'hacluster', 'hacluster', local_user, seed_user, add=True)
 
     # This makes sure the seed host has its own SSH keys in its own
@@ -1731,6 +1731,8 @@ def join_ssh_impl(seed_host, seed_user):
         user_by_host.add(user, node)
     user_by_host.add(local_user, utils.this_node())
     user_by_host.save_local()
+
+    change_user_shell('hacluster', seed_host)
 
 
 def swap_public_ssh_key(

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -194,19 +194,8 @@ class UserOfHost:
         if rc == 0:
             user = userdir.getuser()
             return user, user
-        sudoer = userdir.get_sudoer()
-        if sudoer is None:
+        else:
             return None
-        result = su_subprocess_run(
-            sudoer,
-            'ssh {} -o BatchMode=yes {}@{} sudo true'.format(constants.SSH_OPTION, sudoer, host),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        if result.returncode == 0:
-            return sudoer, sudoer
-        return None
 
 
 

--- a/data-manifest
+++ b/data-manifest
@@ -84,6 +84,7 @@ test/features/qdevice_usercase.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
 test/features/resource_set.feature
+test/features/steps/behave_agent.py
 test/features/steps/const.py
 test/features/steps/__init__.py
 test/features/steps/step_implementation.py

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -5,11 +5,6 @@ Feature: Regression test for bootstrap bugs
   Need nodes: hanode1 hanode2 hanode3
 
   @clean
-  Scenario: parallax OSError: Too many open files
-    Given   Cluster service is "stopped" on "hanode2"
-    When    Run parallax call many times on "hanode2"
-
-  @clean
   Scenario: Set placement-strategy value as "default"(bsc#1129462)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from crmsh import utils, parallax, userdir
+from crmsh import utils , userdir
 import time
 
 
@@ -29,7 +29,8 @@ def before_tag(context, tag):
             resource_cleanup()
             while True:
                 time.sleep(1)
-                if utils.get_dc():
+                rc, stdout, _ = utils.get_stdout_stderr('sudo crmadmin -D -t 1')
+                if rc == 0 and stdout.startswith('Designated'):
                     break
             utils.get_stdout_or_raise_error("sudo crm cluster stop --all")
     if tag == "skip_non_root":

--- a/test/features/steps/behave_agent.py
+++ b/test/features/steps/behave_agent.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# behave_agent.py - a simple agent to execute command
+# NO AUTHENTICATIONS. It should only be used in behave test.
+import io
+import os
+import pwd
+import socket
+import struct
+import subprocess
+import typing
+
+
+MSG_EOF  = 0
+MSG_USER = 1
+MSG_CMD  = 2
+MSG_OUT  = 4 
+MSG_ERR  = 5
+MSG_RC   = 6
+
+
+class Message:
+    @staticmethod
+    def write(output, type: int, data: bytes):
+        output.write(struct.pack('!ii', type, len(data)))
+        output.write(data)
+
+    @staticmethod
+    def read(input):
+        buf = input.read(8)
+        type, length = struct.unpack('!ii', buf)
+        if length > 0:
+            buf = input.read(length)
+        else:
+            buf = b''
+        return type, buf
+
+
+class SocketIO(io.RawIOBase):
+    def __init__(self, s: socket.socket):
+        self._socket = s
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return True
+
+    def read(self, __size: int = -1) -> bytes:
+        return self._socket.recv(__size)
+
+    def readinto(self, __buffer) -> int:
+        return self._socket.recv_into(__buffer)
+
+    def readall(self) -> bytes:
+        raise NotImplementedError
+
+    def write(self, __b) -> int:
+        return self._socket.send(__b)
+
+
+def call(host: str, port: int, cmdline: str, user: typing.Optional[str] = None):
+    family, type, proto, _, sockaddr =  socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)[0]
+    with socket.socket(family, type, proto) as s:
+        s.connect(sockaddr)
+        sout = io.BufferedWriter(SocketIO(s), 4096)
+        Message.write(sout, MSG_USER, user.encode('utf-8') if user else _getuser().encode('utf-8'))
+        Message.write(sout, MSG_CMD, cmdline.encode('utf-8'))
+        Message.write(sout, MSG_EOF, b'')
+        sout.flush()
+        s.shutdown(socket.SHUT_WR)
+        rc = None
+        stdout = []
+        stderr = []
+        sin = io.BufferedReader(SocketIO(s), 4096)
+        while True:
+            type, buf = Message.read(sin)
+            if type == MSG_OUT:
+                stdout.append(buf)
+            elif type == MSG_ERR:
+                stderr.append(buf)
+            elif type == MSG_RC:
+                rc, = struct.unpack('!i', buf)
+            elif type == MSG_EOF:
+                assert rc is not None
+                return rc, b''.join(stdout), b''.join(stderr)
+            else:
+                raise ValueError(f"Unknown message type: {type}")
+
+
+def serve(stdin, stdout, stderr):
+    # This is an xinetd-style service.
+    assert os.geteuid() == 0
+    user = None
+    cmd = None
+    sin = io.BufferedReader(stdin)
+    while True:
+        type, buf = Message.read(sin)
+        if type == MSG_USER:
+            user = buf.decode('utf-8')
+        elif type == MSG_CMD:
+            cmd = buf.decode('utf-8')
+        elif type == MSG_EOF:
+            assert user is not None
+            assert cmd is not None
+            break
+        else:
+            raise ValueError(f"Unknown message type: {type}")
+    if user == 'root':
+        args = ['/bin/sh']
+    else:
+        args = ['/bin/su', '-', user, '-c', '/bin/sh']
+    result = subprocess.run(
+        args,
+        input=cmd.encode('utf-8'),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    sout = io.BufferedWriter(stdout)
+    Message.write(sout, MSG_RC, struct.pack('!i', result.returncode))
+    Message.write(sout, MSG_OUT, result.stdout)
+    Message.write(sout, MSG_ERR, result.stderr)
+    Message.write(sout, MSG_EOF, b'')
+    stdout.flush()
+
+
+def _getuser():
+    return pwd.getpwuid(os.geteuid()).pw_name
+
+
+if __name__ == '__main__':
+    with open(0, 'rb') as stdin, \
+         open(1, 'wb') as stdout, \
+         open(2, 'wb') as stderr:
+        serve(stdin, stdout, stderr)

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -11,7 +11,7 @@ from crmsh import corosync, sbd, userdir, bootstrap
 from crmsh import utils as crmutils
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
                   run_command_local_or_remote, file_in_archive, \
-                  assert_eq, is_unclean
+                  assert_eq, is_unclean, assert_in
 import const
 
 
@@ -141,13 +141,13 @@ def step_impl(context):
 
 @then('Expected "{msg}" in stdout')
 def step_impl(context, msg):
-    assert msg in context.stdout
+    assert_in(msg, context.stdout)
     context.stdout = None
 
 
 @then('Expected "{msg}" in stderr')
 def step_impl(context, msg):
-    assert msg in context.stderr
+    assert_in(msg, context.stderr)
     context.stderr = None
 
 
@@ -177,25 +177,25 @@ def step_impl(context, msg):
 
 @then('Except "{msg}"')
 def step_impl(context, msg):
-    assert msg in context.stderr
+    assert_in(msg, context.stderr)
     context.stderr = None
 
 
 @then('Except multiple lines')
 def step_impl(context):
-    assert context.text in context.stderr
+    assert_in(context.text, context.stderr)
     context.stderr = None
 
 
 @then('Expected multiple lines in output')
 def step_impl(context):
-    assert context.text in context.stdout
+    assert_in(context.text, context.stdout)
     context.stdout = None
 
 
 @then('Except "{msg}" in stderr')
 def step_impl(context, msg):
-    assert msg in context.stderr
+    assert_in(msg, context.stderr)
     context.stderr = None
 
 

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -6,7 +6,8 @@ import yaml
 
 import behave
 from behave import given, when, then
-from crmsh import corosync, parallax, sbd, userdir, bootstrap
+import behave_agent
+from crmsh import corosync, sbd, userdir, bootstrap
 from crmsh import utils as crmutils
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
                   run_command_local_or_remote, file_in_archive, \
@@ -445,32 +446,31 @@ def step_impl(context):
             break
 
 
-@when('Run parallax call many times on "{node}"')
-def step_impl(context, node):
-    import resource
-    resource.setrlimit(resource.RLIMIT_NOFILE, (50, 50))
-    for i in range(51):
-        parallax.parallax_call([node], "true")
-
-
 @then('File "{path}" exists on "{node}"')
 def step_impl(context, path, node):
-    parallax.parallax_call([node], 'sudo test -f {}'.format(path))
+    rc, _, stderr = behave_agent.call(node, 1122, 'test -f {}'.format(path), user='root')
+    assert rc == 0
 
 
 @then('File "{path}" not exist on "{node}"')
 def step_impl(context, path, node):
-    parallax.parallax_call([node], '[ ! -f {} ]'.format(path))
+    cmd = '[ ! -f {} ]'.format(path)
+    rc, _, stderr = behave_agent.call(node, 1122, cmd, user='root')
+    assert rc == 0
 
 
 @then('Directory "{path}" is empty on "{node}"')
 def step_impl(context, path, node):
-    parallax.parallax_call([node], '[ ! "$(ls -A {})" ]'.format(path))
+    cmd = '[ ! "$(ls -A {})" ]'.format(path)
+    rc, _, stderr = behave_agent.call(node, 1122, cmd, user='root')
+    assert rc == 0
 
 
 @then('Directory "{path}" not empty on "{node}"')
 def step_impl(context, path, node):
-    parallax.parallax_call([node], '[ "$(ls -A {})" ]'.format(path))
+    cmd = '[ "$(ls -A {})" ]'.format(path)
+    rc, _, stderr = behave_agent.call(node, 1122, cmd, user='root')
+    assert rc == 0
 
 
 @then('Node "{node}" is UNCLEAN')

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -167,3 +167,10 @@ def assert_eq(expected, actual):
             except Exception:
                 pass
         raise AssertionError(msg)
+
+def assert_in(expected, actual):
+    if expected not in actual:
+        msg = "\033[32m" "Expected" "\033[31m" " not in Actual" "\033[0m" "\n" \
+              "\033[32m" "Expected:" "\033[0m" " {}\n" \
+              "\033[31m" "Actual:" "\033[0m" " {}".format(expected, actual)
+        raise AssertionError(msg)

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"liangxin1300/haleap:15.5"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:15.5"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
 DOCKER_SERVICE="docker.service"

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -24,4 +24,9 @@ RUN echo "$ssh_prv_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
 RUN echo "$ssh_pub_key" > /root/.ssh/id_rsa.pub && chmod 600 /root/.ssh/id_rsa.pub
 RUN echo "$ssh_pub_key" > /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys
 
+COPY behave_agent.py /opt
+COPY behave-agent.socket /etc/systemd/system
+COPY behave-agent@.service /etc/systemd/system
+RUN systemctl enable behave-agent.socket
+
 CMD ["/usr/lib/systemd/systemd", "--system"]

--- a/test_container/behave-agent.socket
+++ b/test_container/behave-agent.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=behave test agent
+
+[Socket]
+ListenStream=1122
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/test_container/behave-agent@.service
+++ b/test_container/behave-agent@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=behave test agent
+CollectMode=inactive-or-failed
+
+[Service]
+ExecStart=/opt/behave_agent.py
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal

--- a/test_container/behave_agent.py
+++ b/test_container/behave_agent.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+import io
+import os
+import pwd
+import socket
+import struct
+import subprocess
+
+
+MSG_EOF  = 0
+MSG_USER = 1
+MSG_CMD  = 2
+MSG_OUT  = 4 
+MSG_ERR  = 5
+MSG_RC   = 6
+
+
+class Message:
+    @staticmethod
+    def write(output, type: int, data: bytes):
+        output.write(struct.pack('!ii', type, len(data)))
+        output.write(data)
+
+    @staticmethod
+    def read(input):
+        buf = input.read(8)
+        type, length = struct.unpack('!ii', buf)
+        if length > 0:
+            buf = input.read(length)
+        else:
+            buf = b''
+        return type, buf
+
+
+class SocketIO(io.RawIOBase):
+    def __init__(self, s: socket.socket):
+        self._socket = s
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return True
+
+    def read(self, __size: int = -1) -> bytes:
+        return self._socket.recv(__size)
+
+    def readinto(self, __buffer) -> int:
+        return self._socket.recv_into(__buffer)
+
+    def readall(self) -> bytes:
+        raise NotImplementedError
+
+    def write(self, __b) -> int:
+        return self._socket.send(__b)
+
+
+def call(host: str, port: int, cmdline: str):
+    family, type, proto, _, sockaddr =  socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)[0]
+    with socket.socket(family, type, proto) as s:
+        s.connect(sockaddr)
+        sout = io.BufferedWriter(SocketIO(s), 4096)
+        Message.write(sout, MSG_USER, _getuser().encode('utf-8'))
+        Message.write(sout, MSG_CMD, cmdline.encode('utf-8'))
+        Message.write(sout, MSG_EOF, b'')
+        sout.flush()
+        s.shutdown(socket.SHUT_WR)
+        rc = None
+        stdout = []
+        stderr = []
+        sin = io.BufferedReader(SocketIO(s), 4096)
+        while True:
+            type, buf = Message.read(sin)
+            if type == MSG_OUT:
+                stdout.append(buf)
+            elif type == MSG_ERR:
+                stderr.append(buf)
+            elif type == MSG_RC:
+                rc, = struct.unpack('!i', buf)
+            elif type == MSG_EOF:
+                s.shutdown(socket.SHUT_RD)
+                assert rc is not None
+                return rc, b''.join(stdout), b''.join(stderr)
+            else:
+                raise ValueError(f"Unknown message type: {type}")
+
+
+def serve(stdin, stdout, stderr):
+    assert os.geteuid() == 0
+    user = None
+    cmd = None
+    sin = io.BufferedReader(stdin)
+    while True:
+        type, buf = Message.read(sin)
+        if type == MSG_USER:
+            user = buf.decode('utf-8')
+        elif type == MSG_CMD:
+            cmd = buf.decode('utf-8')
+        elif type == MSG_EOF:
+            assert user is not None
+            assert cmd is not None
+            break
+        else:
+            raise ValueError(f"Unknown message type: {type}")
+    if user == 'root':
+        args = ['/bin/sh']
+    else:
+        args = ['/bin/su', '-', user, '-c', '/bin/sh']
+    result = subprocess.run(
+        args,
+        input=cmd.encode('utf-8'),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    sout = io.BufferedWriter(stdout)
+    Message.write(sout, MSG_RC, struct.pack('!i', result.returncode))
+    Message.write(sout, MSG_OUT, result.stdout)
+    Message.write(sout, MSG_ERR, result.stderr)
+    Message.write(sout, MSG_EOF, b'')
+    stdout.flush()
+
+
+def _getuser():
+    return pwd.getpwuid(os.geteuid()).pw_name
+
+
+if __name__ == '__main__':
+    with open(0, 'rb') as stdin, \
+         open(1, 'wb') as stdout, \
+         open(2, 'wb') as stderr:
+        serve(stdin, stdout, stderr)


### PR DESCRIPTION
# Background

It is expected that crmsh uses the current user only unless another user
is specified explicitly. However, the code in functional tests needs operate
with different users to cover different use cases, requiring a complex
procedure to choose a user.

# Changes

1. A standalone agent is used to running command in functional test. It is
used only in function test, so the test code and production code is decoupled.

    Close #1182.

2. With the above changes, the user-selecting procedure is simplified in
production code. And several subcommands are found depending on the old
procedure and falls back to sudoer user implicitly when the current user fails
to create ssh session. This implicit fallback behavior is removed, the affected
subcommands are:

    * `crm cluster init qdevice --qnetd-hostname <host>`
    * `crm cluster geo_join --cluster-node <host>`
    * `crm cluster geo_init_arbitrator --cluster-node <host>`