### PR TITLE
[crmsh-4.6] Fix: report: Pick up tarball suffix dynamically (bsc#1215438)

### DIFF
--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -15,6 +15,7 @@ from . import logparser
 from . import utils
 from . import log
 from .sh import ShellUtils
+from crmsh.report import utillib
 
 
 logger = log.setup_logger(__name__)
@@ -106,7 +107,11 @@ def mkarchive(idir):
     if not home:
         logger.error("no home directory, nowhere to pack report")
         return False
-    archive = '%s.tar.bz2' % os.path.join(home, os.path.basename(idir))
+    _, ext = utillib.pick_first_compress()
+    if not ext:
+        return False
+    name = os.path.join(home, os.path.basename(idir))
+    archive = f'{name}.tar{ext}'
     cmd = "tar -C '%s/..' -cj -f '%s' %s" % \
         (idir, archive, os.path.basename(idir))
     if utils.pipe_cmd_nosudo(cmd) != 0:
@@ -464,7 +469,10 @@ class Report(object):
         if not utils.is_path_sane(d):
             return None
         utils.rmdir_r(d)
-        tarball = "%s.tar.bz2" % d
+        _, ext = utillib.pick_first_compress()
+        if not ext:
+            return None
+        tarball = f"{d}.tar{ext}"
         to_option = ""
         if self.to_dt:
             to_option = "-t '%s'" % logtime.human_date(self.to_dt)

--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -1127,25 +1127,25 @@ def pe_to_dot(pe_file):
 
 
 def pick_compress():
-    constants.COMPRESS_PROG = pick_first(["gzip", "bzip2", "xz"])
-    if constants.COMPRESS_PROG:
-        if constants.COMPRESS_PROG == "xz":
-            constants.COMPRESS_EXT = ".xz"
-        elif constants.COMPRESS_PROG == "bzip2":
-            constants.COMPRESS_EXT = ".bz2"
-        else:
-            constants.COMPRESS_EXT = ".gz"
+    prog, ext = pick_first_compress()
+    if prog:
+        constants.COMPRESS_PROG, constants.COMPRESS_EXT = prog, ext
     else:
-        logger.warning("could not find a compression program; \
-                     the resulting tarball may be huge")
+        logger.warning("the resulting tarball may be huge")
         constants.COMPRESS_PROG = "cat"
 
 
-def pick_first(choice):
-    for tmp in choice:
-        if crmutils.is_program(tmp):
-            return tmp
-    return None
+def pick_first_compress():
+    compress_prog_suffix_dict = {
+        "gzip": ".gz",
+        "bzip2": ".bz2",
+        "xz": ".xz"
+    }
+    for cmd, suffix in compress_prog_suffix_dict.items():
+        if shutil.which(cmd):
+            return cmd, suffix
+    logger.warning("Could not find a compression program")
+    return None, None
 
 
 def pkg_ver_deb(packages):


### PR DESCRIPTION
To address a regression introduced after #1256 , due to hard coding the target tarball suffix as 'bz2' in the crm history.