### PR TITLE
[crmsh-4.5] Dev: requirements: remove parallax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 lxml
 PyYAML
 python-dateutil
-parallax


### PR DESCRIPTION
parallax is not a dependency anymore and has already been removed in setup.py. It should also be removed from requirements.txt

backport #1219.