### PR TITLE
Fix: upgradeutil: support the change of path of upgrade_seq in crmsh-4.5 (bsc#1213050)

### DIFF
--- a/test/features/healthcheck.feature
+++ b/test/features/healthcheck.feature
@@ -25,3 +25,10 @@ Feature: healthcheck detect and fix problems in a crmsh deployment
     And     File "~hacluster/.ssh/id_rsa" exists on "hanode1"
     And     File "~hacluster/.ssh/id_rsa" exists on "hanode2"
     And     File "~hacluster/.ssh/id_rsa" exists on "hanode3"
+
+  @clean
+  Scenario: An upgrade_seq file in ~hacluster/crmsh/ will be migrated to /var/lib/crmsh (bsc#1213050)
+    When    Run "mv /var/lib/crmsh ~hacluster/" on "hanode1"
+    Then    File "~hacluster/crmsh/upgrade_seq" exists on "hanode1"
+    When    Run "crm cluster status" on "hanode1"
+    Then    File "/var/lib/crmsh/upgrade_seq" exists on "hanode1"


### PR DESCRIPTION
Copy the seq file from the old path `~hacluster/crmsh/` to the new one `/var/lib/crmsh`, so that it can be found when upgraded to 4.5.