### PR TITLE
Dev: spec: Remove %generate_buildrequires to prevent OBS build failur…

### DIFF
--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -165,7 +165,6 @@ sed -i -e '/data_files/d' setup.py
 %if 0%{?suse_version}
 %python3_pyproject_wheel
 %else
-%generate_buildrequires
 %pyproject_buildrequires -t
 %pyproject_wheel
 %endif


### PR DESCRIPTION
…es on SLE15SP5 and Leap15.5