### PR TITLE
Dev: behave: add coverage and codecov.io for behave tests

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -65,6 +65,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF crm_report_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-20.04
@@ -77,6 +78,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_bugs_non_root:
     runs-on: ubuntu-20.04
@@ -89,6 +91,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_common:
     runs-on: ubuntu-20.04
@@ -101,6 +104,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_common_non_root:
     runs-on: ubuntu-20.04
@@ -113,6 +117,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_options:
     runs-on: ubuntu-20.04
@@ -125,6 +130,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_bootstrap_options_non_root:
     runs-on: ubuntu-20.04
@@ -137,6 +143,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-20.04
@@ -149,6 +156,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_setup_remove_non_root:
     runs-on: ubuntu-20.04
@@ -161,6 +169,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_options:
     runs-on: ubuntu-20.04
@@ -173,6 +182,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_options`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_validate:
     runs-on: ubuntu-20.04
@@ -185,6 +195,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_validate_non_root:
     runs-on: ubuntu-20.04
@@ -197,6 +208,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-20.04
@@ -209,6 +221,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_usercase`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_resource_failcount:
     runs-on: ubuntu-20.04
@@ -221,6 +234,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_failcount`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_resource_set:
     runs-on: ubuntu-20.04
@@ -233,6 +247,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index
+    - uses: codecov/codecov-action@v3
 
   functional_test_resource_set_non_root:
     runs-on: ubuntu-20.04
@@ -245,6 +260,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-20.04
@@ -257,6 +273,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF configure_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_constraints_bugs:
     runs-on: ubuntu-20.04
@@ -269,6 +286,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF constraints_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_geo_cluster:
     runs-on: ubuntu-20.04
@@ -281,6 +299,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF geo_setup`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_healthcheck:
     runs-on: ubuntu-20.04
@@ -293,6 +312,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF healthcheck`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+    - uses: codecov/codecov-action@v3
 
   functional_test_cluster_api:
     runs-on: ubuntu-20.04
@@ -304,6 +324,7 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
+    - uses: codecov/codecov-action@v3
 
   functional_test_user_access:
     runs-on: ubuntu-20.04
@@ -315,6 +336,7 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
+    - uses: codecov/codecov-action@v3
 
   original_regression_test:
     runs-on: ubuntu-20.04

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  after_n_builds: 22

--- a/data-manifest
+++ b/data-manifest
@@ -73,6 +73,7 @@ test/features/bootstrap_sbd_normal.feature
 test/features/cluster_api.feature
 test/features/configure_bugs.feature
 test/features/constraints_bugs.feature
+test/features/coveragerc
 test/features/crm_report_bugs.feature
 test/features/environment.py
 test/features/geo_setup.feature

--- a/test/features/coveragerc
+++ b/test/features/coveragerc
@@ -1,0 +1,4 @@
+[run]
+data_file = /.coverage
+parallel = True
+source_pkgs = crmsh

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:15.5"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:latest"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
 DOCKER_SERVICE="docker.service"
@@ -429,6 +429,23 @@ run_origin_regression_test() {
 }
 
 
+prepare_coverage_env() {
+	for node in $*; do
+            docker exec -t $node /bin/sh -c 'sed -i '\''1a\import coverage\nimport atexit\ncov=coverage.Coverage(config_file="/opt/crmsh/test/features/coveragerc")\natexit.register(lambda:(cov.stop(),cov.save()))\ncov.start()'\'' /usr/sbin/crm'
+	done
+}
+
+
+fetch_coverage_report() {
+	local unique_id=$(dd if=/dev/urandom count=1 bs=6 | base64 | tr '+/' '-_')
+	for node in $*; do
+		docker_exec "$node" "coverage combine; coverage xml -o /opt/coverage.xml"
+		# see https://github.com/codecov/codecov-cli/blob/master/codecov_cli/services/upload/coverage_file_finder.py
+		docker cp "$node":/opt/coverage.xml coverage."$unique_id"."$node".xml
+	done
+}
+
+
 WITH_QNETD_NODE=0
 NORMAL_USER_FLAG=0
 CONFIG_COROSYNC_FLAG=1
@@ -521,12 +538,14 @@ for case_num in $*;do
 	setup_cluster ${node_arry[@]}
 	adjust_test_case ${node_arry[0]} $case_file_in_container
 	echo
+        prepare_coverage_env "${node_arry[@]}"
 	if [ "$NORMAL_USER_FLAG" -eq 0 ];then
 		info "Running \"$case_file_in_container\" under 'root'..."
 		docker_exec ${node_arry[0]} "behave --no-logcapture $case_file_in_container || exit 1" || exit 1
 	else
 		info "Running \"$case_file_in_container\" under normal user 'alice'..."
-		docker_exec ${node_arry[0]} "su - alice -c 'sudo behave --no-logcapture $case_file_in_container || exit 1'" || exit 1
+                docker_exec ${node_arry[0]} "su - alice -c 'sudo behave --no-logcapture $case_file_in_container || exit 1'" || exit 1
 	fi
+	fetch_coverage_report "${node_arry[@]}"
 	echo
 done

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:latest"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:15.5"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
 DOCKER_SERVICE="docker.service"

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1177,18 +1177,18 @@ Node node1: UNCLEAN (offline)
 
 Original: node1 capacity:
 pcmk__primitive_assign: st allocation score on node1: 0
-pcmk__clone_allocate: c1 allocation score on node1: 0
-pcmk__clone_allocate: p1:0 allocation score on node1: 0
+pcmk__clone_assign: c1 allocation score on node1: 0
+pcmk__clone_assign: p1:0 allocation score on node1: 0
 pcmk__primitive_assign: p1:0 allocation score on node1: -INFINITY
-pcmk__clone_allocate: m1 allocation score on node1: 0
-pcmk__clone_allocate: p2:0 allocation score on node1: 0
+pcmk__clone_assign: m1 allocation score on node1: 0
+pcmk__clone_assign: p2:0 allocation score on node1: 0
 pcmk__primitive_assign: p2:0 allocation score on node1: -INFINITY
 p2:0 promotion score on none: 0
 pcmk__primitive_assign: p3 allocation score on node1: -INFINITY
-pcmk__clone_allocate: msg allocation score on node1: 0
-pcmk__clone_allocate: g:0 allocation score on node1: 0
-pcmk__clone_allocate: p0:0 allocation score on node1: 0
-pcmk__clone_allocate: p4:0 allocation score on node1: 0
+pcmk__clone_assign: msg allocation score on node1: 0
+pcmk__clone_assign: g:0 allocation score on node1: 0
+pcmk__clone_assign: p0:0 allocation score on node1: 0
+pcmk__clone_assign: p4:0 allocation score on node1: 0
 pcmk__group_assign: g:0 allocation score on node1: -INFINITY
 pcmk__group_assign: p0:0 allocation score on node1: -INFINITY
 pcmk__group_assign: p4:0 allocation score on node1: -INFINITY

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -1,32 +1,25 @@
 FROM opensuse/leap:15.5
 MAINTAINER Xin Liang <XLiang@suse.com>
 
-ARG ssh_prv_key
-ARG ssh_pub_key
-# docker build -t haleap --build-arg ssh_prv_key="$(cat /root/.ssh/id_rsa)" --build-arg ssh_pub_key="$(cat /root/.ssh/id_rsa.pub)" .
-# docker login
-# docker tag haleap liangxin1300/haleap:15.5
-# docker push liangxin1300/haleap:15.5
+CMD ["/usr/lib/systemd/systemd", "--system"]
 
-RUN zypper ref
-RUN zypper -n install systemd
-RUN zypper -n install make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables
-RUN zypper -n install python3 python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave
-RUN zypper -n install csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
-RUN zypper --non-interactive up zypper
-RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf
-RUN zypper --non-interactive refresh
-RUN zypper --non-interactive up --allow-vendor-change -y resource-agents libqb100 pacemaker
+RUN zypper refresh && \
+    zypper -n install systemd \
+        make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables \
+        python3 python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave \
+        csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
+RUN zypper --non-interactive up zypper && \
+    zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf && \
+    zypper --non-interactive refresh && \
+    zypper --non-interactive up --allow-vendor-change -y resource-agents libqb100 pacemaker
+
+RUN ssh-keygen -t rsa -f /root/.ssh/id_rsa -N '' && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    chmod 0600 /root/.ssh/authorized_keys
 
 RUN mkdir -p /var/log/crmsh
-RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
-RUN echo "$ssh_prv_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-RUN echo "$ssh_pub_key" > /root/.ssh/id_rsa.pub && chmod 600 /root/.ssh/id_rsa.pub
-RUN echo "$ssh_pub_key" > /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys
 
 COPY behave_agent.py /opt
 COPY behave-agent.socket /etc/systemd/system
 COPY behave-agent@.service /etc/systemd/system
 RUN systemctl enable behave-agent.socket
-
-CMD ["/usr/lib/systemd/systemd", "--system"]

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -6,7 +6,7 @@ CMD ["/usr/lib/systemd/systemd", "--system"]
 RUN zypper refresh && \
     zypper -n install systemd \
         make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables \
-        python3 python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave \
+        python3 python3-pip python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave \
         csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
 RUN zypper --non-interactive up zypper && \
     zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15_SP4 repo_nhf && \
@@ -16,6 +16,9 @@ RUN zypper --non-interactive up zypper && \
 RUN ssh-keygen -t rsa -f /root/.ssh/id_rsa -N '' && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     chmod 0600 /root/.ssh/authorized_keys
+
+
+RUN python3 -m pip install coverage
 
 RUN mkdir -p /var/log/crmsh
 


### PR DESCRIPTION
Collect coverage data by patching the entrance file `/usr/sbin/crm` and use codecov.io to collect and combine the result from concurrent runs of different tests.