### PR TITLE
[crmsh-4.6] Dev: refactor shell calling routines

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -25,12 +25,10 @@ import typing
 
 import yaml
 import socket
-from tempfile import mktemp
 from string import Template
 from lxml import etree
 
-import crmsh.parallax
-from . import config, constants
+from . import config, constants, ssh_key, sh
 from . import upgradeutil
 from . import utils
 from . import xmlutil
@@ -45,7 +43,9 @@ from . import ocfs2
 from . import qdevice
 from . import parallax
 from . import log
+from .service_manager import ServiceManager
 from .ui_node import NodeMgmt
+from .user_of_host import UserOfHost, UserNotFoundError
 
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
@@ -142,6 +142,7 @@ class Context(object):
                 COROSYNC_AUTH, "/var/lib/heartbeat/crm/*", "/var/lib/pacemaker/cib/*",
                 "/var/lib/corosync/*", "/var/lib/pacemaker/pengine/*", PCMK_REMOTE_AUTH,
                 "/var/lib/csync2/*", "~/.config/crm/*"]
+        self.ssh_key_file = None
 
     @classmethod
     def set_context(cls, options):
@@ -212,7 +213,7 @@ class Context(object):
         if self.stage == "sbd":
             if not self.sbd_devices and not self.diskless_sbd and self.yes_to_all:
                 utils.fatal("Stage sbd should specify sbd device by -s or diskless sbd by -S option")
-            if utils.service_is_active("sbd.service") and not config.core.force:
+            if ServiceManager().service_is_active("sbd.service") and not config.core.force:
                 utils.fatal("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")
             if self.cluster_is_running:
                 utils.check_all_nodes_reachable()
@@ -424,7 +425,7 @@ def crm_configure_load(action, configuration):
 
     configuration_tmpfile = utils.str2tmp(configuration)
     tmpfiles.add(configuration_tmpfile)
-    utils.get_stdout_or_raise_error(f"crm -F configure load {action} {configuration_tmpfile}")
+    sh.auto_shell().get_stdout_or_raise_error(f"crm -F configure load {action} {configuration_tmpfile}")
 
 
 def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT):
@@ -458,7 +459,7 @@ def get_node_canonical_hostname(host: str) -> str:
     """
     Get the canonical hostname of the cluster node
     """
-    rc, out, err = utils.get_stdout_stderr_auto_ssh_no_input(host, 'crm_node --name')
+    rc, out, err = sh.auto_shell().get_stdout_stderr_no_input(host, 'crm_node --name')
     if rc != 0:
         utils.fatal(err)
     return out
@@ -483,7 +484,7 @@ def is_online():
     if not xmlutil.CrmMonXmlParser.is_node_online(cluster_node):
         shutil.copy(COROSYNC_CONF_ORIG, corosync.conf())
         sync_file(corosync.conf())
-        utils.stop_service("corosync")
+        ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).stop_service("corosync")
         print()
         utils.fatal("Cannot see peer node \"{}\", please check the communication IP".format(cluster_node))
     return True
@@ -570,15 +571,16 @@ def check_prereqs(stage):
 
     timekeepers = ('chronyd.service', 'ntp.service', 'ntpd.service')
     timekeeper = None
+    service_manager = ServiceManager()
     for tk in timekeepers:
-        if utils.service_is_available(tk):
+        if service_manager.service_is_available(tk):
             timekeeper = tk
             break
 
     if timekeeper is None:
         logger.warning("No NTP service found.")
         warned = True
-    elif not utils.service_is_enabled(timekeeper):
+    elif not service_manager.service_is_enabled(timekeeper):
         logger.warning("{} is not configured to start at system boot.".format(timekeeper))
         warned = True
 
@@ -645,7 +647,7 @@ def configure_firewall(tcp=None, udp=None):
         utils.sysconfig_set(SYSCONFIG_FW, FW_CONFIGURATIONS_EXT=ext)
 
         # No need to do anything else if the firewall is inactive
-        if not utils.service_is_active("SuSEfirewall2"):
+        if not ServiceManager().service_is_active("SuSEfirewall2"):
             return
 
         # Firewall is active, either restart or complain if we couldn't tweak it
@@ -654,7 +656,7 @@ def configure_firewall(tcp=None, udp=None):
             utils.fatal("Failed to restart firewall (SuSEfirewall2)")
 
     def init_firewall_firewalld(tcp, udp):
-        has_firewalld = utils.service_is_active("firewalld")
+        has_firewalld = ServiceManager().service_is_active("firewalld")
         cmdbase = 'firewall-cmd --zone=public --permanent ' if has_firewalld else 'firewall-offline-cmd --zone=public '
 
         def cmd(args):
@@ -719,7 +721,7 @@ def firewall_open_corosync_ports():
 
 def init_cluster_local():
     # Caller should check this, but I'm paranoid...
-    if utils.service_is_active("corosync.service"):
+    if ServiceManager().service_is_active("corosync.service"):
         utils.fatal("corosync service is running!")
 
     firewall_open_corosync_ports()
@@ -741,8 +743,9 @@ def init_cluster_local():
     invoke("rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*")
 
     # only try to start hawk if hawk is installed
-    if utils.service_is_available("hawk.service"):
-        utils.start_service("hawk.service", enable=True)
+    service_manager = ServiceManager()
+    if service_manager.service_is_available("hawk.service"):
+        service_manager.start_service("hawk.service", enable=True)
         logger.info("Hawk cluster interface is now running. To see cluster status, open:")
         logger.info("  https://{}:7630/".format(_context.default_ip_list[0]))
         logger.info("Log in with username 'hacluster'{}".format(pass_msg))
@@ -767,7 +770,7 @@ def start_pacemaker(node_list=[], enable_flag=False):
     # not _context means not in init or join process
     if not _context and \
             utils.package_is_installed("sbd") and \
-            utils.service_is_enabled("sbd.service") and \
+            ServiceManager().service_is_enabled("sbd.service") and \
             SBDTimeout.is_sbd_delay_start():
         target_dir = "/run/systemd/system/sbd.service.d/"
         cmd1 = "mkdir -p {}".format(target_dir)
@@ -778,15 +781,16 @@ def start_pacemaker(node_list=[], enable_flag=False):
             parallax.parallax_call(node_list, cmd)
 
     # To avoid possible JOIN flood in corosync
+    service_manager = ServiceManager()
     if len(node_list) > 5:
         for node in node_list[:]:
             time.sleep(0.25)
             try:
-                utils.start_service("corosync.service", remote_addr=node)
+                service_manager.start_service("corosync.service", remote_addr=node)
             except ValueError as err:
                 node_list.remove(node)
                 logger.error(err)
-    return utils.start_service("pacemaker.service", enable=enable_flag, node_list=node_list)
+    return service_manager.start_service("pacemaker.service", enable=enable_flag, node_list=node_list)
 
 
 def install_tmp(tmpfile, to):
@@ -798,7 +802,7 @@ def install_tmp(tmpfile, to):
 
 def append(fromfile, tofile, remote=None):
     cmd = "cat {} >> {}".format(fromfile, tofile)
-    utils.get_stdout_or_raise_error(cmd, remote=remote)
+    sh.auto_shell().get_stdout_or_raise_error(cmd, host=remote)
 
 
 def append_unique(fromfile, tofile, user=None, remote=None, from_local=False):
@@ -828,24 +832,50 @@ def _parse_user_at_host(s: str, default_user: str) -> typing.Tuple[str, str]:
 
 def init_ssh():
     user_host_list = [_parse_user_at_host(x, _context.current_user) for x in _context.user_at_node_list]
-    init_ssh_impl(_context.current_user, user_host_list)
+    init_ssh_impl(
+        _context.current_user,
+        ssh_key.KeyFile(_context.ssh_key_file) if _context.ssh_key_file is not None else None,
+        user_host_list,
+    )
     if user_host_list:
+        service_manager = ServiceManager()
         for user, node in user_host_list:
-            if utils.service_is_active("pacemaker.service", remote_addr=node):
+            if service_manager.service_is_active("pacemaker.service", remote_addr=node):
                 utils.fatal("Cluster is currently active on {} - can't run".format(node))
 
 
-def init_ssh_impl(local_user: str, user_node_list: typing.List[typing.Tuple[str, str]]):
-    """ Configure passwordless SSH."""
-    utils.start_service("sshd.service", enable=True)
-    configure_ssh_key(local_user)
+def init_ssh_impl(local_user: str, ssh_public_key: typing.Optional[ssh_key.Key], user_node_list: typing.List[typing.Tuple[str, str]]):
+    """ Configure passwordless SSH.
+
+    The local_user on local host will be configured.
+    If user_node_list is not empty, those user and host will also be configured.
+    If ssh_public_key is specified, it will be added to authorized_keys; if not, a new key pair will be generated for each node.
+    """
+    ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).start_service("sshd.service", enable=True)
+    shell = sh.SshShell(sh.LocalShell(), local_user)
+    authorized_key_manager = ssh_key.AuthorizedKeyManager(shell)
+    if ssh_public_key is not None:
+        # Use specified key. Do not generate new ones.
+        authorized_key_manager.add(None, local_user, ssh_public_key)
+    else:
+        configure_ssh_key(local_user)
     configure_ssh_key('hacluster')
 
-    # If not use -N/--nodes option
-    if not user_node_list:
-        return
+    if user_node_list:
+        print()
+        if ssh_public_key is not None:
+            for user, node in user_node_list:
+                logger.info("Adding public key to authorized_keys on %s@%s", user, node)
+                authorized_key_manager.add(node, user, ssh_public_key)
+        else:
+            _init_ssh_on_remote_nodes(local_user, ssh_public_key, user_node_list)
 
-    print()
+
+def _init_ssh_on_remote_nodes(
+        local_user: str,
+        ssh_public_key: typing.Optional[ssh_key.Key],
+        user_node_list: typing.List[typing.Tuple[str, str]],
+):
     # Swap public ssh key between remote node and local
     public_key_list = list()
     hacluster_public_key_list = list()
@@ -855,10 +885,11 @@ def init_ssh_impl(local_user: str, user_node_list: typing.List[typing.Tuple[str,
         public_key_list.append(swap_public_ssh_key(node, local_user, remote_user, local_user, remote_user, add=True))
         hacluster_public_key_list.append(swap_public_ssh_key(node, 'hacluster', 'hacluster', local_user, remote_user, add=True))
     if len(user_node_list) > 1:
+        shell = sh.LocalShell()
         shell_script = _merge_authorized_keys(public_key_list)
         hacluster_shell_script = _merge_authorized_keys(hacluster_public_key_list)
         for i, (remote_user, node) in enumerate(user_node_list):
-            result = utils.su_subprocess_run(
+            result = shell.su_subprocess_run(
                 local_user,
                 'ssh {} {}@{} /bin/sh'.format(constants.SSH_OPTION, remote_user, node),
                 input=shell_script,
@@ -867,7 +898,7 @@ def init_ssh_impl(local_user: str, user_node_list: typing.List[typing.Tuple[str,
             )
             if result.returncode != 0:
                 utils.fatal('Failed to add public keys to {}@{}: {}'.format(remote_user, node, result.stdout))
-            result = utils.su_subprocess_run(
+            result = shell.su_subprocess_run(
                 local_user,
                 'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_user, node, 'hacluster'),
                 input=hacluster_shell_script,
@@ -899,7 +930,7 @@ def _merge_authorized_keys(keys: typing.List[str]) -> bytes:
 
 def _fetch_core_hosts(local_user, remote_user, remote_host) -> typing.Tuple[typing.List[str], typing.List[str]]:
     cmd = 'crm options show core.hosts'
-    result = utils.su_subprocess_run(
+    result = sh.LocalShell().su_subprocess_run(
         local_user,
         f'ssh {SSH_OPTION} {remote_user}@{remote_host} sudo /bin/sh',
         input=cmd.encode('utf-8'),
@@ -943,7 +974,7 @@ def is_nologin(user, remote=None):
     pattern = f"{user}:.*:/.*/nologin"
     if remote:
         cmd = f"cat {passwd_file}|grep {pattern}"
-        rc, _, _ = utils.run_cmd_on_remote(cmd, remote)
+        rc, _, _ = sh.auto_shell().get_stdout_stderr_no_input(remote, cmd)
         return rc == 0
     else:
         with open(passwd_file) as f:
@@ -963,7 +994,7 @@ def change_user_shell(user, remote=None):
                 _context.with_other_user = False
                 return
         cmd = f"usermod -s /bin/bash {user}"
-        utils.get_stdout_or_raise_error(cmd, remote)
+        sh.auto_shell().get_stdout_or_raise_error(cmd, remote)
 
 
 def configure_ssh_key(user):
@@ -974,6 +1005,7 @@ def configure_ssh_key(user):
     Add <home_dir>/.ssh/id_rsa.pub to <home_dir>/.ssh/authorized_keys anyway, make sure itself authorized
     """
     change_user_shell(user)
+    shell = sh.LocalShell()
 
     cmd = ""
     private_key, public_key, authorized_file = key_files(user).values()
@@ -985,11 +1017,11 @@ def configure_ssh_key(user):
         cmd = "ssh-keygen -y -f {} > {}".format(private_key, public_key)
 
     if cmd:
-        utils.su_get_stdout_or_raise_error(cmd, user=user)
+        shell.get_stdout_or_raise_error(user, cmd)
 
     if not utils.detect_file(authorized_file):
         cmd = "touch {}".format(authorized_file)
-        utils.su_get_stdout_or_raise_error(cmd, user=user)
+        shell.get_stdout_or_raise_error(user, cmd)
 
     append_unique(public_key, authorized_file, user)
 
@@ -1000,13 +1032,14 @@ def generate_ssh_key_pair_on_remote(
         remote_user: str
 ) -> str:
     """generate a key pair on remote and return the public key"""
+    shell = sh.LocalShell()
     # pass cmd through stdin rather than as arguments. It seems sudo has its own argument parsing mechanics,
     # which breaks shell expansion used in cmd
     cmd = '''
 [ -f ~/.ssh/id_rsa ] || ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -C "Cluster internal on $(hostname)" -N ''
 [ -f ~/.ssh/id_rsa.pub ] || ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
 '''
-    result = utils.su_subprocess_run(
+    result = shell.su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_host, remote_user),
         input=cmd.encode('utf-8'),
@@ -1017,7 +1050,7 @@ def generate_ssh_key_pair_on_remote(
         raise ValueError(codecs.decode(result.stdout, 'utf-8', 'replace'))
 
     cmd = 'cat ~/.ssh/id_rsa.pub'
-    result = utils.su_subprocess_run(
+    result = shell.su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_host, remote_user),
         input=cmd.encode('utf-8'),
@@ -1063,7 +1096,7 @@ def export_ssh_key_non_interactive(local_user_to_export, remote_user_to_swap, re
 {key}
 EOF
 '''.format(user=remote_user_to_swap, key=public_key)
-    result = utils.su_subprocess_run(
+    result = sh.LocalShell().su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_node),
         input=cmd.encode('utf-8'),
@@ -1081,15 +1114,17 @@ def import_ssh_key(local_user, remote_user, local_sudoer, remote_node, remote_su
     remote_key_content = remote_public_key_from(remote_user, local_sudoer, remote_node, remote_sudoer)
     _, _, local_authorized_file = key_files(local_user).values()
     if not utils.check_text_included(remote_key_content, local_authorized_file, remote=None):
-        cmd = "echo '{}' >> {}".format(remote_key_content, local_authorized_file)
-        utils.get_stdout_or_raise_error(cmd, remote=None)
+        sh.LocalShell().get_stdout_or_raise_error(
+            local_user,
+            "sed -i '$a {}' '{}'".format(remote_key_content, local_authorized_file),
+        )
 
 def append_to_remote_file(fromfile, user, remote_node, tofile):
     """
     Append content of fromfile to tofile on remote_node
     """
     cmd = "cat {} | ssh {} {}@{} 'cat >> {}'".format(fromfile, SSH_OPTION, user, remote_node, tofile)
-    utils.get_stdout_or_raise_error(cmd)
+    sh.auto_shell().get_stdout_or_raise_error(cmd)
 
 
 def init_csync2():
@@ -1125,9 +1160,10 @@ key /etc/csync2/key_hagroup;
         for f in [CSYNC2_CFG, CSYNC2_KEY]:
             sync_file(f)
 
+    service_manager = ServiceManager()
     for host in host_list:
         logger.info("Starting {} service on {}".format(CSYNC2_SERVICE, host))
-        utils.start_service(CSYNC2_SERVICE, enable=True, remote_addr=host)
+        service_manager.start_service(CSYNC2_SERVICE, enable=True, remote_addr=host)
 
     _msg = "syncing" if _context.skip_csync2 else "checking"
     with logger_utils.status_long("csync2 {} files".format(_msg)):
@@ -1588,12 +1624,12 @@ def init_qdevice():
         configure_qdevice_interactive()
     # If don't want to config qdevice, return
     if not _context.qdevice_inst:
-        utils.disable_service("corosync-qdevice.service")
+        ServiceManager().disable_service("corosync-qdevice.service")
         return
     logger.info("""Configure Qdevice/Qnetd:""")
     cluster_node_list = utils.list_cluster_nodes()
     for node in cluster_node_list:
-        if not utils.service_is_available("corosync-qdevice.service", node):
+        if not ServiceManager().service_is_available("corosync-qdevice.service", node):
             utils.fatal("corosync-qdevice.service is not available on {}".format(node))
     qdevice_inst = _context.qdevice_inst
     qnetd_addr = qdevice_inst.qnetd_addr
@@ -1603,19 +1639,19 @@ def init_qdevice():
         # if the remote user is specified explicitly, use it
         ssh_user = qdevice_inst.ssh_user
         try:
-            local_user = utils.UserOfHost.instance().user_of(utils.this_node())
-        except utils.UserOfHost.UserNotFoundError:
+            local_user = UserOfHost.instance().user_of(utils.this_node())
+        except UserNotFoundError:
             local_user = ssh_user
     else:
         try:
             # if ssh session has ready been available, use that
-            local_user, ssh_user = utils.UserOfHost.instance().user_pair_for_ssh(qnetd_addr)
-        except utils.UserOfHost.UserNotFoundError:
+            local_user, ssh_user = UserOfHost.instance().user_pair_for_ssh(qnetd_addr)
+        except UserNotFoundError:
             pass
     if ssh_user is None:
         try:
-            local_user = utils.UserOfHost.instance().user_of(utils.this_node())
-        except utils.UserOfHost.UserNotFoundError:
+            local_user = UserOfHost.instance().user_of(utils.this_node())
+        except UserNotFoundError:
             local_user = userdir.getuser()
         ssh_user = local_user
     # Configure ssh passwordless to qnetd if detect password is needed
@@ -1669,7 +1705,7 @@ def join_ssh(seed_host, seed_user):
         utils.fatal("No existing IP/hostname specified (use -c option)")
 
     local_user = _context.current_user
-    utils.start_service("sshd.service", enable=True)
+    ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).start_service("sshd.service", enable=True)
     configure_ssh_key(local_user)
     if 0 != utils.ssh_copy_id_no_raise(local_user, seed_user, seed_host):
         msg = f"Failed to login to {seed_user}@{seed_host}. Please check the credentials."
@@ -1692,11 +1728,11 @@ def join_ssh(seed_host, seed_user):
     # authorized_keys file (again, to help with the case where the
     # user has done manual initial setup without the assistance of
     # ha-cluster-init).
-    utils.su_get_stdout_or_raise_error(
+    sh.LocalShell().get_stdout_or_raise_error(
+        local_user,
         "ssh {} {}@{} sudo crm cluster init -i {} ssh_remote".format(
             SSH_OPTION, seed_user, seed_host, _context.default_nic_list[0],
         ),
-        local_user,
     )
     user_by_host = utils.HostUserConfig()
     user_by_host.add(seed_user, seed_host)
@@ -1724,7 +1760,7 @@ def swap_public_ssh_key(
     if add:
         public_key = generate_ssh_key_pair_on_remote(local_sudoer, remote_node, remote_sudoer, remote_user_to_swap)
         _, _, local_authorized_file = key_files(local_user_to_swap).values()
-        utils.su_get_stdout_or_raise_error("sed -i '$a {}' '{}'".format(public_key, local_authorized_file), local_user_to_swap)
+        sh.LocalShell().get_stdout_or_raise_error(local_user_to_swap, "sed -i '$a {}' '{}'".format(public_key, local_authorized_file))
         return public_key
     else:
         try:
@@ -1736,7 +1772,7 @@ def swap_public_ssh_key(
 def remote_public_key_from(remote_user, local_sudoer, remote_node, remote_sudoer):
     "Get the id_rsa.pub from the remote node"
     cmd = 'cat ~/.ssh/id_rsa.pub'
-    result = utils.su_subprocess_run(
+    result = sh.LocalShell().su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_node, remote_user),
         input=cmd.encode('utf-8'),
@@ -1769,8 +1805,9 @@ def join_csync2(seed_host, remote_user):
 
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
+    shell = sh.auto_shell()
     cmd = "crm cluster init -i {} csync2_remote {}".format(_context.default_nic_list[0], utils.this_node())
-    utils.get_stdout_or_raise_error(cmd, seed_host)
+    shell.get_stdout_or_raise_error(cmd, seed_host)
 
     # This is necessary if syncing /etc/hosts (to ensure everyone's got the
     # same list of hosts)
@@ -1782,7 +1819,7 @@ def join_csync2(seed_host, remote_user):
     utils.copy_remote_textfile(remote_user, seed_host, "/etc/csync2/key_hagroup", "/etc/csync2")
 
     logger.info("Starting {} service".format(CSYNC2_SERVICE))
-    utils.start_service(CSYNC2_SERVICE, enable=True)
+    ServiceManager(shell).start_service(CSYNC2_SERVICE, enable=True)
 
     # Sync new config out.  This goes to all hosts; csync2.cfg definitely
     # needs to go to all hosts (else hosts other than the seed and the
@@ -1795,7 +1832,7 @@ def join_csync2(seed_host, remote_user):
     # when it updates expected_votes.  Grrr...
     with logger_utils.status_long("csync2 syncing files in cluster"):
         cmd = "sudo csync2 -rm /;sudo csync2 -rxv || sudo csync2 -rf / && sudo csync2 -rxv"
-        rc, _, stderr = utils.get_stdout_stderr_auto_ssh_no_input(seed_host, cmd)
+        rc, _, stderr = shell.get_stdout_stderr_no_input(seed_host, cmd)
         if rc != 0:
             print("")
             logger.warning("csync2 run failed - some files may not be sync'd: %s", stderr)
@@ -1821,7 +1858,7 @@ def join_ssh_merge(cluster_node, remote_user):
     cat_cmd = "[ -e ~/.ssh/known_hosts ] && cat ~/.ssh/known_hosts || true"
     #logger_utils.log_only_to_file("parallax.call {} : {}".format(hosts, cat_cmd))
     for host in hosts:
-        known_hosts_content = utils.get_stdout_or_raise_error(cat_cmd, remote=host)
+        known_hosts_content = sh.auto_shell().get_stdout_or_raise_error(cat_cmd, host)
         if known_hosts_content:
             known_hosts_new.update((utils.to_ascii(known_hosts_content) or "").splitlines())
 
@@ -1829,7 +1866,7 @@ def join_ssh_merge(cluster_node, remote_user):
         hoststxt = "\n".join(sorted(known_hosts_new))
         #results = parallax.parallax_copy(hosts, tmpf, known_hosts_path, strict=False)
         for host in hosts:
-            utils.write_remote_file(hoststxt, "~/.ssh/known_hosts", utils.user_of(host), remote=host)
+            utils.write_remote_file(hoststxt, "~/.ssh/known_hosts", utils.user_of(host), host)
 
 
 def update_expected_votes():
@@ -1919,8 +1956,9 @@ def setup_passwordless_with_other_nodes(init_node, remote_user):
     """
     # Fetch cluster nodes list
     local_user = _context.current_user
+    shell = sh.LocalShell()
     cmd = f'ssh {SSH_OPTION} {remote_user}@{init_node} sudo crm_node -l'
-    rc, out, err = utils.su_get_stdout_stderr(local_user, cmd)
+    rc, out, err = shell.get_stdout_stderr(local_user, cmd)
     if rc != 0:
         utils.fatal("Can't fetch cluster nodes list from {}: {}".format(init_node, err))
     cluster_nodes_list = []
@@ -1953,7 +1991,7 @@ def setup_passwordless_with_other_nodes(init_node, remote_user):
 
     # Filter out init node from cluster_nodes_list
     cmd = "ssh {} {}@{} hostname".format(SSH_OPTION, remote_user , init_node)
-    rc, out, err = utils.su_get_stdout_stderr(local_user, cmd)
+    rc, out, err = shell.get_stdout_stderr(local_user, cmd)
     if rc != 0:
         utils.fatal("Can't fetch hostname of {}: {}".format(init_node, err))
     # Swap ssh public key between join node and other cluster nodes
@@ -1976,16 +2014,17 @@ def swap_key_for_hacluster(other_node_list):
     In some cases, old cluster may not be configured passwordless for hacluster.
     The new join node should check and swap the public key between the old cluster nodes.
     """
+    shell = sh.auto_shell()
     for node in other_node_list:
         for n in other_node_list:
             if node == n:
                 continue
             logger.info("Checking passwordless for hacluster between %s and %s", node, n)
             _, public_key, authorized_file = key_files('hacluster').values()
-            public_key_content = utils.get_stdout_or_raise_error(f'cat {public_key}', remote=n)
-            if not utils.check_text_included(public_key_content, authorized_file, remote=node):
+            public_key_content = shell.get_stdout_or_raise_error(f'cat {public_key}', n)
+            if not utils.check_text_included(public_key_content, authorized_file, node):
                 cmd = "echo '{}' >> {}".format(public_key_content, authorized_file)
-                utils.get_stdout_or_raise_error(cmd, remote=node)
+                shell.get_stdout_or_raise_error(cmd, node)
 
 
 def sync_files_to_disk():
@@ -2014,7 +2053,7 @@ def join_cluster(seed_host, remote_user):
             corosync.set_value("totem.nodeid", nodeid)
 
     is_qdevice_configured = utils.is_qdevice_configured()
-    if is_qdevice_configured and not utils.service_is_available("corosync-qdevice.service"):
+    if is_qdevice_configured and not ServiceManager().service_is_available("corosync-qdevice.service"):
         utils.fatal("corosync-qdevice.service is not available")
 
     shutil.copy(corosync.conf(), COROSYNC_CONF_ORIG)
@@ -2040,8 +2079,9 @@ def join_cluster(seed_host, remote_user):
     # mountpoints for clustered filesystems.  Unfortunately we don't have
     # that yet, so the following crawling horror takes a punt on the seed
     # node being up, then asks it for a list of mountpoints...
+    shell = sh.auto_shell()
     if seed_host:
-        _rc, outp, _ = utils.get_stdout_stderr_auto_ssh_no_input(seed_host, "cibadmin -Q --xpath \"//primitive\"")
+        _rc, outp, _ = shell.get_stdout_stderr_no_input(seed_host, "cibadmin -Q --xpath \"//primitive\"")
         if outp:
             xml = etree.fromstring(outp)
             mountpoints = xml.xpath(' and '.join(['//primitive[@class="ocf"',
@@ -2083,7 +2123,7 @@ def join_cluster(seed_host, remote_user):
         except corosync.IPAlreadyConfiguredError as e:
             logger.warning(e)
         sync_file(corosync.conf())
-        utils.get_stdout_or_raise_error('sudo corosync-cfgtool -R', seed_host)
+        shell.get_stdout_or_raise_error('sudo corosync-cfgtool -R', seed_host)
 
     _context.sbd_manager.join_sbd(remote_user, seed_host)
 
@@ -2156,7 +2196,7 @@ def join_cluster(seed_host, remote_user):
     if is_qdevice_configured:
         start_qdevice_on_join_node(seed_host)
     else:
-        utils.disable_service("corosync-qdevice.service")
+        ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).disable_service("corosync-qdevice.service")
 
 
 def adjust_priority_in_rsc_defaults(is_2node_wo_qdevice):
@@ -2180,7 +2220,7 @@ def adjust_priority_fencing_delay(is_2node_wo_qdevice):
     and the current cluster is 2 nodes without qdevice,
     set priority-fencing-delay=2*pcmk_delay_max
     """
-    out = utils.get_stdout_or_raise_error("crm configure show related:stonith")
+    out = sh.auto_shell().get_stdout_or_raise_error("crm configure show related:stonith")
     if not out:
         return
     pcmk_delay_max_v_list = re.findall("pcmk_delay_max=(\w+)", out)
@@ -2205,7 +2245,7 @@ def start_qdevice_on_join_node(seed_host):
             qnetd_addr = corosync.get_value("quorum.device.net.host")
             qdevice_inst = qdevice.QDevice(qnetd_addr, cluster_node=seed_host)
             qdevice_inst.certificate_process_on_join()
-        utils.start_service("corosync-qdevice.service", enable=True)
+        ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).start_service("corosync-qdevice.service", enable=True)
 
 
 def get_cluster_node_ip(node: str) -> str:
@@ -2231,22 +2271,24 @@ def stop_services(stop_list, remote_addr=None):
     """
     Stop cluster related service
     """
+    service_manager = ServiceManager()
     for service in stop_list:
-        if utils.service_is_active(service, remote_addr=remote_addr):
+        if service_manager.service_is_active(service, remote_addr=remote_addr):
             logger.info("Stopping the %s%s", service, " on {}".format(remote_addr) if remote_addr else "")
-            utils.stop_service(service, disable=True, remote_addr=remote_addr)
+            service_manager.stop_service(service, disable=True, remote_addr=remote_addr)
 
 
 def rm_configuration_files(remote=None):
     """
     Delete configuration files from the node to be removed
     """
-    utils.get_stdout_or_raise_error("rm -f {}".format(' '.join(_context.rm_list)), remote=remote)
+    shell = sh.auto_shell()
+    shell.get_stdout_or_raise_error("rm -f {}".format(' '.join(_context.rm_list)), remote)
     # restore original sbd configuration file from /usr/share/fillup-templates/sysconfig.sbd
     if utils.package_is_installed("sbd", remote_addr=remote):
         from .sbd import SBDManager
         cmd = "cp {} {}".format(SBDManager.SYSCONFIG_SBD_TEMPLATE, SYSCONFIG_SBD)
-        utils.get_stdout_or_raise_error(cmd, remote=remote)
+        shell.get_stdout_or_raise_error(cmd, remote)
 
 
 def remove_node_from_cluster(node):
@@ -2358,7 +2400,8 @@ def bootstrap_init(context):
             utils.fatal("Expected NODE argument to csync2_remote")
         _context.cluster_node = args[1]
 
-    if stage and _context.cluster_is_running and not utils.service_is_active(CSYNC2_SERVICE):
+    if stage and _context.cluster_is_running and \
+            not ServiceManager(shell=sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active(CSYNC2_SERVICE):
         _context.skip_csync2 = True
         _context.node_list_in_cluster = utils.list_cluster_nodes()
     elif not _context.cluster_is_running:
@@ -2369,7 +2412,7 @@ def bootstrap_init(context):
     else:
         init_ssh()
         if _context.skip_csync2:
-            utils.stop_service(CSYNC2_SERVICE, disable=True)
+            ServiceManager().stop_service(CSYNC2_SERVICE, disable=True)
         else:
             init_csync2()
         init_corosync()
@@ -2410,7 +2453,7 @@ def bootstrap_add(context):
         logger.info("Adding node {} to cluster".format(node))
         cmd = 'crm cluster join -y {} -c {}@{}'.format(options, _context.current_user, utils.this_node())
         logger.info("Running command on {}: {}".format(node, cmd))
-        out = utils.get_stdout_or_raise_error(cmd, node)
+        out = sh.auto_shell().get_stdout_or_raise_error(cmd, node)
         print(out)
 
 
@@ -2426,7 +2469,7 @@ def bootstrap_join(context):
 
     check_tty()
 
-    corosync_active = utils.service_is_active("corosync.service")
+    corosync_active = ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service")
     if corosync_active and _context.stage != "ssh":
         utils.fatal("Abort: Cluster is currently active. Run this command on a node joining the cluster.")
 
@@ -2456,9 +2499,10 @@ def bootstrap_join(context):
         join_ssh(cluster_node, remote_user)
         remote_user = utils.user_of(cluster_node)
 
+        service_manager = ServiceManager()
         n = 0
         while n < REJOIN_COUNT:
-            if utils.service_is_active("pacemaker.service", cluster_node):
+            if service_manager.service_is_active("pacemaker.service", cluster_node):
                 break
             n += 1
             logger.warning("Cluster is inactive on %s. Retry in %d seconds", cluster_node, REJOIN_INTERVAL)
@@ -2472,9 +2516,9 @@ def bootstrap_join(context):
                 _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(cluster_node)
                 setup_passwordless_with_other_nodes(cluster_node, remote_user)
                 join_remote_auth(cluster_node, remote_user)
-                _context.skip_csync2 = not utils.service_is_active(CSYNC2_SERVICE, cluster_node)
+                _context.skip_csync2 = not service_manager.service_is_active(CSYNC2_SERVICE, cluster_node)
                 if _context.skip_csync2:
-                    utils.stop_service(CSYNC2_SERVICE, disable=True)
+                    service_manager.stop_service(CSYNC2_SERVICE, disable=True)
                     retrieve_all_config_files(cluster_node)
                     logger.warning("csync2 is not initiated yet. Before using csync2 for the first time, please run \"crm cluster init csync2 -y\" on any one node. Note, this may take a while.")
                 else:
@@ -2554,13 +2598,14 @@ def bootstrap_remove(context):
 
     init()
 
-    if not utils.service_is_active("corosync.service"):
+    service_manager = ServiceManager()
+    if not service_manager.service_is_active("corosync.service"):
         utils.fatal("Cluster is not active - can't execute removing action")
 
     if _context.qdevice_rm_flag and _context.cluster_node:
         utils.fatal("Either remove node or qdevice")
 
-    _context.skip_csync2 = not utils.service_is_active(CSYNC2_SERVICE)
+    _context.skip_csync2 = not service_manager.service_is_active(CSYNC2_SERVICE)
     if _context.skip_csync2:
         _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(utils.this_node())
 
@@ -2596,7 +2641,7 @@ def bootstrap_remove(context):
         utils.fatal("Specified node {} is not configured in cluster! Unable to remove.".format(cluster_node))
 
     # In case any crm command can re-generate upgrade_seq again
-    utils.get_stdout_or_raise_error("rm -rf /var/lib/crmsh", cluster_node)
+    sh.auto_shell().get_stdout_or_raise_error("rm -rf /var/lib/crmsh", cluster_node)
     bootstrap_finished()
 
 
@@ -2608,7 +2653,7 @@ def remove_self(force_flag=False):
     if othernode is not None:
         # remove from other node
         cmd = "crm{} cluster remove{} -c {}".format(" -F" if force_flag else "", " -y" if yes_to_all else "", me)
-        rc, _, _ = utils.get_stdout_stderr_auto_ssh_no_input(othernode, cmd)
+        rc, _, _ = sh.auto_shell().get_stdout_stderr_no_input(othernode, cmd)
         if rc != 0:
             utils.fatal("Failed to remove this node from {}".format(othernode))
     else:
@@ -2706,16 +2751,16 @@ def geo_fetch_config(node):
     if user is not None:
         try:
             local_user = utils.user_of(utils.this_node())
-        except utils.UserOfHost.UserNotFoundError:
+        except UserNotFoundError:
             local_user = user
         remote_user = user
     else:
         try:
-            local_user, remote_user = utils.UserOfHost.instance().user_pair_for_ssh(node)
-        except utils.UserOfHost.UserNotFoundError:
+            local_user, remote_user = UserOfHost.instance().user_pair_for_ssh(node)
+        except UserNotFoundError:
             try:
                 local_user = utils.user_of(utils.this_node())
-            except utils.UserOfHost.UserNotFoundError:
+            except UserNotFoundError:
                 local_user = userdir.getuser()
             remote_user = local_user
     configure_ssh_key(local_user)
@@ -2736,7 +2781,7 @@ def geo_fetch_config(node):
         finally:
             os.close(pipe_outlet)
         try:
-            result = utils.subprocess_run_auto_ssh_no_input(cmd, node, stdout=pipe_inlet, stderr=subprocess.PIPE)
+            result = sh.auto_shell().subprocess_run_no_input(node, None, cmd, stdout=pipe_inlet, stderr=subprocess.PIPE)
         finally:
             os.close(pipe_inlet)
         rc = child.wait()
@@ -2803,7 +2848,7 @@ def bootstrap_arbitrator(context):
         utils.fatal("Failed to copy {} from {}".format(BOOTH_CFG, _context.cluster_node))
     # TODO: verify that the arbitrator IP in the configuration is us?
     logger.info("Enabling and starting the booth arbitrator service")
-    utils.start_service("booth@booth", enable=True)
+    ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).start_service("booth@booth", enable=True)
 
 
 def get_stonith_timeout_generally_expected():
@@ -2828,15 +2873,16 @@ def adjust_pcmk_delay_max(is_2node_wo_qdevice):
     """
     cib_factory.refresh()
 
+    shell = sh.auto_shell()
     if is_2node_wo_qdevice:
         for res in cib_factory.fence_id_list_without_pcmk_delay():
             cmd = "crm resource param {} set pcmk_delay_max {}s".format(res, PCMK_DELAY_MAX)
-            utils.get_stdout_or_raise_error(cmd)
+            shell.get_stdout_or_raise_error(cmd)
             logger.debug("Add parameter 'pcmk_delay_max={}s' for resource '{}'".format(PCMK_DELAY_MAX, res))
     else:
         for res in cib_factory.fence_id_list_with_pcmk_delay():
             cmd = "crm resource param {} delete pcmk_delay_max".format(res)
-            utils.get_stdout_or_raise_error(cmd)
+            shell.get_stdout_or_raise_error(cmd)
             logger.debug("Delete parameter 'pcmk_delay_max' for resource '{}'".format(res))
 
 
@@ -2844,7 +2890,7 @@ def adjust_stonith_timeout():
     """
     Adjust stonith-timeout for sbd and other scenarios
     """
-    if utils.service_is_active("sbd.service"):
+    if ServiceManager().service_is_active("sbd.service"):
         from .sbd import SBDTimeout
         SBDTimeout.adjust_sbd_timeout_related_cluster_configuration()
     else:
@@ -2867,7 +2913,7 @@ def adjust_properties():
     - remove qdevice
     - add sbd via stage
     """
-    if not utils.service_is_active("pacemaker.service"):
+    if not ServiceManager().service_is_active("pacemaker.service"):
         return
     is_2node_wo_qdevice = utils.is_2node_cluster_without_qdevice()
     adjust_pcmk_delay_max(is_2node_wo_qdevice)
@@ -2893,7 +2939,7 @@ def retrieve_all_config_files(cluster_node):
         finally:
             os.close(pipe_outlet)
         try:
-            result = utils.subprocess_run_auto_ssh_no_input(cmd, cluster_node, stdout=pipe_inlet, stderr=subprocess.DEVNULL)
+            result = sh.auto_shell().subprocess_run_no_input(cluster_node, None, cmd, stdout=pipe_inlet, stderr=subprocess.DEVNULL)
         finally:
             os.close(pipe_inlet)
         rc = child.wait()

--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -2,7 +2,7 @@
 # See COPYING for license information.
 
 import re
-from . import utils
+from .sh import ShellUtils
 from . import log
 
 
@@ -20,7 +20,7 @@ def _prettify(line, indent=0):
 
 
 def verify(cib):
-    rc, _, stderr = utils.get_stdout_stderr(cib_verify, cib.encode('utf-8'))
+    rc, _, stderr = ShellUtils().get_stdout_stderr(cib_verify, cib.encode('utf-8'))
     for i, line in enumerate(line for line in stderr.split('\n') if line):
         if i == 0:
             if "warning:" in line:

--- a/crmsh/cmd_status.py
+++ b/crmsh/cmd_status.py
@@ -5,6 +5,7 @@
 import re
 from . import clidisplay
 from . import utils
+from .sh import ShellUtils
 
 _crm_mon = None
 
@@ -75,18 +76,19 @@ def crm_mon(opts=''):
     returns: rc, stdout
     """
     global _crm_mon
+    shell = ShellUtils()
     if _crm_mon is None:
         prog = utils.is_program("crm_mon")
         if not prog:
             raise IOError("crm_mon not available, check your installation")
-        _, out = utils.get_stdout("%s --help" % (prog))
+        _, out = shell.get_stdout("%s --help" % (prog))
         if "--pending" in out:
             _crm_mon = "%s -1 -j" % (prog)
         else:
             _crm_mon = "%s -1" % (prog)
 
     status_cmd = "%s %s" % (_crm_mon, opts)
-    return utils.get_stdout(utils.add_sudo(status_cmd))
+    return shell.get_stdout(utils.add_sudo(status_cmd))
 
 
 def cmd_status(args):
@@ -137,7 +139,7 @@ def cmd_verify(args):
             cmd1 += " -s"
 
     cmd1 = utils.add_sudo(cmd1)
-    rc, s, e = utils.get_stdout_stderr(cmd1)
+    rc, s, e = ShellUtils().get_stdout_stderr(cmd1)
     e = '\n'.join(clidisplay.error(l) for l in e.split('\n')).strip()
     utils.page_string("\n".join((s, e)))
     return rc == 0 and not e

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -13,6 +13,7 @@ from . import utils, sh
 from . import tmpfiles
 from . import parallax
 from . import log
+from .sh import ShellUtils
 
 
 logger = log.setup_logger(__name__)
@@ -31,11 +32,11 @@ def check_tools():
 
 
 def cfgtool(*args):
-    return utils.get_stdout(['corosync-cfgtool'] + list(args), shell=False)
+    return ShellUtils().get_stdout(['corosync-cfgtool'] + list(args), shell=False)
 
 
 def quorumtool(*args):
-    return utils.get_stdout(['corosync-quorumtool'] + list(args), shell=False)
+    return ShellUtils().get_stdout(['corosync-quorumtool'] + list(args), shell=False)
 
 
 def query_status(status_type):
@@ -60,7 +61,7 @@ def query_ring_status():
     """
     Query corosync ring status
     """
-    rc, out, err = utils.get_stdout_stderr("corosync-cfgtool -s")
+    rc, out, err = ShellUtils().get_stdout_stderr("corosync-cfgtool -s")
     if rc != 0 and err:
         raise ValueError(err)
     if out:
@@ -73,7 +74,7 @@ def query_quorum_status():
 
     """
     utils.print_cluster_nodes()
-    rc, out, err = utils.get_stdout_stderr("corosync-quorumtool -s")
+    rc, out, err = ShellUtils().get_stdout_stderr("corosync-quorumtool -s")
     if rc != 0 and err:
         raise ValueError(err)
     # If the return code of corosync-quorumtool is 2,

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -9,7 +9,7 @@ import os
 import re
 import socket
 
-from . import utils
+from . import utils, sh
 from . import tmpfiles
 from . import parallax
 from . import log
@@ -89,7 +89,7 @@ def query_qdevice_status():
     if not utils.is_qdevice_configured():
         raise ValueError("QDevice/QNetd not configured!")
     cmd = "corosync-qdevice-tool -sv"
-    out = utils.get_stdout_or_raise_error(cmd)
+    out = sh.auto_shell().get_stdout_or_raise_error(cmd)
     utils.print_cluster_nodes()
     print(out)
 
@@ -763,7 +763,7 @@ def get_corosync_value(key):
     Get corosync configuration value from corosync-cmapctl or corosync.conf
     """
     try:
-        out = utils.get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
+        out = sh.auto_shell().get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
         res = re.search(r'{}\s+.*=\s+(.*)'.format(key), out)
         return res.group(1) if res else None
     except ValueError:

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -89,7 +89,7 @@ def query_qdevice_status():
     if not utils.is_qdevice_configured():
         raise ValueError("QDevice/QNetd not configured!")
     cmd = "corosync-qdevice-tool -sv"
-    out = sh.auto_shell().get_stdout_or_raise_error(cmd)
+    out = sh.cluster_shell().get_stdout_or_raise_error(cmd)
     utils.print_cluster_nodes()
     print(out)
 
@@ -763,7 +763,7 @@ def get_corosync_value(key):
     Get corosync configuration value from corosync-cmapctl or corosync.conf
     """
     try:
-        out = sh.auto_shell().get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
+        out = sh.cluster_shell().get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
         res = re.search(r'{}\s+.*=\s+(.*)'.format(key), out)
         return res.group(1) if res else None
     except ValueError:

--- a/crmsh/crash_test/check.py
+++ b/crmsh/crash_test/check.py
@@ -1,6 +1,5 @@
 import re
 import os
-import sys
 
 from crmsh import utils as crmshutils
 from crmsh import bootstrap as crmshboot
@@ -10,6 +9,7 @@ from . import utils
 from . import task
 from . import config
 from ..service_manager import ServiceManager
+from ..sh import ShellUtils
 
 
 def fix(context):
@@ -155,7 +155,7 @@ def check_port_open(task, firewall_type):
         return
 
     if firewall_type == "firewalld":
-        rc, out, err = crmshutils.get_stdout_stderr('firewall-cmd --list-port')
+        rc, out, err = ShellUtils().get_stdout_stderr('firewall-cmd --list-port')
         if rc != 0:
             task.error(err)
             return
@@ -236,7 +236,7 @@ def check_fencing():
             return
 
         task_inst.info("stonith is enabled")
-        rc, outp, _ = crmshutils.get_stdout_stderr("crm_mon -r1 | grep '(stonith:.*):'")
+        rc, outp, _ = ShellUtils().get_stdout_stderr("crm_mon -r1 | grep '(stonith:.*):'")
         if rc != 0:
             task_inst.warn("No stonith resource configured!")
             return
@@ -268,7 +268,7 @@ def check_nodes():
     """
     task_inst = task.TaskCheck("Checking nodes")
     with task_inst.run():
-        rc, outp, errp = crmshutils.get_stdout_stderr("crm_mon -1")
+        rc, outp, errp = ShellUtils().get_stdout_stderr("crm_mon -1")
         if rc != 0:
             task_inst.error("run \"crm_mon -1\" error: {}".format(errp))
             return

--- a/crmsh/crash_test/check.py
+++ b/crmsh/crash_test/check.py
@@ -9,6 +9,7 @@ from crmsh import completers
 from . import utils
 from . import task
 from . import config
+from ..service_manager import ServiceManager
 
 
 def fix(context):
@@ -122,10 +123,11 @@ def check_time_service():
     """
     task_inst = task.TaskCheck("Checking time service")
     with task_inst.run():
+        service_manager = ServiceManager()
         timekeepers = ('chronyd.service', 'ntp.service', 'ntpd.service')
         timekeeper = None
         for tk in timekeepers:
-            if crmshutils.service_is_available(tk):
+            if service_manager.service_is_available(tk):
                 timekeeper = tk
                 break
         else:
@@ -133,11 +135,11 @@ def check_time_service():
             return
 
         task_inst.info("{} is available".format(timekeeper))
-        if crmshutils.service_is_enabled(timekeeper):
+        if service_manager.service_is_enabled(timekeeper):
             task_inst.info("{} is enabled".format(timekeeper))
         else:
             task_inst.warn("{} is disabled".format(timekeeper))
-        if crmshutils.service_is_active(timekeeper):
+        if service_manager.service_is_active(timekeeper):
             task_inst.info("{} is active".format(timekeeper))
         else:
             task_inst.warn("{} is not active".format(timekeeper))
@@ -176,7 +178,7 @@ def check_firewall():
         for item in ("firewalld", "SuSEfirewall2"):
             if crmshutils.package_is_installed(item):
                 task_inst.info("{}.service is available".format(item))
-                if crmshutils.service_is_active(item):
+                if ServiceManager().service_is_active(item):
                     task_inst.info("{}.service is active".format(item))
                     check_port_open(task_inst, item)
                 else:
@@ -204,16 +206,17 @@ def check_cluster_service(quiet=False):
     """
     task_inst = task.TaskCheck("Checking cluster service", quiet=quiet)
     with task_inst.run():
-        if crmshutils.service_is_enabled("pacemaker"):
+        service_manager = ServiceManager()
+        if service_manager.service_is_enabled("pacemaker"):
             task_inst.info("pacemaker.service is enabled")
         else:
             task_inst.warn("pacemaker.service is disabled")
 
-        if crmshutils.service_is_enabled("corosync"):
+        if service_manager.service_is_enabled("corosync"):
             task_inst.warn("corosync.service is enabled")
 
         for s in ("corosync", "pacemaker"):
-            if crmshutils.service_is_active(s):
+            if service_manager.service_is_active(s):
                 task_inst.info("{}.service is running".format(s))
             else:
                 task_inst.error("{}.service is not running!".format(s))
@@ -250,7 +253,7 @@ def check_fencing():
             task_inst.warn(state_msg)
 
         if re.search(r'sbd$', res_agent):
-            if crmshutils.service_is_active("sbd"):
+            if ServiceManager().service_is_active("sbd"):
                 task_inst.info("sbd service is running")
             else:
                 task_inst.warn("sbd service is not running!")

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -10,7 +10,7 @@ from crmsh import utils as crmshutils
 from crmsh import log
 from . import utils
 from . import config
-
+from ..service_manager import ServiceManager
 
 logger = log.setup_logger(__name__)
 
@@ -102,7 +102,7 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
           * pacemaker.service is active
           * stonith is enabled
         """
-        if not crmshutils.service_is_active("pacemaker.service"):
+        if not ServiceManager().service_is_active("pacemaker.service"):
             raise TaskError("Cluster not running!")
         if need_fence:
             self.get_fence_info()

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import re
 import time
 import threading
@@ -11,6 +10,7 @@ from crmsh import log
 from . import utils
 from . import config
 from ..service_manager import ServiceManager
+from ..sh import ShellUtils
 
 logger = log.setup_logger(__name__)
 
@@ -130,7 +130,7 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
 
         # Try to find out which node fire the fence action
         while not self.thread_stop_event.is_set():
-            rc, out, _ = crmshutils.get_stdout_stderr("crm_mon -1|grep -A1 \"Fencing Actions:\"")
+            rc, out, _ = ShellUtils().get_stdout_stderr("crm_mon -1|grep -A1 \"Fencing Actions:\"")
             if rc == 0 and out:
                 match = re.search(r"of (.*) pending: .*origin=(.*)$", out)
                 if match:
@@ -142,7 +142,7 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
 
         # Try to find out proof that fence happened
         while not self.thread_stop_event.is_set():
-            rc, out, _ = crmshutils.get_stdout_stderr(config.FENCE_HISTORY.format(node=target_node))
+            rc, out, _ = ShellUtils().get_stdout_stderr(config.FENCE_HISTORY.format(node=target_node))
             if rc == 0 and out:
                 match = re.search(r"Node {} last fenced at: (.*)".format(target_node), out)
                 if match:
@@ -201,7 +201,7 @@ Fence timeout:     {}
         self.task_pre_check()
 
         for cmd in ['crm_node', 'stonith_admin', 'crm_attribute']:
-            rc, _, err = crmshutils.get_stdout_stderr("which {}".format(cmd))
+            rc, _, err = ShellUtils().get_stdout_stderr("which {}".format(cmd))
             if rc != 0 and err:
                 raise TaskError(err)
 
@@ -213,7 +213,7 @@ Fence timeout:     {}
         Fence node and start a thread to monitor the result
         """
         self.info("Trying to fence node \"{}\"".format(self.target_node))
-        crmshutils.get_stdout_stderr(config.FENCE_NODE.format(self.target_node))
+        ShellUtils().get_stdout_stderr(config.FENCE_NODE.format(self.target_node))
         th = threading.Thread(target=self.fence_action_monitor)
         th.start()
 
@@ -404,7 +404,7 @@ Expected State:    {}
             else:
                 continue
             self.info("Trying to run \"{}\"".format(self.cmd))
-            crmshutils.get_stdout_stderr(self.cmd)
+            ShellUtils().get_stdout_stderr(self.cmd)
             # endless loop will lead to fence
             if not self.looping:
                 break
@@ -481,7 +481,7 @@ Fence timeout:     {}
         self.task_pre_check()
 
         for cmd in ["iptables"]:
-            rc, _, err = crmshutils.get_stdout_stderr("which {}".format(cmd))
+            rc, _, err = ShellUtils().get_stdout_stderr("which {}".format(cmd))
             if rc != 0 and err:
                 raise TaskError(err)
 
@@ -507,7 +507,7 @@ Fence timeout:     {}
         for node in self.peer_nodelist:
             self.info("Trying to temporarily block {} communication ip".format(node))
             for ip in crmshutils.get_iplist_from_name(node):
-                crmshutils.get_stdout_stderr(config.BLOCK_IP.format(action='I', peer_ip=ip))
+                ShellUtils().get_stdout_stderr(config.BLOCK_IP.format(action='I', peer_ip=ip))
 
     def un_block(self):
         """
@@ -522,14 +522,14 @@ Fence timeout:     {}
         for node in self.peer_nodelist:
             self.info("Trying to recover {} communication ip".format(node))
             for ip in crmshutils.get_iplist_from_name(node):
-                crmshutils.get_stdout_stderr(config.BLOCK_IP.format(action='D', peer_ip=ip))
+                ShellUtils().get_stdout_stderr(config.BLOCK_IP.format(action='D', peer_ip=ip))
 
     def run(self):
         """
         Fence node and start a thread to monitor the result
         """
         #self.info("Trying to fence node \"{}\"".format(self.target_node))
-        #crmshutils.get_stdout_stderr(config.FENCE_NODE.format(self.target_node), wait=False)
+        #ShellUtils().get_stdout_stderr(config.FENCE_NODE.format(self.target_node), wait=False)
         th = threading.Thread(target=self.fence_action_monitor)
         th.start()
 

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from crmsh import utils as crmshutils
 from . import config
 from crmsh import log
+from crmsh.sh import ShellUtils
 
 
 logger = log.setup_logger(__name__)
@@ -129,7 +130,7 @@ def check_node_status(node, state):
     """
     Check whether the node has expected state
     """
-    rc, stdout, stderr = crmshutils.get_stdout_stderr('crm_node -l')
+    rc, stdout, stderr = ShellUtils().get_stdout_stderr('crm_node -l')
     if rc != 0:
         msg_error(stderr)
         return False
@@ -143,7 +144,7 @@ def online_nodes():
     """
     Get online node list
     """
-    rc, stdout, stderr = crmshutils.get_stdout_stderr('crm_mon -1')
+    rc, stdout, stderr = ShellUtils().get_stdout_stderr('crm_mon -1')
     if rc == 0 and stdout:
         res = re.search(r'Online:\s+\[\s(.*)\s\]', stdout)
         if res:
@@ -167,7 +168,7 @@ def this_node():
     Try to get the node name from crm_node command
     If failed, use its hostname
     """
-    rc, stdout, stderr = crmshutils.get_stdout_stderr("crm_node --name")
+    rc, stdout, stderr = ShellUtils().get_stdout_stderr("crm_node --name")
     if rc != 0:
         msg_error(stderr)
         return crmshutils.this_node()
@@ -183,7 +184,7 @@ def corosync_port_list():
     Get corosync ports using corosync-cmapctl
     """
     ports = []
-    rc, out, _ = crmshutils.get_stdout_stderr("corosync-cmapctl totem.interface")
+    rc, out, _ = ShellUtils().get_stdout_stderr("corosync-cmapctl totem.interface")
     if rc == 0 and out:
         ports = re.findall(r'(?:mcastport.*) ([0-9]+)', out)
     return ports
@@ -251,7 +252,7 @@ def is_valid_sbd(dev):
     if not os.path.exists(dev):
         return False
 
-    rc, out, err = crmshutils.get_stdout_stderr(config.SBD_CHECK_CMD.format(dev=dev))
+    rc, out, err = ShellUtils().get_stdout_stderr(config.SBD_CHECK_CMD.format(dev=dev))
     if rc != 0 and err:
         msg_error(err)
         return False

--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -150,6 +150,7 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
         local_user = crmsh.utils.user_pair_for_ssh(remote_nodes[0])[0]
         crmsh.bootstrap.init_ssh_impl(
             local_user,
+            None,
             [(crmsh.utils.user_pair_for_ssh(node)[1], node) for node in remote_nodes],
         )
 

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -27,7 +27,8 @@ Help for the level itself is like this:
 
 import os
 import re
-from .utils import page_string, get_stdout_stderr
+from .sh import ShellUtils
+from .utils import page_string
 from . import config
 from . import clidisplay
 from .ordereddict import odict
@@ -95,7 +96,7 @@ class HelpEntry(object):
 
         short_help = clidisplay.help_header(self.short)
         if self.from_cli and self.level and self.name:
-            _, output, _ = get_stdout_stderr(f"crm {self.level} {self.name} --help-without-redirect")
+            _, output, _ = ShellUtils().get_stdout_stderr(f"crm {self.level} {self.name} --help-without-redirect")
             page_string(short_help + '\n\n'+ output)
             return
 

--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -9,12 +9,12 @@ import glob
 import configparser
 
 from . import config
-from . import constants
 from . import userdir
 from . import logtime
 from . import logparser
 from . import utils
 from . import log
+from .sh import ShellUtils
 
 
 logger = log.setup_logger(__name__)
@@ -222,7 +222,7 @@ class Report(object):
                 self.error(msg)
                 return None
         try:
-            rc, tf_loc = utils.get_stdout("tar -t%s < %s 2> /dev/null | head -1" % (tar_unpack_option, utils.quote(bfname)))
+            rc, tf_loc = ShellUtils().get_stdout("tar -t%s < %s 2> /dev/null | head -1" % (tar_unpack_option, utils.quote(bfname)))
             if os.path.abspath(tf_loc) != os.path.abspath(loc):
                 logger.debug("top directory in tarball: %s, doesn't match the tarball name: %s", tf_loc, loc)
                 loc = os.path.join(os.path.dirname(loc), tf_loc)
@@ -477,7 +477,7 @@ class Report(object):
                 "-v" if config.core.debug else "", self.from_dt.ctime(),
                 to_option, nodes_option, str(config.core.report_tool_options), d)
         logger.debug("Running command: {}".format(cmd))
-        rc, out, err = utils.get_stdout_stderr(cmd)
+        rc, out, err = ShellUtils().get_stdout_stderr(cmd)
         if rc != 0:
             if err:
                 print(err)

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -6,9 +6,10 @@ import re
 import time
 from contextlib import contextmanager
 
-from . import utils, sh
+from . import sh
 from . import config
 from . import log
+from .sh import ShellUtils
 
 
 logger = log.setup_logger(__name__)
@@ -45,7 +46,7 @@ class Lock(object):
         """
         Run command on local
         """
-        return utils.get_stdout_stderr(cmd)
+        return ShellUtils().get_stdout_stderr(cmd)
 
     def _create_lock_dir(self):
         """

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -6,7 +6,7 @@ import re
 import time
 from contextlib import contextmanager
 
-from . import utils
+from . import utils, sh
 from . import config
 from . import log
 
@@ -115,7 +115,7 @@ class RemoteLock(Lock):
         Run command on remote node
         """
         # TODO: pass SSH_OPTION
-        rc, out, err = utils.run_cmd_on_remote(cmd, self.remote_node)
+        rc, out, err = sh.auto_shell().get_stdout_stderr_no_input(self.remote_node, cmd)
         if rc == self.SSH_EXIT_ERR:
             raise SSHError(err)
         return rc, out, err

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -115,7 +115,7 @@ class RemoteLock(Lock):
         Run command on remote node
         """
         # TODO: pass SSH_OPTION
-        rc, out, err = sh.auto_shell().get_stdout_stderr_no_input(self.remote_node, cmd)
+        rc, out, err = sh.cluster_shell().get_rc_stdout_stderr_without_input(self.remote_node, cmd)
         if rc == self.SSH_EXIT_ERR:
             raise SSHError(err)
         return rc, out, err

--- a/crmsh/ocfs2.py
+++ b/crmsh/ocfs2.py
@@ -93,7 +93,7 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         """
         if not self.use_stage:
             return
-        out = sh.auto_shell().get_stdout_or_raise_error("crm configure show")
+        out = sh.cluster_shell().get_stdout_or_raise_error("crm configure show")
         if "fstype=ocfs2" in out:
             logger.info("Already configured OCFS2 related resources")
             raise utils.TerminateSubCommand
@@ -140,7 +140,7 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
                 raise utils.TerminateSubCommand
 
         for dev in self.ocfs2_devices:
-            sh.auto_shell().get_stdout_or_raise_error("wipefs -a {}".format(dev))
+            sh.cluster_shell().get_stdout_or_raise_error("wipefs -a {}".format(dev))
 
     def _dynamic_verify(self):
         """
@@ -168,14 +168,14 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         """
         with logger_utils.status_long("  Creating OCFS2 filesystem for {}".format(target)):
             self.cluster_name = corosync.get_value('totem.cluster_name')
-            sh.auto_shell().get_stdout_or_raise_error(self.MKFS_CMD.format(self.cluster_name, self.MAX_CLONE_NUM, target))
+            sh.cluster_shell().get_stdout_or_raise_error(self.MKFS_CMD.format(self.cluster_name, self.MAX_CLONE_NUM, target))
 
     @contextmanager
     def _vg_change(self):
         """
         vgchange process using contextmanager
         """
-        shell = sh.auto_shell()
+        shell = sh.cluster_shell()
         shell.get_stdout_or_raise_error("vgchange -ay {}".format(self.vg_id))
         try:
             yield
@@ -187,7 +187,7 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         Create PV, VG, LV and return LV path
         """
         disks_string = ' '.join(self.ocfs2_devices)
-        shell = sh.auto_shell()
+        shell = sh.cluster_shell()
 
         # Create PV
         with logger_utils.status_long("  Creating PV for {}".format(disks_string)):
@@ -314,7 +314,7 @@ e.g. crm cluster init ocfs2 -o <ocfs2_device>
         """
         Find device name from OCF Filesystem param on peer node
         """
-        out = sh.auto_shell().get_stdout_or_raise_error("crm configure show", peer)
+        out = sh.cluster_shell().get_stdout_or_raise_error("crm configure show", peer)
         for line in out.splitlines():
             if "fstype=ocfs2" in line:
                 res = re.search("device=\"(.*?)\"", line)

--- a/crmsh/parallax.py
+++ b/crmsh/parallax.py
@@ -2,7 +2,7 @@
 # See COPYING for license information.
 import typing
 
-import crmsh.utils
+from crmsh.sh import Utils
 from crmsh.prun import prun
 
 
@@ -22,7 +22,10 @@ def parallax_call(nodes, cmd, *, timeout_seconds: int = -1):
         if isinstance(result, prun.PRunError):
             raise ValueError('Failed to run command {} on {}@{}: {}'.format(cmd, result.user, result.host, result))
         elif result.returncode != 0:
-            raise ValueError("Failed on {}: {}".format(node, crmsh.utils.to_ascii(result.stderr)))
+            raise ValueError("Failed on {}: {}".format(
+                node,
+                Utils.decode_str(result.stderr) if result.stderr is not None else None,
+            ))
     return [(node, (result.returncode, result.stdout, result.stderr)) for node, result in results.items()]
 
 

--- a/crmsh/prun/prun.py
+++ b/crmsh/prun/prun.py
@@ -6,9 +6,9 @@ import typing
 
 import crmsh.constants
 import crmsh.userdir
-import crmsh.utils
 from crmsh.prun.runner import Task, Runner
-
+from crmsh.user_of_host import UserOfHost
+from crmsh.sh import Utils
 
 _DEFAULT_CONCURRENCY = 32
 
@@ -96,7 +96,7 @@ def prun_multimap(
 
 
 def _build_run_task(remote: str, cmdline: str) -> Task:
-    local_sudoer, remote_sudoer = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(remote)
+    local_sudoer, remote_sudoer = UserOfHost.instance().user_pair_for_ssh(remote)
     if _is_local_host(remote):
         if 0 == os.geteuid():
             args = ['/bin/sh']
@@ -125,7 +125,7 @@ def _handle_run_result(task: Task, interceptor: PRunInterceptor = PRunIntercepto
     if task.returncode is None:
         return interceptor.exception(TimeOutError(task.context['ssh_user'], task.context['host']))
     elif task.returncode == 255:
-        return interceptor.exception(SSHError(task.context['ssh_user'], task.context['host'], crmsh.utils.to_ascii(task.stderr)))
+        return interceptor.exception(SSHError(task.context['ssh_user'], task.context['host'], Utils.decode_str(task.stderr)))
     else:
         return interceptor.result(ProcessResult(task.returncode, task.stdout, task.stderr))
 
@@ -147,7 +147,7 @@ def pcopy_to_remote(
         else:
             return {x: None for x in hosts}
     flags = '-pr' if recursive else '-p'
-    local_sudoer, _ = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(hosts[0])
+    local_sudoer, _ = UserOfHost.instance().user_pair_for_ssh(hosts[0])
     script = "put {} '{}' '{}'\n".format(flags, src, dst)
     ssh = None
     try:
@@ -171,7 +171,7 @@ exec sudo -u {local_sudoer} ssh "$@"''')
 
 
 def _build_copy_task(ssh: str, script: str, host: str):
-    _, remote_sudoer = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(host)
+    _, remote_sudoer = UserOfHost.instance().user_pair_for_ssh(host)
     cmd = "sftp {} {} -o BatchMode=yes -s 'sudo PATH=/usr/lib/ssh:/usr/libexec/ssh /bin/sh -c \"exec sftp-server\"' -b - {}@{}".format(
         ssh,
         crmsh.constants.SSH_OPTION,
@@ -190,9 +190,9 @@ def _parse_copy_result(task: Task) -> typing.Optional[PRunError]:
     if task.returncode == 0:
         return None
     elif task.returncode == 255:
-        return SSHError(task.context['ssh_user'], task.context['host'], crmsh.utils.to_ascii(task.stdout))
+        return SSHError(task.context['ssh_user'], task.context['host'], Utils.decode_str(task.stdout))
     else:
-        return PRunError(task.context['ssh_user'], task.context['host'], crmsh.utils.to_ascii(task.stdout))
+        return PRunError(task.context['ssh_user'], task.context['host'], Utils.decode_str(task.stdout))
 
 
 def pfetch_from_remote(
@@ -206,7 +206,7 @@ def pfetch_from_remote(
 
     Files are copied to directory <dst>/<host>/ corresponding to each source host."""
     flags = '-pR' if recursive else '-p'
-    local_sudoer, _ = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(hosts[0])
+    local_sudoer, _ = UserOfHost.instance().user_pair_for_ssh(hosts[0])
     ssh = None
     try:
         ssh = tempfile.NamedTemporaryFile('w', encoding='utf-8', delete=False)
@@ -232,7 +232,7 @@ exec sudo -u {local_sudoer} ssh "$@"''')
 
 
 def _build_fetch_task( ssh: str, host: str, src: str, dst: str, flags: str) -> Task:
-    _, remote_sudoer = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(host)
+    _, remote_sudoer = UserOfHost.instance().user_pair_for_ssh(host)
     cmd = "sftp {} {} -o BatchMode=yes -s 'sudo PATH=/usr/lib/ssh:/usr/libexec/ssh /bin/sh -c \"exec sftp-server\"' -b - {}@{}".format(
         ssh,
         crmsh.constants.SSH_OPTION,

--- a/crmsh/pyshim.py
+++ b/crmsh/pyshim.py
@@ -1,0 +1,21 @@
+import functools
+
+
+try:
+    from functools import cache
+except ImportError:
+    def cache(f):
+        cached_return_value = dict()
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            nonlocal cached_return_value
+            key = (tuple(args), tuple(sorted(kwargs.items())))
+            try:
+                return cached_return_value[key]
+            except KeyError:
+                ret = f(*args, **kwargs)
+                cached_return_value[key] = ret
+                return ret
+
+        return wrapper

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -295,7 +295,7 @@ class QDevice(object):
         exception_msg = ""
         suggest = ""
         duplicated_cluster_name = False
-        shell = sh.auto_shell()
+        shell = sh.cluster_shell()
         if not utils.package_is_installed("corosync-qnetd", remote_addr=self.qnetd_addr):
             exception_msg = "Package \"corosync-qnetd\" not installed on {}!".format(self.qnetd_addr)
             suggest = "install \"corosync-qnetd\" on {}".format(self.qnetd_addr)
@@ -427,7 +427,7 @@ class QDevice(object):
         """
         cmd = "corosync-qdevice-net-certutil -r -n {}".format(self.cluster_name)
         QDevice.log_only_to_file("Step 5: Generate certificate request {}".format(self.qdevice_crq_filename), cmd)
-        sh.auto_shell().get_stdout_or_raise_error(cmd)
+        sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
     def copy_crq_to_qnetd(self):
         """
@@ -473,7 +473,7 @@ class QDevice(object):
         QDevice.log_only_to_file(
                 "Step 9: Import certificate file {} on local".format(os.path.basename(self.qnetd_cluster_crt_on_local)),
                 cmd)
-        sh.auto_shell().get_stdout_or_raise_error(cmd)
+        sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
     def copy_p12_to_cluster(self):
         """
@@ -546,7 +546,7 @@ class QDevice(object):
 
         cmd = "corosync-qdevice-net-certutil -i -c {}".format(self.qnetd_cacert_on_cluster)
         QDevice.log_only_to_file("Step 2: Initialize database on local", cmd)
-        sh.auto_shell().get_stdout_or_raise_error(cmd)
+        sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
     def fetch_p12_from_cluster(self):
         """
@@ -569,7 +569,7 @@ class QDevice(object):
         """
         cmd = "corosync-qdevice-net-certutil -m -c {}".format(self.qdevice_p12_on_cluster)
         QDevice.log_only_to_file("Step 4: Import cluster certificate and key", cmd)
-        sh.auto_shell().get_stdout_or_raise_error(cmd)
+        sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
     def certificate_process_on_join(self):
         """
@@ -635,7 +635,7 @@ class QDevice(object):
         qnetd_host = corosync.get_value('quorum.device.net.host')
         cluster_name = corosync.get_value('totem.cluster_name')
         cls_inst = cls(qnetd_host, cluster_name=cluster_name)
-        shell = sh.auto_shell()
+        shell = sh.cluster_shell()
         cmd = "test -f {crt_file} && rm -f {crt_file}".format(crt_file=cls_inst.qnetd_cluster_crt_on_qnetd)
         shell.get_stdout_or_raise_error(cmd, qnetd_host)
         cmd = "test -f {crq_file} && rm -f {crq_file}".format(crq_file=cls_inst.qdevice_crq_on_qnetd)
@@ -708,7 +708,7 @@ class QDevice(object):
         """
         Check if qdevice can contribute vote
         """
-        out = sh.auto_shell().get_stdout_or_raise_error("corosync-quorumtool -s", success_exit_status={0, 2})
+        out = sh.cluster_shell().get_stdout_or_raise_error("corosync-quorumtool -s", success_exit_status={0, 2})
         res = re.search(r'\s+0\s+0\s+Qdevice', out)
         if res:
             qnetd_host = corosync.get_value('quorum.device.net.host')

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -8,7 +8,7 @@ import typing
 from enum import Enum
 
 import crmsh.parallax
-from . import constants
+from . import constants, sh
 from . import utils
 from . import parallax
 from . import corosync
@@ -16,7 +16,7 @@ from . import xmlutil
 from . import bootstrap
 from . import lock
 from . import log
-
+from .service_manager import ServiceManager
 
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
@@ -295,17 +295,18 @@ class QDevice(object):
         exception_msg = ""
         suggest = ""
         duplicated_cluster_name = False
+        shell = sh.auto_shell()
         if not utils.package_is_installed("corosync-qnetd", remote_addr=self.qnetd_addr):
             exception_msg = "Package \"corosync-qnetd\" not installed on {}!".format(self.qnetd_addr)
             suggest = "install \"corosync-qnetd\" on {}".format(self.qnetd_addr)
-        elif utils.service_is_active("corosync-qnetd", remote_addr=self.qnetd_addr):
+        elif ServiceManager().service_is_active("corosync-qnetd", remote_addr=self.qnetd_addr):
             cmd = "corosync-qnetd-tool -l -c {}".format(self.cluster_name)
-            if utils.get_stdout_or_raise_error(cmd, remote=self.qnetd_addr):
+            if shell.get_stdout_or_raise_error(cmd, self.qnetd_addr):
                 duplicated_cluster_name = True
         else:
             cmd = "test -f {}".format(self.qnetd_cluster_crt_on_qnetd)
             try:
-                utils.get_stdout_or_raise_error(cmd, remote=self.qnetd_addr)
+                shell.get_stdout_or_raise_error(cmd, self.qnetd_addr)
             except ValueError:
                 # target file not exist
                 pass
@@ -323,16 +324,16 @@ class QDevice(object):
             raise ValueError(exception_msg)
 
     def enable_qnetd(self):
-        utils.enable_service(self.qnetd_service, remote_addr=self.qnetd_addr)
+        ServiceManager().enable_service(self.qnetd_service, remote_addr=self.qnetd_addr)
 
     def disable_qnetd(self):
-        utils.disable_service(self.qnetd_service, remote_addr=self.qnetd_addr)
+        ServiceManager().disable_service(self.qnetd_service, remote_addr=self.qnetd_addr)
 
     def start_qnetd(self):
-        utils.start_service(self.qnetd_service, remote_addr=self.qnetd_addr)
+        ServiceManager().start_service(self.qnetd_service, remote_addr=self.qnetd_addr)
 
     def stop_qnetd(self):
-        utils.stop_service(self.qnetd_service, remote_addr=self.qnetd_addr)
+        ServiceManager().stop_service(self.qnetd_service, remote_addr=self.qnetd_addr)
 
     def set_cluster_name(self):
         if not self.cluster_name:
@@ -426,7 +427,7 @@ class QDevice(object):
         """
         cmd = "corosync-qdevice-net-certutil -r -n {}".format(self.cluster_name)
         QDevice.log_only_to_file("Step 5: Generate certificate request {}".format(self.qdevice_crq_filename), cmd)
-        utils.get_stdout_or_raise_error(cmd)
+        sh.auto_shell().get_stdout_or_raise_error(cmd)
 
     def copy_crq_to_qnetd(self):
         """
@@ -472,7 +473,7 @@ class QDevice(object):
         QDevice.log_only_to_file(
                 "Step 9: Import certificate file {} on local".format(os.path.basename(self.qnetd_cluster_crt_on_local)),
                 cmd)
-        utils.get_stdout_or_raise_error(cmd)
+        sh.auto_shell().get_stdout_or_raise_error(cmd)
 
     def copy_p12_to_cluster(self):
         """
@@ -545,7 +546,7 @@ class QDevice(object):
 
         cmd = "corosync-qdevice-net-certutil -i -c {}".format(self.qnetd_cacert_on_cluster)
         QDevice.log_only_to_file("Step 2: Initialize database on local", cmd)
-        utils.get_stdout_or_raise_error(cmd)
+        sh.auto_shell().get_stdout_or_raise_error(cmd)
 
     def fetch_p12_from_cluster(self):
         """
@@ -568,7 +569,7 @@ class QDevice(object):
         """
         cmd = "corosync-qdevice-net-certutil -m -c {}".format(self.qdevice_p12_on_cluster)
         QDevice.log_only_to_file("Step 4: Import cluster certificate and key", cmd)
-        utils.get_stdout_or_raise_error(cmd)
+        sh.auto_shell().get_stdout_or_raise_error(cmd)
 
     def certificate_process_on_join(self):
         """
@@ -634,10 +635,11 @@ class QDevice(object):
         qnetd_host = corosync.get_value('quorum.device.net.host')
         cluster_name = corosync.get_value('totem.cluster_name')
         cls_inst = cls(qnetd_host, cluster_name=cluster_name)
+        shell = sh.auto_shell()
         cmd = "test -f {crt_file} && rm -f {crt_file}".format(crt_file=cls_inst.qnetd_cluster_crt_on_qnetd)
-        utils.get_stdout_or_raise_error(cmd, remote=qnetd_host)
+        shell.get_stdout_or_raise_error(cmd, qnetd_host)
         cmd = "test -f {crq_file} && rm -f {crq_file}".format(crq_file=cls_inst.qdevice_crq_on_qnetd)
-        utils.get_stdout_or_raise_error(cmd, remote=qnetd_host)
+        shell.get_stdout_or_raise_error(cmd, qnetd_host)
 
     def config_qdevice(self):
         """
@@ -706,7 +708,7 @@ class QDevice(object):
         """
         Check if qdevice can contribute vote
         """
-        out = utils.get_stdout_or_raise_error("corosync-quorumtool -s", success_val_list=[0, 2])
+        out = sh.auto_shell().get_stdout_or_raise_error("corosync-quorumtool -s", success_exit_status={0, 2})
         res = re.search(r'\s+0\s+0\s+Qdevice', out)
         if res:
             qnetd_host = corosync.get_value('quorum.device.net.host')

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -13,8 +13,9 @@ from . import config
 from . import options
 from . import userdir
 from . import utils
+from .sh import ShellUtils
 from .utils import stdout2list, is_program, is_process, to_ascii
-from .utils import os_types_list, get_stdout
+from .utils import os_types_list
 from .utils import crm_msec, crm_time_cmp
 from . import log
 
@@ -53,7 +54,7 @@ def can_use_lrmadmin():
     # after this glue release all users can get meta-data and
     # similar from lrmd
     minimum_glue = "1.0.10"
-    _rc, glue_ver = get_stdout("%s -v" % lrmadmin_prog, stderr_on=False)
+    _rc, glue_ver = ShellUtils().get_stdout("%s -v" % lrmadmin_prog, stderr_on=False)
     if not glue_ver:  # lrmadmin probably not found
         return False
     v_min = version.LooseVersion(minimum_glue)
@@ -69,7 +70,7 @@ def can_use_lrmadmin():
 
 @utils.memoize
 def can_use_crm_resource():
-    _rc, s = get_stdout("crm_resource --list-ocf-providers", stderr_on=False)
+    _rc, s = ShellUtils().get_stdout("crm_resource --list-ocf-providers", stderr_on=False)
     return s != ""
 
 

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -55,11 +55,11 @@ def collect_ratraces():
     """
     # since the "trace_dir" attribute been removed from cib after untrace
     # need to parse crmsh log file to extract custom trace ra log directory on each node
-    shell = sh.auto_shell()
+    shell = sh.cluster_shell()
     log_contents = ""
     cmd = "grep 'INFO: Trace for .* is written to ' {}*|grep -v 'collect'".format(log.CRMSH_LOG_FILE)
     for node in crmutils.list_cluster_nodes():
-        log_contents += shell.get_stdout_stderr_no_input(node, cmd)[1] + "\n"
+        log_contents += shell.get_rc_stdout_stderr_without_input(node, cmd)[1] + "\n"
     trace_dir_str = ' '.join(list(set(re.findall("written to (.*)/.*", log_contents))))
     if not trace_dir_str:
         return

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -13,6 +13,7 @@ import datetime
 from crmsh import log, sh
 from crmsh import utils as crmutils
 from crmsh.report import constants, utillib
+from crmsh.sh import ShellUtils
 
 
 logger = log.setup_report_logger(__name__)
@@ -21,7 +22,7 @@ logger = log.setup_report_logger(__name__)
 def collect_ocfs2_info():
     ocfs2_f = os.path.join(constants.WORKDIR, constants.OCFS2_F)
     with open(ocfs2_f, "w") as f:
-        rc, out, err = crmutils.get_stdout_stderr("mounted.ocfs2 -d")
+        rc, out, err = ShellUtils().get_stdout_stderr("mounted.ocfs2 -d")
         if rc != 0:
             f.write("Failed to run \"mounted.ocfs2 -d\": {}".format(err))
             return
@@ -43,7 +44,7 @@ def collect_ocfs2_info():
             if not utillib.which(cmd_name) or \
                cmd_name == "cat" and not os.path.exists(cmd.split()[1]):
                 continue
-            _, out = crmutils.get_stdout(cmd)
+            _, out = ShellUtils().get_stdout(cmd)
             f.write("\n\n#=====[ Command ] ==========================#\n")
             f.write("# %s\n"%(cmd))
             f.write(out)
@@ -226,7 +227,7 @@ def collect_sbd_info():
     sbd_f = os.path.join(constants.WORKDIR, constants.SBD_F)
     cmd = ". {};export SBD_DEVICE;{};{}".format(constants.SBDCONF, "sbd dump", "sbd list")
     with open(sbd_f, "w") as f:
-        _, out = crmutils.get_stdout(cmd)
+        _, out = ShellUtils().get_stdout(cmd)
         f.write("\n\n#=====[ Command ] ==========================#\n")
         f.write("# %s\n"%(cmd))
         f.write(out)

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -10,7 +10,7 @@ import stat
 import pwd
 import datetime
 
-from crmsh import log
+from crmsh import log, sh
 from crmsh import utils as crmutils
 from crmsh.report import constants, utillib
 
@@ -55,10 +55,11 @@ def collect_ratraces():
     """
     # since the "trace_dir" attribute been removed from cib after untrace
     # need to parse crmsh log file to extract custom trace ra log directory on each node
+    shell = sh.auto_shell()
     log_contents = ""
     cmd = "grep 'INFO: Trace for .* is written to ' {}*|grep -v 'collect'".format(log.CRMSH_LOG_FILE)
     for node in crmutils.list_cluster_nodes():
-        log_contents += crmutils.get_stdout_or_raise_error(cmd, remote=node, no_raise=True) + "\n"
+        log_contents += shell.get_stdout_stderr_no_input(node, cmd)[1] + "\n"
     trace_dir_str = ' '.join(list(set(re.findall("written to (.*)/.*", log_contents))))
     if not trace_dir_str:
         return

--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -13,6 +13,7 @@ import shutil
 from crmsh import utils as crmutils
 from crmsh import config, log, userdir
 from crmsh.report import constants, utillib
+from crmsh.sh import ShellUtils
 
 
 logger = log.setup_report_logger(__name__)
@@ -290,7 +291,7 @@ def run():
     if is_collector():
         utillib.collect_info()
         cmd = r"cd %s/.. && tar -h -cf - %s" % (constants.WORKDIR, constants.WE)
-        code, out, err = crmutils.get_stdout_stderr(cmd, raw=True)
+        code, out, err = ShellUtils().get_stdout_stderr(cmd, raw=True)
         print("{}{}".format(constants.COMPRESS_DATA_FLAG, out))
     else:
         p_list = []

--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -416,7 +416,7 @@ def get_distro_info():
         res = re.search("PRETTY_NAME=\"(.*)\"", read_from_file(constants.OSRELEASE))
     elif which("lsb_release"):
         logger.debug("Using lsb_release to get distribution info")
-        out = sh.auto_shell().get_stdout_or_raise_error("lsb_release -d")
+        out = sh.cluster_shell().get_stdout_or_raise_error("lsb_release -d")
         res = re.search("Description:\s+(.*)", out)
     return res.group(1) if res else "Unknown"
 
@@ -1362,7 +1362,7 @@ def start_slave_collector(node, arg_str):
         cmd = r'ssh {} {} "{} {}"'.format(constants.SSH_OPTS, node, constants.SUDO, cmd)
         for item in arg_str.split():
             cmd += " {}".format(str(item))
-        code, out, err = sh.LocalShell().get_stdout_stderr(constants.SSH_USER, cmd)
+        code, out, err = sh.LocalShell().get_rc_stdout_stderr(constants.SSH_USER, cmd)
         if code != 0:
             logger.warning(err)
             for ip in get_peer_ip():

--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -22,7 +22,7 @@ from threading import Timer
 from inspect import getmembers, isfunction
 
 import crmsh.config
-from crmsh import utils as crmutils
+from crmsh import utils as crmutils, sh
 from crmsh import corosync, log, userdir
 from crmsh.report import constants, collect
 
@@ -416,7 +416,7 @@ def get_distro_info():
         res = re.search("PRETTY_NAME=\"(.*)\"", read_from_file(constants.OSRELEASE))
     elif which("lsb_release"):
         logger.debug("Using lsb_release to get distribution info")
-        out = crmutils.get_stdout_or_raise_error("lsb_release -d")
+        out = sh.auto_shell().get_stdout_or_raise_error("lsb_release -d")
         res = re.search("Description:\s+(.*)", out)
     return res.group(1) if res else "Unknown"
 
@@ -1362,7 +1362,7 @@ def start_slave_collector(node, arg_str):
         cmd = r'ssh {} {} "{} {}"'.format(constants.SSH_OPTS, node, constants.SUDO, cmd)
         for item in arg_str.split():
             cmd += " {}".format(str(item))
-        code, out, err = crmutils.su_get_stdout_stderr(constants.SSH_USER, cmd)
+        code, out, err = sh.LocalShell().get_stdout_stderr(constants.SSH_USER, cmd)
         if code != 0:
             logger.warning(err)
             for ip in get_peer_ip():

--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -25,6 +25,7 @@ import crmsh.config
 from crmsh import utils as crmutils, sh
 from crmsh import corosync, log, userdir
 from crmsh.report import constants, collect
+from crmsh.sh import ShellUtils
 
 
 logger = log.setup_report_logger(__name__)
@@ -767,7 +768,7 @@ def get_cib_dir():
 
 
 def get_command_info(cmd):
-    code, out, err = crmutils.get_stdout_stderr(cmd)
+    code, out, err = ShellUtils().get_stdout_stderr(cmd)
     if out:
         return (code, out + '\n')
     else:
@@ -1120,7 +1121,7 @@ def mktemplate(argv):
 def pe_to_dot(pe_file):
     dotf = '.'.join(pe_file.split('.')[:-1]) + '.dot'
     cmd = "%s -D %s -x %s" % (constants.PTEST, dotf, pe_file)
-    code, _ = crmutils.get_stdout(cmd)
+    code, _ = ShellUtils().get_stdout(cmd)
     if code != 0:
         logger.warning("pe_to_dot: %s -> %s failed", pe_file, dotf)
 
@@ -1216,7 +1217,7 @@ def print_log(logf):
     """
     cat = find_decompressor(logf)
     cmd = "%s %s" % (cat, logf)
-    out = crmutils.get_stdout(cmd)
+    out = ShellUtils().get_stdout(cmd)
     return out
 
 
@@ -1356,7 +1357,7 @@ def start_slave_collector(node, arg_str):
     if node == constants.WE:
         for item in arg_str.split():
             cmd += " {}".format(str(item))
-        _, out = crmutils.get_stdout(cmd)
+        _, out = ShellUtils().get_stdout(cmd)
     else:
         node = f"{constants.SSH_USER}@{node}" if constants.SSH_USER else node
         cmd = r'ssh {} {} "{} {}"'.format(constants.SSH_OPTS, node, constants.SUDO, cmd)
@@ -1368,7 +1369,7 @@ def start_slave_collector(node, arg_str):
             for ip in get_peer_ip():
                 logger.info("Trying connect by %s", ip)
                 cmd = cmd.replace(node, ip, 1)
-                code, out, err = crmutils.get_stdout_stderr(cmd)
+                code, out, err = ShellUtils().get_stdout_stderr(cmd)
                 if code != 0:
                     logger.warning(err)
                 break
@@ -1388,7 +1389,7 @@ def start_slave_collector(node, arg_str):
             print(data)
 
     cmd = r"(cd {} && tar xf -)".format(constants.WORKDIR)
-    crmutils.get_stdout(cmd, input_s=eval(compress_data))
+    ShellUtils().get_stdout(cmd, input_s=eval(compress_data))
 
 
 def str_to_bool(v):
@@ -1404,15 +1405,15 @@ def dump_D_process():
     dump D-state process stack
     '''
     out_string = ""
-    _, out, _ = crmutils.get_stdout_stderr("ps aux|awk '$8 ~ /^D/{print $2}'")
+    _, out, _ = ShellUtils().get_stdout_stderr("ps aux|awk '$8 ~ /^D/{print $2}'")
     len_D_process = len(out.split('\n')) if out else 0
     out_string += "Dump D-state process stack: {}\n".format(len_D_process)
     if len_D_process == 0:
         return out_string
     for pid in out.split('\n'):
-        _, cmd_out, _ = crmutils.get_stdout_stderr("cat /proc/{}/comm".format(pid))
+        _, cmd_out, _ = ShellUtils().get_stdout_stderr("cat /proc/{}/comm".format(pid))
         out_string += "pid: {}     comm: {}\n".format(pid, cmd_out)
-        _, stack_out, _ = crmutils.get_stdout_stderr("cat /proc/{}/stack".format(pid))
+        _, stack_out, _ = ShellUtils().get_stdout_stderr("cat /proc/{}/stack".format(pid))
         out_string += stack_out + "\n\n"
     return out_string
 
@@ -1422,13 +1423,13 @@ def lsof_ocfs2_device():
     List open files for OCFS2 device
     """
     out_string = ""
-    _, out, _ = crmutils.get_stdout_stderr("mount")
+    _, out, _ = ShellUtils().get_stdout_stderr("mount")
     dev_list = re.findall("\n(.*) on .* type ocfs2 ", out)
     for dev in dev_list:
         cmd = "lsof {}".format(dev)
         out_string += "\n\n#=====[ Command ] ==========================#\n"
         out_string += "# {}\n".format(cmd)
-        _, cmd_out, _ = crmutils.get_stdout_stderr(cmd)
+        _, cmd_out, _ = ShellUtils().get_stdout_stderr(cmd)
         if cmd_out:
             out_string += cmd_out
     return out_string
@@ -1462,7 +1463,7 @@ def verify_deb(packages):
     res = ""
     for pack in packages.split():
         cmd = r"dpkg --verify %s | grep -v 'not installed'" % pack
-        code, out = crmutils.get_stdout(cmd)
+        code, out = ShellUtils().get_stdout(cmd)
         if code != 0 and out:
             res = "For package %s:\n" % pack
             res += out + "\n"
@@ -1495,7 +1496,7 @@ def verify_rpm(packages):
     res = ""
     for pack in packages.split():
         cmd = r"rpm --verify %s|grep -v 'not installed'" % pack
-        code, out = crmutils.get_stdout(cmd)
+        code, out = ShellUtils().get_stdout(cmd)
         if code != 0 and out:
             res = "For package %s:\n" % pack
             res += out + "\n"

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -90,7 +90,7 @@ class SBDTimeout(object):
         """
         Get msgwait for sbd device
         """
-        out = sh.auto_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev))
+        out = sh.cluster_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev))
         # Format like "Timeout (msgwait)  : 30"
         res = re.search("\(msgwait\)\s+:\s+(\d+)", out)
         if not res:
@@ -204,7 +204,7 @@ class SBDTimeout(object):
             return
 
         cmd = "systemctl show -p TimeoutStartUSec sbd --value"
-        out = sh.auto_shell().get_stdout_or_raise_error(cmd)
+        out = sh.cluster_shell().get_stdout_or_raise_error(cmd)
         start_timeout = utils.get_systemd_timeout_start_in_sec(out)
         if start_timeout > int(sbd_delay_start_value):
             return
@@ -292,7 +292,7 @@ class SBDManager(object):
         """
         Get UUID for specific device and node
         """
-        out = sh.auto_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev), node)
+        out = sh.cluster_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev), node)
         res = re.search("UUID\s*:\s*(.*)\n", out)
         if not res:
             raise ValueError("Cannot find sbd device UUID for {}".format(dev))
@@ -524,7 +524,7 @@ class SBDManager(object):
                 not ServiceManager().service_is_enabled("sbd.service") or \
                 xmlutil.CrmMonXmlParser.is_resource_configured(self.SBD_RA):
             return
-        shell = sh.auto_shell()
+        shell = sh.cluster_shell()
 
         # disk-based sbd
         if self._get_sbd_device_from_config():

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -9,6 +9,7 @@ from . import constants
 from . import corosync
 from . import xmlutil
 from .service_manager import ServiceManager
+from .sh import ShellUtils
 
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
@@ -619,7 +620,7 @@ class SBDManager(object):
         Check if sbd device already initialized
         """
         cmd = "sbd -d {} dump".format(dev)
-        rc, _, _ = utils.get_stdout_stderr(cmd)
+        rc, _, _ = ShellUtils().get_stdout_stderr(cmd)
         return rc == 0
 
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1,14 +1,14 @@
 import os
 import re
 import shutil
-from . import utils
+from . import utils, sh
 from . import bootstrap
 from .bootstrap import SYSCONFIG_SBD, SBD_SYSTEMD_DELAY_START_DIR
 from . import log
 from . import constants
 from . import corosync
 from . import xmlutil
-
+from .service_manager import ServiceManager
 
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
@@ -73,7 +73,7 @@ class SBDTimeout(object):
         When using diskless SBD with Qdevice, adjust value of sbd_watchdog_timeout
         """
         # add sbd after qdevice started
-        if utils.is_qdevice_configured() and utils.service_is_active("corosync-qdevice.service"):
+        if utils.is_qdevice_configured() and ServiceManager().service_is_active("corosync-qdevice.service"):
             qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
             if self.sbd_watchdog_timeout <= qdevice_sync_timeout:
                 watchdog_timeout_with_qdevice = qdevice_sync_timeout + self.QDEVICE_SYNC_TIMEOUT_MARGIN
@@ -90,7 +90,7 @@ class SBDTimeout(object):
         """
         Get msgwait for sbd device
         """
-        out = utils.get_stdout_or_raise_error("sbd -d {} dump".format(dev))
+        out = sh.auto_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev))
         # Format like "Timeout (msgwait)  : 30"
         res = re.search("\(msgwait\)\s+:\s+(\d+)", out)
         if not res:
@@ -113,7 +113,7 @@ class SBDTimeout(object):
         For non-bootstrap case, get stonith-watchdog-timeout value from cluster property
         """
         default = SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT
-        if not utils.service_is_active("pacemaker.service"):
+        if not ServiceManager().service_is_active("pacemaker.service"):
             return default
         value = utils.get_property("stonith-watchdog-timeout")
         return int(value.strip('s')) if value else default
@@ -204,7 +204,7 @@ class SBDTimeout(object):
             return
 
         cmd = "systemctl show -p TimeoutStartUSec sbd --value"
-        out = utils.get_stdout_or_raise_error(cmd)
+        out = sh.auto_shell().get_stdout_or_raise_error(cmd)
         start_timeout = utils.get_systemd_timeout_start_in_sec(out)
         if start_timeout > int(sbd_delay_start_value):
             return
@@ -292,7 +292,7 @@ class SBDManager(object):
         """
         Get UUID for specific device and node
         """
-        out = utils.get_stdout_or_raise_error("sbd -d {} dump".format(dev), remote=node)
+        out = sh.auto_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev), node)
         res = re.search("UUID\s*:\s*(.*)\n", out)
         if not res:
             raise ValueError("Cannot find sbd device UUID for {}".format(dev))
@@ -521,13 +521,14 @@ class SBDManager(object):
         Configure stonith-sbd resource and related properties
         """
         if not utils.package_is_installed("sbd") or \
-                not utils.service_is_enabled("sbd.service") or \
+                not ServiceManager().service_is_enabled("sbd.service") or \
                 xmlutil.CrmMonXmlParser.is_resource_configured(self.SBD_RA):
             return
+        shell = sh.auto_shell()
 
         # disk-based sbd
         if self._get_sbd_device_from_config():
-            utils.get_stdout_or_raise_error("crm configure primitive {} {}".format(self.SBD_RA_ID, self.SBD_RA))
+            shell.get_stdout_or_raise_error("crm configure primitive {} {}".format(self.SBD_RA_ID, self.SBD_RA))
             utils.set_property("stonith-enabled", "true")
         # disk-less sbd
         else:
@@ -535,7 +536,7 @@ class SBDManager(object):
                 self.timeout_inst = SBDTimeout(self._context)
                 self.timeout_inst.initialize_timeout()
             cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, constants.STONITH_TIMEOUT_DEFAULT)
-            utils.get_stdout_or_raise_error(cmd)
+            shell.get_stdout_or_raise_error(cmd)
 
         # in sbd stage
         if self._context.cluster_is_running:
@@ -551,7 +552,7 @@ class SBDManager(object):
 
         if not utils.package_is_installed("sbd"):
             return
-        if not os.path.exists(SYSCONFIG_SBD) or not utils.service_is_enabled("sbd.service", peer_host):
+        if not os.path.exists(SYSCONFIG_SBD) or not ServiceManager().service_is_enabled("sbd.service", peer_host):
             bootstrap.invoke("systemctl disable sbd.service")
             return
         self._watchdog_inst = Watchdog(remote_user=remote_user, peer_host=peer_host)
@@ -591,7 +592,7 @@ class SBDManager(object):
         """
         inst = cls(bootstrap.Context())
         dev_list = inst._get_sbd_device_from_config()
-        if not dev_list and utils.service_is_active("sbd.service"):
+        if not dev_list and ServiceManager().service_is_active("sbd.service"):
             return True
         return False
 

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -24,7 +24,8 @@ from . import options
 from . import userdir
 from . import utils
 from . import log
-from crmsh.prun import prun
+from .prun import prun
+from .sh import ShellUtils
 import crmsh.parallax
 
 
@@ -1993,7 +1994,7 @@ class RunActions(object):
             return {}
         elif config.core.debug:
             self.printer.print_command(self.local_node_name(), cmdline)
-        rc, out, err = utils.get_stdout_stderr(cmdline, input_s=input_s, shell=True)
+        rc, out, err = ShellUtils().get_stdout_stderr(cmdline, input_s=input_s, shell=True)
         if rc != 0:
             self.printer.error(self.local_node_name(), "Error (%d): %s" % (rc, err))
             return None

--- a/crmsh/service_manager.py
+++ b/crmsh/service_manager.py
@@ -9,11 +9,8 @@ class ServiceManager(object):
     Class to manage systemctl services
     """
 
-    def __init__(self, shell: crmsh.sh.AutoShell = None):
-        if shell is None:
-            self._shell = crmsh.sh.auto_shell()
-        else:
-            self._shell = shell
+    def __init__(self, shell: crmsh.sh.ClusterShell = None):
+        self._shell = crmsh.sh.cluster_shell() if shell is None else shell
 
     def service_is_available(self, name, remote_addr=None):
         """
@@ -60,7 +57,7 @@ class ServiceManager(object):
                 return list()
 
     def _run_on_single_host(self, cmd, host):
-        rc, _, _ = self._shell.get_stdout_stderr_no_input(host, cmd)
+        rc, _, _ = self._shell.get_rc_stdout_stderr_without_input(host, cmd)
         if rc == 255:
             raise ValueError("Failed to run command on host {}: {}".format(host, cmd))
         return rc

--- a/crmsh/service_manager.py
+++ b/crmsh/service_manager.py
@@ -1,0 +1,100 @@
+import typing
+
+import crmsh.parallax
+import crmsh.sh
+
+
+class ServiceManager(object):
+    """
+    Class to manage systemctl services
+    """
+
+    def __init__(self, shell: crmsh.sh.AutoShell = None):
+        if shell is None:
+            self._shell = crmsh.sh.auto_shell()
+        else:
+            self._shell = shell
+
+    def service_is_available(self, name, remote_addr=None):
+        """
+        Check whether service is available
+        """
+        return 0 == self._run_on_single_host("systemctl list-unit-files '{}'".format(name), remote_addr)
+
+    def service_is_enabled(self, name, remote_addr=None):
+        """
+        Check whether service is enabled
+        """
+        return 0 == self._run_on_single_host("systemctl is-enabled '{}'".format(name), remote_addr)
+
+    def service_is_active(self, name, remote_addr=None):
+        """
+        Check whether service is active
+        """
+        return 0 == self._run_on_single_host("systemctl is-active '{}'".format(name), remote_addr)
+
+    def start_service(self, name, enable=False, remote_addr=None, node_list=[]):
+        """
+        Start service
+        Return success node list
+        """
+        if enable:
+            cmd = "systemctl enable --now '{}'".format(name)
+        else:
+            cmd = "systemctl start '{}'".format(name)
+        return self._call(remote_addr, node_list, cmd)
+
+    def _call(self, remote_addr: str, node_list: typing.List[str], cmd: str) -> typing.List[str]:
+        assert not (bool(remote_addr) and bool(node_list))
+        if len(node_list) == 1:
+            remote_addr = node_list[0]
+            node_list = list()
+        if node_list:
+            results = ServiceManager._call_with_parallax(cmd, node_list)
+            return [host for host, result in results.items() if isinstance(result, tuple) and result[0] == 0]
+        else:
+            rc = self._run_on_single_host(cmd, remote_addr)
+            if rc == 0:
+                return [remote_addr]
+            else:
+                return list()
+
+    def _run_on_single_host(self, cmd, host):
+        rc, _, _ = self._shell.get_stdout_stderr_no_input(host, cmd)
+        if rc == 255:
+            raise ValueError("Failed to run command on host {}: {}".format(host, cmd))
+        return rc
+
+    @staticmethod
+    def _call_with_parallax(cmd, host_list):
+        ret = crmsh.parallax.parallax_run(host_list, cmd)
+        if ret is crmsh.parallax.Error:
+            raise ret
+        return ret
+
+    def stop_service(self, name, disable=False, remote_addr=None, node_list=[]):
+        """
+        Stop service
+        Return success node list
+        """
+        if disable:
+            cmd = "systemctl disable --now '{}'".format(name)
+        else:
+            cmd = "systemctl stop '{}'".format(name)
+        return self._call(remote_addr, node_list, cmd)
+
+    def enable_service(self, name, remote_addr=None, node_list=[]):
+        """
+        Enable service
+        Return success node list
+        """
+        cmd = "systemctl enable '{}'".format(name)
+        return self._call(remote_addr, node_list, cmd)
+
+    def disable_service(self, name, remote_addr=None, node_list=[]):
+        """
+        Disable service
+        Return success node list
+        """
+        cmd = "systemctl disable '{}'".format(name)
+        return self._call(remote_addr, node_list, cmd)

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -7,10 +7,10 @@ There many variant of the methods to allow fine-gain control of parameter passin
 
 1. LocalShell allows to run command on local host as various users. It is the most feature-rich one, allowing
    interactive I/O from/to the terminal.
-2. SshShell allows to run command on both local and remote hosts. When running on a remote host, it creates a direct
+2. SSHShell allows to run command on both local and remote hosts. When running on a remote host, it creates a direct
    connection from a specified local_user to the destination host and user. User input from terminal is not allowed, as
    the command is passed through the stdin.
-3. AutoShell runs command on cluster nodes. It leverages su, sudo and ssh to obtain a appreciated session on a
+3. ClusterShell runs command on cluster nodes. It leverages su, sudo and ssh to obtain a appreciated session on a
    destination node. It is only available after ssh bootstrap as it depends on the knowledge about cluster node and user
    configurations.
 
@@ -101,8 +101,13 @@ class LocalShell:
             cmd: str,
             tty=False,
             preserve_env: typing.Optional[typing.List[str]] = None,
-            **kwargs
+            **kwargs,
     ):
+        """Call subprocess.run as another user.
+
+        This variant is the most flexible one as it pass unknown kwargs to the underlay subprocess.run. However, it
+        accepts only cmdline but not argv, as the argv is used internally to switch user.
+        """
         if self.get_effective_user_name() == user:
             args = ['/bin/sh', '-c', cmd]
         elif 0 == self.geteuid():
@@ -120,7 +125,7 @@ class LocalShell:
         logger.debug('su_subprocess_run: %s, %s', args, kwargs)
         return subprocess.run(args, **kwargs)
 
-    def get_stdout_stderr_raw(self, user: str, cmd: str, input: typing.Optional[bytes] = None):
+    def get_rc_stdout_stderr_raw(self, user: str, cmd: str, input: typing.Optional[bytes] = None):
         result = self.su_subprocess_run(
             user, cmd,
             input=input,
@@ -129,8 +134,8 @@ class LocalShell:
         )
         return result.returncode, result.stdout, result.stderr
 
-    def get_stdout_stderr(self, user: str, cmd: str, input: typing.Optional[str] = None):
-        rc, stdout, stderr = self.get_stdout_stderr_raw(user, cmd, input.encode('utf-8') if input is not None else None)
+    def get_rc_stdout_stderr(self, user: str, cmd: str, input: typing.Optional[str] = None):
+        rc, stdout, stderr = self.get_rc_stdout_stderr_raw(user, cmd, input.encode('utf-8') if input is not None else None)
         return rc, Utils.decode_str(stdout).strip(), Utils.decode_str(stderr).strip()
 
     def get_rc_and_error(
@@ -188,7 +193,7 @@ class LocalShell:
             raise CommandFailure(cmd, None, user, Utils.decode_str(result.stderr).strip())
 
 
-class SshShell:
+class SSHShell:
     """Provides methods to run commands on both local and remote hosts as various users.
 
     For remote commands, SSH sessions are created to the destination host and user from a specified local_user.
@@ -217,7 +222,7 @@ class SshShell:
         If the return code is 0, outputs from the command will be ignored and (0, None) is returned.
         If the return code is not 0, outputs from the stdout and stderr is combined as a single message.
         """
-        result = self.subprocess_run_no_input(
+        result = self.subprocess_run_without_input(
             host, user, cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -228,7 +233,7 @@ class SshShell:
         else:
             return result.returncode, Utils.decode_str(result.stdout).strip()
 
-    def subprocess_run_no_input(self, host: typing.Optional[str], user: str, cmd: str, **kwargs):
+    def subprocess_run_without_input(self, host: typing.Optional[str], user: str, cmd: str, **kwargs):
         assert 'input' not in kwargs and 'stdin' not in kwargs
         if host is None or host == self.local_shell.hostname():
             if user == self.local_shell.get_effective_user_name():
@@ -249,12 +254,17 @@ class SshShell:
             )
 
 
-class AutoShell:
+class ClusterShell:
+    """Provides methods to run commands on both local and remote cluster nodes.
+
+    For remote nodes, the local and remote user used for SSH sessions are determined from cluster configuration recorded
+    during bootstrap.
+    """
     def __init__(self, local_shell: LocalShell, user_of_host: UserOfHost):
         self.local_shell = local_shell
         self.user_of_host = user_of_host
 
-    def subprocess_run_no_input(self, host: typing.Optional[str], user: typing.Optional[str], cmd: str, **kwargs):
+    def subprocess_run_without_input(self, host: typing.Optional[str], user: typing.Optional[str], cmd: str, **kwargs):
         assert 'input' not in kwargs and 'stdin' not in kwargs
         if host is None or host == self.local_shell.hostname():
             return subprocess.run(
@@ -273,16 +283,16 @@ class AutoShell:
                 **kwargs,
             )
 
-    def get_raw_stdout_stderr_no_input(self, host, cmd) -> typing.Tuple[int, bytes, bytes]:
-        result = self.subprocess_run_no_input(
+    def get_rc_stdout_stderr_raw_without_input(self, host, cmd) -> typing.Tuple[int, bytes, bytes]:
+        result = self.subprocess_run_without_input(
             host, None, cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
         return result.returncode, result.stdout, result.stderr
 
-    def get_stdout_stderr_no_input(self, host, cmd) -> typing.Tuple[int, str, str]:
-        rc, stdout, stderr = self.get_raw_stdout_stderr_no_input(host, cmd)
+    def get_rc_stdout_stderr_without_input(self, host, cmd) -> typing.Tuple[int, str, str]:
+        rc, stdout, stderr = self.get_rc_stdout_stderr_raw_without_input(host, cmd)
         return rc, Utils.decode_str(stdout).strip(), Utils.decode_str(stderr).strip()
 
     def get_stdout_or_raise_error(
@@ -291,7 +301,7 @@ class AutoShell:
             host: typing.Optional[str] = None,
             success_exit_status: typing.Optional[typing.Set[int]] = None,
     ):
-        rc, stdout, stderr = self.get_raw_stdout_stderr_no_input(host, cmd)
+        rc, stdout, stderr = self.get_rc_stdout_stderr_raw_without_input(host, cmd)
         to_raise = False
         if success_exit_status is None:
             if rc != 0:
@@ -305,11 +315,17 @@ class AutoShell:
             raise CommandFailure(cmd, host, None, Utils.decode_str(stderr).strip())
 
 
-class LocalOnlyAutoShell(AutoShell):
+class LocalOnlyClusterShell(ClusterShell):
+    """A adaptor to wrap a LocalShell as a ClusterShell.
+
+    Some modules depend on shell and are called both during bootstrap and after bootstrap. Use a LocalShell as their
+    implementation in bootstrap make the difference more explicit, avoid dependency on outdated cluster configurations
+    (for example, the configurations left from previous cluster bootstrap) and help to catch errors in tests.
+    """
     def __init__(self, local_shell: LocalShell):
         super().__init__(local_shell, None)
 
-    def subprocess_run_no_input(self, host: str, user: typing.Optional[str], cmd: str, **kwargs):
+    def subprocess_run_without_input(self, host: str, user: typing.Optional[str], cmd: str, **kwargs):
         assert 'input' not in kwargs and 'stdin' not in kwargs
         assert host is None or host == self.local_shell.hostname()
         if user is None:
@@ -317,5 +333,5 @@ class LocalOnlyAutoShell(AutoShell):
         return self.local_shell.su_subprocess_run(user, cmd, **kwargs)
 
 
-def auto_shell():
-    return AutoShell(LocalShell(), user_of_host.instance())
+def cluster_shell():
+    return ClusterShell(LocalShell(), user_of_host.instance())

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -1,0 +1,321 @@
+"""Run shell commands.
+
+This module provides various methods to run shell commands, on both local and remote hosts, as current or another user.
+There many variant of the methods to allow fine-gain control of parameter passing and error handling.
+
+3 different implementations are provided:
+
+1. LocalShell allows to run command on local host as various users. It is the most feature-rich one, allowing
+   interactive I/O from/to the terminal.
+2. SshShell allows to run command on both local and remote hosts. When running on a remote host, it creates a direct
+   connection from a specified local_user to the destination host and user. User input from terminal is not allowed, as
+   the command is passed through the stdin.
+3. AutoShell runs command on cluster nodes. It leverages su, sudo and ssh to obtain a appreciated session on a
+   destination node. It is only available after ssh bootstrap as it depends on the knowledge about cluster node and user
+   configurations.
+
+The LocalShell and SshShell is expected to be used in ssh bootstrap. Once the ssh bootstrap finishes, AuthShell should
+be used.
+"""
+import logging
+import os
+import pwd
+import socket
+import subprocess
+import typing
+
+from . import constants
+from .pyshim import cache
+from . import user_of_host
+from .user_of_host import UserOfHost
+
+logger = logging.getLogger(__name__)
+
+
+class Error(ValueError):
+    def __init__(self, msg, cmd):
+        super().__init__(msg)
+        self.cmd = cmd
+
+
+class AuthorizationError(Error):
+    def __init__(self, cmd: str, host: typing.Optional[str], user: str, msg: str):
+        super().__init__(
+            'Failed to run command on {optional_user}{host}: {msg}: {cmd}'.format(
+                optional_user=f'{user}@' if user is not None else '',
+                host=host, msg=msg, cmd=cmd
+            ),
+            cmd
+        )
+        self.host = host
+        self.user = user
+
+
+class CommandFailure(Error):
+    def __init__(self, cmd: str, host: typing.Optional[str], user: typing.Optional[str], msg: str):
+        if host is None and user is None:
+            super().__init__("Failed to run '{}': {}".format(cmd, msg), cmd)
+        elif user is None:
+            super().__init__("Failed to run command on {}: '{}': {}".format(host, cmd, msg), cmd)
+        elif host is None:
+            super().__init__("Failed to run command as {}: '{}': {}".format(user, cmd, msg), cmd)
+        else:
+            super().__init__("Failed to run command as {}@{}: '{}': {}".format(user, host, cmd, msg), cmd)
+        self.host = host
+        self.user = user
+
+
+class Utils:
+    @staticmethod
+    def decode_str(x: bytes):
+        try:
+            return x.decode('utf-8')
+        except UnicodeDecodeError as e:
+            logger.debug('UTF-8 decode failure', exc_info=e)
+            return x.decode('utf-8', errors='backslashreplace')
+
+
+class LocalShell:
+    """Provides methods to run commands on localhost, both as current user and switching to another user"""
+    @staticmethod
+    @cache
+    def hostname():
+        return socket.gethostname()
+
+    @staticmethod
+    @cache
+    def geteuid() -> int:
+        return os.geteuid()
+
+    @staticmethod
+    @cache
+    def get_effective_user_name() -> str:
+        return pwd.getpwuid(LocalShell.geteuid()).pw_name
+
+    def can_run_as(self, user: str):
+        return self.geteuid() == 0 or self.get_effective_user_name() == user
+
+    def su_subprocess_run(
+            self,
+            user: str,
+            cmd: str,
+            tty=False,
+            preserve_env: typing.Optional[typing.List[str]] = None,
+            **kwargs
+    ):
+        if self.get_effective_user_name() == user:
+            args = ['/bin/sh', '-c', cmd]
+        elif 0 == self.geteuid():
+            args = ['su', user, '--login', '-c', cmd]
+            if tty:
+                args.append('--pty')
+            if preserve_env:
+                args.append('-w')
+                args.append(','.join(preserve_env))
+        else:
+            raise AuthorizationError(
+                cmd, None, user,
+                f"non-root user '{self.get_effective_user_name()}' cannot switch to another user"
+            )
+        logger.debug('su_subprocess_run: %s, %s', args, kwargs)
+        return subprocess.run(args, **kwargs)
+
+    def get_stdout_stderr_raw(self, user: str, cmd: str, input: typing.Optional[bytes] = None):
+        result = self.su_subprocess_run(
+            user, cmd,
+            input=input,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def get_stdout_stderr(self, user: str, cmd: str, input: typing.Optional[str] = None):
+        rc, stdout, stderr = self.get_stdout_stderr_raw(user, cmd, input.encode('utf-8') if input is not None else None)
+        return rc, Utils.decode_str(stdout).strip(), Utils.decode_str(stderr).strip()
+
+    def get_rc_and_error(
+            self,
+            user: str,
+            cmd: str,
+    ) -> typing.Tuple[int, typing.Optional[str]]:
+        """Run a command for its side effects. Returns (rc, error_message)
+
+        If the return code is 0, outputs from the command will be ignored and (0, None) is returned.
+        If the return code is not 0, outputs from the stdout and stderr is combined as a single message.
+        """
+        if self.get_effective_user_name() == user:
+            args = ['/bin/sh', '-c', cmd]
+        elif self.geteuid() == 0:
+            args = ['su', user, '--login', '-c', cmd]
+        else:
+            raise AuthorizationError(
+                cmd, None, user,
+                f"non-root user '{self.get_effective_user_name()}' cannot switch to another user"
+            )
+        result = subprocess.run(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        if result.returncode == 0:
+            return 0, None
+        else:
+            return result.returncode, Utils.decode_str(result.stdout).strip()
+
+    def get_stdout_or_raise_error(
+            self,
+            user: str,
+            cmd: str,
+            success_exit_status: typing.Optional[typing.Set[int]] = None,
+    ):
+        result = self.su_subprocess_run(
+            user, cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        to_raise = False
+        if success_exit_status is None:
+            if result.returncode != 0:
+                to_raise = True
+        else:
+            if result.returncode not in success_exit_status:
+                to_raise = True
+        if not to_raise:
+            return Utils.decode_str(result.stdout).strip()
+        else:
+            raise CommandFailure(cmd, None, user, Utils.decode_str(result.stderr).strip())
+
+
+class SshShell:
+    """Provides methods to run commands on both local and remote hosts as various users.
+
+    For remote commands, SSH sessions are created to the destination host and user from a specified local_user.
+    """
+    def __init__(self, local_shell: LocalShell, local_user):
+        self.local_shell = local_shell
+        self.local_user = local_user
+
+    def can_run_as(self, host: typing.Optional[str], user: str) -> bool:
+        if host is None or host == self.local_shell.hostname():
+            return self.local_shell.can_run_as(user)
+        else:
+            ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
+            ssh_cmd = "ssh {} -T -o Batchmode=yes {}@{} true".format(ssh_options, user, host)
+            rc, output = self.local_shell.get_rc_and_error(self.local_user, ssh_cmd)
+            return rc == 0
+
+    def get_rc_and_error(
+            self,
+            host: typing.Optional[str],
+            user: str,
+            cmd: str,
+    ) -> typing.Tuple[int, typing.Optional[str]]:
+        """Run a command for its side effects. Returns (rc, error_message)
+
+        If the return code is 0, outputs from the command will be ignored and (0, None) is returned.
+        If the return code is not 0, outputs from the stdout and stderr is combined as a single message.
+        """
+        result = self.subprocess_run_no_input(
+            host, user, cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        if result.returncode == 0:
+            return 0, None
+        else:
+            return result.returncode, Utils.decode_str(result.stdout).strip()
+
+    def subprocess_run_no_input(self, host: typing.Optional[str], user: str, cmd: str, **kwargs):
+        assert 'input' not in kwargs and 'stdin' not in kwargs
+        if host is None or host == self.local_shell.hostname():
+            if user == self.local_shell.get_effective_user_name():
+                args = ['/bin/sh']
+            else:
+                args = ['sudo', '-H', '-u', user, '/bin/sh']
+            return subprocess.run(
+                args,
+                input=cmd.encode('utf-8'),
+                **kwargs,
+            )
+        else:
+            return self.local_shell.su_subprocess_run(
+                self.local_user,
+                'ssh {} {}@{} /bin/sh'.format(constants.SSH_OPTION, user, host),
+                input=cmd.encode('utf-8'),
+                **kwargs,
+            )
+
+
+class AutoShell:
+    def __init__(self, local_shell: LocalShell, user_of_host: UserOfHost):
+        self.local_shell = local_shell
+        self.user_of_host = user_of_host
+
+    def subprocess_run_no_input(self, host: typing.Optional[str], user: typing.Optional[str], cmd: str, **kwargs):
+        assert 'input' not in kwargs and 'stdin' not in kwargs
+        if host is None or host == self.local_shell.hostname():
+            return subprocess.run(
+                ['/bin/sh'],
+                input=cmd.encode('utf-8'),
+                **kwargs,
+            )
+        else:
+            if user is None:
+                user = 'root'
+            local_user, remote_user = self.user_of_host.user_pair_for_ssh(host)
+            return self.local_shell.su_subprocess_run(
+                local_user,
+                'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_user, host, user),
+                input=cmd.encode('utf-8'),
+                **kwargs,
+            )
+
+    def get_raw_stdout_stderr_no_input(self, host, cmd) -> typing.Tuple[int, bytes, bytes]:
+        result = self.subprocess_run_no_input(
+            host, None, cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def get_stdout_stderr_no_input(self, host, cmd) -> typing.Tuple[int, str, str]:
+        rc, stdout, stderr = self.get_raw_stdout_stderr_no_input(host, cmd)
+        return rc, Utils.decode_str(stdout).strip(), Utils.decode_str(stderr).strip()
+
+    def get_stdout_or_raise_error(
+            self,
+            cmd: str,
+            host: typing.Optional[str] = None,
+            success_exit_status: typing.Optional[typing.Set[int]] = None,
+    ):
+        rc, stdout, stderr = self.get_raw_stdout_stderr_no_input(host, cmd)
+        to_raise = False
+        if success_exit_status is None:
+            if rc != 0:
+                to_raise = True
+        else:
+            if rc not in success_exit_status:
+                to_raise = True
+        if not to_raise:
+            return Utils.decode_str(stdout).strip()
+        else:
+            raise CommandFailure(cmd, host, None, Utils.decode_str(stderr).strip())
+
+
+class LocalOnlyAutoShell(AutoShell):
+    def __init__(self, local_shell: LocalShell):
+        super().__init__(local_shell, None)
+
+    def subprocess_run_no_input(self, host: str, user: typing.Optional[str], cmd: str, **kwargs):
+        assert 'input' not in kwargs and 'stdin' not in kwargs
+        assert host is None or host == self.local_shell.hostname()
+        if user is None:
+            user = 'root'
+        return self.local_shell.su_subprocess_run(user, cmd, **kwargs)
+
+
+def auto_shell():
+    return AutoShell(LocalShell(), user_of_host.instance())

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -39,7 +39,7 @@ class KeyFile(Key):
 
 
 class AuthorizedKeyManager:
-    def __init__(self, shell: sh.SshShell):
+    def __init__(self, shell: sh.SSHShell):
         self._shell = shell
 
     def add(self, host: typing.Optional[str], user: str, key: Key):

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import pwd
+import tempfile
+import typing
+
+from crmsh import utils
+from crmsh import sh
+
+
+logger = logging.getLogger(__name__)
+
+
+class Error(ValueError):
+    def __init__(self, msg: str):
+        super().__init__(msg)
+
+
+class Key:
+    def public_key(self) -> str:
+        raise NotImplementedError
+
+
+class KeyFile(Key):
+    def __init__(self, path: str):
+        self._path = os.path.realpath(path)
+        self._public_key = None
+
+    def public_key_file(self) -> typing.Optional[str]:
+        return self._path
+
+    def public_key(self) -> str:
+        if self._public_key:
+            return self._public_key
+        else:
+            with open(self._path, 'r', encoding='utf-8') as f:
+                self._public_key = f.read().strip()
+            return self._public_key
+
+
+class AuthorizedKeyManager:
+    def __init__(self, shell: sh.SshShell):
+        self._shell = shell
+
+    def add(self, host: typing.Optional[str], user: str, key: Key):
+        if host is None:
+            self._add_local(user, key)
+        else:
+            self._add_remote(host, user, key)
+
+    def _add_local(self, user: str, key: Key):
+        public_key = key.public_key()
+        file = f'~{user}/.ssh/authorized_keys'
+        cmd = f'''grep "{public_key}" {file} > /dev/null || sed -i '$a {public_key}' {file}'''
+        rc, output = self._shell.local_shell.get_rc_and_error(user, cmd)
+        if rc != 0:
+            # unlikely
+            raise Error(output)
+
+    def _add_remote(self, host: str, user: str, key: Key):
+        if self._shell.can_run_as(host, user):
+            rc, _ = self._shell.get_rc_and_error(
+                host, user,
+                f"grep '{key.public_key()}' ~{user}/.ssh/authorized_key > /dev/null",
+            )
+            if rc == 0:
+                return
+        if isinstance(key, KeyFile) and key.public_key_file() is not None:
+            user_info = pwd.getpwnam(user)
+            if os.stat(key.public_key_file()).st_uid == user_info.pw_uid:
+                cmd = "ssh-copy-id -f -i '{}' '{}@{}' &> /dev/null".format(key.public_key_file(), user, host)
+                logger.info("Configuring SSH passwordless with %s@%s", user, host)
+                result = self._shell.local_shell.su_subprocess_run(self._shell.local_user, cmd, tty=True, preserve_env=['SSH_AUTH_SOCK'])
+            else:
+                with tempfile.NamedTemporaryFile('w', encoding='utf-8') as tmp:
+                    os.chown(tmp.fileno(), user_info.pw_uid, user_info.pw_gid)
+                    print(key.public_key(), file=tmp)
+                    cmd = "ssh-copy-id -f -i '{}' '{}@{}' &> /dev/null".format(tmp.name, user, host)
+                    logger.info("Configuring SSH passwordless with %s@%s", user, host)
+                    result = self._shell.local_shell.su_subprocess_run(self._shell.local_user, cmd, tty=True)
+            if result.returncode != 0:
+                raise Error(f'Failed configuring SSH passwordless with {user}@{host}.')
+            # TODO: error handling

--- a/crmsh/ui_cib.py
+++ b/crmsh/ui_cib.py
@@ -13,6 +13,7 @@ from . import config
 from . import options
 from .cibstatus import cib_status
 from .cibconfig import cib_factory
+from .sh import ShellUtils
 from . import tmpfiles
 from . import completers as compl
 from . import log
@@ -154,7 +155,7 @@ class CibShadow(command.UI):
     @command.skill_level('administrator')
     def do_diff(self, context):
         "usage: diff"
-        rc, s = utils.get_stdout(utils.add_sudo("%s -d" % self.extcmd_stdout))
+        rc, s = ShellUtils().get_stdout(utils.add_sudo("%s -d" % self.extcmd_stdout))
         utils.page_string(s)
 
     @command.skill_level('administrator')

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -62,7 +62,7 @@ def script_args(args):
 
 def get_cluster_name():
     cluster_name = None
-    if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
+    if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
         name = corosync.get_values('totem.cluster_name')
         if name:
             cluster_name = name[0]
@@ -449,7 +449,7 @@ Examples:
         boot_context.ui_context = context
         boot_context.stage = stage
         boot_context.args = args
-        boot_context.cluster_is_running = ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("pacemaker.service")
+        boot_context.cluster_is_running = ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("pacemaker.service")
         boot_context.type = "init"
         boot_context.initialize_qdevice()
         boot_context.validate_option()
@@ -562,7 +562,7 @@ the config.core.force option.""",
         '''
         Rename the cluster.
         '''
-        if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
+        if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
             context.fatal_error("Can't rename cluster when cluster service is stopped")
         old_name = cib_factory.get_property('cluster-name')
         if old_name and new_name == old_name:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -19,6 +19,7 @@ from . import qdevice
 from .cibconfig import cib_factory
 from .prun import prun
 from .service_manager import ServiceManager
+from .sh import ShellUtils
 from .ui_node import parse_option_for_nodes
 from . import constants
 
@@ -767,7 +768,7 @@ to get the geo cluster configuration.""",
             else:
                 print("%-16s unknown" % (svc))
 
-        rc, outp = utils.get_stdout(['corosync-cfgtool', '-s'], shell=False)
+        rc, outp = ShellUtils().get_stdout(['corosync-cfgtool', '-s'], shell=False)
         if rc == 0:
             print("")
             print(outp)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -9,7 +9,7 @@ import typing
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import crmsh.parallax
-from . import command
+from . import command, sh
 from . import utils
 from . import scripts
 from . import completers as compl
@@ -18,6 +18,7 @@ from . import corosync
 from . import qdevice
 from .cibconfig import cib_factory
 from .prun import prun
+from .service_manager import ServiceManager
 from .ui_node import parse_option_for_nodes
 from . import constants
 
@@ -61,7 +62,7 @@ def script_args(args):
 
 def get_cluster_name():
     cluster_name = None
-    if not utils.service_is_active("corosync.service"):
+    if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
         name = corosync.get_values('totem.cluster_name')
         if name:
             cluster_name = name[0]
@@ -174,16 +175,17 @@ class Cluster(command.UI):
             start_qdevice = True
             service_check_list.append("corosync-qdevice.service")
 
+        service_manager = ServiceManager()
         node_list = parse_option_for_nodes(context, *args)
         for node in node_list[:]:
-            if all([utils.service_is_active(srv, remote_addr=node) for srv in service_check_list]):
+            if all([service_manager.service_is_active(srv, remote_addr=node) for srv in service_check_list]):
                 logger.info("The cluster stack already started on {}".format(node))
                 node_list.remove(node)
         if not node_list:
             return
 
         if start_qdevice:
-            utils.start_service("corosync-qdevice", node_list=node_list)
+            service_manager.start_service("corosync-qdevice", node_list=node_list)
         node_list = bootstrap.start_pacemaker(node_list)
         if start_qdevice:
             qdevice.QDevice.check_qdevice_vote()
@@ -195,17 +197,18 @@ class Cluster(command.UI):
         '''
         Stops the cluster stack on all nodes or specific node(s)
         '''
+        service_manager = ServiceManager()
         node_list = parse_option_for_nodes(context, *args)
         for node in node_list[:]:
-            if not utils.service_is_active("corosync.service", remote_addr=node):
-                if utils.service_is_active("sbd.service", remote_addr=node):
-                    utils.stop_service("corosync", remote_addr=node)
+            if not service_manager.service_is_active("corosync.service", remote_addr=node):
+                if service_manager.service_is_active("sbd.service", remote_addr=node):
+                    service_manager.stop_service("corosync", remote_addr=node)
                     logger.info("The cluster stack stopped on {}".format(node))
                 else:
                     logger.info("The cluster stack already stopped on {}".format(node))
                 node_list.remove(node)
-            elif not utils.service_is_active("pacemaker.service", remote_addr=node):
-                utils.stop_service("corosync", remote_addr=node)
+            elif not service_manager.service_is_active("pacemaker.service", remote_addr=node):
+                service_manager.stop_service("corosync", remote_addr=node)
                 logger.info("The cluster stack stopped on {}".format(node))
                 node_list.remove(node)
         if not node_list:
@@ -226,12 +229,12 @@ class Cluster(command.UI):
             utils.set_dlm_option(enable_quorum_fencing=0, enable_quorum_lockspace=0)
 
         # Stop pacemaker since it can make sure cluster has quorum until stop corosync
-        node_list = utils.stop_service("pacemaker", node_list=node_list)
+        node_list = service_manager.stop_service("pacemaker", node_list=node_list)
         # Then, stop qdevice if is active
-        if utils.service_is_active("corosync-qdevice.service"):
-            utils.stop_service("corosync-qdevice.service", node_list=node_list)
+        if service_manager.service_is_active("corosync-qdevice.service"):
+            service_manager.stop_service("corosync-qdevice.service", node_list=node_list)
         # Last, stop corosync
-        node_list = utils.stop_service("corosync", node_list=node_list)
+        node_list = service_manager.stop_service("corosync", node_list=node_list)
 
         for node in node_list:
             logger.info("The cluster stack stopped on {}".format(node))
@@ -251,9 +254,10 @@ class Cluster(command.UI):
         Enable the cluster services on this node
         '''
         node_list = parse_option_for_nodes(context, *args)
-        node_list = utils.enable_service("pacemaker.service", node_list=node_list)
-        if utils.service_is_available("corosync-qdevice.service") and utils.is_qdevice_configured():
-            utils.enable_service("corosync-qdevice.service", node_list=node_list)
+        service_manager = ServiceManager()
+        node_list = service_manager.enable_service("pacemaker.service", node_list=node_list)
+        if service_manager.service_is_available("corosync-qdevice.service") and utils.is_qdevice_configured():
+            service_manager.enable_service("corosync-qdevice.service", node_list=node_list)
         for node in node_list:
             logger.info("Cluster services enabled on %s", node)
 
@@ -263,8 +267,9 @@ class Cluster(command.UI):
         Disable the cluster services on this node
         '''
         node_list = parse_option_for_nodes(context, *args)
-        node_list = utils.disable_service("pacemaker.service", node_list=node_list)
-        utils.disable_service("corosync-qdevice.service", node_list=node_list)
+        service_manager = ServiceManager()
+        node_list = service_manager.disable_service("pacemaker.service", node_list=node_list)
+        service_manager.disable_service("corosync-qdevice.service", node_list=node_list)
         for node in node_list:
             logger.info("Cluster services disabled on %s", node)
 
@@ -430,7 +435,7 @@ Examples:
             parser.error("Invalid stage (%s)" % (stage))
 
         if options.qnetd_addr:
-            if not utils.service_is_available("corosync-qdevice.service"):
+            if not ServiceManager().service_is_available("corosync-qdevice.service"):
                 utils.fatal("corosync-qdevice.service is not available")
             if options.qdevice_heuristics_mode and not options.qdevice_heuristics:
                 parser.error("Option --qdevice-heuristics is required if want to configure heuristics mode")
@@ -444,7 +449,7 @@ Examples:
         boot_context.ui_context = context
         boot_context.stage = stage
         boot_context.args = args
-        boot_context.cluster_is_running = utils.service_is_active("pacemaker.service")
+        boot_context.cluster_is_running = ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("pacemaker.service")
         boot_context.type = "init"
         boot_context.initialize_qdevice()
         boot_context.validate_option()
@@ -557,7 +562,7 @@ the config.core.force option.""",
         '''
         Rename the cluster.
         '''
-        if not utils.service_is_active("corosync.service"):
+        if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
             context.fatal_error("Can't rename cluster when cluster service is stopped")
         old_name = cib_factory.get_property('cluster-name')
         if old_name and new_name == old_name:

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -62,7 +62,7 @@ class Corosync(command.UI):
         '''
         Quick cluster health status. Corosync status or QNetd status
         '''
-        if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
+        if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
             logger.error("corosync.service is not running!")
             return False
 

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -2,14 +2,14 @@
 # See COPYING for license information.
 
 import os
-from . import command
+from . import command, sh
 from . import completers
 from . import utils
 from . import corosync
 from . import parallax
 from . import bootstrap
 from . import log
-
+from .service_manager import ServiceManager
 
 logger = log.setup_logger(__name__)
 
@@ -62,7 +62,7 @@ class Corosync(command.UI):
         '''
         Quick cluster health status. Corosync status or QNetd status
         '''
-        if not utils.service_is_active("corosync.service"):
+        if not ServiceManager(sh.LocalOnlyAutoShell(sh.LocalShell())).service_is_active("corosync.service"):
             logger.error("corosync.service is not running!")
             return False
 

--- a/crmsh/ui_history.py
+++ b/crmsh/ui_history.py
@@ -15,6 +15,7 @@ from . import ui_utils
 from . import xmlutil
 from . import options
 from .cibconfig import mkset_obj, cib_factory
+from .sh import ShellUtils
 from . import history
 from . import cmd_status
 from . import log
@@ -440,7 +441,7 @@ class History(command.UI):
             f2 = utils.str2tmp(s2)
             try:
                 if f1 and f2:
-                    _, s = utils.get_stdout(cmd.format(f1=f1, f2=f2))
+                    _, s = ShellUtils().get_stdout(cmd.format(f1=f1, f2=f2))
             finally:
                 for f in (f1, f2):
                     try:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -17,7 +17,7 @@ from . import xmlutil
 from .cliformat import cli_nvpairs, nvpairs2list
 from . import term
 from .cibconfig import cib_factory
-from .ui_resource import rm_meta_attribute
+from .sh import ShellUtils
 from . import log
 
 
@@ -516,7 +516,7 @@ class NodeMgmt(command.UI):
     def call_delnode(cls, node):
         "Remove node (how depends on cluster stack)"
         rc = True
-        ec, s = utils.get_stdout("%s -p" % cls.crm_node)
+        ec, s = ShellUtils().get_stdout("%s -p" % cls.crm_node)
         if not s:
             logger.error('%s -p could not list any nodes (rc=%d)', cls.crm_node, ec)
             rc = False
@@ -535,7 +535,7 @@ class NodeMgmt(command.UI):
         if ec != 0:
             node_xpath = "//nodes/node[@uname='{}']".format(node)
             cmd = 'cibadmin --delete-all --force --xpath "{}"'.format(node_xpath)
-            rc, _, err = utils.get_stdout_stderr(cmd)
+            rc, _, err = ShellUtils().get_stdout_stderr(cmd)
             if rc != 0:
                 logger.error('"%s" failed, rc=%d, %s', cmd, rc, err)
                 return False

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -11,6 +11,7 @@ from . import xmlutil
 from . import ui_utils
 from . import options
 from .cibconfig import cib_factory
+from .sh import ShellUtils
 from . import log
 
 
@@ -508,7 +509,7 @@ class RscMgmt(command.UI):
         if cmd == "set":
             # query the current failcount status
             query_cmd = "cibadmin -Ql --xpath '/cib/status/node_state[@id='{}']'".format(nodeid)
-            rc, out, err = utils.get_stdout_stderr(query_cmd)
+            rc, out, err = ShellUtils().get_stdout_stderr(query_cmd)
             if rc != 0:
                 context.fatal_error(err)
 

--- a/crmsh/user_of_host.py
+++ b/crmsh/user_of_host.py
@@ -1,0 +1,116 @@
+import logging
+import socket
+import subprocess
+import typing
+
+from . import config
+from . import constants
+from . import userdir
+from .pyshim import cache
+
+
+logger = logging.getLogger(__name__)
+
+
+class UserNotFoundError(ValueError):
+    pass
+
+
+class UserOfHost:
+    @staticmethod
+    def instance():
+        return _user_of_host_instance
+
+    @staticmethod
+    @cache
+    def this_node():
+        return socket.gethostname()
+
+    def __init__(self):
+        self._user_cache = dict()
+        self._user_pair_cache = dict()
+
+    def user_of(self, host):
+        cached = self._user_cache.get(host)
+        if cached is None:
+            ret = self._get_user_of_host_from_config(host)
+            if ret is None:
+                raise UserNotFoundError()
+            else:
+                self._user_cache[host] = ret
+                return ret
+        else:
+            return cached
+
+    def user_pair_for_ssh(self, host: str) -> typing.Tuple[str, str]:
+        """Return (local_user, remote_user) pair for ssh connection"""
+        local_user = None
+        remote_user = None
+        try:
+            local_user = self.user_of(self.this_node())
+            remote_user = self.user_of(host)
+            return local_user, remote_user
+        except UserNotFoundError:
+            cached = self._user_pair_cache.get(host)
+            if cached is None:
+                if local_user is not None:
+                    ret = local_user, local_user
+                    self._user_pair_cache[host] = ret
+                    return ret
+                else:
+                    ret = self._guess_user_for_ssh(host)
+                    if ret is None:
+                        raise UserNotFoundError
+                    else:
+                        self._user_pair_cache[host] = ret
+                        return ret
+            else:
+                return cached
+
+
+    @staticmethod
+    def _get_user_of_host_from_config(host):
+        try:
+            canonical, aliases, _ = socket.gethostbyaddr(host)
+            aliases = set(aliases)
+            aliases.add(canonical)
+            aliases.add(host)
+        except (socket.herror, socket.gaierror):
+            aliases = {host}
+        hosts = config.get_option('core', 'hosts')
+        if hosts == ['']:
+            return None
+        for item in hosts:
+            if item.find('@') != -1:
+                user, node = item.split('@')
+            else:
+                user = userdir.getuser()
+                node = item
+            if node in aliases:
+                return user
+        logger.debug('Failed to get the user of host %s (aliases: %s). Known hosts are %s', host, aliases, hosts)
+        return None
+
+    @staticmethod
+    def _guess_user_for_ssh(host: str) -> typing.Tuple[str, str]:
+        args = ['ssh']
+        args.extend(constants.SSH_OPTION_ARGS)
+        args.extend(['-o', 'BatchMode=yes', host, 'sudo', 'true'])
+        rc = subprocess.call(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if rc == 0:
+            user = userdir.getuser()
+            return user, user
+        else:
+            return None
+
+
+_user_of_host_instance = UserOfHost()
+
+
+def instance():
+    return _user_of_host_instance

--- a/crmsh/watchdog.py
+++ b/crmsh/watchdog.py
@@ -2,6 +2,7 @@ import re
 from . import utils
 from .constants import SSH_OPTION
 from .bootstrap import invoke, invokerc, WATCHDOG_CFG, SYSCONFIG_SBD
+from .sh import ShellUtils
 
 
 class Watchdog(object):
@@ -30,7 +31,7 @@ class Watchdog(object):
         """
         Use wdctl to verify watchdog device
         """
-        rc, _, err = utils.get_stdout_stderr("wdctl {}".format(dev))
+        rc, _, err = ShellUtils().get_stdout_stderr("wdctl {}".format(dev))
         if rc != 0:
             if ignore_error:
                 return False
@@ -59,7 +60,7 @@ class Watchdog(object):
         """
         Check if driver was already loaded
         """
-        _, out, _ = utils.get_stdout_stderr("lsmod")
+        _, out, _ = ShellUtils().get_stdout_stderr("lsmod")
         return re.search("\n{}\s+".format(driver), out)
 
     def _set_watchdog_info(self):
@@ -67,7 +68,7 @@ class Watchdog(object):
         Set watchdog info through sbd query-watchdog command
         Content in self._watchdog_info_dict: {device_name: driver_name}
         """
-        rc, out, err = utils.get_stdout_stderr(self.QUERY_CMD)
+        rc, out, err = ShellUtils().get_stdout_stderr(self.QUERY_CMD)
         if rc == 0 and out:
             # output format might like:
             #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n
@@ -90,7 +91,7 @@ class Watchdog(object):
         """
         # FIXME
         cmd = "ssh {} {}@{} {}".format(SSH_OPTION, self._remote_user, self._peer_host, self.QUERY_CMD)
-        rc, out, err = utils.get_stdout_stderr(cmd)
+        rc, out, err = ShellUtils().get_stdout_stderr(cmd)
         if rc == 0 and out:
             # output format might like:
             #   [1] /dev/watchdog\nIdentity: Software Watchdog\nDriver: softdog\n

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -9,14 +9,14 @@ import copy
 import bz2
 from collections import defaultdict
 
-from . import config
+from . import config, sh
 from . import options
 from . import schema
 from . import constants
 from . import userdir
 from tempfile import mktemp
 from .utils import add_sudo, str2file, str2tmp, get_boolean, handle_role_for_ocf_1_1, copy_local_file, rmfile
-from .utils import get_stdout, get_stdout_or_raise_error, stdout2list, crm_msec, crm_time_cmp
+from .utils import get_stdout, stdout2list, crm_msec, crm_time_cmp
 from .utils import olist, get_cib_in_use, get_tempdir, to_ascii, is_boolean_true
 from . import log
 
@@ -1521,7 +1521,7 @@ class CrmMonXmlParser(object):
         """
         Load xml output of crm_mon
         """
-        output = get_stdout_or_raise_error(constants.CRM_MON_XML_OUTPUT, remote=self.peer, no_raise=True)
+        rc, output, stderr = sh.auto_shell().get_stdout_stderr_no_input(self.peer, constants.CRM_MON_XML_OUTPUT)
         self.xml_elem = text2elem(output)
 
     @classmethod

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1521,7 +1521,7 @@ class CrmMonXmlParser(object):
         """
         Load xml output of crm_mon
         """
-        rc, output, stderr = sh.auto_shell().get_stdout_stderr_no_input(self.peer, constants.CRM_MON_XML_OUTPUT)
+        rc, output, stderr = sh.cluster_shell().get_rc_stdout_stderr_without_input(self.peer, constants.CRM_MON_XML_OUTPUT)
         self.xml_elem = text2elem(output)
 
     @classmethod

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -8,15 +8,16 @@ from lxml import etree, doctestcompare
 import copy
 import bz2
 from collections import defaultdict
+from tempfile import mktemp
 
 from . import config, sh
 from . import options
 from . import schema
 from . import constants
 from . import userdir
-from tempfile import mktemp
+from .sh import ShellUtils
 from .utils import add_sudo, str2file, str2tmp, get_boolean, handle_role_for_ocf_1_1, copy_local_file, rmfile
-from .utils import get_stdout, stdout2list, crm_msec, crm_time_cmp
+from .utils import stdout2list, crm_msec, crm_time_cmp
 from .utils import olist, get_cib_in_use, get_tempdir, to_ascii, is_boolean_true
 from . import log
 
@@ -293,7 +294,7 @@ class RscState(object):
         if not is_live_cib():
             return False
         test_id = self.rsc_clone(ident) or ident
-        rc, outp = get_stdout(self.rsc_status % test_id, stderr_on=False)
+        rc, outp = ShellUtils().get_stdout(self.rsc_status % test_id, stderr_on=False)
         return outp.find("running") > 0 and outp.find("NOT") == -1
 
     def is_group(self, ident):

--- a/data-manifest
+++ b/data-manifest
@@ -202,6 +202,8 @@ test/unittests/test_qdevice.py
 test/unittests/test_ratrace.py
 test/unittests/test_sbd.py
 test/unittests/test_scripts.py
+test/unittests/test_service_manager.py
+test/unittests/test_sh.py
 test/unittests/test_time.py
 test/unittests/test_ui_cluster.py
 test/unittests/test_upgradeuitl.py

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -5,10 +5,11 @@ import time
 
 import crmsh.userdir
 import crmsh.utils
+from crmsh.sh import ShellUtils
 
 
 def get_online_nodes():
-    _, out, _ = crmsh.utils.get_stdout_stderr('sudo crm_node -l')
+    _, out, _ = ShellUtils().get_stdout_stderr('sudo crm_node -l')
     if out:
         return re.findall(r'[0-9]+ (.*) member', out)
     else:
@@ -37,7 +38,7 @@ def before_tag(context, tag):
             resource_cleanup()
             while True:
                 time.sleep(1)
-                rc, stdout, _ = crmsh.utils.get_stdout_stderr('sudo crmadmin -D -t 1')
+                rc, stdout, _ = ShellUtils().get_stdout_stderr('sudo crmadmin -D -t 1')
                 if rc == 0 and stdout.startswith('Designated'):
                     break
             subprocess.call(

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -9,6 +9,7 @@ from behave import given, when, then
 import behave_agent
 from crmsh import corosync, sbd, userdir, bootstrap
 from crmsh import utils as crmutils
+from crmsh.sh import ShellUtils
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
                   run_command_local_or_remote, file_in_archive, \
                   assert_eq, is_unclean, assert_in
@@ -48,7 +49,7 @@ def step_impl(context, nodes):
     for node in nodes:
         # wait for ssh service
         for _ in range(10):
-            rc, _, _ = crmutils.get_stdout_stderr('ssh {} true'.format(node))
+            rc, _, _ = ShellUtils().get_stdout_stderr('ssh {} true'.format(node))
             if rc == 0:
                 break
             time.sleep(1)
@@ -384,13 +385,13 @@ def step_impl(context, f):
 
 @given('Resource "{res_id}" is started on "{node}"')
 def step_impl(context, res_id, node):
-    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    rc, out, err = ShellUtils().get_stdout_stderr("crm_mon -1")
     assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None
 
 
 @then('Resource "{res_id}" is started on "{node}"')
 def step_impl(context, res_id, node):
-    rc, out, err = crmutils.get_stdout_stderr("crm_mon -1")
+    rc, out, err = ShellUtils().get_stdout_stderr("crm_mon -1")
     assert re.search(r'\*\s+{}\s+.*Started\s+{}'.format(res_id, node), out) is not None
 
 
@@ -487,7 +488,7 @@ def step_impl(context, node):
 def step_impl(context, count, node):
     index = 0
     while index <= int(count):
-        rc, out, _ = crmutils.get_stdout_stderr("stonith_admin -h {}".format(node))
+        rc, out, _ = ShellUtils().get_stdout_stderr("stonith_admin -h {}".format(node))
         if "Node {} last fenced at:".format(node) in out:
             return True
         time.sleep(1)

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -5,6 +5,7 @@ import glob
 import re
 import socket
 from crmsh import utils, userdir
+from crmsh.sh import ShellUtils
 import behave_agent
 
 
@@ -12,7 +13,7 @@ COLOR_MODE = r'\x1b\[[0-9]+m'
 
 
 def get_file_type(file_path):
-    rc, out, _ = utils.get_stdout_stderr("file {}".format(file_path))
+    rc, out, _ = ShellUtils().get_stdout_stderr("file {}".format(file_path))
     if re.search(r'{}: bzip2'.format(file_path), out):
         return "bzip2"
     if re.search(r'{}: directory'.format(file_path), out):
@@ -68,7 +69,7 @@ def _wrap_cmd_non_root(cmd):
 
 def run_command(context, cmd, exit_on_fail=True):
     cmd = _wrap_cmd_non_root(cmd)
-    rc, out, err = utils.get_stdout_stderr(cmd)
+    rc, out, err = ShellUtils().get_stdout_stderr(cmd)
     context.return_code = rc
     if out:
         out = re.sub(COLOR_MODE, '', out)
@@ -135,13 +136,13 @@ def check_cluster_state(context, state, addr):
 
 
 def is_unclean(node):
-    rc, out, err = utils.get_stdout_stderr("crm_mon -1")
+    rc, out, err = ShellUtils().get_stdout_stderr("crm_mon -1")
     return "{}: UNCLEAN".format(node) in out
 
 
 def online(context, nodelist):
     rc = True
-    _, out = utils.get_stdout("sudo crm_node -l")
+    _, out = ShellUtils().get_stdout("sudo crm_node -l")
     for node in nodelist.split():
         node_info = "{} member".format(node)
         if not node_info in out:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -478,7 +478,7 @@ class TestBootstrap(unittest.TestCase):
         mock_nologin.assert_called_once_with("hacluster", None)
         mock_confirm.assert_called_once_with("Continue?")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.is_nologin')
     def test_change_user_shell(self, mock_nologin, mock_invoke):
         bootstrap._context = mock.Mock(yes_to_all=True)
@@ -550,7 +550,7 @@ class TestBootstrap(unittest.TestCase):
         mock_check.assert_called_once_with("fromfile", "tofile", remote=None, source_local=False)
         mock_append.assert_called_once_with("fromfile", "tofile", remote=None)
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_append_to_remote_file(self, mock_run):
         bootstrap.append_to_remote_file("fromfile", "root", "node1", "tofile")
         cmd = "cat fromfile | ssh {} root@node1 'cat >> tofile'".format(constants.SSH_OPTION)
@@ -648,7 +648,7 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.bootstrap_add(ctx)
         mock_this_node.assert_not_called()
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add(self, mock_this_node, mock_info, mock_run):
@@ -663,7 +663,7 @@ class TestBootstrap(unittest.TestCase):
             ])
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.sh.LocalShell.get_stdout_stderr')
+    @mock.patch('crmsh.sh.LocalShell.get_rc_stdout_stderr')
     def test_setup_passwordless_with_other_nodes_failed_fetch_nodelist(self, mock_run, mock_error):
         bootstrap._context = mock.Mock(current_user="carol")
         mock_run.return_value = (1, None, None)
@@ -678,7 +678,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.utils.HostUserConfig')
     @mock.patch('crmsh.bootstrap._fetch_core_hosts')
-    @mock.patch('crmsh.sh.LocalShell.get_stdout_stderr')
+    @mock.patch('crmsh.sh.LocalShell.get_rc_stdout_stderr')
     def test_setup_passwordless_with_other_nodes_failed_fetch_hostname(
             self,
             mock_run,
@@ -712,7 +712,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.utils.ssh_copy_id')
     @mock.patch('crmsh.utils.user_of')
     @mock.patch('crmsh.bootstrap.swap_public_ssh_key')
-    @mock.patch('crmsh.sh.LocalShell.get_stdout_stderr')
+    @mock.patch('crmsh.sh.LocalShell.get_rc_stdout_stderr')
     def test_setup_passwordless_with_other_nodes(
             self,
             mock_run,
@@ -788,7 +788,7 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_append.assert_called_once_with("/home/alice/.ssh/id_rsa.pub", "/home/alice/.ssh/authorized_keys")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_get_node_canonical_hostname(self, mock_run):
         mock_run.return_value = (0, "Node1", None)
 
@@ -797,7 +797,7 @@ class TestBootstrap(unittest.TestCase):
         mock_run.assert_called_once_with('node1', 'crm_node --name')
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_get_node_canonical_hostname_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         mock_error.side_effect = SystemExit
@@ -1252,7 +1252,7 @@ class TestBootstrap(unittest.TestCase):
         mock_cluster_cmd.assert_called_once_with("sync file1 file2")
 
     @mock.patch('logging.Logger.debug')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.cib_factory')
     def test_adjust_pcmk_delay_2node(self, mock_cib_factory, mock_run, mock_debug):
         mock_cib_factory.refresh = mock.Mock()
@@ -1262,7 +1262,7 @@ class TestBootstrap(unittest.TestCase):
         mock_run.assert_called_once_with("crm resource param res_1 set pcmk_delay_max {}s".format(constants.PCMK_DELAY_MAX))
 
     @mock.patch('logging.Logger.debug')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.cib_factory')
     def test_adjust_pcmk_delay(self, mock_cib_factory, mock_run, mock_debug):
         mock_cib_factory.refresh = mock.Mock()
@@ -1298,14 +1298,14 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.adjust_priority_in_rsc_defaults(False)
         mock_set.assert_called_once_with('priority', 0, property_type='rsc_defaults')
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_adjust_priority_fencing_delay_no_fence_agent(self, mock_run):
         mock_run.return_value = None
         bootstrap.adjust_priority_fencing_delay(False)
         mock_run.assert_called_once_with("crm configure show related:stonith")
 
     @mock.patch('crmsh.utils.set_property')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_adjust_priority_fencing_delay_no_pcmk_delay(self, mock_run, mock_set):
         mock_run.return_value = "data"
         bootstrap.adjust_priority_fencing_delay(False)
@@ -1578,7 +1578,7 @@ class TestValidation(unittest.TestCase):
         mock_this_node.assert_called_once_with()
         mock_error.assert_called_once_with("Removing self requires --force")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.remove_self')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
@@ -1644,7 +1644,7 @@ class TestValidation(unittest.TestCase):
         mock_this_node.assert_called_once_with()
         mock_error.assert_called_once_with("Specified node node2 is not configured in cluster! Unable to remove.")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.utils.fetch_cluster_node_list_from_node')
     @mock.patch('crmsh.bootstrap.remove_node_from_cluster')
     @mock.patch('crmsh.xmlutil.listnodes')
@@ -1682,7 +1682,7 @@ class TestValidation(unittest.TestCase):
         mock_run.assert_called_once_with('rm -rf /var/lib/crmsh', 'node2')
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     @mock.patch('crmsh.xmlutil.listnodes')
     @mock.patch('crmsh.utils.this_node')
     def test_remove_self_other_nodes(self, mock_this_node, mock_list, mock_run, mock_error):
@@ -1700,7 +1700,7 @@ class TestValidation(unittest.TestCase):
         mock_error.assert_called_once_with("Failed to remove this node from node2")
 
     @mock.patch('crmsh.utils.package_is_installed')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_rm_configuration_files(self, mock_run, mock_installed):
         bootstrap._context = mock.Mock(rm_list=["file1", "file2"])
         mock_installed.return_value = True

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1223,7 +1223,7 @@ class TestBootstrap(unittest.TestCase):
         mock_qdevice_inst.certificate_process_on_join.assert_called_once_with()
         mock_start_service.assert_called_once_with("corosync-qdevice.service", enable=True)
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.log.LoggerUtils.log_only_to_file')
     def test_invoke(self, mock_log, mock_run):
         mock_run.return_value = (0, "output", "error")

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -63,7 +63,7 @@ def test_query_qdevice_status_exception(mock_configured):
 
 
 @mock.patch('crmsh.utils.print_cluster_nodes')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.is_qdevice_configured')
 def test_query_qdevice_status(mock_configured, mock_run, mock_print):
     mock_configured.return_value = True
@@ -270,7 +270,7 @@ def test_get_corosync_value_dict(mock_get_value):
 
 
 @mock.patch('crmsh.corosync.get_value')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_corosync_value_raise(mock_run, mock_get_value):
     mock_run.side_effect = ValueError
     mock_get_value.return_value = None
@@ -279,7 +279,7 @@ def test_get_corosync_value_raise(mock_run, mock_get_value):
     mock_get_value.assert_called_once_with("xxx")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_corosync_value(mock_run):
     mock_run.return_value = "totem.token = 10000"
     assert corosync.get_corosync_value("totem.token") == "10000"

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -96,7 +96,7 @@ def test_query_status_except():
     assert str(err.value) == "Wrong type \"xxx\" to query status"
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_query_ring_status_except(mock_run):
     mock_run.return_value = (1, None, "error")
     with pytest.raises(ValueError) as err:
@@ -105,7 +105,7 @@ def test_query_ring_status_except(mock_run):
     mock_run.assert_called_once_with("corosync-cfgtool -s")
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_query_ring_status(mock_run):
     mock_run.return_value = (0, "data", None)
     corosync.query_ring_status()
@@ -113,7 +113,7 @@ def test_query_ring_status(mock_run):
 
 
 @mock.patch("crmsh.utils.print_cluster_nodes")
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_query_quorum_status_except(mock_run, mock_print_nodes):
     mock_run.return_value = (1, None, "error")
     with pytest.raises(ValueError) as err:
@@ -124,7 +124,7 @@ def test_query_quorum_status_except(mock_run, mock_print_nodes):
 
 
 @mock.patch("crmsh.utils.print_cluster_nodes")
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_query_quorum_status(mock_run, mock_print_nodes):
     mock_run.return_value = (0, "data", None)
     corosync.query_quorum_status()
@@ -133,7 +133,7 @@ def test_query_quorum_status(mock_run, mock_print_nodes):
 
 
 @mock.patch("crmsh.utils.print_cluster_nodes")
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_query_quorum_status_no_quorum(mock_run, mock_print_nodes):
     mock_run.return_value = (2, "no quorum", None)
     corosync.query_quorum_status()

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -63,7 +63,7 @@ def test_query_qdevice_status_exception(mock_configured):
 
 
 @mock.patch('crmsh.utils.print_cluster_nodes')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.is_qdevice_configured')
 def test_query_qdevice_status(mock_configured, mock_run, mock_print):
     mock_configured.return_value = True
@@ -270,7 +270,7 @@ def test_get_corosync_value_dict(mock_get_value):
 
 
 @mock.patch('crmsh.corosync.get_value')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_corosync_value_raise(mock_run, mock_get_value):
     mock_run.side_effect = ValueError
     mock_get_value.return_value = None
@@ -279,7 +279,7 @@ def test_get_corosync_value_raise(mock_run, mock_get_value):
     mock_get_value.assert_called_once_with("xxx")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_corosync_value(mock_run):
     mock_run.return_value = "totem.token = 10000"
     assert corosync.get_corosync_value("totem.token") == "10000"

--- a/test/unittests/test_crashtest_check.py
+++ b/test/unittests/test_crashtest_check.py
@@ -44,9 +44,9 @@ class TestCheck(TestCase):
         mock_hostname.assert_called_once_with()
         mock_task_inst.error.assert_called_once_with('Hostname "node1" is unresolvable.\n  Please add an entry to /etc/hosts or configure DNS.')
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_enabled')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_available')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_available')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_time_service_none(self, mock_task, mock_service_available, mock_service_enabled, mock_service_active):
         mock_task_inst = mock.Mock()
@@ -65,9 +65,9 @@ class TestCheck(TestCase):
             ])
         mock_task_inst.warn.assert_called_once_with("No NTP service found.")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_enabled')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_available')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_available')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_time_service_warn(self, mock_task, mock_service_available, mock_service_enabled, mock_service_active):
         mock_task_inst = mock.Mock()
@@ -88,9 +88,9 @@ class TestCheck(TestCase):
             mock.call("chronyd.service is not active"),
             ])
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_enabled')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_available')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_available')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_time_service(self, mock_task, mock_service_available, mock_service_enabled, mock_service_active):
         mock_task_inst = mock.Mock()
@@ -170,7 +170,7 @@ class TestCheck(TestCase):
             ])
         mock_task_inst.warn.assert_called_once_with("Failed to detect firewall")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.crash_test.check.crmshutils.package_is_installed')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_firewall_warn(self, mock_task, mock_installed, mock_active):
@@ -189,7 +189,7 @@ class TestCheck(TestCase):
         mock_task_inst.warn.assert_called_once_with("firewalld.service is not active")
 
     @mock.patch('crmsh.crash_test.check.check_port_open')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.crash_test.check.crmshutils.package_is_installed')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_firewall(self, mock_task, mock_installed, mock_active, mock_check_port):
@@ -229,8 +229,8 @@ class TestCheck(TestCase):
         mock_check_nodes.assert_called_once_with()
         mock_check_resources.assert_called_once_with()
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_cluster_service_pacemaker_disable(self, mock_task, mock_enabled, mock_active):
         mock_task_inst = mock.Mock(passed=False)
@@ -259,8 +259,8 @@ class TestCheck(TestCase):
         mock_task_inst.info.assert_called_once_with("corosync.service is running")
         mock_task_inst.error.assert_called_once_with("pacemaker.service is not running!")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_cluster_service(self, mock_task, mock_enabled, mock_active):
         mock_task_inst = mock.Mock(passed=True)
@@ -325,7 +325,7 @@ class TestCheck(TestCase):
         mock_task_inst.info.assert_called_once_with("stonith is enabled")
         mock_task_inst.warn.assert_called_once_with("No stonith resource configured!")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.FenceInfo')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
@@ -353,7 +353,7 @@ class TestCheck(TestCase):
             mock.call("sbd service is not running!")
             ])
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.FenceInfo')
     @mock.patch('crmsh.crash_test.task.TaskCheck')

--- a/test/unittests/test_crashtest_check.py
+++ b/test/unittests/test_crashtest_check.py
@@ -111,7 +111,7 @@ class TestCheck(TestCase):
             mock.call("chronyd.service is active")
             ])
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.corosync_port_list')
     def test_check_port_open_return(self, mock_corosync_port, mock_run):
         mock_corosync_port.return_value = ["1234", "5678"]
@@ -134,7 +134,7 @@ class TestCheck(TestCase):
         mock_corosync_port.assert_called_once_with()
         task_inst.error.assert_called_once_with("Can not get corosync's port")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.corosync_port_list')
     def test_check_port_open(self, mock_corosync_port, mock_run):
         mock_corosync_port.return_value = ["1234", "5678"]
@@ -305,7 +305,7 @@ class TestCheck(TestCase):
         mock_fence_info.assert_called_once_with()
         mock_task_inst.warn.assert_called_once_with("stonith is disabled")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.FenceInfo')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_fencing_no_resources(self, mock_task, mock_fence_info, mock_run):
@@ -326,7 +326,7 @@ class TestCheck(TestCase):
         mock_task_inst.warn.assert_called_once_with("No stonith resource configured!")
 
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.FenceInfo')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_fencing_has_warn(self, mock_task, mock_fence_info, mock_run, mock_active):
@@ -354,7 +354,7 @@ class TestCheck(TestCase):
             ])
 
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.utils.FenceInfo')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_fencing(self, mock_task, mock_fence_info, mock_run, mock_active):
@@ -380,7 +380,7 @@ class TestCheck(TestCase):
             ])
         mock_active.assert_called_once_with("sbd")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_nodes_error(self, mock_task, mock_run):
         mock_task_inst = mock.Mock()
@@ -395,7 +395,7 @@ class TestCheck(TestCase):
         mock_run.assert_called_once_with("crm_mon -1")
         mock_task_inst.error.assert_called_once_with("run \"crm_mon -1\" error: error data")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_nodes(self, mock_task, mock_run):
         mock_task_inst = mock.Mock()
@@ -428,7 +428,7 @@ Node List:
             ])
         mock_task_inst.warn.assert_called_once_with("OFFLINE nodes: [ 15sp2-2 ]")
 
-    @mock.patch('crmsh.crash_test.check.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
     def test_check_nodes_warn(self, mock_task, mock_run):
         mock_task_inst = mock.Mock()
@@ -545,7 +545,7 @@ Active Resources:
     @mock.patch('crmsh.crash_test.task.TaskCheck.print_result')
     @mock.patch('crmsh.crash_test.utils.is_valid_sbd')
     @mock.patch('crmsh.crash_test.utils.msg_info')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.utils.parse_sysconfig')
     @mock.patch('os.path.exists')
     def test_check_sbd_exist_and_valid(cls, mock_os_path_exists,
@@ -570,7 +570,7 @@ Active Resources:
     @mock.patch('crmsh.crash_test.utils.find_candidate_sbd')
     @mock.patch('crmsh.crash_test.utils.is_valid_sbd')
     @mock.patch('crmsh.crash_test.utils.msg_warn')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.utils.parse_sysconfig')
     @mock.patch('os.path.exists')
     def test_check_sbd_exist_and_not_valid_but_no_can(cls, mock_os_path_exists,
@@ -601,7 +601,7 @@ Active Resources:
     @mock.patch('crmsh.crash_test.utils.is_valid_sbd')
     @mock.patch('crmsh.crash_test.utils.msg_info')
     @mock.patch('crmsh.crash_test.utils.msg_warn')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.utils.parse_sysconfig')
     @mock.patch('os.path.exists')
     def test_check_sbd_exist_and_not_exist_has_can(cls, mock_os_path_exists,
@@ -633,7 +633,7 @@ Active Resources:
     @mock.patch('crmsh.crash_test.utils.is_valid_sbd')
     @mock.patch('crmsh.crash_test.utils.msg_info')
     @mock.patch('crmsh.crash_test.utils.msg_warn')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.utils.parse_sysconfig')
     @mock.patch('os.path.exists')
     def test_check_sbd_exist_and_not_valid_has_can(cls, mock_os_path_exists,

--- a/test/unittests/test_crashtest_task.py
+++ b/test/unittests/test_crashtest_task.py
@@ -124,7 +124,7 @@ Expected State:    a) sbd process restarted
     @mock.patch('crmsh.crash_test.task.TaskKill.process_monitor')
     @mock.patch('crmsh.crash_test.task.Task.fence_action_monitor')
     @mock.patch('threading.Thread')
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.info')
     @mock.patch('crmsh.crash_test.utils.get_process_status')
     def test_run(self, mock_status, mock_info, mock_run, mock_thread, mock_fence_monitor, mock_process_monitor):
@@ -343,7 +343,7 @@ Fence timeout:     60
         mock_result.assert_called_once_with()
         mock_json.assert_called_once_with()
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
     def test_pre_check_no_cmd(self, mock_pre_check, mock_run):
         mock_run.return_value = (1, None, "error")
@@ -354,7 +354,7 @@ Fence timeout:     60
         mock_pre_check.assert_called_once_with()
 
     @mock.patch('crmsh.crash_test.utils.online_nodes')
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
     def test_pre_check_error(self, mock_pre_check, mock_run, mock_online_nodes):
         mock_run.return_value = (0, None, None)
@@ -365,7 +365,7 @@ Fence timeout:     60
         mock_run.assert_called_once_with("which iptables")
         mock_online_nodes.assert_called_once_with()
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.crmshutils.get_iplist_from_name')
     @mock.patch('crmsh.crash_test.task.Task.info')
     @mock.patch('crmsh.crash_test.utils.peer_node_list')
@@ -394,7 +394,7 @@ Fence timeout:     60
         self.task_sp_inst.un_block()
         mock_unblock_iptables.assert_called_once_with()
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.crmshutils.get_iplist_from_name')
     @mock.patch('crmsh.crash_test.task.Task.info')
     def test_un_block_iptables(self, mock_info, mock_get_iplist, mock_run):
@@ -480,7 +480,7 @@ Fence timeout:     60
         mock_result.assert_called_once_with()
         mock_json.assert_called_once_with()
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
     def test_pre_check_no_cmd(self, mock_pre_check, mock_run):
         mock_run.return_value = (1, None, "error")
@@ -491,7 +491,7 @@ Fence timeout:     60
         mock_pre_check.assert_called_once_with()
 
     @mock.patch('crmsh.crash_test.utils.check_node_status')
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
     def test_pre_check_error(self, mock_pre_check, mock_run, mock_node_status):
         mock_run.side_effect = [(0, None, None), (0, None, None), (0, None, None)]
@@ -508,7 +508,7 @@ Fence timeout:     60
 
     @mock.patch('crmsh.crash_test.task.Task.fence_action_monitor')
     @mock.patch('threading.Thread')
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.info')
     def test_run(self, mock_info, mock_run, mock_thread, mock_monitor):
         mock_thread_inst = mock.Mock()
@@ -669,7 +669,7 @@ class TestTask(TestCase):
     @mock.patch('crmsh.crash_test.utils.str_to_datetime')
     @mock.patch('time.sleep')
     @mock.patch('crmsh.crash_test.task.Task.info')
-    @mock.patch('crmsh.crash_test.task.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_fence_action_monitor(self, mock_run, mock_info, mock_sleep, mock_datetime):
         self.task_inst.thread_stop_event = mock.Mock()
         self.task_inst.thread_stop_event.is_set.side_effect = [False, False, False, False]

--- a/test/unittests/test_crashtest_task.py
+++ b/test/unittests/test_crashtest_task.py
@@ -589,7 +589,7 @@ class TestTask(TestCase):
     def test_to_json(self):
         self.task_inst.to_json()
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_task_pre_check_exception(self, mock_active):
         mock_active.return_value = False
         with self.assertRaises(task.TaskError) as err:
@@ -597,7 +597,7 @@ class TestTask(TestCase):
         self.assertEqual("Cluster not running!", str(err.exception))
         mock_active.assert_called_once_with("pacemaker.service")
 
-    @mock.patch('crmsh.crash_test.task.crmshutils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_task_pre_check_exception_no_fence(self, mock_active):
         mock_active.return_value = True
         self.task_inst.get_fence_info = mock.Mock()

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -203,7 +203,7 @@ class TestUtils(TestCase):
 
     @mock.patch('crmsh.crash_test.utils.crmshutils.this_node')
     @mock.patch('crmsh.crash_test.utils.msg_error')
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_this_node_false(self, mock_run, mock_error, mock_this_node):
         mock_run.return_value = (1, None, "error data")
         mock_this_node.return_value = "node1"
@@ -215,7 +215,7 @@ class TestUtils(TestCase):
         mock_error.assert_called_once_with("error data")
         mock_this_node.assert_called_once_with()
     
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_this_node(self, mock_run):
         mock_run.return_value = (0, "data", None)
         res = utils.this_node()
@@ -227,7 +227,7 @@ class TestUtils(TestCase):
         utils.str_to_datetime("Mon Nov  2 15:37:11 2020", "%a %b %d %H:%M:%S %Y")
         mock_datetime.strptime.assert_called_once_with("Mon Nov  2 15:37:11 2020", "%a %b %d %H:%M:%S %Y")
 
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_corosync_port_list(self, mock_run):
         output = """
 totem.interface.0.bindnetaddr (str) = 10.10.10.121
@@ -335,7 +335,7 @@ totem.interface.1.ttl (u8) = 1
             ])
 
     @mock.patch('crmsh.crash_test.utils.msg_error')
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_check_node_status_error_cmd(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         res = utils.check_node_status("node1", "member")
@@ -344,7 +344,7 @@ totem.interface.1.ttl (u8) = 1
         mock_error.assert_called_once_with("error")
 
     @mock.patch('crmsh.crash_test.utils.msg_error')
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_check_node_status(self, mock_run, mock_error):
         output = """
 1084783297 15sp2-1 member
@@ -363,14 +363,14 @@ totem.interface.1.ttl (u8) = 1
             ])
         mock_error.assert_not_called()
 
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_online_nodes_empty(self, mock_run):
         mock_run.return_value = (0, "data", None)
         res = utils.online_nodes()
         self.assertEqual(res, [])
         mock_run.assert_called_once_with("crm_mon -1")
 
-    @mock.patch('crmsh.crash_test.utils.crmshutils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_online_nodes(self, mock_run):
         output = """
 Node List:
@@ -412,7 +412,7 @@ Node List:
 
     @classmethod
     @mock.patch('crmsh.crash_test.utils.msg_error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('os.path.exists')
     def test_is_valid_sbd_cmd_error(cls, mock_os_path_exists,
                                     mock_sbd_check_header, mock_msg_err):
@@ -430,7 +430,7 @@ Node List:
 
     @classmethod
     @mock.patch('crmsh.crash_test.utils.msg_error')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('os.path.exists')
     def test_is_valid_sbd_not_sbd(cls, mock_os_path_exists,
                                   mock_sbd_check_header, mock_msg_err):
@@ -452,7 +452,7 @@ sbd failed; please check the logs.
         mock_msg_err.assert_called_once_with(err_output)
 
     @classmethod
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('os.path.exists')
     def test_is_valid_sbd_is_sbd(cls, mock_os_path_exists,
                                  mock_sbd_check_header):

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -48,7 +48,7 @@ class TestLock(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_run(self, mock_run):
         mock_run.return_value = (0, "output data", None)
         rc, out, err = self.local_inst._run("test_cmd")

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -132,7 +132,7 @@ class TestRemoteLock(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_run_ssh_error(self, mock_run):
         mock_run.return_value = (255, None, "ssh error")
         with self.assertRaises(lock.SSHError) as err:
@@ -140,7 +140,7 @@ class TestRemoteLock(unittest.TestCase):
         self.assertEqual("ssh error", str(err.exception))
         mock_run.assert_called_once_with("node1", "cmd")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_run(self, mock_run):
         mock_run.return_value = (0, None, None)
         res = self.lock_inst._run("cmd")

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -132,20 +132,20 @@ class TestRemoteLock(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.utils.run_cmd_on_remote')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_run_ssh_error(self, mock_run):
         mock_run.return_value = (255, None, "ssh error")
         with self.assertRaises(lock.SSHError) as err:
             self.lock_inst._run("cmd")
         self.assertEqual("ssh error", str(err.exception))
-        mock_run.assert_called_once_with("cmd", "node1")
+        mock_run.assert_called_once_with("node1", "cmd")
 
-    @mock.patch('crmsh.utils.run_cmd_on_remote')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_run(self, mock_run):
         mock_run.return_value = (0, None, None)
         res = self.lock_inst._run("cmd")
         self.assertEqual(res, mock_run.return_value)
-        mock_run.assert_called_once_with("cmd", "node1")
+        mock_run.assert_called_once_with("node1", "cmd")
 
     def test_lock_timeout_error_format(self):
         config.core.lock_timeout = "pwd"

--- a/test/unittests/test_ocfs2.py
+++ b/test/unittests/test_ocfs2.py
@@ -132,7 +132,7 @@ class TestOCFS2Manager(unittest.TestCase):
         self.ocfs2_inst3._check_if_already_configured()
 
     @mock.patch('logging.Logger.info')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_check_if_already_configured(self, mock_run, mock_info):
         mock_run.return_value = "data xxx fstype=ocfs2  sss"
         with self.assertRaises(utils.TerminateSubCommand):
@@ -158,7 +158,7 @@ class TestOCFS2Manager(unittest.TestCase):
 
     @mock.patch('crmsh.ocfs2.OCFS2Manager._dynamic_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_device_from_config')
-    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     def test_check_sbd_and_ocfs2_dev(self, mock_enabled, mock_get_device, mock_error):
         mock_enabled.return_value = True
         mock_get_device.return_value = ["/dev/sdb2"]
@@ -186,7 +186,7 @@ class TestOCFS2Manager(unittest.TestCase):
             mock.call("/dev/sdc2 contains a ext4 file system - Proceed anyway?")
             ])
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.utils.get_dev_fs_type')
     @mock.patch('crmsh.utils.has_dev_partitioned')
@@ -237,7 +237,7 @@ class TestOCFS2Manager(unittest.TestCase):
         assert res == ("g1", "\ngroup g1 d vip")
         mock_gen_unused.assert_called_once_with([], "g1")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('crmsh.log.LoggerUtils.status_long')
     def test_mkfs(self, mock_long, mock_get_value, mock_run):
@@ -247,7 +247,7 @@ class TestOCFS2Manager(unittest.TestCase):
         mock_get_value.assert_called_once_with("totem.cluster_name")
         mock_run.assert_called_once_with("mkfs.ocfs2 --cluster-stack pcmk --cluster-name hacluster -N 8 -x /dev/sdb2")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_vg_change(self, mock_run):
         self.ocfs2_inst3.vg_id = "vg1"
         with self.ocfs2_inst3._vg_change():
@@ -260,7 +260,7 @@ class TestOCFS2Manager(unittest.TestCase):
     @mock.patch('crmsh.utils.get_pe_number')
     @mock.patch('crmsh.utils.gen_unused_id')
     @mock.patch('crmsh.utils.get_all_vg_name')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.log.LoggerUtils.status_long')
     def test_create_lv(self, mock_long, mock_run, mock_all_vg, mock_unused, mock_pe_num):
         mock_all_vg.return_value = []
@@ -410,14 +410,14 @@ class TestOCFS2Manager(unittest.TestCase):
         mock_all_id.assert_called_once_with()
         mock_ocfs2.assert_called_once_with()
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_find_target_on_join_none(self, mock_run):
         mock_run.return_value = "data"
         res = self.ocfs2_inst3._find_target_on_join("node1")
         assert res is None
-        mock_run.assert_called_once_with("crm configure show", remote="node1")
+        mock_run.assert_called_once_with("crm configure show", "node1")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_find_target_on_join_exception(self, mock_run):
         mock_run.return_value = """
 params directory="/srv/clusterfs" fstype=ocfs2
@@ -425,16 +425,16 @@ params directory="/srv/clusterfs" fstype=ocfs2
         with self.assertRaises(ValueError) as err:
             self.ocfs2_inst3._find_target_on_join("node1")
         self.assertEqual("Filesystem require configure device", str(err.exception))
-        mock_run.assert_called_once_with("crm configure show", remote="node1")
+        mock_run.assert_called_once_with("crm configure show", "node1")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_find_target_on_join(self, mock_run):
         mock_run.return_value = """
 params directory="/srv/clusterfs" fstype=ocfs2 device="/dev/sda2"
         """
         res = self.ocfs2_inst3._find_target_on_join("node1")
         self.assertEqual(res, "/dev/sda2")
-        mock_run.assert_called_once_with("crm configure show", remote="node1")
+        mock_run.assert_called_once_with("crm configure show", "node1")
 
     @mock.patch('crmsh.ocfs2.OCFS2Manager._find_target_on_join')
     def test_join_ocfs2_return(self, mock_find):

--- a/test/unittests/test_ocfs2.py
+++ b/test/unittests/test_ocfs2.py
@@ -132,7 +132,7 @@ class TestOCFS2Manager(unittest.TestCase):
         self.ocfs2_inst3._check_if_already_configured()
 
     @mock.patch('logging.Logger.info')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_check_if_already_configured(self, mock_run, mock_info):
         mock_run.return_value = "data xxx fstype=ocfs2  sss"
         with self.assertRaises(utils.TerminateSubCommand):
@@ -186,7 +186,7 @@ class TestOCFS2Manager(unittest.TestCase):
             mock.call("/dev/sdc2 contains a ext4 file system - Proceed anyway?")
             ])
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.utils.get_dev_fs_type')
     @mock.patch('crmsh.utils.has_dev_partitioned')
@@ -237,7 +237,7 @@ class TestOCFS2Manager(unittest.TestCase):
         assert res == ("g1", "\ngroup g1 d vip")
         mock_gen_unused.assert_called_once_with([], "g1")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('crmsh.log.LoggerUtils.status_long')
     def test_mkfs(self, mock_long, mock_get_value, mock_run):
@@ -247,7 +247,7 @@ class TestOCFS2Manager(unittest.TestCase):
         mock_get_value.assert_called_once_with("totem.cluster_name")
         mock_run.assert_called_once_with("mkfs.ocfs2 --cluster-stack pcmk --cluster-name hacluster -N 8 -x /dev/sdb2")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_vg_change(self, mock_run):
         self.ocfs2_inst3.vg_id = "vg1"
         with self.ocfs2_inst3._vg_change():
@@ -260,7 +260,7 @@ class TestOCFS2Manager(unittest.TestCase):
     @mock.patch('crmsh.utils.get_pe_number')
     @mock.patch('crmsh.utils.gen_unused_id')
     @mock.patch('crmsh.utils.get_all_vg_name')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.log.LoggerUtils.status_long')
     def test_create_lv(self, mock_long, mock_run, mock_all_vg, mock_unused, mock_pe_num):
         mock_all_vg.return_value = []
@@ -410,14 +410,14 @@ class TestOCFS2Manager(unittest.TestCase):
         mock_all_id.assert_called_once_with()
         mock_ocfs2.assert_called_once_with()
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_find_target_on_join_none(self, mock_run):
         mock_run.return_value = "data"
         res = self.ocfs2_inst3._find_target_on_join("node1")
         assert res is None
         mock_run.assert_called_once_with("crm configure show", "node1")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_find_target_on_join_exception(self, mock_run):
         mock_run.return_value = """
 params directory="/srv/clusterfs" fstype=ocfs2
@@ -427,7 +427,7 @@ params directory="/srv/clusterfs" fstype=ocfs2
         self.assertEqual("Filesystem require configure device", str(err.exception))
         mock_run.assert_called_once_with("crm configure show", "node1")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_find_target_on_join(self, mock_run):
         mock_run.return_value = """
 params directory="/srv/clusterfs" fstype=ocfs2 device="/dev/sda2"

--- a/test/unittests/test_prun.py
+++ b/test/unittests/test_prun.py
@@ -12,7 +12,7 @@ class TestPrun(unittest.TestCase):
     @mock.patch("os.geteuid")
     @mock.patch("crmsh.userdir.getuser")
     @mock.patch("crmsh.prun.prun._is_local_host")
-    @mock.patch("crmsh.utils.UserOfHost.user_pair_for_ssh")
+    @mock.patch("crmsh.user_of_host.UserOfHost.user_pair_for_ssh")
     @mock.patch("crmsh.prun.runner.Runner.run")
     @mock.patch("crmsh.prun.runner.Runner.add_task")
     def test_prun(
@@ -61,7 +61,7 @@ class TestPrun(unittest.TestCase):
     @mock.patch("os.geteuid")
     @mock.patch("crmsh.userdir.getuser")
     @mock.patch("crmsh.prun.prun._is_local_host")
-    @mock.patch("crmsh.utils.UserOfHost.user_pair_for_ssh")
+    @mock.patch("crmsh.user_of_host.UserOfHost.user_pair_for_ssh")
     @mock.patch("crmsh.prun.runner.Runner.run")
     @mock.patch("crmsh.prun.runner.Runner.add_task")
     def test_prun_root(

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -324,7 +324,7 @@ class TestQDevice(unittest.TestCase):
 
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
     @mock.patch("crmsh.utils.package_is_installed")
     def test_valid_qnetd_duplicated_with_qnetd_running(self, mock_installed, mock_is_active, mock_run):
@@ -342,7 +342,7 @@ class TestQDevice(unittest.TestCase):
         mock_is_active.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
         mock_run.assert_called_once_with("corosync-qnetd-tool -l -c cluster1", "10.10.10.123")
 
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
     @mock.patch("crmsh.utils.package_is_installed")
     def test_valid_qnetd_duplicated_without_qnetd_running(self, mock_installed, mock_is_active, mock_run):
@@ -496,7 +496,7 @@ class TestQDevice(unittest.TestCase):
                                           "corosync-qdevice-net-certutil -i -c {}".format(mock_qnetd_cacert_local.return_value))
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     def test_create_ca_request(self, mock_stdout_stderr, mock_log):
         mock_stdout_stderr.return_value = (0, None, None)
 
@@ -553,7 +553,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net", mock_crt_on_qnetd.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cluster_crt_on_local", new_callable=mock.PropertyMock)
     def test_import_cluster_crt(self, mock_crt_on_local, mock_stdout_stderr, mock_log):
         mock_crt_on_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/cluster-hacluster.crt"
@@ -698,7 +698,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["node1.com"], "/etc/corosync/qdevice/net", mock_qnetd_cacert_local.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_cluster", new_callable=mock.PropertyMock)
     def test_init_db_on_local(self, mock_qnetd_cacert_cluster, mock_stdout_stderr, mock_log):
         mock_qnetd_cacert_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qnetd-cacert.crt"
@@ -749,7 +749,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["node1.com"], '/etc/corosync/qdevice/net', mock_p12_on_local.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_cluster", new_callable=mock.PropertyMock)
     def test_import_p12_on_local(self, mock_p12_on_cluster, mock_stdout_stderr, mock_log):
         mock_p12_on_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qdevice-net-node.p12"
@@ -862,7 +862,7 @@ class TestQDevice(unittest.TestCase):
 
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.corosync.get_value')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_check_qdevice_vote(self, mock_run, mock_get_value, mock_warning):
         data = """
 Membership information
@@ -1013,7 +1013,7 @@ Membership information
         qdevice.QDevice.remove_certification_files_on_qnetd()
         mock_configured.assert_called_once_with()
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     def test_remove_certification_files_on_qnetd(self, mock_configured, mock_get_value, mock_run):

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -322,8 +322,8 @@ class TestQDevice(unittest.TestCase):
 
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
-    @mock.patch("crmsh.utils.service_is_active")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
     @mock.patch("crmsh.utils.package_is_installed")
     def test_valid_qnetd_duplicated_with_qnetd_running(self, mock_installed, mock_is_active, mock_run):
         mock_installed.return_value = True
@@ -338,10 +338,10 @@ class TestQDevice(unittest.TestCase):
 
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
         mock_is_active.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
-        mock_run.assert_called_once_with("corosync-qnetd-tool -l -c cluster1", remote="10.10.10.123")
+        mock_run.assert_called_once_with("corosync-qnetd-tool -l -c cluster1", "10.10.10.123")
 
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
-    @mock.patch("crmsh.utils.service_is_active")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+    @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
     @mock.patch("crmsh.utils.package_is_installed")
     def test_valid_qnetd_duplicated_without_qnetd_running(self, mock_installed, mock_is_active, mock_run):
         mock_installed.return_value = True
@@ -355,24 +355,24 @@ class TestQDevice(unittest.TestCase):
 
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
         mock_is_active.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
-        mock_run.assert_called_once_with("test -f /etc/corosync/qnetd/nssdb/cluster-hacluster1.crt", remote="10.10.10.123")
+        mock_run.assert_called_once_with("test -f /etc/corosync/qnetd/nssdb/cluster-hacluster1.crt", "10.10.10.123")
 
-    @mock.patch("crmsh.utils.enable_service")
+    @mock.patch("crmsh.service_manager.ServiceManager.enable_service")
     def test_enable_qnetd(self, mock_enable):
         self.qdevice_with_ip.enable_qnetd()
         mock_enable.assert_called_once_with("corosync-qnetd.service", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.utils.disable_service")
+    @mock.patch("crmsh.service_manager.ServiceManager.disable_service")
     def test_disable_qnetd(self, mock_disable):
         self.qdevice_with_ip.disable_qnetd()
         mock_disable.assert_called_once_with("corosync-qnetd.service", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.utils.start_service")
+    @mock.patch("crmsh.service_manager.ServiceManager.start_service")
     def test_start_qnetd(self, mock_start):
         self.qdevice_with_ip.start_qnetd()
         mock_start.assert_called_once_with("corosync-qnetd.service", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.utils.stop_service")
+    @mock.patch("crmsh.service_manager.ServiceManager.stop_service")
     def test_stop_qnetd(self, mock_stop):
         self.qdevice_with_ip.stop_qnetd()
         mock_stop.assert_called_once_with("corosync-qnetd.service", remote_addr="10.10.10.123")
@@ -494,7 +494,7 @@ class TestQDevice(unittest.TestCase):
                                           "corosync-qdevice-net-certutil -i -c {}".format(mock_qnetd_cacert_local.return_value))
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
     def test_create_ca_request(self, mock_stdout_stderr, mock_log):
         mock_stdout_stderr.return_value = (0, None, None)
 
@@ -551,7 +551,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net", mock_crt_on_qnetd.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cluster_crt_on_local", new_callable=mock.PropertyMock)
     def test_import_cluster_crt(self, mock_crt_on_local, mock_stdout_stderr, mock_log):
         mock_crt_on_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/cluster-hacluster.crt"
@@ -696,7 +696,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["node1.com"], "/etc/corosync/qdevice/net", mock_qnetd_cacert_local.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_cluster", new_callable=mock.PropertyMock)
     def test_init_db_on_local(self, mock_qnetd_cacert_cluster, mock_stdout_stderr, mock_log):
         mock_qnetd_cacert_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qnetd-cacert.crt"
@@ -747,7 +747,7 @@ class TestQDevice(unittest.TestCase):
         mock_parallax_slurp.assert_called_once_with(["node1.com"], '/etc/corosync/qdevice/net', mock_p12_on_local.return_value)
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
-    @mock.patch("crmsh.utils.get_stdout_or_raise_error")
+    @mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_cluster", new_callable=mock.PropertyMock)
     def test_import_p12_on_local(self, mock_p12_on_cluster, mock_stdout_stderr, mock_log):
         mock_p12_on_cluster.return_value = "/etc/corosync/qdevice/net/node1.com/qdevice-net-node.p12"
@@ -860,7 +860,7 @@ class TestQDevice(unittest.TestCase):
 
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.corosync.get_value')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_check_qdevice_vote(self, mock_run, mock_get_value, mock_warning):
         data = """
 Membership information
@@ -872,7 +872,7 @@ Membership information
         mock_run.return_value = data
         mock_get_value.return_value = "qnetd-node"
         qdevice.QDevice.check_qdevice_vote()
-        mock_run.assert_called_once_with("corosync-quorumtool -s", success_val_list=[0, 2])
+        mock_run.assert_called_once_with("corosync-quorumtool -s", success_exit_status={0, 2})
         mock_get_value.assert_called_once_with("quorum.device.net.host")
         mock_warning.assert_called_once_with("Qdevice's vote is 0, which simply means Qdevice can't talk to Qnetd(qnetd-node) for various reasons.")
 
@@ -1011,7 +1011,7 @@ Membership information
         qdevice.QDevice.remove_certification_files_on_qnetd()
         mock_configured.assert_called_once_with()
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     def test_remove_certification_files_on_qnetd(self, mock_configured, mock_get_value, mock_run):
@@ -1027,5 +1027,5 @@ Membership information
         crq_file = "/etc/corosync/qnetd/nssdb/qdevice-net-node.crq.cluster1"
         crq_cmd = "test -f {crq_file} && rm -f {crq_file}".format(crq_file=crq_file)
         mock_run.assert_has_calls([
-            mock.call(crt_cmd, remote="qnetd-node"),
-            mock.call(crq_cmd, remote="qnetd-node")])
+            mock.call(crt_cmd, "qnetd-node"),
+            mock.call(crq_cmd, "qnetd-node")])

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -255,7 +255,9 @@ class TestQDevice(unittest.TestCase):
         excepted_err_string = "invalid ALGORITHM choice: '1' (choose from 'ffsplit', 'lms')"
         self.assertEqual(excepted_err_string, str(err.exception))
 
-    def test_check_qdevice_tie_breaker(self):
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    def test_check_qdevice_tie_breaker(self, mock_is_active):
+        mock_is_active.return_value = False
         with self.assertRaises(ValueError) as err:
             qdevice.QDevice.check_qdevice_tie_breaker("1")
         excepted_err_string = "invalid qdevice tie_breaker(lowest/highest/valid_node_id)"

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -81,7 +81,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.sbd_timeout_inst._adjust_sbd_watchdog_timeout_with_diskless_and_qdevice()
         mock_warn.assert_called_once_with("sbd_watchdog_timeout is set to 35 for qdevice, it was 5")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_get_sbd_msgwait_exception(self, mock_run):
         mock_run.return_value = "data"
         with self.assertRaises(ValueError) as err:
@@ -89,7 +89,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.assertEqual("Cannot get sbd msgwait for /dev/sda1", str(err.exception))
         mock_run.assert_called_once_with("sbd -d /dev/sda1 dump")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_get_sbd_msgwait(self, mock_run):
         mock_run.return_value = """
         Timeout (loop)     : 1
@@ -234,7 +234,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.sbd_timeout_inst.adjust_sbd_delay_start()
         mock_update.assert_called_once_with({"SBD_DELAY_START": "100"})
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start_no(self, mock_get_sbd_value, mock_run):
         mock_get_sbd_value.return_value = "no"
@@ -243,7 +243,7 @@ class TestSBDTimeout(unittest.TestCase):
 
     @mock.patch('crmsh.utils.mkdirp')
     @mock.patch('crmsh.utils.get_systemd_timeout_start_in_sec')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start_return(self, mock_get_sbd_value, mock_run, mock_get_systemd_sec, mock_mkdirp):
         mock_get_sbd_value.return_value = "10"
@@ -259,7 +259,7 @@ class TestSBDTimeout(unittest.TestCase):
     @mock.patch('crmsh.utils.str2file')
     @mock.patch('crmsh.utils.mkdirp')
     @mock.patch('crmsh.utils.get_systemd_timeout_start_in_sec')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start(self, mock_get_sbd_value, mock_run, mock_get_systemd_sec, mock_mkdirp, mock_str2file, mock_csync2, mock_cluster_run):
         mock_get_sbd_value.return_value = "100"
@@ -676,7 +676,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.sbd.SBDTimeout.adjust_sbd_timeout_related_cluster_configuration')
     @mock.patch('crmsh.utils.set_property')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_resource_configured')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
@@ -823,7 +823,7 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("Device /dev/sdb1 doesn't have the same UUID with node1", str(err.exception))
         mock_get_uuid.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdb1", "node1")])
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_get_device_uuid_not_match(self, mock_run):
         mock_run.return_value = "data"
         with self.assertRaises(ValueError) as err:
@@ -831,7 +831,7 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("Cannot find sbd device UUID for /dev/sdb1", str(err.exception))
         mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump", None)
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     def test_get_device_uuid(self, mock_run):
         output = """
         ==Dumping header on disk /dev/sda1

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -673,16 +673,21 @@ class TestSBDManager(unittest.TestCase):
         self.sbd_inst.configure_sbd_resource_and_properties()
         mock_package.assert_called_once_with("sbd")
 
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.sbd.SBDTimeout.adjust_sbd_timeout_related_cluster_configuration')
     @mock.patch('crmsh.utils.set_property')
     @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_resource_configured')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
-    def test_configure_sbd_resource_and_properties(self, mock_package, mock_enabled, mock_configured, mock_run, mock_set_property, sbd_adjust):
+    def test_configure_sbd_resource_and_properties(
+            self,
+            mock_package, mock_enabled, mock_configured, mock_run, mock_set_property, sbd_adjust, mock_is_active,
+    ):
         mock_package.return_value = True
         mock_enabled.return_value = True
         mock_configured.return_value = False
+        mock_is_active.return_value = False
         self.sbd_inst._context = mock.Mock(cluster_is_running=True)
         self.sbd_inst._get_sbd_device_from_config = mock.Mock()
         self.sbd_inst._get_sbd_device_from_config.return_value = ["/dev/sda1"]

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -63,7 +63,7 @@ class TestSBDTimeout(unittest.TestCase):
 
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.utils.get_qdevice_sync_timeout')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     def test_adjust_sbd_watchdog_timeout_with_diskless_and_qdevice_sbd_stage(self, mock_is_configured, mock_is_active, mock_get_sync, mock_warn):
         mock_is_configured.return_value = True
@@ -81,7 +81,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.sbd_timeout_inst._adjust_sbd_watchdog_timeout_with_diskless_and_qdevice()
         mock_warn.assert_called_once_with("sbd_watchdog_timeout is set to 35 for qdevice, it was 5")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_get_sbd_msgwait_exception(self, mock_run):
         mock_run.return_value = "data"
         with self.assertRaises(ValueError) as err:
@@ -89,7 +89,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.assertEqual("Cannot get sbd msgwait for /dev/sda1", str(err.exception))
         mock_run.assert_called_once_with("sbd -d /dev/sda1 dump")
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_get_sbd_msgwait(self, mock_run):
         mock_run.return_value = """
         Timeout (loop)     : 1
@@ -115,7 +115,7 @@ class TestSBDTimeout(unittest.TestCase):
         assert res == 5
         mock_get.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
 
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_get_stonith_watchdog_timeout_return(self, mock_active):
         mock_active.return_value = False
         res = sbd.SBDTimeout.get_stonith_watchdog_timeout()
@@ -123,7 +123,7 @@ class TestSBDTimeout(unittest.TestCase):
         mock_active.assert_called_once_with("pacemaker.service")
 
     @mock.patch('crmsh.utils.get_property')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_get_stonith_watchdog_timeout(self, mock_active, mock_get_property):
         mock_active.return_value = True
         mock_get_property.return_value = "60s"
@@ -234,7 +234,7 @@ class TestSBDTimeout(unittest.TestCase):
         self.sbd_timeout_inst.adjust_sbd_delay_start()
         mock_update.assert_called_once_with({"SBD_DELAY_START": "100"})
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start_no(self, mock_get_sbd_value, mock_run):
         mock_get_sbd_value.return_value = "no"
@@ -243,7 +243,7 @@ class TestSBDTimeout(unittest.TestCase):
 
     @mock.patch('crmsh.utils.mkdirp')
     @mock.patch('crmsh.utils.get_systemd_timeout_start_in_sec')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start_return(self, mock_get_sbd_value, mock_run, mock_get_systemd_sec, mock_mkdirp):
         mock_get_sbd_value.return_value = "10"
@@ -259,7 +259,7 @@ class TestSBDTimeout(unittest.TestCase):
     @mock.patch('crmsh.utils.str2file')
     @mock.patch('crmsh.utils.mkdirp')
     @mock.patch('crmsh.utils.get_systemd_timeout_start_in_sec')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
     def test_adjust_systemd_start_timeout_no_delay_start(self, mock_get_sbd_value, mock_run, mock_get_systemd_sec, mock_mkdirp, mock_str2file, mock_csync2, mock_cluster_run):
         mock_get_sbd_value.return_value = "100"
@@ -675,9 +675,9 @@ class TestSBDManager(unittest.TestCase):
 
     @mock.patch('crmsh.sbd.SBDTimeout.adjust_sbd_timeout_related_cluster_configuration')
     @mock.patch('crmsh.utils.set_property')
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_resource_configured')
-    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_configure_sbd_resource_and_properties(self, mock_package, mock_enabled, mock_configured, mock_run, mock_set_property, sbd_adjust):
         mock_package.return_value = True
@@ -713,7 +713,7 @@ class TestSBDManager(unittest.TestCase):
         mock_invoke.assert_called_once_with("systemctl disable sbd.service")
 
     @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_join_sbd_config_disabled(self, mock_package, mock_exists, mock_enabled, mock_invoke):
@@ -733,7 +733,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.sbd.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_join_sbd(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_watchdog, mock_get_device, mock_verify, mock_status):
@@ -763,7 +763,7 @@ class TestSBDManager(unittest.TestCase):
     @mock.patch('crmsh.sbd.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.watchdog.Watchdog')
     @mock.patch('crmsh.bootstrap.invoke')
-    @mock.patch('crmsh.utils.service_is_enabled')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
     @mock.patch('os.path.exists')
     @mock.patch('crmsh.utils.package_is_installed')
     def test_join_sbd_diskless(self, mock_package, mock_exists, mock_enabled, mock_invoke, mock_watchdog, mock_get_device, mock_warn, mock_status, mock_set):
@@ -818,15 +818,15 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("Device /dev/sdb1 doesn't have the same UUID with node1", str(err.exception))
         mock_get_uuid.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdb1", "node1")])
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_get_device_uuid_not_match(self, mock_run):
         mock_run.return_value = "data"
         with self.assertRaises(ValueError) as err:
             self.sbd_inst._get_device_uuid("/dev/sdb1")
         self.assertEqual("Cannot find sbd device UUID for /dev/sdb1", str(err.exception))
-        mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump", remote=None)
+        mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump", None)
 
-    @mock.patch('crmsh.utils.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
     def test_get_device_uuid(self, mock_run):
         output = """
         ==Dumping header on disk /dev/sda1
@@ -843,10 +843,10 @@ class TestSBDManager(unittest.TestCase):
         mock_run.return_value = output
         res = self.sbd_inst._get_device_uuid("/dev/sda1", node="node1")
         self.assertEqual(res, "a2e9a92c-cc72-4ef9-ac55-ccc342f3546b")
-        mock_run.assert_called_once_with("sbd -d /dev/sda1 dump", remote="node1")
+        mock_run.assert_called_once_with("sbd -d /dev/sda1 dump", "node1")
 
     @mock.patch('crmsh.sbd.SBDManager._get_sbd_device_from_config')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.bootstrap.Context')
     def test_is_using_diskless_sbd_true(self, mock_context, mock_is_active, mock_get_sbd):
         context_inst = mock.Mock()

--- a/test/unittests/test_service_manager.py
+++ b/test/unittests/test_service_manager.py
@@ -12,12 +12,12 @@ class TestServiceManager(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
         self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
         self.service_manager._call = mock.Mock(self.service_manager._call)
 
     def test_call_single_node(self, mock_call_with_parallax: mock.MagicMock):
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
         self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
         self.service_manager._run_on_single_host.return_value = 0
         self.assertEqual(['node1'], self.service_manager._call('node1', list(), 'foo'))
@@ -25,7 +25,7 @@ class TestServiceManager(unittest.TestCase):
         mock_call_with_parallax.assert_not_called()
 
     def test_call_single_node_failure(self, mock_call_with_parallax: mock.MagicMock):
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
         self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
         self.service_manager._run_on_single_host.return_value = 1
         self.assertEqual(list(), self.service_manager._call('node1', list(), 'foo'))
@@ -33,7 +33,7 @@ class TestServiceManager(unittest.TestCase):
         mock_call_with_parallax.assert_not_called()
 
     def test_call_multiple_node(self, mock_call_with_parallax: mock.MagicMock):
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
         self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
         mock_call_with_parallax.return_value = {'node1': (0, '', ''), 'node2': (1, 'out', 'err')}
         self.assertEqual(['node1'], self.service_manager._call(None, ['node1', 'node2'], 'foo'))
@@ -41,17 +41,17 @@ class TestServiceManager(unittest.TestCase):
         mock_call_with_parallax.assert_called_once_with('foo', ['node1', 'node2'])
 
     def test_run_on_single_host_return_1(self, mock_call_with_parallax: mock.MagicMock):
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
-        self.service_manager._shell.get_stdout_stderr_no_input.return_value = (1, 'bar', 'err')
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
+        self.service_manager._shell.get_rc_stdout_stderr_without_input.return_value = (1, 'bar', 'err')
         self.assertEqual(1, self.service_manager._run_on_single_host('foo', 'node1'))
-        self.service_manager._shell.get_stdout_stderr_no_input.assert_called_once_with('node1', 'foo')
+        self.service_manager._shell.get_rc_stdout_stderr_without_input.assert_called_once_with('node1', 'foo')
 
     def test_run_on_single_host_return_255(self, mock_call_with_parallax: mock.MagicMock):
-        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
-        self.service_manager._shell.get_stdout_stderr_no_input.return_value = (255, 'bar', 'err')
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.ClusterShell))
+        self.service_manager._shell.get_rc_stdout_stderr_without_input.return_value = (255, 'bar', 'err')
         with self.assertRaises(ValueError):
             self.service_manager._run_on_single_host('foo', 'node1')
-        self.service_manager._shell.get_stdout_stderr_no_input.assert_called_once_with('node1', 'foo')
+        self.service_manager._shell.get_rc_stdout_stderr_without_input.assert_called_once_with('node1', 'foo')
 
     def test_start_service(self, mock_call_with_parallax: mock.MagicMock):
         self.service_manager._call.return_value = ['node1']

--- a/test/unittests/test_service_manager.py
+++ b/test/unittests/test_service_manager.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest import mock
+
+import crmsh.sh
+from crmsh.service_manager import ServiceManager
+
+
+@mock.patch("crmsh.service_manager.ServiceManager._call_with_parallax")
+class TestServiceManager(unittest.TestCase):
+    """
+    Unitary tests for class ServiceManager
+    """
+
+    def setUp(self) -> None:
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
+        self.service_manager._call = mock.Mock(self.service_manager._call)
+
+    def test_call_single_node(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
+        self.service_manager._run_on_single_host.return_value = 0
+        self.assertEqual(['node1'], self.service_manager._call('node1', list(), 'foo'))
+        self.service_manager._run_on_single_host.assert_called_once_with('foo', 'node1')
+        mock_call_with_parallax.assert_not_called()
+
+    def test_call_single_node_failure(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
+        self.service_manager._run_on_single_host.return_value = 1
+        self.assertEqual(list(), self.service_manager._call('node1', list(), 'foo'))
+        self.service_manager._run_on_single_host.assert_called_once_with('foo', 'node1')
+        mock_call_with_parallax.assert_not_called()
+
+    def test_call_multiple_node(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._run_on_single_host = mock.Mock(self.service_manager._run_on_single_host)
+        mock_call_with_parallax.return_value = {'node1': (0, '', ''), 'node2': (1, 'out', 'err')}
+        self.assertEqual(['node1'], self.service_manager._call(None, ['node1', 'node2'], 'foo'))
+        self.service_manager._run_on_single_host.assert_not_called()
+        mock_call_with_parallax.assert_called_once_with('foo', ['node1', 'node2'])
+
+    def test_run_on_single_host_return_1(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._shell.get_stdout_stderr_no_input.return_value = (1, 'bar', 'err')
+        self.assertEqual(1, self.service_manager._run_on_single_host('foo', 'node1'))
+        self.service_manager._shell.get_stdout_stderr_no_input.assert_called_once_with('node1', 'foo')
+
+    def test_run_on_single_host_return_255(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager = ServiceManager(mock.Mock(crmsh.sh.AutoShell))
+        self.service_manager._shell.get_stdout_stderr_no_input.return_value = (255, 'bar', 'err')
+        with self.assertRaises(ValueError):
+            self.service_manager._run_on_single_host('foo', 'node1')
+        self.service_manager._shell.get_stdout_stderr_no_input.assert_called_once_with('node1', 'foo')
+
+    def test_start_service(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1']
+        self.assertEqual(['node1'], self.service_manager.start_service('service1', remote_addr='node1'))
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl start 'service1'")
+
+    def test_start_service_on_multiple_host(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1', 'node2']
+        self.assertEqual(['node1', 'node2'], self.service_manager.start_service('service1', node_list=['node1', 'node2']))
+        self.service_manager._call.assert_called_once_with(None, ['node1', 'node2'], "systemctl start 'service1'")
+
+    def test_start_and_enable_service(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1']
+        self.assertEqual(['node1'], self.service_manager.start_service('service1', enable=True, remote_addr='node1'))
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl enable --now 'service1'")
+
+    def test_stop_service(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1']
+        self.assertEqual(['node1'], self.service_manager.stop_service('service1', remote_addr='node1'))
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl stop 'service1'")
+
+    def test_enable_service(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1']
+        self.assertEqual(['node1'], self.service_manager.enable_service('service1', remote_addr='node1'))
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl enable 'service1'")
+
+    def test_disable_service(self, mock_call_with_parallax: mock.MagicMock):
+        self.service_manager._call.return_value = ['node1']
+        self.assertEqual(['node1'], self.service_manager.disable_service('service1', remote_addr='node1'))
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl disable 'service1'")

--- a/test/unittests/test_sh.py
+++ b/test/unittests/test_sh.py
@@ -1,0 +1,189 @@
+import subprocess
+import unittest
+from unittest import mock
+
+import crmsh.sh
+from crmsh.user_of_host import UserOfHost
+
+
+class TestLocalShell(unittest.TestCase):
+    def setUp(self) -> None:
+        self.local_shell = crmsh.sh.LocalShell()
+        self.local_shell.get_effective_user_name = mock.Mock(self.local_shell.get_effective_user_name)
+        self.local_shell.geteuid = mock.Mock(self.local_shell.geteuid)
+        self.local_shell.hostname = mock.Mock(self.local_shell.hostname)
+
+    @mock.patch('subprocess.run')
+    def test_su_subprocess_run(self, mock_run: mock.MagicMock):
+        self.local_shell.get_effective_user_name.return_value = 'root'
+        self.local_shell.geteuid.return_value = 0
+        self.local_shell.su_subprocess_run(
+            'alice', 'foo',
+            input=b'bar',
+        )
+        mock_run.assert_called_once_with(
+            ['su', 'alice', '--login', '-c', 'foo'],
+            input=b'bar',
+        )
+
+    @mock.patch('subprocess.run')
+    def test_su_subprocess_run_as_root(self, mock_run: mock.MagicMock):
+        self.local_shell.get_effective_user_name.return_value = 'root'
+        self.local_shell.geteuid.return_value = 0
+        self.local_shell.su_subprocess_run(
+            'root', 'foo',
+            input=b'bar',
+        )
+        mock_run.assert_called_once_with(
+            ['/bin/sh', '-c', 'foo'],
+            input=b'bar',
+        )
+
+    @mock.patch('subprocess.run')
+    def test_su_subprocess_run_unauthorized(self, mock_run: mock.MagicMock):
+        self.local_shell.get_effective_user_name.return_value = 'bob'
+        self.local_shell.geteuid.return_value = 1001
+        with self.assertRaises(crmsh.sh.AuthorizationError) as ctx:
+            self.local_shell.su_subprocess_run(
+                'root', 'foo',
+                input=b'bar',
+            )
+        self.assertIsInstance(ctx.exception, ValueError)
+
+    def test_get_stdout_stderr_decoded_and_stripped(self):
+        self.local_shell.get_stdout_stderr_raw = mock.Mock(self.local_shell.get_stdout_stderr_raw)
+        self.local_shell.get_stdout_stderr_raw.return_value = 1, b' out \n', b'\terr\t\n'
+        rc, out, err = self.local_shell.get_stdout_stderr('alice', 'foo', 'input')
+        self.assertEqual(1, rc)
+        self.assertEqual('out', out)
+        self.assertEqual('err', err)
+        self.local_shell.get_stdout_stderr_raw.assert_called_once_with(
+            'alice', 'foo', b'input',
+        )
+
+    def test_get_stdout_or_raise_error(self):
+        self.local_shell.su_subprocess_run = mock.Mock(self.local_shell.su_subprocess_run)
+        self.local_shell.su_subprocess_run.return_value = subprocess.CompletedProcess(
+            args=mock.Mock(),
+            returncode=1,
+            stdout=b'foo',
+            stderr=b' bar ',
+        )
+        with self.assertRaises(crmsh.sh.CommandFailure) as ctx:
+            self.local_shell.get_stdout_or_raise_error('root', 'foo')
+        self.assertIsInstance(ctx.exception, ValueError)
+
+
+class TestSshShell(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ssh_shell = crmsh.sh.SshShell(mock.Mock(crmsh.sh.LocalShell), 'alice')
+        self.ssh_shell.local_shell.hostname.return_value = 'node1'
+        self.ssh_shell.local_shell.get_effective_user_name.return_value = 'root'
+        self.ssh_shell.local_shell.can_run_as.return_value = True
+
+    def test_can_run_as(self):
+        self.ssh_shell.local_shell.get_rc_and_error.return_value = 255, 'bar'
+        self.assertFalse(self.ssh_shell.can_run_as('node2', 'root'))
+        self.ssh_shell.local_shell.can_run_as.assert_not_called()
+
+    def test_can_run_as_local(self):
+        self.assertTrue(self.ssh_shell.can_run_as(None, 'root'))
+        self.ssh_shell.local_shell.can_run_as.assert_called_once_with('root')
+
+    def test_subprocess_run_no_input(self):
+        self.ssh_shell.subprocess_run_no_input(
+            'node2', 'bob',
+            'foo',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        args, kwargs = self.ssh_shell.local_shell.su_subprocess_run.call_args
+        self.assertEqual('alice', args[0])
+        self.assertIn('bob@node2', args[1])
+        self.assertEqual(b'foo', kwargs['input'])
+        self.assertEqual(subprocess.PIPE, kwargs['stdout'])
+        self.assertEqual(subprocess.PIPE, kwargs['stderr'])
+
+    def test_subprocess_run_no_input_with_input_kwargs(self):
+        with self.assertRaises(AssertionError):
+            self.ssh_shell.subprocess_run_no_input(
+                'node2', 'bob',
+                'foo',
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                input=b'bar'
+            )
+        self.ssh_shell.local_shell.su_subprocess_run.assert_not_called()
+        with self.assertRaises(AssertionError):
+            self.ssh_shell.subprocess_run_no_input(
+                'node2', 'bob',
+                'foo',
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
+        self.ssh_shell.local_shell.su_subprocess_run.assert_not_called()
+
+    @mock.patch('subprocess.run')
+    def test_subprocess_run_no_input_local(self, mock_run):
+        self.ssh_shell.subprocess_run_no_input(
+            'node1', 'bob',
+            'foo',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.ssh_shell.local_shell.su_subprocess_run.assert_not_called()
+        mock_run.assert_called_once_with(
+            ['sudo', '-H', '-u', 'bob', '/bin/sh'],
+            input=b'foo',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+class TestAutoShell(unittest.TestCase):
+    def setUp(self) -> None:
+        self.auto_shell = crmsh.sh.AutoShell(mock.Mock(crmsh.sh.LocalShell), mock.Mock(UserOfHost))
+        self.auto_shell.local_shell.hostname.return_value = 'node1'
+        self.auto_shell.local_shell.get_effective_user_name.return_value = 'root'
+        self.auto_shell.local_shell.can_run_as.return_value = True
+        self.auto_shell.user_of_host.user_pair_for_ssh.return_value = ('alice', 'bob')
+
+    def test_subprocess_run_no_input(self):
+        self.auto_shell.subprocess_run_no_input(
+            'node2',
+            None,
+            'foo',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.auto_shell.user_of_host.user_pair_for_ssh.assert_called_once_with('node2')
+        args, kwargs = self.auto_shell.local_shell.su_subprocess_run.call_args
+        self.assertEqual('alice', args[0])
+        self.assertIn('bob@node2', args[1])
+        self.assertIn('-u root', args[1])
+        self.assertEqual(b'foo', kwargs['input'])
+        self.assertEqual(subprocess.PIPE, kwargs['stdout'])
+        self.assertEqual(subprocess.PIPE, kwargs['stderr'])
+
+    def test_subprocess_run_no_input_with_input_kwargs(self):
+        with self.assertRaises(AssertionError):
+            self.auto_shell.subprocess_run_no_input(
+                'node2',
+                None,
+                'foo',
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                input=b'bar',
+            )
+        self.auto_shell.local_shell.su_subprocess_run.assert_not_called()
+        with self.assertRaises(AssertionError):
+            self.auto_shell.subprocess_run_no_input(
+                'node2',
+                None,
+                'foo',
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
+        self.auto_shell.local_shell.su_subprocess_run.assert_not_called()

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -37,7 +37,7 @@ class TestCluster(unittest.TestCase):
         """
 
     @mock.patch('logging.Logger.info')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     @mock.patch('crmsh.utils.is_qdevice_configured')
     def test_do_start_already_started(self, mock_qdevice_configured, mock_parse_nodes, mock_active, mock_info):
@@ -60,8 +60,8 @@ class TestCluster(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.start_pacemaker')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.utils.is_qdevice_configured')
-    @mock.patch('crmsh.utils.start_service')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.start_service')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     def test_do_start(self, mock_parse_nodes, mock_active, mock_start, mock_qdevice_configured, mock_info, mock_start_pacemaker, mock_check_qdevice):
         context_inst = mock.Mock()
@@ -81,7 +81,7 @@ class TestCluster(unittest.TestCase):
         mock_info.assert_called_once_with("The cluster stack started on node1")
 
     @mock.patch('logging.Logger.info')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     def test_do_stop_already_stopped(self, mock_parse_nodes, mock_active, mock_info):
         context_inst = mock.Mock()
@@ -96,14 +96,14 @@ class TestCluster(unittest.TestCase):
 
     @mock.patch('logging.Logger.debug')
     @mock.patch('logging.Logger.info')
-    @mock.patch('crmsh.utils.stop_service')
+    @mock.patch('crmsh.service_manager.ServiceManager.stop_service')
     @mock.patch('crmsh.utils.set_dlm_option')
     @mock.patch('crmsh.utils.is_quorate')
     @mock.patch('crmsh.utils.is_dlm_running')
     @mock.patch('crmsh.utils.get_dc')
     @mock.patch('crmsh.utils.check_function_with_timeout')
     @mock.patch('crmsh.utils.get_property')
-    @mock.patch('crmsh.utils.service_is_active')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     def test_do_stop(self, mock_parse_nodes, mock_active, mock_get_property, mock_check, mock_get_dc, mock_dlm_running, mock_is_quorate, mock_set_dlm, mock_stop, mock_info, mock_debug):
         context_inst = mock.Mock()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -27,14 +27,14 @@ def setup_function():
     imp.reload(utils)
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_print_cluster_nodes(mock_run):
     mock_run.return_value = (0, "data", None)
     utils.print_cluster_nodes()
     mock_run.assert_called_once_with("crm_node -l")
 
 
-@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout")
 def test_package_is_installed_local(mock_run):
     mock_run.return_value = (0, None)
     res = utils.package_is_installed("crmsh")
@@ -72,7 +72,7 @@ def test_check_file_content_included(mock_detect, mock_run):
         ])
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_get_iplist_corosync_using_exception(mock_run):
     mock_run.return_value = (1, None, "error of cfgtool")
     with pytest.raises(ValueError) as err:
@@ -81,7 +81,7 @@ def test_get_iplist_corosync_using_exception(mock_run):
     mock_run.assert_called_once_with("corosync-cfgtool -s")
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_get_iplist_corosync_using(mock_run):
     output = """
 RING ID 0
@@ -98,7 +98,7 @@ RING ID 1
 
 
 @mock.patch('re.search')
-@mock.patch('crmsh.utils.get_stdout')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout')
 def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
     mock_get_stdout.return_value = (1, None)
     mock_re_search_inst = mock.Mock()
@@ -110,7 +110,7 @@ def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
 
 
 @mock.patch('re.search')
-@mock.patch('crmsh.utils.get_stdout')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout')
 def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
     mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
     mock_re_search.return_value = None
@@ -121,7 +121,7 @@ def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
 
 
 @mock.patch('re.search')
-@mock.patch('crmsh.utils.get_stdout')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout')
 def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
     mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
     mock_re_search_inst = mock.Mock()
@@ -146,7 +146,7 @@ def test_check_ssh_passwd_need(mock_run):
 
 
 @mock.patch('logging.Logger.debug')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_get_member_iplist_None(mock_get_stdout_stderr, mock_common_debug):
     mock_get_stdout_stderr.return_value = (1, None, "Failed to initialize the cmap API. Error CS_ERR_LIBRARY")
     assert utils.get_member_iplist() is None
@@ -155,7 +155,7 @@ def test_get_member_iplist_None(mock_get_stdout_stderr, mock_common_debug):
 
 
 def test_get_member_iplist():
-    with mock.patch('crmsh.utils.get_stdout_stderr') as mock_get_stdout_stderr:
+    with mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr') as mock_get_stdout_stderr:
         cmap_value = '''
 runtime.totem.pg.mrp.srp.members.336860211.config_version (u64) = 0
 runtime.totem.pg.mrp.srp.members.336860211.ip (str) = r(0) ip(20.20.20.51)
@@ -426,7 +426,7 @@ def test_is_qdevice_tls_on_true(mock_get_value):
     assert utils.is_qdevice_tls_on() is True
     mock_get_value.assert_called_once_with("quorum.device.net.tls")
 
-@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout")
 def test_get_nodeinfo_from_cmaptool_return_none(mock_get_stdout):
     mock_get_stdout.return_value = (1, None)
     assert bool(utils.get_nodeinfo_from_cmaptool()) is False
@@ -434,7 +434,7 @@ def test_get_nodeinfo_from_cmaptool_return_none(mock_get_stdout):
 
 @mock.patch("re.findall")
 @mock.patch("re.search")
-@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout")
 def test_get_nodeinfo_from_cmaptool(mock_get_stdout, mock_search, mock_findall):
     mock_get_stdout.return_value = (0, 'runtime.totem.pg.mrp.srp.members.1.ip (str) = r(0) ip(192.168.43.129)\nruntime.totem.pg.mrp.srp.members.2.ip (str) = r(0) ip(192.168.43.128)')
     match_inst1 = mock.Mock()
@@ -600,7 +600,7 @@ def test_detect_cloud_gcp(mock_is_program, mock_aws, mock_azure, mock_gcp):
     mock_azure.assert_called_once_with()
     mock_gcp.assert_called_once_with()
 
-@mock.patch("crmsh.utils.get_stdout")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout")
 def test_interface_choice(mock_get_stdout):
     ip_a_output = """
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
@@ -818,7 +818,7 @@ class TestInterfacesInfo(unittest.TestCase):
         Global tearDown.
         """
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_interfaces_info_no_address(self, mock_run):
         only_lo = "1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever"
         mock_run.return_value = (0, only_lo, None)
@@ -828,7 +828,7 @@ class TestInterfacesInfo(unittest.TestCase):
         mock_run.assert_called_once_with("ip -4 -o addr show")
 
     @mock.patch('crmsh.utils.Interface')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_interfaces_info_one_addr(self, mock_run, mock_interface):
         mock_run.return_value = (0, self.network_output_error, None)
         mock_interface_inst_1 = mock.Mock(is_loopback=True, is_link_local=False)
@@ -901,7 +901,7 @@ class TestInterfacesInfo(unittest.TestCase):
     @mock.patch('crmsh.utils.InterfacesInfo.nic_list', new_callable=mock.PropertyMock)
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.utils.InterfacesInfo.get_interfaces_info')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_default_nic_list_from_route_no_default(self, mock_run, mock_get_interfaces_info, mock_warn, mock_nic_list):
         output = """10.10.10.0/24 dev eth1 proto kernel scope link src 10.10.10.51 
         20.20.20.0/24 dev eth2 proto kernel scope link src 20.20.20.51"""
@@ -915,7 +915,7 @@ class TestInterfacesInfo(unittest.TestCase):
         mock_warn.assert_called_once_with("No default route configured. Using the first found nic")
         mock_nic_list.assert_has_calls([mock.call(), mock.call()])
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_default_nic_list_from_route(self, mock_run):
         output = """default via 192.168.122.1 dev eth8 proto dhcp 
         10.10.10.0/24 dev eth1 proto kernel scope link src 10.10.10.51 
@@ -1023,7 +1023,7 @@ def test_get_iplist_from_name(mock_get_nodeid, mock_get_nodeinfo):
     mock_get_nodeinfo.assert_called_once_with()
 
 
-@mock.patch("crmsh.utils.get_stdout_stderr")
+@mock.patch("crmsh.sh.ShellUtils.get_stdout_stderr")
 def test_ping_node(mock_run):
     mock_run.return_value = (1, None, "error data")
     with pytest.raises(ValueError) as err:
@@ -1274,7 +1274,7 @@ def test_check_all_nodes_reachable(mock_run, mock_ping):
     mock_ping.assert_called_once_with("15sp2-1")
 
 
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_detect_virt(mock_run):
     mock_run.return_value = (0, None, None)
     assert utils.detect_virt() is True
@@ -1354,7 +1354,7 @@ Quorate:          Yes
 
 
 @mock.patch('crmsh.utils.etree.fromstring')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_list_cluster_nodes_none(mock_run, mock_etree):
     mock_run.return_value = (0, "data", None)
     mock_etree.return_value = None
@@ -1365,7 +1365,7 @@ def test_list_cluster_nodes_none(mock_run, mock_etree):
 
 
 @mock.patch('crmsh.utils.etree.fromstring')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_list_cluster_nodes_none_no_reg(mock_run, mock_etree):
     mock_run.return_value = (0, "data", None)
     mock_etree.return_value = None
@@ -1377,7 +1377,7 @@ def test_list_cluster_nodes_none_no_reg(mock_run, mock_etree):
 
 @mock.patch('os.path.isfile')
 @mock.patch('os.getenv')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_list_cluster_nodes_cib_not_exist(mock_run, mock_env, mock_isfile):
     mock_run.return_value = (1, None, None)
     mock_env.return_value = constants.CIB_RAW_FILE
@@ -1392,7 +1392,7 @@ def test_list_cluster_nodes_cib_not_exist(mock_run, mock_env, mock_isfile):
 @mock.patch('crmsh.xmlutil.file2cib_elem')
 @mock.patch('os.path.isfile')
 @mock.patch('os.getenv')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_list_cluster_nodes(mock_run, mock_env, mock_isfile, mock_file2elem):
     mock_run.return_value = (1, None, None)
     mock_env.return_value = constants.CIB_RAW_FILE
@@ -1419,7 +1419,7 @@ def test_list_cluster_nodes(mock_run, mock_env, mock_isfile, mock_file2elem):
 
 
 @mock.patch('os.getenv')
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_get_property(mock_run, mock_env):
     mock_run.return_value = (0, "data", None)
     mock_env.return_value = "cib.xml"
@@ -1558,7 +1558,7 @@ def test_cluster_copy_file_return(mock_list_nodes):
     assert utils.cluster_copy_file("/file1") == True
 
 
-@mock.patch('crmsh.utils.get_stdout_stderr')
+@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
 def test_has_sudo_access(mock_run):
     mock_run.return_value = (0, None, None)
     assert utils.has_sudo_access() is True

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -53,7 +53,7 @@ def test_check_file_content_included_target_not_exist(mock_detect):
         ])
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.detect_file')
 def test_check_file_content_included(mock_detect, mock_run):
     mock_detect.side_effect = [True, True]
@@ -67,8 +67,8 @@ def test_check_file_content_included(mock_detect, mock_run):
         mock.call("file2", remote=None)
         ])
     mock_run.assert_has_calls([
-        mock.call("cat file2", remote=None),
-        mock.call("cat file1", remote=None)
+        mock.call("cat file2", host=None),
+        mock.call("cat file1", host=None)
         ])
 
 
@@ -134,12 +134,12 @@ def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
     mock_re_search_inst.group.assert_called_once_with(1)
 
 
-@mock.patch('crmsh.utils.su_get_stdout_stderr')
-def test_check_ssh_passwd_need(mock_su_get_stdout_stderr):
-    mock_su_get_stdout_stderr.return_value = (1, None, None)
+@mock.patch('crmsh.sh.LocalShell.get_rc_and_error')
+def test_check_ssh_passwd_need(mock_run):
+    mock_run.return_value = (1, 'foo')
     res = utils.check_ssh_passwd_need("bob", "alice", "node1")
     assert res is True
-    mock_su_get_stdout_stderr.assert_called_once_with(
+    mock_run.assert_called_once_with(
         "bob",
         "ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes alice@node1 true",
     )
@@ -461,7 +461,7 @@ def test_get_nodeinfo_from_cmaptool(mock_get_stdout, mock_search, mock_findall):
     ])
 
 @mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
-@mock.patch("crmsh.utils.service_is_active")
+@mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
 def test_valid_nodeid_false_service_not_active(mock_is_active, mock_nodeinfo):
     mock_is_active.return_value = False
     assert utils.valid_nodeid("3") is False
@@ -469,7 +469,7 @@ def test_valid_nodeid_false_service_not_active(mock_is_active, mock_nodeinfo):
     mock_nodeinfo.assert_not_called()
 
 @mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
-@mock.patch("crmsh.utils.service_is_active")
+@mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
 def test_valid_nodeid_false(mock_is_active, mock_nodeinfo):
     mock_is_active.return_value = True
     mock_nodeinfo.return_value = {'1': ["10.10.10.1"], "2": ["20.20.20.2"]}
@@ -478,7 +478,7 @@ def test_valid_nodeid_false(mock_is_active, mock_nodeinfo):
     mock_nodeinfo.assert_called_once_with()
 
 @mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
-@mock.patch("crmsh.utils.service_is_active")
+@mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
 def test_valid_nodeid_true(mock_is_active, mock_nodeinfo):
     mock_is_active.return_value = True
     mock_nodeinfo.return_value = {'1': ["10.10.10.1"], "2": ["20.20.20.2"]}
@@ -486,7 +486,7 @@ def test_valid_nodeid_true(mock_is_active, mock_nodeinfo):
     mock_is_active.assert_called_once_with('corosync.service')
     mock_nodeinfo.assert_called_once_with()
 
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_aws_false(mock_run):
     mock_run.side_effect = ["test", "test"]
     assert utils.detect_aws() is False
@@ -495,7 +495,7 @@ def test_detect_aws_false(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_aws_xen(mock_run):
     mock_run.side_effect = ["4.2.amazon", "Xen"]
     assert utils.detect_aws() is True
@@ -504,7 +504,7 @@ def test_detect_aws_xen(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_aws_kvm(mock_run):
     mock_run.side_effect = ["Not Specified", "Amazon EC2"]
     assert utils.detect_aws() is True
@@ -513,7 +513,7 @@ def test_detect_aws_kvm(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_azure_false(mock_run):
     mock_run.side_effect = ["test", "test"]
     assert utils.detect_azure() is False
@@ -523,7 +523,7 @@ def test_detect_azure_false(mock_run):
         ])
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_azure_microsoft_corporation(mock_run, mock_request):
     mock_run.side_effect = ["microsoft corporation", "test"]
     mock_request.return_value = "data"
@@ -534,7 +534,7 @@ def test_detect_azure_microsoft_corporation(mock_run, mock_request):
         ])
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_azure_chassis(mock_run, mock_request):
     mock_run.side_effect = ["test", "7783-7084-3265-9085-8269-3286-77"]
     mock_request.return_value = "data"
@@ -544,14 +544,14 @@ def test_detect_azure_chassis(mock_run, mock_request):
         mock.call("dmidecode -s chassis-asset-tag")
         ])
 
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_gcp_false(mock_run):
     mock_run.return_value = "test"
     assert utils.detect_gcp() is False
     mock_run.assert_called_once_with("dmidecode -s bios-vendor")
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_detect_gcp(mock_run, mock_request):
     mock_run.return_value = "Google instance"
     mock_request.return_value = "data"
@@ -993,96 +993,6 @@ class TestInterfacesInfo(unittest.TestCase):
         mock_interface_inst_2.ip_in_network.assert_called_once_with("10.10.10.1")
 
 
-class TestServiceManager(unittest.TestCase):
-    """
-    Unitary tests for class utils.ServiceManager
-    """
-    @mock.patch('crmsh.utils.ServiceManager._call_with_parallax')
-    @mock.patch('crmsh.utils.ServiceManager._run_on_single_host')
-    def test_call_single_node(
-            self,
-            mock_run_on_single_host:mock.MagicMock,
-            mock_call_with_parallax: mock.MagicMock,
-    ):
-        mock_run_on_single_host.return_value = 0
-        self.assertEqual(['node1'], utils.ServiceManager._call('node1', list(), 'foo'))
-        mock_run_on_single_host.assert_called_once_with('foo', 'node1')
-        mock_call_with_parallax.assert_not_called()
-
-    @mock.patch('crmsh.utils.ServiceManager._call_with_parallax')
-    @mock.patch('crmsh.utils.ServiceManager._run_on_single_host')
-    def test_call_single_node_failure(
-            self,
-            mock_run_on_single_host:mock.MagicMock,
-            mock_call_with_parallax: mock.MagicMock,
-    ):
-        mock_run_on_single_host.return_value = 1
-        self.assertEqual(list(), utils.ServiceManager._call('node1', list(), 'foo'))
-        mock_run_on_single_host.assert_called_once_with('foo', 'node1')
-        mock_call_with_parallax.assert_not_called()
-
-    @mock.patch('crmsh.utils.ServiceManager._call_with_parallax')
-    @mock.patch('crmsh.utils.ServiceManager._run_on_single_host')
-    def test_call_multiple_node(
-            self,
-            mock_run_on_single_host: mock.MagicMock,
-            mock_call_with_parallax: mock.MagicMock,
-    ):
-        mock_call_with_parallax.return_value = {'node1': (0, '', ''), 'node2': (1, 'out', 'err')}
-        self.assertEqual(['node1'], utils.ServiceManager._call(None, ['node1', 'node2'], 'foo'))
-        mock_run_on_single_host.assert_not_called()
-        mock_call_with_parallax.assert_called_once_with('foo', ['node1', 'node2'])
-
-    @mock.patch('crmsh.utils.get_stdout_stderr_auto_ssh_no_input')
-    def test_run_on_single_host_return_1(self, mock_run: mock.MagicMock):
-        mock_run.return_value = (1, 'bar', 'err')
-        self.assertEqual(1, crmsh.utils.ServiceManager._run_on_single_host('foo', 'node1'))
-        mock_run.assert_called_once_with('node1', 'foo')
-
-    @mock.patch('crmsh.utils.get_stdout_stderr_auto_ssh_no_input')
-    def test_run_on_single_host_return_255(self, mock_run: mock.MagicMock):
-        mock_run.return_value = (255, 'bar', 'err')
-        with self.assertRaises(ValueError):
-            crmsh.utils.ServiceManager._run_on_single_host('foo', 'node1')
-        mock_run.assert_called_once_with('node1', 'foo')
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_start_service(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1']
-        self.assertEqual(['node1'], utils.ServiceManager.start_service('service1', remote_addr='node1'))
-        mock_call.assert_called_once_with('node1', [], "systemctl start 'service1'")
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_start_service_on_multiple_host(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1', 'node2']
-        self.assertEqual(['node1', 'node2'], utils.ServiceManager.start_service('service1', node_list=['node1', 'node2']))
-        mock_call.assert_called_once_with(None, ['node1', 'node2'], "systemctl start 'service1'")
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_start_and_enable_service(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1']
-        self.assertEqual(['node1'], utils.ServiceManager.start_service('service1', enable=True, remote_addr='node1'))
-        mock_call.assert_called_once_with('node1', [], "systemctl enable --now 'service1'")
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_stop_service(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1']
-        self.assertEqual(['node1'], utils.ServiceManager.stop_service('service1', remote_addr='node1'))
-        mock_call.assert_called_once_with('node1', [], "systemctl stop 'service1'")
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_enable_service(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1']
-        self.assertEqual(['node1'], utils.ServiceManager.enable_service('service1', remote_addr='node1'))
-        mock_call.assert_called_once_with('node1', [], "systemctl enable 'service1'")
-
-    @mock.patch('crmsh.utils.ServiceManager._call')
-    def test_disable_service(self, mock_call: mock.MagicMock):
-        mock_call.return_value = ['node1']
-        self.assertEqual(['node1'], utils.ServiceManager.disable_service('service1', remote_addr='node1'))
-        mock_call.assert_called_once_with('node1', [], "systemctl disable 'service1'")
-
-
 @mock.patch("crmsh.utils.get_nodeid_from_name")
 def test_get_iplist_from_name_no_nodeid(mock_get_nodeid):
     mock_get_nodeid.return_value = None
@@ -1127,185 +1037,7 @@ def test_calculate_quorate_status():
     assert utils.calculate_quorate_status(3, 1) is False
 
 
-@mock.patch("crmsh.utils.subprocess_run_auto_ssh_no_input")
-@mock.patch("subprocess.run")
-def test_get_stdout_or_raise_error_local(
-        mock_subprocess_run: mock.MagicMock,
-        mock_subprocess_run_auto_ssh_no_input: mock.MagicMock,
-):
-    mock_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-    out = utils.get_stdout_or_raise_error("foo")
-    mock_subprocess_run.assert_called_once_with(
-        ['/bin/sh'],
-        input=b'foo',
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    mock_subprocess_run_auto_ssh_no_input.assert_not_called()
-    assert "bar" == out
-
-
-@mock.patch("crmsh.utils.subprocess_run_auto_ssh_no_input")
-@mock.patch("subprocess.run")
-def test_get_stdout_or_raise_error_local_failure(
-        mock_subprocess_run: mock.MagicMock,
-        mock_subprocess_run_auto_ssh_no_input: mock.MagicMock,
-):
-    mock_subprocess_run.return_value = mock.Mock(returncode=1, stdout=b'bar', stderr=b'err')
-    exception = None
-    try:
-        out = utils.get_stdout_or_raise_error("foo")
-    except ValueError as e:
-        exception = e
-
-    mock_subprocess_run.assert_called_once_with(
-        ['/bin/sh'],
-        input=b'foo',
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    mock_subprocess_run_auto_ssh_no_input.assert_not_called()
-    assert isinstance(exception, ValueError)
-
-
-@mock.patch("crmsh.utils.subprocess_run_auto_ssh_no_input")
-@mock.patch("subprocess.run")
-def test_get_stdout_or_raise_error_local_failure_no_raise(
-        mock_subprocess_run: mock.MagicMock,
-        mock_subprocess_run_auto_ssh_no_input: mock.MagicMock,
-):
-    mock_subprocess_run.return_value = mock.Mock(returncode=1, stdout=b'bar', stderr=b'err')
-    out = utils.get_stdout_or_raise_error("foo", no_raise=True)
-
-    mock_subprocess_run.assert_called_once_with(
-        ['/bin/sh'],
-        input=b'foo',
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
-    mock_subprocess_run_auto_ssh_no_input.assert_not_called()
-    assert "bar" == out
-
-
-@mock.patch("crmsh.utils.subprocess_run_auto_ssh_no_input")
-@mock.patch("subprocess.run")
-def test_get_stdout_or_raise_error_remote(
-        mock_subprocess_run: mock.MagicMock,
-        mock_subprocess_run_auto_ssh_no_input: mock.MagicMock,
-):
-    mock_subprocess_run_auto_ssh_no_input.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-    out = utils.get_stdout_or_raise_error("foo", 'node1')
-    mock_subprocess_run.assert_not_called()
-    mock_subprocess_run_auto_ssh_no_input.assert_called_once_with(
-        "foo",
-        'node1',
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    assert "bar" == out
-
-
-class TestSubprocessRunUtils(unittest.TestCase):
-    @mock.patch("subprocess.run")
-    def test_subprocess_run_auto_ssh_no_input_local_no_su(self, mock_subprocess_run):
-        mock_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-        result = utils.subprocess_run_auto_ssh_no_input("foo", stderr=subprocess.DEVNULL)
-        mock_subprocess_run.assert_called_once_with(['/bin/sh'], input=b'foo', stderr=subprocess.DEVNULL)
-        self.assertEqual(0, result.returncode)
-        self.assertEqual(b'bar', result.stdout)
-
-    @mock.patch("subprocess.run")
-    def test_subprocess_run_auto_ssh_no_input_local_su(self, mock_subprocess_run):
-        mock_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-        result = utils.subprocess_run_auto_ssh_no_input("foo", user="alice", stderr=subprocess.DEVNULL)
-        mock_subprocess_run.assert_called_once_with(
-            ['sudo', '-H', '-u', 'alice', '/bin/sh'],
-            input=b'foo',
-            stderr=subprocess.DEVNULL,
-        )
-        self.assertEqual(0, result.returncode)
-        self.assertEqual(b'bar', result.stdout)
-
-    @mock.patch("crmsh.utils.this_node")
-    @mock.patch('crmsh.utils.user_pair_for_ssh')
-    @mock.patch("crmsh.utils.su_subprocess_run")
-    @mock.patch("subprocess.run")
-    def test_subprocess_run_auto_ssh_no_input_remote_no_user(
-            self,
-            mock_subprocess_run: mock.MagicMock,
-            mock_su_subprocess_run: mock.MagicMock,
-            mock_user_pair_for_ssh: mock.MagicMock,
-            mock_this_node: mock.MagicMock,
-    ):
-        mock_this_node.return_value = 'node1'
-        mock_user_pair_for_ssh.return_value = "alice", "bob"
-        mock_su_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-        result = utils.subprocess_run_auto_ssh_no_input("foo", "node2", stderr=subprocess.DEVNULL)
-        mock_user_pair_for_ssh.assert_called_once_with('node2')
-        mock_subprocess_run.assert_not_called()
-        mock_su_subprocess_run.assert_called_once_with(
-            'alice',
-            'ssh -o StrictHostKeyChecking=no bob@node2 sudo -H -u root /bin/sh',
-            input=b'foo',
-            stderr=subprocess.DEVNULL,
-        )
-        self.assertEqual(0, result.returncode)
-        self.assertEqual(b'bar', result.stdout)
-
-    @mock.patch("os.geteuid")
-    @mock.patch("crmsh.userdir.getuser")
-    @mock.patch("subprocess.run")
-    def test_su_subprocess_run(
-            self,
-            mock_subprocess_run: mock.MagicMock,
-            mock_get_user: mock.MagicMock,
-            mock_geteuid: mock.MagicMock,
-    ):
-        mock_geteuid.return_value = 0
-        mock_get_user.return_value = 'root'
-        mock_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-        result = utils.su_subprocess_run('alice', 'foo')
-        mock_subprocess_run.assert_called_once_with(
-            ['su', 'alice', '--login', '-c', 'foo']
-        )
-        self.assertEqual(0, result.returncode)
-        self.assertEqual(b'bar', result.stdout)
-
-    @mock.patch("os.geteuid")
-    @mock.patch("crmsh.userdir.getuser")
-    @mock.patch("subprocess.run")
-    def test_su_subprocess_run_with_non_root_user(
-            self,
-            mock_subprocess_run: mock.MagicMock,
-            mock_get_user: mock.MagicMock,
-            mock_geteuid: mock.MagicMock,
-    ):
-        mock_geteuid.return_value = 1000
-        mock_get_user.return_value = 'bob'
-        with self.assertRaises(AssertionError):
-            result = utils.su_subprocess_run('alice', 'foo')
-
-    @mock.patch("os.geteuid")
-    @mock.patch("crmsh.userdir.getuser")
-    @mock.patch("subprocess.run")
-    def test_su_subprocess_run_to_self(
-            self,
-            mock_subprocess_run: mock.MagicMock,
-            mock_get_user: mock.MagicMock,
-            mock_geteuid: mock.MagicMock,
-    ):
-        mock_geteuid.return_value = 1000
-        mock_get_user.return_value = 'alice'
-        mock_subprocess_run.return_value = mock.Mock(returncode=0, stdout=b'bar', stderr=b'')
-        result = utils.su_subprocess_run('alice', 'foo')
-        mock_subprocess_run.assert_called_once_with(
-            ['/bin/sh', '-c', 'foo'],
-        )
-        self.assertEqual(0, result.returncode)
-        self.assertEqual(b'bar', result.stdout)
-
-
-@mock.patch("crmsh.utils.get_stdout_or_raise_error")
+@mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
 def test_get_quorum_votes_dict(mock_run):
     mock_run.return_value = """
 Votequorum information
@@ -1318,7 +1050,7 @@ Flags:            Quorate
     """
     res = utils.get_quorum_votes_dict()
     assert res == {'Expected': '1', 'Total': '1'}
-    mock_run.assert_called_once_with("corosync-quorumtool -s", remote=None, success_val_list=[0, 2])
+    mock_run.assert_called_once_with("corosync-quorumtool -s", None, success_exit_status={0, 2})
 
 
 def test_re_split_string():
@@ -1386,12 +1118,12 @@ def test_is_dev_a_plain_raw_disk_or_partition(mock_dev_info):
     mock_dev_info.assert_called_once_with("/dev/md127", "TYPE", peer=None)
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_dev_info(mock_run):
     mock_run.return_value = "data"
     res = utils.get_dev_info("/dev/sda1", "TYPE")
     assert res == "data"
-    mock_run.assert_called_once_with("lsblk -fno TYPE /dev/sda1", remote=None)
+    mock_run.assert_called_once_with("lsblk -fno TYPE /dev/sda1", None)
 
 
 @mock.patch('crmsh.utils.get_dev_info')
@@ -1410,7 +1142,7 @@ def test_get_dev_uuid(mock_get_info):
     mock_get_info.assert_called_once_with("/dev/sda1", "UUID", peer=None)
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_pe_number_except(mock_run):
     mock_run.return_value = "data"
     with pytest.raises(ValueError) as err:
@@ -1419,7 +1151,7 @@ def test_get_pe_number_except(mock_run):
     mock_run.assert_called_once_with("vgdisplay vg1")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_pe_number(mock_run):
     mock_run.return_value = """
 PE Size               4.00 MiB
@@ -1431,7 +1163,7 @@ Alloc PE / Size       1534 / 5.99 GiB
     mock_run.assert_called_once_with("vgdisplay vg1")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_all_vg_name(mock_run):
     mock_run.return_value = """
 --- Volume group ---
@@ -1471,7 +1203,7 @@ def test_all_exist_id(mock_cib):
     mock_cib.refresh.assert_called_once_with()
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_has_mount_point_used(mock_run):
     mock_run.return_value = """
 /dev/vda2 on /usr/local type btrfs (rw,relatime,space_cache,subvolid=259,subvol=/@/usr/local)
@@ -1483,7 +1215,7 @@ def test_has_mount_point_used(mock_run):
     mock_run.assert_called_once_with("mount")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_has_disk_mounted(mock_run):
     mock_run.return_value = """
 /dev/vda2 on /usr/local type btrfs (rw,relatime,space_cache,subvolid=259,subvol=/@/usr/local)
@@ -1496,7 +1228,7 @@ def test_has_disk_mounted(mock_run):
 
 
 @mock.patch('crmsh.sbd.SBDManager.is_using_diskless_sbd')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_has_stonith_running(mock_run, mock_diskless):
     mock_run.return_value = """
 stonith-sbd
@@ -1534,7 +1266,7 @@ def test_is_block_device(mock_stat, mock_isblk):
 
 
 @mock.patch('crmsh.utils.ping_node')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_check_all_nodes_reachable(mock_run, mock_ping):
     mock_run.return_value = "1084783297 15sp2-1 member"
     utils.check_all_nodes_reachable()
@@ -1549,7 +1281,7 @@ def test_detect_virt(mock_run):
     mock_run.assert_called_once_with("systemd-detect-virt")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_is_standby(mock_run):
     mock_run.return_value = """
 Node List:
@@ -1559,7 +1291,7 @@ Node List:
     mock_run.assert_called_once_with("crm_mon -1")
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_get_dlm_option_dict(mock_run):
     mock_run.return_value = """
 key1=value1
@@ -1584,7 +1316,7 @@ def test_set_dlm_option_exception(mock_get_dict):
     assert str(err.value) == '"name" is not dlm config option'
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.get_dlm_option_dict')
 def test_set_dlm_option(mock_get_dict, mock_run):
     mock_get_dict.return_value = {
@@ -1602,23 +1334,23 @@ def test_is_dlm_configured(mock_configured):
     mock_configured.assert_called_once_with(constants.DLM_CONTROLD_RA)
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_is_quorate_exception(mock_run):
     mock_run.return_value = "data"
     with pytest.raises(ValueError) as err:
         utils.is_quorate()
     assert str(err.value) == "Failed to get quorate status from corosync-quorumtool"
-    mock_run.assert_called_once_with("corosync-quorumtool -s", success_val_list=[0, 2])
+    mock_run.assert_called_once_with("corosync-quorumtool -s", success_exit_status={0, 2})
 
 
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_is_quorate(mock_run):
     mock_run.return_value = """
 Ring ID:          1084783297/440
 Quorate:          Yes
     """
     assert utils.is_quorate() is True
-    mock_run.assert_called_once_with("corosync-quorumtool -s", success_val_list=[0, 2])
+    mock_run.assert_called_once_with("corosync-quorumtool -s", success_exit_status={0, 2})
 
 
 @mock.patch('crmsh.utils.etree.fromstring')
@@ -1696,7 +1428,7 @@ def test_get_property(mock_run, mock_env):
 
 
 @mock.patch('logging.Logger.warning')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.get_property')
 def test_set_property(mock_get, mock_run, mock_warn):
     mock_get.return_value = "start"
@@ -1804,7 +1536,7 @@ def test_compatible_role():
 
 
 @mock.patch('logging.Logger.warning')
-@mock.patch('crmsh.utils.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
 def test_fetch_cluster_node_list_from_node(mock_run, mock_warn):
     mock_run.return_value = """
 
@@ -1813,7 +1545,7 @@ def test_fetch_cluster_node_list_from_node(mock_run, mock_warn):
     3 node3 member
     """
     assert utils.fetch_cluster_node_list_from_node("node1") == ["node3"]
-    mock_run.assert_called_once_with("crm_node -l", remote="node1")
+    mock_run.assert_called_once_with("crm_node -l", "node1")
     mock_warn.assert_has_calls([
         mock.call("The node '%s' has no known name and/or state information", "1"),
         mock.call("The node '%s'(state '%s') is not a current member", "node2", "lost")

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -53,7 +53,7 @@ def test_check_file_content_included_target_not_exist(mock_detect):
         ])
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.detect_file')
 def test_check_file_content_included(mock_detect, mock_run):
     mock_detect.side_effect = [True, True]
@@ -486,7 +486,7 @@ def test_valid_nodeid_true(mock_is_active, mock_nodeinfo):
     mock_is_active.assert_called_once_with('corosync.service')
     mock_nodeinfo.assert_called_once_with()
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_aws_false(mock_run):
     mock_run.side_effect = ["test", "test"]
     assert utils.detect_aws() is False
@@ -495,7 +495,7 @@ def test_detect_aws_false(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_aws_xen(mock_run):
     mock_run.side_effect = ["4.2.amazon", "Xen"]
     assert utils.detect_aws() is True
@@ -504,7 +504,7 @@ def test_detect_aws_xen(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_aws_kvm(mock_run):
     mock_run.side_effect = ["Not Specified", "Amazon EC2"]
     assert utils.detect_aws() is True
@@ -513,7 +513,7 @@ def test_detect_aws_kvm(mock_run):
         mock.call("dmidecode -s system-manufacturer")
         ])
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_azure_false(mock_run):
     mock_run.side_effect = ["test", "test"]
     assert utils.detect_azure() is False
@@ -523,7 +523,7 @@ def test_detect_azure_false(mock_run):
         ])
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_azure_microsoft_corporation(mock_run, mock_request):
     mock_run.side_effect = ["microsoft corporation", "test"]
     mock_request.return_value = "data"
@@ -534,7 +534,7 @@ def test_detect_azure_microsoft_corporation(mock_run, mock_request):
         ])
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_azure_chassis(mock_run, mock_request):
     mock_run.side_effect = ["test", "7783-7084-3265-9085-8269-3286-77"]
     mock_request.return_value = "data"
@@ -544,14 +544,14 @@ def test_detect_azure_chassis(mock_run, mock_request):
         mock.call("dmidecode -s chassis-asset-tag")
         ])
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_gcp_false(mock_run):
     mock_run.return_value = "test"
     assert utils.detect_gcp() is False
     mock_run.assert_called_once_with("dmidecode -s bios-vendor")
 
 @mock.patch("crmsh.utils._cloud_metadata_request")
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_detect_gcp(mock_run, mock_request):
     mock_run.return_value = "Google instance"
     mock_request.return_value = "data"
@@ -1037,7 +1037,7 @@ def test_calculate_quorate_status():
     assert utils.calculate_quorate_status(3, 1) is False
 
 
-@mock.patch("crmsh.sh.AutoShell.get_stdout_or_raise_error")
+@mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
 def test_get_quorum_votes_dict(mock_run):
     mock_run.return_value = """
 Votequorum information
@@ -1118,7 +1118,7 @@ def test_is_dev_a_plain_raw_disk_or_partition(mock_dev_info):
     mock_dev_info.assert_called_once_with("/dev/md127", "TYPE", peer=None)
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_dev_info(mock_run):
     mock_run.return_value = "data"
     res = utils.get_dev_info("/dev/sda1", "TYPE")
@@ -1142,7 +1142,7 @@ def test_get_dev_uuid(mock_get_info):
     mock_get_info.assert_called_once_with("/dev/sda1", "UUID", peer=None)
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_pe_number_except(mock_run):
     mock_run.return_value = "data"
     with pytest.raises(ValueError) as err:
@@ -1151,7 +1151,7 @@ def test_get_pe_number_except(mock_run):
     mock_run.assert_called_once_with("vgdisplay vg1")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_pe_number(mock_run):
     mock_run.return_value = """
 PE Size               4.00 MiB
@@ -1163,7 +1163,7 @@ Alloc PE / Size       1534 / 5.99 GiB
     mock_run.assert_called_once_with("vgdisplay vg1")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_all_vg_name(mock_run):
     mock_run.return_value = """
 --- Volume group ---
@@ -1203,7 +1203,7 @@ def test_all_exist_id(mock_cib):
     mock_cib.refresh.assert_called_once_with()
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_has_mount_point_used(mock_run):
     mock_run.return_value = """
 /dev/vda2 on /usr/local type btrfs (rw,relatime,space_cache,subvolid=259,subvol=/@/usr/local)
@@ -1215,7 +1215,7 @@ def test_has_mount_point_used(mock_run):
     mock_run.assert_called_once_with("mount")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_has_disk_mounted(mock_run):
     mock_run.return_value = """
 /dev/vda2 on /usr/local type btrfs (rw,relatime,space_cache,subvolid=259,subvol=/@/usr/local)
@@ -1228,7 +1228,7 @@ def test_has_disk_mounted(mock_run):
 
 
 @mock.patch('crmsh.sbd.SBDManager.is_using_diskless_sbd')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_has_stonith_running(mock_run, mock_diskless):
     mock_run.return_value = """
 stonith-sbd
@@ -1266,7 +1266,7 @@ def test_is_block_device(mock_stat, mock_isblk):
 
 
 @mock.patch('crmsh.utils.ping_node')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_check_all_nodes_reachable(mock_run, mock_ping):
     mock_run.return_value = "1084783297 15sp2-1 member"
     utils.check_all_nodes_reachable()
@@ -1281,7 +1281,7 @@ def test_detect_virt(mock_run):
     mock_run.assert_called_once_with("systemd-detect-virt")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_is_standby(mock_run):
     mock_run.return_value = """
 Node List:
@@ -1291,7 +1291,7 @@ Node List:
     mock_run.assert_called_once_with("crm_mon -1")
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_get_dlm_option_dict(mock_run):
     mock_run.return_value = """
 key1=value1
@@ -1316,7 +1316,7 @@ def test_set_dlm_option_exception(mock_get_dict):
     assert str(err.value) == '"name" is not dlm config option'
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.get_dlm_option_dict')
 def test_set_dlm_option(mock_get_dict, mock_run):
     mock_get_dict.return_value = {
@@ -1334,7 +1334,7 @@ def test_is_dlm_configured(mock_configured):
     mock_configured.assert_called_once_with(constants.DLM_CONTROLD_RA)
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_is_quorate_exception(mock_run):
     mock_run.return_value = "data"
     with pytest.raises(ValueError) as err:
@@ -1343,7 +1343,7 @@ def test_is_quorate_exception(mock_run):
     mock_run.assert_called_once_with("corosync-quorumtool -s", success_exit_status={0, 2})
 
 
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_is_quorate(mock_run):
     mock_run.return_value = """
 Ring ID:          1084783297/440
@@ -1428,7 +1428,7 @@ def test_get_property(mock_run, mock_env):
 
 
 @mock.patch('logging.Logger.warning')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 @mock.patch('crmsh.utils.get_property')
 def test_set_property(mock_get, mock_run, mock_warn):
     mock_get.return_value = "start"
@@ -1536,7 +1536,7 @@ def test_compatible_role():
 
 
 @mock.patch('logging.Logger.warning')
-@mock.patch('crmsh.sh.AutoShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_fetch_cluster_node_list_from_node(mock_run, mock_warn):
     mock_run.return_value = """
 

--- a/test/unittests/test_watchdog.py
+++ b/test/unittests/test_watchdog.py
@@ -43,7 +43,7 @@ class TestWatchdog(unittest.TestCase):
         res = self.watchdog_inst.watchdog_device_name
         assert res is None
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_verify_watchdog_device_ignore_error(self, mock_run):
         mock_run.return_value = (1, None, "error")
         res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog", True)
@@ -51,7 +51,7 @@ class TestWatchdog(unittest.TestCase):
         mock_run.assert_called_once_with("wdctl /dev/watchdog")
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_verify_watchdog_device_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         mock_error.side_effect = ValueError
@@ -60,7 +60,7 @@ class TestWatchdog(unittest.TestCase):
         mock_error.assert_called_once_with("Invalid watchdog device /dev/watchdog: error")
         mock_run.assert_called_once_with("wdctl /dev/watchdog")
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_verify_watchdog_device(self, mock_run):
         mock_run.return_value = (0, None, None)
         res = self.watchdog_inst._verify_watchdog_device("/dev/watchdog")
@@ -83,7 +83,7 @@ class TestWatchdog(unittest.TestCase):
         self.assertEqual(res, "/dev/watchdog")
         mock_parse.assert_called_once_with(bootstrap.SYSCONFIG_SBD)
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_driver_is_loaded(self, mock_run):
         output = """
 button                 24576  0
@@ -96,7 +96,7 @@ btrfs                1474560  1
         mock_run.assert_called_once_with("lsmod")
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_set_watchdog_info_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         mock_error.side_effect = ValueError
@@ -105,7 +105,7 @@ btrfs                1474560  1
         mock_run.assert_called_once_with(watchdog.Watchdog.QUERY_CMD)
         mock_error.assert_called_once_with("Failed to run {}: error".format(watchdog.Watchdog.QUERY_CMD))
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_set_watchdog_info(self, mock_run):
         output = """
 Discovered 3 watchdog devices:
@@ -145,21 +145,21 @@ Driver: iTCO_wdt
         mock_verify.assert_called_once_with("/dev/watchdog1")
 
     @mock.patch('crmsh.utils.fatal')
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_driver_through_device_remotely_error(self, mock_run, mock_error):
         mock_run.return_value = (1, None, "error")
         self.watchdog_join_inst._get_driver_through_device_remotely("test")
         mock_run.assert_called_once_with("ssh {} alice@node1 sudo sbd query-watchdog".format(constants.SSH_OPTION))
         mock_error.assert_called_once_with("Failed to run sudo sbd query-watchdog remotely: error")
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_driver_through_device_remotely_none(self, mock_run):
         mock_run.return_value = (0, "data", None)
         res = self.watchdog_join_inst._get_driver_through_device_remotely("/dev/watchdog")
         self.assertEqual(res, None)
         mock_run.assert_called_once_with("ssh {} alice@node1 sudo sbd query-watchdog".format(constants.SSH_OPTION))
 
-    @mock.patch('crmsh.utils.get_stdout_stderr')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     def test_get_driver_through_device_remotely(self, mock_run):
         output = """
 Discovered 3 watchdog devices:

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -53,40 +53,40 @@ class TestCrmMonXmlParser(unittest.TestCase):
         """
 
     @mock.patch('crmsh.xmlutil.text2elem')
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_load(self, mock_run, mock_text2elem):
-        mock_run.return_value = "data"
+        mock_run.return_value = (0, "data", "")
         mock_text2elem.return_value = mock.Mock()
         self.parser_inst._load()
-        mock_run.assert_called_once_with(constants.CRM_MON_XML_OUTPUT, remote=None, no_raise=True)
+        mock_run.assert_called_once_with(None, constants.CRM_MON_XML_OUTPUT)
         mock_text2elem.assert_called_once_with("data")
 
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_is_node_online(self, mock_run):
-        mock_run.return_value = self.nodes_xml
+        mock_run.return_value = (0, self.nodes_xml, "")
         assert xmlutil.CrmMonXmlParser.is_node_online("node1") is False
         assert xmlutil.CrmMonXmlParser.is_node_online("tbw-2") is True
 
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_is_resource_configured(self, mock_run):
-        mock_run.return_value = self.resources_xml
+        mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_resource_configured("test") is False
         assert xmlutil.CrmMonXmlParser.is_resource_configured("ocf::heartbeat:Filesystem") is True
 
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_is_any_resource_running(self, mock_run):
-        mock_run.return_value = self.resources_xml
+        mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_any_resource_running() is True
 
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_is_resource_started(self, mock_run):
-        mock_run.return_value = self.resources_xml
+        mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_resource_started("test") is False
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocfs2-clusterfs") is True
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocf::pacemaker:controld") is True
 
-    @mock.patch('crmsh.xmlutil.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
     def test_get_resource_id_list_via_type(self, mock_run):
-        mock_run.return_value = self.resources_xml
+        mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.get_resource_id_list_via_type("test") == []
         assert xmlutil.CrmMonXmlParser.get_resource_id_list_via_type("ocf::pacemaker:controld")[0] == "ocfs2-dlm"

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -53,7 +53,7 @@ class TestCrmMonXmlParser(unittest.TestCase):
         """
 
     @mock.patch('crmsh.xmlutil.text2elem')
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_load(self, mock_run, mock_text2elem):
         mock_run.return_value = (0, "data", "")
         mock_text2elem.return_value = mock.Mock()
@@ -61,31 +61,31 @@ class TestCrmMonXmlParser(unittest.TestCase):
         mock_run.assert_called_once_with(None, constants.CRM_MON_XML_OUTPUT)
         mock_text2elem.assert_called_once_with("data")
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_is_node_online(self, mock_run):
         mock_run.return_value = (0, self.nodes_xml, "")
         assert xmlutil.CrmMonXmlParser.is_node_online("node1") is False
         assert xmlutil.CrmMonXmlParser.is_node_online("tbw-2") is True
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_is_resource_configured(self, mock_run):
         mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_resource_configured("test") is False
         assert xmlutil.CrmMonXmlParser.is_resource_configured("ocf::heartbeat:Filesystem") is True
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_is_any_resource_running(self, mock_run):
         mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_any_resource_running() is True
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_is_resource_started(self, mock_run):
         mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.is_resource_started("test") is False
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocfs2-clusterfs") is True
         assert xmlutil.CrmMonXmlParser.is_resource_started("ocf::pacemaker:controld") is True
 
-    @mock.patch('crmsh.sh.AutoShell.get_stdout_stderr_no_input')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_get_resource_id_list_via_type(self, mock_run):
         mock_run.return_value = (0, self.resources_xml, "")
         assert xmlutil.CrmMonXmlParser.get_resource_id_list_via_type("test") == []


### PR DESCRIPTION
1. Move shell calling routines to module `crmsh.sh` and group them into 3 classes.
2. Move `ServiceManager` from `utils` to a new module.
3. Move `UserOfHost` from `utils` to a new module.
4. Make the dependencies between `crmsh.sh`, `UserOfHost` and `ServiceManager` injectable.
5. Partially move ssh key related routines to module `crmsh.ssh_key`.