### PR TITLE
[crmsh-4.6] Fix: report: Pick 'gzip' as the first compress prog for cross-platfor…

### DIFF
--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -1127,7 +1127,7 @@ def pe_to_dot(pe_file):
 
 
 def pick_compress():
-    constants.COMPRESS_PROG = pick_first(["bzip2", "gzip", "xz"])
+    constants.COMPRESS_PROG = pick_first(["gzip", "bzip2", "xz"])
     if constants.COMPRESS_PROG:
         if constants.COMPRESS_PROG == "xz":
             constants.COMPRESS_EXT = ".xz"


### PR DESCRIPTION
…m compatibility(bsc#1215438)

'bzip2' create 'bz2' file, which is not supported by browsers when collecting crm report via Hawk on Windows; Choose 'gzip' as the first compress program, since 'gz' is coded in the browsers