### PR TITLE
Fix: codecov: delay notifications until all reports are uploaded

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 codecov: 
-   token: 16b01c29-3b23-4923-b33a-4d26a49d80c4
+  token: 16b01c29-3b23-4923-b33a-4d26a49d80c4
+  notify:
+    after_n_builds: 22
 comment:
   after_n_builds: 22


### PR DESCRIPTION
Sometimes codecov/patch check stuck in failed status. Try to fix it.

See https://community.codecov.com/t/github-status-check-reported-too-early/3043.