### PR TITLE
Fix: bootstrap: fix the validation of option -N and -c (bsc#1212436) 

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -95,9 +95,8 @@ class Context(object):
         self.watchdog = None
         self.no_overwrite_sshkey = None
         self.nic_list = []
-        self.node_list = []
+        self.user_at_node_list = []
         self.node_list_in_cluster = []
-        self.user_list = []
         self.current_user = None
         self.unicast = None
         self.multicast = None
@@ -117,7 +116,6 @@ class Context(object):
         self.use_cluster_lvm2 = None
         self.mount_point = None
         self.cluster_node = None
-        self.cluster_node_ip = None
         self.force = None
         self.arbitrator = None
         self.clusters = None
@@ -150,6 +148,7 @@ class Context(object):
         ctx = cls()
         for opt in vars(options):
             setattr(ctx, opt, getattr(options, opt))
+        ctx.initialize_user()
         return ctx
 
     def initialize_qdevice(self):
@@ -176,10 +175,18 @@ class Context(object):
                 mode=self.qdevice_heuristics_mode,
                 is_stage=self.stage == "qdevice")
 
-    def initialize_user(self, users_of_specified_hosts: str):
+    def initialize_user(self):
         """
         users_of_specified_hosts: 'not_specified', 'specified', 'no_hosts'
         """
+        if self.cluster_node is None and self.user_at_node_list is None:
+            users_of_specified_hosts = 'no_hosts'
+        elif self.cluster_node is not None and '@' in self.cluster_node:
+            users_of_specified_hosts = 'specified'
+        elif self.user_at_node_list is not None and any('@' in x for x in self.user_at_node_list):
+            users_of_specified_hosts = 'specified'
+        else:
+            users_of_specified_hosts = 'not_specified'
         sudoer = userdir.get_sudoer()
         has_sudoer = sudoer is not None
         if users_of_specified_hosts == 'specified':
@@ -214,48 +221,17 @@ class Context(object):
         """
         Validate -N/--nodes option
         """
-        if self.type == "join":
-            user, node = utils.parse_user_at_host(self.cluster_node)
-            if user is not None:
-                self.user_list = [user]
-                self.cluster_node = node
-                self.initialize_user(users_of_specified_hosts='specified')
-            else:
-                self.initialize_user(users_of_specified_hosts='not_specified')
-                self.user_list = [self.current_user]
-            self.node_list = [self.cluster_node]
-            return
-
-        if any('@' in user_node for user_node in self.node_list):
-            self.initialize_user(users_of_specified_hosts='specified')
-        elif len(self.node_list) == 0:
-            self.initialize_user(users_of_specified_hosts='no_hosts')
-        else:
-            self.initialize_user(users_of_specified_hosts='not_specified')
-        me = utils.this_node()
-        _node_list = []
-        _user_list = []
-        was_localhost_already = False
-        for user_node in self.node_list:
-            user, node = utils.parse_user_at_host(user_node)
-            if user is None:
-                user = self.current_user
-            if node == me:
-                if was_localhost_already:
-                    utils.fatal("Duplicated input for -N/--nodes option")
-                was_localhost_already = True
-                if user != self.current_user:
-                    utils.fatal("Overriding current user '{}' by '{}'. Ouch, don't do it.".format(
-                        self.current_user, user))
-            else:
-                _node_list.append(node)
-                _user_list.append(user)
-        self.node_list = _node_list
-        self.user_list = _user_list
-
-        if self.node_list and self.stage:
+        if self.user_at_node_list and self.stage:
             utils.fatal("Can't use -N/--nodes option and stage({}) together".format(self.stage))
-        for node in self.node_list:
+        me = utils.this_node()
+        was_localhost_already = False
+        li = [utils.parse_user_at_host(x) for x in self.user_at_node_list]
+        if utils.has_dup_value([node for user, node in li]):
+            utils.fatal("Duplicated host in -N/--nodes options.")
+        for user in (user for user, node in li if node == me and user is not None and user != self.current_user):
+            utils.fatal(f"Overriding current user '{self.current_user}' by '{user}'. Ouch, don't do it.")
+        self.user_at_node_list = [value for (user, node), value in zip(li, self.user_at_node_list) if node != me]
+        for user, node in (utils.parse_user_at_host(x) for x in self.user_at_node_list):
             utils.ping_node(node)
 
     def _validate_cluster_node(self):
@@ -263,13 +239,14 @@ class Context(object):
         Validate cluster_node on join side
         """
         if self.cluster_node and self.type == 'join':
+            user, node = _parse_user_at_host(self.cluster_node, None)
             try:
                 # self.cluster_node might be hostname or IP address
-                ip_addr = socket.gethostbyname(self.cluster_node)
+                ip_addr = socket.gethostbyname(node)
                 if utils.InterfacesInfo.ip_in_local(ip_addr):
                     utils.fatal("Please specify peer node's hostname or IP address")
             except socket.gaierror as err:
-                utils.fatal("\"{}\": {}".format(self.cluster_node, err))
+                utils.fatal("\"{}\": {}".format(node, err))
 
     def validate_option(self):
         """
@@ -292,8 +269,8 @@ class Context(object):
             self.skip_csync2 = utils.get_boolean(os.getenv("SKIP_CSYNC2_SYNC"))
         if self.skip_csync2 and self.stage:
             utils.fatal("-x option or SKIP_CSYNC2_SYNC can't be used with any stage")
-        self._validate_nodes_option()
         self._validate_cluster_node()
+        self._validate_nodes_option()
         self._validate_sbd_option()
 
     def init_sbd_manager(self):
@@ -477,17 +454,14 @@ def wait_for_cluster(timeout_ms=WAIT_TIMEOUT_MS_DEFAULT):
             sleep(2)
 
 
-def get_cluster_node_hostname():
+def get_node_canonical_hostname(host: str) -> str:
     """
-    Get the hostname of the cluster node
+    Get the canonical hostname of the cluster node
     """
-    peer_node = None
-    if _context.cluster_node:
-        rc, out, err = utils.get_stdout_stderr_auto_ssh_no_input(_context.cluster_node, 'crm_node --name')
-        if rc != 0:
-            utils.fatal(err)
-        peer_node = out
-    return peer_node
+    rc, out, err = utils.get_stdout_stderr_auto_ssh_no_input(host, 'crm_node --name')
+    if rc != 0:
+        utils.fatal(err)
+    return out
 
 
 def is_online():
@@ -499,18 +473,19 @@ def is_online():
         return False
 
     # if peer_node is None, this is in the init process
-    peer_node = get_cluster_node_hostname()
-    if peer_node is None:
+    if _context.cluster_node is None:
         return True
     # In join process
     # If the joining node is already online but can't find the init node
     # The communication IP maybe mis-configured
-    if not xmlutil.CrmMonXmlParser.is_node_online(peer_node):
+    user, cluster_node = _parse_user_at_host(_context.cluster_node, None)
+    cluster_node = get_node_canonical_hostname(cluster_node)
+    if not xmlutil.CrmMonXmlParser.is_node_online(cluster_node):
         shutil.copy(COROSYNC_CONF_ORIG, corosync.conf())
         sync_file(corosync.conf())
         utils.stop_service("corosync")
         print()
-        utils.fatal("Cannot see peer node \"{}\", please check the communication IP".format(peer_node))
+        utils.fatal("Cannot see peer node \"{}\", please check the communication IP".format(cluster_node))
     return True
 
 
@@ -844,39 +819,45 @@ def append_unique(fromfile, tofile, user=None, remote=None, from_local=False):
             append(fromfile, tofile, remote=remote)
 
 
+def _parse_user_at_host(s: str, default_user: str) -> typing.Tuple[str, str]:
+    user, host = utils.parse_user_at_host(s)
+    if user is None:
+        user = default_user
+    return user, host
+
+
 def init_ssh():
-    init_ssh_impl(_context.current_user, _context.node_list, _context.user_list)
-    if _context.node_list:
-        for node in _context.node_list:
+    user_host_list = [_parse_user_at_host(x, _context.current_user) for x in _context.user_at_node_list]
+    init_ssh_impl(_context.current_user, user_host_list)
+    if user_host_list:
+        for user, node in user_host_list:
             if utils.service_is_active("pacemaker.service", remote_addr=node):
                 utils.fatal("Cluster is currently active on {} - can't run".format(node))
 
 
-def init_ssh_impl(local_user: str, node_list: typing.List[str], user_list: typing.List[str]):
+def init_ssh_impl(local_user: str, user_node_list: typing.List[typing.Tuple[str, str]]):
     """ Configure passwordless SSH."""
     utils.start_service("sshd.service", enable=True)
     configure_ssh_key(local_user)
     configure_ssh_key('hacluster')
 
     # If not use -N/--nodes option
-    if not node_list:
+    if not user_node_list:
         return
 
     print()
     # Swap public ssh key between remote node and local
     public_key_list = list()
     hacluster_public_key_list = list()
-    for i, node in enumerate(node_list):
-        remote_user = user_list[i]
+    for i, (remote_user, node) in enumerate(user_node_list):
         utils.ssh_copy_id(local_user, remote_user, node)
         # After this, login to remote_node is passwordless
         public_key_list.append(swap_public_ssh_key(node, local_user, remote_user, local_user, remote_user, add=True))
         hacluster_public_key_list.append(swap_public_ssh_key(node, 'hacluster', 'hacluster', local_user, remote_user, add=True))
-    if len(node_list) > 1:
+    if len(user_node_list) > 1:
         shell_script = _merge_authorized_keys(public_key_list)
         hacluster_shell_script = _merge_authorized_keys(hacluster_public_key_list)
-        for i, node in enumerate(node_list):
-            remote_user = user_list[i]
+        for i, (remote_user, node) in enumerate(user_node_list):
             result = utils.su_subprocess_run(
                 local_user,
                 'ssh {} {}@{} /bin/sh'.format(constants.SSH_OPTION, remote_user, node),
@@ -896,11 +877,11 @@ def init_ssh_impl(local_user: str, node_list: typing.List[str], user_list: typin
             if result.returncode != 0:
                 utils.fatal('Failed to add public keys to {}@{}: {}'.format(remote_user, node, result.stdout))
     user_by_host = utils.HostUserConfig()
-    for user, node in zip(user_list, node_list):
+    for user, node in user_node_list:
         user_by_host.add(user, node)
     user_by_host.add(local_user, utils.this_node())
-    user_by_host.save_remote(node_list)
-    for node in node_list:
+    user_by_host.save_remote([node for user, node in user_node_list])
+    for user, node in user_node_list:
         change_user_shell('hacluster', node)
 
 
@@ -1182,9 +1163,9 @@ def init_csync2_remote():
     remote node to csync2 config on some existing node.  It is intentionally
     not documented in ha-cluster-init's user-visible usage information.
     """
-    newhost = _context.cluster_node
-    if not newhost:
+    if not _context.cluster_node:
         utils.fatal("Hostname not specified")
+    user, newhost = _parse_user_at_host(_context.cluster_node, _context.current_user)
 
     curr_cfg = open(CSYNC2_CFG).read()
 
@@ -1680,11 +1661,7 @@ def init():
     init_network()
 
 
-def join_ssh(seed_host):
-    join_ssh_impl(seed_host, _context.user_list[0])
-
-
-def join_ssh_impl(seed_host, seed_user):
+def join_ssh(seed_host, seed_user):
     """
     SSH configuration for joining node.
     """
@@ -1722,8 +1699,7 @@ def join_ssh_impl(seed_host, seed_user):
         local_user,
     )
     user_by_host = utils.HostUserConfig()
-    for user, node in zip(_context.user_list, _context.node_list):
-        user_by_host.add(user, node)
+    user_by_host.add(seed_user, seed_host)
     user_by_host.add(local_user, utils.this_node())
     user_by_host.save_local()
 
@@ -1775,7 +1751,7 @@ def remote_public_key_from(remote_user, local_sudoer, remote_node, remote_sudoer
     return result.stdout.decode('utf-8')
 
 
-def join_csync2(seed_host):
+def join_csync2(seed_host, remote_user):
     """
     Csync2 configuration for joining node.
     """
@@ -1791,7 +1767,6 @@ def join_csync2(seed_host):
     # local hosts_line=$(etc_hosts_get_me)
     # [ -n "$hosts_line" ] || error "No valid entry for $(hostname) in /etc/hosts - csync2 can't work"
 
-    remote_user = _context.user_list[0]
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
     cmd = "crm cluster init -i {} csync2_remote {}".format(_context.default_nic_list[0], utils.this_node())
@@ -1826,14 +1801,16 @@ def join_csync2(seed_host):
             logger.warning("csync2 run failed - some files may not be sync'd: %s", stderr)
 
 
-def join_ssh_merge(_cluster_node):
+def join_ssh_merge(cluster_node, remote_user):
     """
     Ensure known_hosts is the same in all nodes
     """
     logger.info("Merging known_hosts")
 
-    hosts = [utils.this_node()] + _context.node_list_in_cluster
-    users = [_context.current_user] + _context.user_list
+    hosts = utils.list_cluster_nodes()
+    if hosts is None:
+        hosts = list()
+    hosts.append(cluster_node)
 
     # To create local entry in known_hosts
     rc, _, _ = utils.get_stdout_stderr_as_local_sudoer("ssh {} {} true".format(SSH_OPTION, utils.this_node()))
@@ -1851,8 +1828,8 @@ def join_ssh_merge(_cluster_node):
     if known_hosts_new:
         hoststxt = "\n".join(sorted(known_hosts_new))
         #results = parallax.parallax_copy(hosts, tmpf, known_hosts_path, strict=False)
-        for user, host in zip(users, hosts):
-            utils.write_remote_file(hoststxt, "~/.ssh/known_hosts", user, remote=host)
+        for host in hosts:
+            utils.write_remote_file(hoststxt, "~/.ssh/known_hosts", utils.user_of(host), remote=host)
 
 
 def update_expected_votes():
@@ -1934,14 +1911,13 @@ def update_expected_votes():
     sync_file(corosync.conf())
 
 
-def setup_passwordless_with_other_nodes(init_node):
+def setup_passwordless_with_other_nodes(init_node, remote_user):
     """
     Setup passwordless with other cluster nodes
 
     Should fetch the node list from init node, then swap the key
     """
     # Fetch cluster nodes list
-    remote_user = _context.user_list[0]
     local_user = _context.current_user
     cmd = f'ssh {SSH_OPTION} {remote_user}@{init_node} sudo crm_node -l'
     rc, out, err = utils.su_get_stdout_stderr(local_user, cmd)
@@ -2021,7 +1997,7 @@ def sync_files_to_disk():
         utils.cluster_run_cmd("sync {}".format(files_string.strip()))
 
 
-def join_cluster(seed_host):
+def join_cluster(seed_host, remote_user):
     """
     Cluster configuration for joining node.
     """
@@ -2064,8 +2040,7 @@ def join_cluster(seed_host):
     # mountpoints for clustered filesystems.  Unfortunately we don't have
     # that yet, so the following crawling horror takes a punt on the seed
     # node being up, then asks it for a list of mountpoints...
-    remote_user = _context.user_list[0]
-    if _context.cluster_node:
+    if seed_host:
         _rc, outp, _ = utils.get_stdout_stderr_auto_ssh_no_input(seed_host, "cibadmin -Q --xpath \"//primitive\"")
         if outp:
             xml = etree.fromstring(outp)
@@ -2233,7 +2208,7 @@ def start_qdevice_on_join_node(seed_host):
         utils.start_service("corosync-qdevice.service", enable=True)
 
 
-def set_cluster_node_ip():
+def get_cluster_node_ip(node: str) -> str:
     """
     ringx_addr might be hostname or IP
     _context.cluster_node by now is always hostname
@@ -2242,7 +2217,6 @@ def set_cluster_node_ip():
     Then filter out which one is configured as ring0_addr
     At last assign that ip to _context.cluster_node_ip which will be removed later
     """
-    node = _context.cluster_node
     addr_list = corosync.get_values('nodelist.node.ring0_addr')
     if node in addr_list:
         return
@@ -2250,8 +2224,7 @@ def set_cluster_node_ip():
     ip_list = utils.get_iplist_from_name(node)
     for ip in ip_list:
         if ip in addr_list:
-            _context.cluster_node_ip = ip
-            break
+            return ip
 
 
 def stop_services(stop_list, remote_addr=None):
@@ -2276,13 +2249,11 @@ def rm_configuration_files(remote=None):
         utils.get_stdout_or_raise_error(cmd, remote=remote)
 
 
-def remove_node_from_cluster():
+def remove_node_from_cluster(node):
     """
     Remove node from running cluster and the corosync / pacemaker configuration.
     """
-    node = _context.cluster_node
-    set_cluster_node_ip()
-
+    node_ip = get_cluster_node_ip(node)
     stop_services(SERVICES_STOP_LIST, remote_addr=node)
     qdevice.QDevice.remove_qdevice_db([node])
     rm_configuration_files(node)
@@ -2297,8 +2268,7 @@ def remove_node_from_cluster():
 
     # Remove node from nodelist
     if corosync.get_values("nodelist.node.ring0_addr"):
-        del_target = _context.cluster_node_ip or node
-        corosync.del_node(del_target)
+        corosync.del_node(node_ip if node_ip is not None else node)
 
     decrease_expected_votes()
 
@@ -2424,7 +2394,7 @@ def bootstrap_add(context):
     """
     Adds the given node to the cluster.
     """
-    if not context.node_list:
+    if not context.user_at_node_list:
         return
 
     global _context
@@ -2435,7 +2405,7 @@ def bootstrap_add(context):
         options += '-i {} '.format(nic)
     options = " {}".format(options.strip()) if options else ""
 
-    for (user, node) in zip(_context.user_list, _context.node_list):
+    for (user, node) in (_parse_user_at_host(x, _context.current_user) for x in _context.user_at_node_list):
         print()
         logger.info("Adding node {} to cluster".format(node))
         cmd = 'crm cluster join -y {} -c {}@{}'.format(options, _context.current_user, utils.this_node())
@@ -2463,11 +2433,11 @@ def bootstrap_join(context):
     if not check_prereqs("join"):
         return
 
-    cluster_node = _context.cluster_node
     if _context.stage != "":
-        globals()["join_" + _context.stage](cluster_node)
+        remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
+        globals()["join_" + _context.stage](cluster_node, remote_user)
     else:
-        if not _context.yes_to_all and cluster_node is None:
+        if not _context.yes_to_all and _context.cluster_node is None:
             logger.info("""Join This Node to Cluster:
   You will be asked for the IP address of an existing node, from which
   configuration will be copied.  If you have not already configured
@@ -2475,15 +2445,17 @@ def bootstrap_join(context):
   password of the existing node.
 """)
             # TODO: prompt for user@host
-            cluster_node = prompt_for_string("IP address or hostname of existing node (e.g.: 192.168.1.1)", ".+")
-            _context.cluster_node = cluster_node
+            cluster_user_at_node = prompt_for_string("IP address or hostname of existing node (e.g.: 192.168.1.1)", ".+")
+            _context.cluster_node = cluster_user_at_node
+            _context.initialize_user()
 
         init_upgradeutil()
+        remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
         utils.ping_node(cluster_node)
 
-        join_ssh_impl(cluster_node, _context.user_list[0])
-
+        join_ssh(cluster_node, remote_user)
         remote_user = utils.user_of(cluster_node)
+
         n = 0
         while n < REJOIN_COUNT:
             if utils.service_is_active("pacemaker.service", cluster_node):
@@ -2498,19 +2470,19 @@ def bootstrap_join(context):
         try:
             with lock_inst.lock():
                 _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(cluster_node)
-                setup_passwordless_with_other_nodes(cluster_node)
-                join_remote_auth(cluster_node)
+                setup_passwordless_with_other_nodes(cluster_node, remote_user)
+                join_remote_auth(cluster_node, remote_user)
                 _context.skip_csync2 = not utils.service_is_active(CSYNC2_SERVICE, cluster_node)
                 if _context.skip_csync2:
                     utils.stop_service(CSYNC2_SERVICE, disable=True)
                     retrieve_all_config_files(cluster_node)
                     logger.warning("csync2 is not initiated yet. Before using csync2 for the first time, please run \"crm cluster init csync2 -y\" on any one node. Note, this may take a while.")
                 else:
-                    join_csync2(cluster_node)
-                join_ssh_merge(cluster_node)
+                    join_csync2(cluster_node, remote_user)
+                join_ssh_merge(cluster_node, remote_user)
                 probe_partitions()
-                join_ocfs2(cluster_node)
-                join_cluster(cluster_node)
+                join_ocfs2(cluster_node, remote_user)
+                join_cluster(cluster_node, remote_user)
         except (lock.SSHError, lock.ClaimLockError) as err:
             utils.fatal(err)
 
@@ -2521,7 +2493,7 @@ def bootstrap_finished():
     logger.info("Done (log saved to %s)" % (log.CRMSH_LOG_FILE))
 
 
-def join_ocfs2(peer_host):
+def join_ocfs2(peer_host, peer_user):
     """
     If init node configured OCFS2 device, verify that device on join node
     """
@@ -2529,7 +2501,7 @@ def join_ocfs2(peer_host):
     ocfs2_inst.join_ocfs2(peer_host)
 
 
-def join_remote_auth(node):
+def join_remote_auth(node, user):
     if os.path.exists(PCMK_REMOTE_AUTH):
         utils.rmfile(PCMK_REMOTE_AUTH)
     pcmk_remote_dir = os.path.dirname(PCMK_REMOTE_AUTH)
@@ -2603,31 +2575,33 @@ def bootstrap_remove(context):
   executed from a different node in the cluster.
 """)
         _context.cluster_node = prompt_for_string("IP address or hostname of cluster node (e.g.: 192.168.1.1)", ".+")
+        _context.initialize_user()
 
     if not _context.cluster_node:
         utils.fatal("No existing IP/hostname specified (use -c option)")
 
-    _context.cluster_node = get_cluster_node_hostname()
+    remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
+    cluster_node = get_node_canonical_hostname(cluster_node)
 
-    if not force_flag and not confirm("Removing node \"{}\" from the cluster: Are you sure?".format(_context.cluster_node)):
+    if not force_flag and not confirm("Removing node \"{}\" from the cluster: Are you sure?".format(cluster_node)):
         return
 
-    if _context.cluster_node == utils.this_node():
+    if cluster_node == utils.this_node():
         if not force_flag:
             utils.fatal("Removing self requires --force")
         remove_self(force_flag)
-    elif _context.cluster_node in xmlutil.listnodes():
-        remove_node_from_cluster()
+    elif cluster_node in xmlutil.listnodes():
+        remove_node_from_cluster(cluster_node)
     else:
-        utils.fatal("Specified node {} is not configured in cluster! Unable to remove.".format(_context.cluster_node))
+        utils.fatal("Specified node {} is not configured in cluster! Unable to remove.".format(cluster_node))
 
     # In case any crm command can re-generate upgrade_seq again
-    utils.get_stdout_or_raise_error("rm -rf /var/lib/crmsh", _context.cluster_node)
+    utils.get_stdout_or_raise_error("rm -rf /var/lib/crmsh", cluster_node)
     bootstrap_finished()
 
 
 def remove_self(force_flag=False):
-    me = _context.cluster_node
+    me = utils.this_node()
     yes_to_all = _context.yes_to_all
     nodes = xmlutil.listnodes(include_remote_nodes=False)
     othernode = next((x for x in nodes if x != me), None)
@@ -2821,13 +2795,12 @@ def bootstrap_arbitrator(context):
     """
     global _context
     _context = context
-    node = _context.cluster_node
 
     init_common_geo()
     check_tty()
-    geo_fetch_config(node)
+    geo_fetch_config(_context.cluster_node)
     if not os.path.isfile(BOOTH_CFG):
-        utils.fatal("Failed to copy {} from {}".format(BOOTH_CFG, node))
+        utils.fatal("Failed to copy {} from {}".format(BOOTH_CFG, _context.cluster_node))
     # TODO: verify that the arbitrator IP in the configuration is us?
     logger.info("Enabling and starting the booth arbitrator service")
     utils.start_service("booth@booth", enable=True)

--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -148,8 +148,10 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
         remote_nodes.remove(local_node)
         remote_nodes = list(remote_nodes)
         local_user = crmsh.utils.user_pair_for_ssh(remote_nodes[0])[0]
-        remote_users = [crmsh.utils.user_pair_for_ssh(node)[1] for node in remote_nodes]
-        crmsh.bootstrap.init_ssh_impl(local_user, remote_nodes, remote_users)
+        crmsh.bootstrap.init_ssh_impl(
+            local_user,
+            [(crmsh.utils.user_pair_for_ssh(node)[1], node) for node in remote_nodes],
+        )
 
 
 def main_check_local(args) -> int:

--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -123,7 +123,9 @@ def upgrade_if_needed():
     if not crmsh.utils.can_ask(background_wait=False):
         return
     nodes = crmsh.utils.list_cluster_nodes(no_reg=True)
-    if nodes and _is_upgrade_needed(nodes) and not crmsh.utils.check_passwordless_between_nodes(nodes):
+    if nodes is not None and len(nodes) > 1 \
+            and _is_upgrade_needed(nodes) \
+            and not crmsh.utils.check_passwordless_between_nodes(nodes):
         logger.debug("upgradeutil: configuration fix needed")
         try:
             if not _is_cluster_target_seq_consistent(nodes):

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -69,7 +69,7 @@ optional arguments:
                         destructive, especially those storage related
                         configurations and stages.)
   -n NAME, --name NAME  Set the name of the configured cluster.
-  -N NODENAME, --node NODENAME
+  -N [USER@]HOST, --node [USER@]HOST
                         The member node of the cluster. Note: the current node
                         is always get initialized during bootstrap in the
                         beginning.
@@ -285,8 +285,8 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution)
-  -a IP, --arbitrator IP
-                        IP address of geo cluster arbitrator
+  -a [USER@]HOST, --arbitrator [USER@]HOST
+                        Geo cluster arbitrator
   -s DESC, --clusters DESC
                         Geo cluster description (see details below)
   -t LIST, --tickets LIST
@@ -325,9 +325,8 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution)
-  -c IP, --cluster-node IP
-                        IP address of an already-configured geo cluster or
-                        arbitrator
+  -c [USER@]HOST, --cluster-node [USER@]HOST
+                        An already-configured geo cluster or arbitrator
   -s DESC, --clusters DESC
                         Geo cluster description (see geo-init for details)'''
 
@@ -344,5 +343,5 @@ optional arguments:
   -h, --help            Show this help message
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution)
-  -c IP, --cluster-node IP
-                        IP address of an already-configured geo cluster'''
+  -c [USER@]HOST, --cluster-node [USER@]HOST
+                        An already-configured geo cluster'''

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -136,7 +136,7 @@ class TestContext(unittest.TestCase):
     @mock.patch('socket.gethostbyname')
     @mock.patch('crmsh.utils.InterfacesInfo.ip_in_local')
     def test_validate_cluster_node_same_name(self, mock_ip_in_local, mock_gethost, mock_fatal):
-        options = mock.Mock(cluster_node="me", type="join")
+        options = mock.Mock(cluster_user_at_node="me", type="join")
         ctx = self.ctx_inst.set_context(options)
         mock_fatal.side_effect = SystemExit
         mock_gethost.return_value = ("10.10.10.41", None)
@@ -148,7 +148,7 @@ class TestContext(unittest.TestCase):
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('socket.gethostbyname')
     def test_validate_cluster_node_unknown_name(self, mock_gethost, mock_fatal):
-        options = mock.Mock(cluster_node="xxxx", type="join")
+        options = mock.Mock(cluster_user_at_node="xxxx", type="join")
         ctx = self.ctx_inst.set_context(options)
         mock_fatal.side_effect = SystemExit
         mock_gethost.side_effect = socket.gaierror("gethostbyname error")
@@ -319,7 +319,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.configure_ssh_key')
     @mock.patch('crmsh.utils.start_service')
     def test_init_ssh(self, mock_start_service, mock_config_ssh):
-        bootstrap._context = mock.Mock(current_user="alice", node_list=[])
+        bootstrap._context = mock.Mock(current_user="alice", user_at_node_list=[])
         bootstrap.init_ssh()
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
         mock_config_ssh.assert_has_calls([
@@ -435,7 +435,7 @@ class TestBootstrap(unittest.TestCase):
     def test_join_ssh_no_seed_host(self, mock_error):
         mock_error.side_effect = ValueError
         with self.assertRaises(ValueError):
-            bootstrap.join_ssh_impl(None, None)
+            bootstrap.join_ssh(None, None)
         mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
 
     @mock.patch('crmsh.bootstrap.change_user_shell')
@@ -450,7 +450,7 @@ class TestBootstrap(unittest.TestCase):
         mock_swap.return_value = None
         mock_ssh_copy_id.return_value = 0
 
-        bootstrap.join_ssh_impl("node1", "alice")
+        bootstrap.join_ssh("node1", "alice")
 
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
         mock_config_ssh.assert_has_calls([
@@ -480,7 +480,7 @@ class TestBootstrap(unittest.TestCase):
         mock_ssh_copy_id.return_value = 255
 
         with self.assertRaises(ValueError):
-            bootstrap.join_ssh_impl("node1", "alice")
+            bootstrap.join_ssh("node1", "alice")
 
         mock_start_service.assert_called_once_with("sshd.service", enable=True)
         mock_config_ssh.assert_has_calls([
@@ -519,7 +519,7 @@ class TestBootstrap(unittest.TestCase):
 
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add_return(self, mock_this_node):
-        ctx = mock.Mock(node_list=[])
+        ctx = mock.Mock(user_at_node_list=[])
         bootstrap.bootstrap_add(ctx)
         mock_this_node.assert_not_called()
 
@@ -527,7 +527,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add(self, mock_this_node, mock_info, mock_run):
-        ctx = mock.Mock(current_user="alice", user_list=["bob", "carol"], node_list=["node2", "node3"], nic_list=["eth1"])
+        ctx = mock.Mock(current_user="alice", user_at_node_list=["bob@node2", "carol@node3"], nic_list=["eth1"])
         mock_this_node.return_value = "node1"
         bootstrap.bootstrap_add(ctx)
         mock_info.assert_has_calls([
@@ -540,12 +540,12 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.su_get_stdout_stderr')
     def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
-        bootstrap._context = mock.Mock(user_list=["alice"], current_user="carol")
+        bootstrap._context = mock.Mock(current_user="carol")
         mock_run.return_value = (1, None, None)
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap.setup_passwordless_with_other_nodes("node1")
+            bootstrap.setup_passwordless_with_other_nodes("node1", "alice")
 
         mock_run.assert_called_once_with('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION))
         mock_error.assert_called_once_with("Can't fetch cluster nodes list from node1: None")
@@ -561,7 +561,7 @@ class TestBootstrap(unittest.TestCase):
             mock_host_user_config_class,
             mock_error,
     ):
-        bootstrap._context = mock.Mock(user_list=["alice"], current_user="carol")
+        bootstrap._context = mock.Mock(current_user="carol")
         out_node_list = """1 node1 member
         2 node2 member"""
         mock_run.side_effect = [
@@ -572,7 +572,7 @@ class TestBootstrap(unittest.TestCase):
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap.setup_passwordless_with_other_nodes("node1")
+            bootstrap.setup_passwordless_with_other_nodes("node1", "alice")
 
         mock_run.assert_has_calls([
             mock.call('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION)),
@@ -609,7 +609,7 @@ class TestBootstrap(unittest.TestCase):
                 (0, "node1", None)
                 ]
 
-        bootstrap.setup_passwordless_with_other_nodes("node1")
+        bootstrap.setup_passwordless_with_other_nodes("node1", "alice")
 
         mock_run.assert_has_calls([
             mock.call('carol', 'ssh {} alice@node1 sudo crm_node -l'.format(constants.SSH_OPTION)),
@@ -664,52 +664,51 @@ class TestBootstrap(unittest.TestCase):
         mock_append.assert_called_once_with("/home/alice/.ssh/id_rsa.pub", "/home/alice/.ssh/authorized_keys")
 
     @mock.patch('crmsh.utils.get_stdout_stderr_auto_ssh_no_input')
-    def test_get_cluster_node_hostname(self, mock_run):
-        bootstrap._context = mock.Mock(cluster_node="node1")
+    def test_get_node_canonical_hostname(self, mock_run):
         mock_run.return_value = (0, "Node1", None)
 
-        peer_node = bootstrap.get_cluster_node_hostname()
+        peer_node = bootstrap.get_node_canonical_hostname('node1')
         self.assertEqual('Node1', peer_node)
         mock_run.assert_called_once_with('node1', 'crm_node --name')
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.get_stdout_stderr_auto_ssh_no_input')
-    def test_get_cluster_node_hostname_error(self, mock_run, mock_error):
-        bootstrap._context = mock.Mock(cluster_node="node1")
+    def test_get_node_canonical_hostname_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap.get_cluster_node_hostname()
+            bootstrap.get_node_canonical_hostname('node1')
 
         mock_run.assert_called_once_with("node1", "crm_node --name")
         mock_error.assert_called_once_with("error")
 
     @mock.patch('crmsh.utils.this_node')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
-    def test_is_online_local_offline(self, mock_is_online, mock_get_peer, mock_this_node):
+    def test_is_online_local_offline(self, mock_is_online, mock_get_hostname, mock_this_node):
+        bootstrap._context = mock.Mock(cluster_user_at_node='node2')
         mock_this_node.return_value = "node1"
         mock_is_online.return_value = False
 
         assert bootstrap.is_online() is False
 
         mock_this_node.assert_called_once_with()
-        mock_get_peer.assert_not_called()
+        mock_get_hostname.assert_not_called()
         mock_is_online.assert_called_once_with("node1")
 
     @mock.patch('crmsh.utils.this_node')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
-    def test_is_online_on_init_node(self, mock_is_online, mock_get_peer, mock_this_node):
+    def test_is_online_on_init_node(self, mock_is_online, mock_get_hostname, mock_this_node):
+        bootstrap._context = mock.Mock(cluster_user_at_node=None)
         mock_this_node.return_value = "node1"
-        mock_get_peer.return_value = None
         mock_is_online.return_value = True
 
         assert bootstrap.is_online() is True
 
         mock_this_node.assert_called_once_with()
-        mock_get_peer.assert_called_once_with()
+        mock_get_hostname.assert_not_called()
         mock_is_online.assert_called_once_with("node1")
 
     @mock.patch('crmsh.utils.fatal')
@@ -718,21 +717,22 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.corosync.conf')
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
-    def test_is_online_peer_offline(self, mock_is_online, mock_get_peer, mock_this_node,
+    def test_is_online_peer_offline(self, mock_is_online, mock_get_hostname, mock_this_node,
             mock_copy, mock_corosync_conf, mock_csync2, mock_stop_service, mock_error):
+        bootstrap._context = mock.Mock(cluster_user_at_node='node1')
         mock_is_online.side_effect = [True, False]
         bootstrap.COROSYNC_CONF_ORIG = "/tmp/crmsh_tmpfile"
         mock_this_node.return_value = "node2"
-        mock_get_peer.return_value = "node1"
+        mock_get_hostname.return_value = "node1"
         mock_corosync_conf.side_effect = [ "/etc/corosync/corosync.conf",
                 "/etc/corosync/corosync.conf"]
 
         bootstrap.is_online()
 
         mock_this_node.assert_called_once_with()
-        mock_get_peer.assert_called_once_with()
+        mock_get_hostname.assert_called_once_with('node1')
         mock_corosync_conf.assert_has_calls([
             mock.call(),
             mock.call()
@@ -748,18 +748,19 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.corosync.conf')
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
-    def test_is_online_both_online(self, mock_is_online, mock_get_peer, mock_this_node,
+    def test_is_online_both_online(self, mock_is_online, mock_get_hostname, mock_this_node,
             mock_copy, mock_corosync_conf, mock_csync2, mock_stop_service, mock_error):
+        bootstrap._context = mock.Mock(cluster_user_at_node='node2')
         mock_is_online.side_effect = [True, True]
         mock_this_node.return_value = "node2"
-        mock_get_peer.return_value = "node1"
+        mock_get_hostname.return_value = "node2"
 
         assert bootstrap.is_online() is True
 
         mock_this_node.assert_called_once_with()
-        mock_get_peer.assert_called_once_with()
+        mock_get_hostname.assert_called_once_with('node2')
         mock_corosync_conf.assert_not_called()
         mock_copy.assert_not_called()
         mock_csync2.assert_not_called()
@@ -1331,7 +1332,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_qdevice(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice):
-        mock_context_inst = mock.Mock(qdevice=True, cluster_node=None)
+        mock_context_inst = mock.Mock(qdevice=True, cluster_user_at_node=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
 
@@ -1371,7 +1372,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_no_cluster_node(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_status, mock_prompt):
-        mock_context_inst = mock.Mock(yes_to_all=False, cluster_node=None, qdevice_rm_flag=None)
+        mock_context_inst = mock.Mock(yes_to_all=False, cluster_user_at_node=None, qdevice_rm_flag=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
         mock_prompt.return_value = None
@@ -1391,7 +1392,7 @@ class TestValidation(unittest.TestCase):
         mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
 
     @mock.patch('crmsh.bootstrap.confirm')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.remove_qdevice')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.service_is_active')
@@ -1399,7 +1400,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_no_confirm(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_hostname, mock_confirm):
-        mock_context_inst = mock.Mock(cluster_node="node1", force=False, qdevice_rm_flag=None)
+        mock_context_inst = mock.Mock(cluster_user_at_node="node1", force=False, qdevice_rm_flag=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
         mock_hostname.return_value = "node1"
@@ -1414,12 +1415,12 @@ class TestValidation(unittest.TestCase):
             ])
         mock_qdevice.assert_not_called()
         mock_error.assert_not_called()
-        mock_hostname.assert_called_once_with()
+        mock_hostname.assert_called_once_with('node1')
         mock_confirm.assert_called_once_with('Removing node "node1" from the cluster: Are you sure?')
 
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.remove_qdevice')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.service_is_active')
@@ -1427,7 +1428,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_self_need_force(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node):
-        mock_context_inst = mock.Mock(cluster_node="node1", force=False, qdevice_rm_flag=None)
+        mock_context_inst = mock.Mock(cluster_user_at_node="node1", force=False, qdevice_rm_flag=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
         mock_hostname.return_value = "node1"
@@ -1444,7 +1445,7 @@ class TestValidation(unittest.TestCase):
             mock.call("csync2.socket")
             ])
         mock_qdevice.assert_not_called()
-        mock_hostname.assert_called_once_with()
+        mock_hostname.assert_called_once_with('node1')
         mock_confirm.assert_called_once_with('Removing node "node1" from the cluster: Are you sure?')
         mock_this_node.assert_called_once_with()
         mock_error.assert_called_once_with("Removing self requires --force")
@@ -1453,7 +1454,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.remove_self')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.remove_qdevice')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.service_is_active')
@@ -1461,7 +1462,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_self(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node, mock_self, mock_run):
-        mock_context_inst = mock.Mock(cluster_node="node1", force=True, qdevice_rm_flag=None)
+        mock_context_inst = mock.Mock(cluster_user_at_node="node1", force=True, qdevice_rm_flag=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
         mock_hostname.return_value = "node1"
@@ -1475,7 +1476,7 @@ class TestValidation(unittest.TestCase):
             mock.call("csync2.socket")
             ])
         mock_qdevice.assert_not_called()
-        mock_hostname.assert_called_once_with()
+        mock_hostname.assert_called_once_with('node1')
         mock_confirm.assert_not_called()
         mock_this_node.assert_called_once_with()
         mock_error.assert_not_called()
@@ -1485,7 +1486,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.xmlutil.listnodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.remove_qdevice')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.service_is_active')
@@ -1493,7 +1494,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.Context')
     def test_bootstrap_remove_not_in_cluster(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node, mock_list):
-        mock_context_inst = mock.Mock(cluster_node="node2", force=True, qdevice_rm_flag=None)
+        mock_context_inst = mock.Mock(cluster_user_at_node="node2", force=True, qdevice_rm_flag=None)
         mock_context.return_value = mock_context_inst
         mock_active.return_value = [True, True]
         mock_hostname.return_value = "node2"
@@ -1510,7 +1511,7 @@ class TestValidation(unittest.TestCase):
             mock.call("csync2.socket")
             ])
         mock_qdevice.assert_not_called()
-        mock_hostname.assert_called_once_with()
+        mock_hostname.assert_called_once_with('node2')
         mock_confirm.assert_not_called()
         mock_this_node.assert_called_once_with()
         mock_error.assert_called_once_with("Specified node node2 is not configured in cluster! Unable to remove.")
@@ -1521,7 +1522,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.xmlutil.listnodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_hostname')
+    @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.remove_qdevice')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.service_is_active')
@@ -1530,7 +1531,7 @@ class TestValidation(unittest.TestCase):
     def test_bootstrap_remove(self, mock_context, mock_init, mock_active,
             mock_error, mock_qdevice, mock_hostname, mock_confirm, mock_this_node,
             mock_list, mock_remove, mock_fetch, mock_run):
-        mock_context_inst = mock.Mock(cluster_node="node2", qdevice_rm_flag=None, force=True)
+        mock_context_inst = mock.Mock(cluster_user_at_node="node2", qdevice_rm_flag=None, force=True)
         mock_context.return_value = mock_context_inst
         mock_active.side_effect = [True, False]
         mock_hostname.return_value = "node2"
@@ -1546,22 +1547,24 @@ class TestValidation(unittest.TestCase):
             mock.call("csync2.socket")
             ])
         mock_qdevice.assert_not_called()
-        mock_hostname.assert_called_once_with()
+        mock_hostname.assert_called_once_with('node2')
         mock_confirm.assert_not_called()
         mock_error.assert_not_called()
-        mock_remove.assert_called_once_with()
+        mock_remove.assert_called_once_with('node2')
         mock_run.assert_called_once_with('rm -rf /var/lib/crmsh', 'node2')
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.get_stdout_stderr_auto_ssh_no_input')
     @mock.patch('crmsh.xmlutil.listnodes')
-    def test_remove_self_other_nodes(self, mock_list, mock_run, mock_error):
+    @mock.patch('crmsh.utils.this_node')
+    def test_remove_self_other_nodes(self, mock_this_node, mock_list, mock_run, mock_error):
+        mock_this_node.return_value = 'node1'
         mock_list.return_value = ["node1", "node2"]
         mock_run.return_value = (1, '', 'err')
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True)
+            bootstrap._context = mock.Mock(cluster_user_at_node="node1", yes_to_all=True)
             bootstrap.remove_self()
 
         mock_list.assert_called_once_with(include_remote_nodes=False)
@@ -1581,20 +1584,18 @@ class TestValidation(unittest.TestCase):
 
     @mock.patch('crmsh.utils.get_iplist_from_name')
     @mock.patch('crmsh.corosync.get_values')
-    def test_set_cluster_node_ip_host(self, mock_get_values, mock_get_iplist):
+    def test_get_cluster_node_ip_host(self, mock_get_values, mock_get_iplist):
         mock_get_values.return_value = ["node1", "node2"]
-        bootstrap._context = mock.Mock(cluster_node="node1")
-        bootstrap.set_cluster_node_ip()
+        self.assertIsNone(bootstrap.get_cluster_node_ip('node1'))
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
         mock_get_iplist.assert_not_called()
 
     @mock.patch('crmsh.utils.get_iplist_from_name')
     @mock.patch('crmsh.corosync.get_values')
-    def test_set_cluster_node_ip(self, mock_get_values, mock_get_iplist):
+    def test_get_cluster_node_ip(self, mock_get_values, mock_get_iplist):
         mock_get_values.return_value = ["10.10.10.1", "10.10.10.2"]
         mock_get_iplist.return_value = ["10.10.10.1"]
-        bootstrap._context = mock.Mock(cluster_node="node1")
-        bootstrap.set_cluster_node_ip()
+        self.assertEqual("10.10.10.1", bootstrap.get_cluster_node_ip('node1'))
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
         mock_get_iplist.assert_called_once_with('node1')
 
@@ -1629,16 +1630,17 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_services')
-    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
     def test_remove_node_from_cluster_rm_node_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_error, mock_rm_conf_files, mock_call_delnode):
+        mock_get_ip.return_value = '192.0.2.100'
         mock_call_delnode.return_value = False
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
-            bootstrap.remove_node_from_cluster()
+            bootstrap._context = mock.Mock(cluster_user_at_node="node1", rm_list=["file1", "file2"])
+            bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with()
+        mock_get_ip.assert_not_called()
         mock_status.assert_called_once_with("Removing the node node1")
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
         mock_invoke.assert_not_called()
@@ -1652,17 +1654,18 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_services')
-    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
     def test_remove_node_from_cluster_rm_csync_failed(self, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_invokerc, mock_error, mock_rm_conf_files, mock_call_delnode):
+        mock_get_ip.return_value = '192.0.2.100'
         mock_call_delnode.return_value = True
         mock_invokerc.return_value = False
         mock_error.side_effect = SystemExit
 
         with self.assertRaises(SystemExit):
-            bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
-            bootstrap.remove_node_from_cluster()
+            bootstrap._context = mock.Mock(cluster_user_at_node="node1", rm_list=["file1", "file2"])
+            bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with()
+        mock_get_ip.assert_not_called()
         mock_status.assert_called_once_with("Removing the node node1")
         mock_stop.assert_called_once_with(bootstrap.SERVICES_STOP_LIST, remote_addr="node1")
         mock_invoke.assert_not_called()
@@ -1685,18 +1688,19 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_services')
-    @mock.patch('crmsh.bootstrap.set_cluster_node_ip')
+    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
     def test_remove_node_from_cluster_hostname(self, mock_get_ip, mock_stop, mock_status,
             mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2, mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_cal_delnode):
+        mock_get_ip.return_value = "10.10.10.1"
         mock_cal_delnode.return_value = True
         mock_invoke.side_effect = [(True, None, None)]
         mock_invokerc.return_value = True
         mock_get_values.return_value = ["10.10.10.1"]
 
-        bootstrap._context = mock.Mock(cluster_node="node1", cluster_node_ip=None, rm_list=["file1", "file2"])
-        bootstrap.remove_node_from_cluster()
+        bootstrap._context = mock.Mock(cluster_user_at_node="node1", rm_list=["file1", "file2"])
+        bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with()
+        mock_get_ip.assert_called_once_with('node1')
         mock_status.assert_has_calls([
             mock.call("Removing the node node1"),
             mock.call("Propagating configuration changes across the remaining nodes")
@@ -1709,7 +1713,7 @@ class TestValidation(unittest.TestCase):
         mock_invokerc.assert_called_once_with("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
         mock_error.assert_not_called()
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
-        mock_del.assert_called_once_with("node1")
+        mock_del.assert_called_once_with("10.10.10.1")
         mock_decrease.assert_called_once_with()
         mock_csync2.assert_has_calls([
             mock.call(bootstrap.CSYNC2_CFG),


### PR DESCRIPTION
These options should be able to input interactively on prompt. So
they are not required to present in command line args and the
parsing should be deferred.