### PR TITLE
[master] Fix: upgradeutil: support the change of path of upgrade_seq in crmsh-4.5 (bsc#1213050)

### DIFF
--- a/crmsh/upgradeutil.py
+++ b/crmsh/upgradeutil.py
@@ -68,8 +68,21 @@ def _is_upgrade_needed(nodes):
     except FileNotFoundError:
         pass
     if not needed:
+        s = _get_file_content(SEQ_FILE_PATH, b'').strip()
+        if s == b'':
+            # try the old path
+            seq_file_path = os.path.expanduser('~hacluster/crmsh') + '/upgrade_seq'
+            s = _get_file_content(seq_file_path, b'').strip()
+            if s != b'':
+                try:
+                    os.mkdir(DATA_DIR)
+                except FileExistsError:
+                    pass
+                with open(SEQ_FILE_PATH, 'wb') as f:
+                    f.write(s)
+                    f.write(b'\n')
         try:
-            local_seq = _parse_upgrade_seq(_get_file_content(SEQ_FILE_PATH, b'').strip())
+            local_seq = _parse_upgrade_seq(s)
         except ValueError:
             local_seq = (0, 0)
         needed = CURRENT_UPGRADE_SEQ > local_seq

--- a/test/features/healthcheck.feature
+++ b/test/features/healthcheck.feature
@@ -26,3 +26,12 @@ Feature: healthcheck detect and fix problems in a crmsh deployment
     # And     File "~hacluster/.ssh/id_rsa" exists on "hanode1"
     # And     File "~hacluster/.ssh/id_rsa" exists on "hanode2"
     # And     File "~hacluster/.ssh/id_rsa" exists on "hanode3"
+
+  # skip non-root as behave_agent is not able to run commands interactively with non-root sudoer
+  @skip_non_root
+  @clean
+  Scenario: An upgrade_seq file in ~hacluster/crmsh/ will be migrated to /var/lib/crmsh (bsc#1213050)
+    When    Run "mv /var/lib/crmsh ~hacluster/" on "hanode1"
+    Then    File "~hacluster/crmsh/upgrade_seq" exists on "hanode1"
+    When    Run "crm cluster status" on "hanode1"
+    Then    File "/var/lib/crmsh/upgrade_seq" exists on "hanode1"


### PR DESCRIPTION
A cluster running 4.4 should be able to upgrade to current master, without upgrade to the latest version in 4.4 branch first.

This requires #1212 to be ported to master.