### PR TITLE
[crmsh-4.6] Dev: bootstrap: implement ssh-agent support (jsc#PED-5774) 

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -333,6 +333,18 @@ jobs:
         $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
     - uses: codecov/codecov-action@v3
 
+  functional_test_ssh_agent:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v3
+    - name: functional test for user access
+      run:  |
+        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent`
+    - uses: codecov/codecov-action@v3
+
   original_regression_test:
     runs-on: ubuntu-20.04
     timeout-minutes: 40

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -342,7 +342,7 @@ jobs:
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
-        $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent`
+        $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent` && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
     - uses: codecov/codecov-action@v3
 
   original_regression_test:

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,6 @@ coverage:
 codecov: 
   token: 16b01c29-3b23-4923-b33a-4d26a49d80c4
   notify:
-    after_n_builds: 22
+    after_n_builds: 23
 comment:
-  after_n_builds: 22
+  after_n_builds: 23

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1792,15 +1792,16 @@ def join_ssh_with_ssh_agent(
 ):
     # As ssh-agent is used, the local_user does not have any effects
     shell = sh.SSHShell(local_shell, 'root')
+    authorized_key_manager = ssh_key.AuthorizedKeyManager(shell)
     if not shell.can_run_as(seed_host, seed_user):
-        raise ValueError(f'Failed to login to {seed_user}@{seed_host}')
+        for key in ssh_public_keys:
+            authorized_key_manager.add(seed_host, seed_user, key)
     if seed_user != 'root' and 0 != shell.subprocess_run_without_input(
             seed_host, seed_user, 'sudo true',
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
     ).returncode:
         raise ValueError(f'Failed to sudo on {seed_user}@{seed_host}')
-    authorized_key_manager = ssh_key.AuthorizedKeyManager(shell)
     for key in ssh_public_keys:
         authorized_key_manager.add(None, local_user, key)
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -837,6 +837,7 @@ def init_ssh():
         try:
             ssh_agent = ssh_key.AgentClient()
             keys = ssh_agent.list()
+            logger.info("Using public keys from ssh-agent...")
         except ssh_key.Error:
             logger.error("Cannot get a public key from ssh-agent.")
             raise
@@ -866,6 +867,7 @@ def init_ssh_impl(local_user: str, ssh_public_keys: typing.List[ssh_key.Key], us
     authorized_key_manager = ssh_key.AuthorizedKeyManager(shell)
     if ssh_public_keys:
         # Use specified key. Do not generate new ones.
+        logger.info("Adding public keys to authorized_keys for user %s...", local_user)
         for key in ssh_public_keys:
             authorized_key_manager.add(None, local_user, key)
     else:
@@ -879,7 +881,7 @@ def init_ssh_impl(local_user: str, ssh_public_keys: typing.List[ssh_key.Key], us
         print()
         if ssh_public_keys:
             for user, node in user_node_list:
-                logger.info("Adding public key to authorized_keys on %s@%s", user, node)
+                logger.info("Adding public keys to authorized_keys on %s@%s", user, node)
                 for key in ssh_public_keys:
                     authorized_key_manager.add(node, local_user, key)
                 if user != 'root' and 0 != shell.subprocess_run_without_input(
@@ -1669,6 +1671,7 @@ def init_qdevice():
         ssh_user = local_user
     # Configure ssh passwordless to qnetd if detect password is needed
     if UserOfHost.instance().use_ssh_agent():
+        logger.info("Adding public keys to authorized_keys for user root...")
         for key in ssh_key.AgentClient().list():
             ssh_key.AuthorizedKeyManager(sh.SSHShell(
                 sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': os.environ.get('SSH_AUTH_SOCK')}),
@@ -1728,6 +1731,7 @@ def join_ssh(seed_host, seed_user):
         try:
             ssh_agent = ssh_key.AgentClient()
             keys = ssh_agent.list()
+            logger.info("Using public keys from ssh-agent...")
         except ssh_key.Error:
             logger.error("Cannot get a public key from ssh-agent.")
             raise
@@ -2907,6 +2911,7 @@ def bootstrap_join_geo(context):
             try:
                 ssh_agent = ssh_key.AgentClient()
                 keys = ssh_agent.list()
+                logger.info("Using public keys from ssh-agent...")
             except ssh_key.Error:
                 logger.error("Cannot get a public key from ssh-agent.")
                 raise
@@ -2945,6 +2950,7 @@ def bootstrap_arbitrator(context):
             try:
                 ssh_agent = ssh_key.AgentClient()
                 keys = ssh_agent.list()
+                logger.info("Using public keys from ssh-agent...")
             except ssh_key.Error:
                 logger.error("Cannot get a public key from ssh-agent.")
                 raise

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -239,6 +239,7 @@ DEFAULTS = {
         'pager': opt_program('PAGER', ('less', 'more', 'pg')),
         'user': opt_string(''),
         'hosts': opt_list([]), # 'alice@host1, bob@host2'
+        'no_generating_ssh_key': opt_boolean('no'),
         'skill_level': opt_choice('expert', ('operator', 'administrator', 'expert')),
         'sort_elements': opt_boolean('yes'),
         'check_frequency': opt_choice('always', ('always', 'on-verify', 'never')),

--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -147,12 +147,10 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
         remote_nodes = set(nodes)
         remote_nodes.remove(local_node)
         remote_nodes = list(remote_nodes)
-        local_user = crmsh.utils.user_pair_for_ssh(remote_nodes[0])[0]
-        crmsh.bootstrap.init_ssh_impl(
-            local_user,
-            None,
-            [(crmsh.utils.user_pair_for_ssh(node)[1], node) for node in remote_nodes],
-        )
+        crmsh.bootstrap.configure_ssh_key('hacluster')
+        crmsh.bootstrap.swap_key_for_hacluster(remote_nodes)
+        for node in remote_nodes:
+            crmsh.bootstrap.change_user_shell('hacluster', node)
 
 
 def main_check_local(args) -> int:

--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -417,7 +417,7 @@ def get_distro_info():
         res = re.search("PRETTY_NAME=\"(.*)\"", read_from_file(constants.OSRELEASE))
     elif which("lsb_release"):
         logger.debug("Using lsb_release to get distribution info")
-        out = sh.cluster_shell().get_stdout_or_raise_error("lsb_release -d")
+        out = sh.LocalShell().get_stdout_or_raise_error("lsb_release -d")
         res = re.search("Description:\s+(.*)", out)
     return res.group(1) if res else "Unknown"
 

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -279,11 +279,14 @@ class ClusterShell:
         self.raise_ssh_error = raise_ssh_error
 
     def can_run_as(self, host: typing.Optional[str], user: str) -> bool:
-        result = self.subprocess_run_without_input(
-            host, user, 'true',
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        try:
+            result = self.subprocess_run_without_input(
+                host, user, 'true',
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except user_of_host.UserNotFoundError:
+            return False
         return 0 == result.returncode
 
     def subprocess_run_without_input(self, host: typing.Optional[str], user: typing.Optional[str], cmd: str, **kwargs):

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -118,7 +118,7 @@ class LocalShell:
         if user is None or self.get_effective_user_name() == user:
             args = ['/bin/sh', '-c', cmd]
         elif 0 == self.geteuid():
-            args = ['su', user, '--login', '-c', cmd]
+            args = ['su', user, '--login', '-s', '/bin/sh', '-c', cmd]
             if tty:
                 args.append('--pty')
             if self.preserve_env:

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import pwd
+import re
+import subprocess
 import tempfile
 import typing
 
-from crmsh import utils
 from crmsh import sh
 
 
@@ -14,6 +15,14 @@ logger = logging.getLogger(__name__)
 class Error(ValueError):
     def __init__(self, msg: str):
         super().__init__(msg)
+
+
+class AgentNotAvailableError(Error):
+    pass
+
+
+class NoKeysInAgentError(Error):
+    pass
 
 
 class Key:
@@ -38,6 +47,14 @@ class KeyFile(Key):
             return self._public_key
 
 
+class InMemoryPublicKey(Key):
+    def __init__(self, content: str):
+        self.content = content
+
+    def public_key(self) -> str:
+        return self.content
+
+
 class AuthorizedKeyManager:
     def __init__(self, shell: sh.SSHShell):
         self._shell = shell
@@ -49,9 +66,7 @@ class AuthorizedKeyManager:
             self._add_remote(host, user, key)
 
     def _add_local(self, user: str, key: Key):
-        public_key = key.public_key()
-        file = f'~{user}/.ssh/authorized_keys'
-        cmd = f'''grep "{public_key}" {file} > /dev/null || sed -i '$a {public_key}' {file}'''
+        cmd = self._add_by_editing_file(user, key)
         rc, output = self._shell.local_shell.get_rc_and_error(user, cmd)
         if rc != 0:
             # unlikely
@@ -59,25 +74,142 @@ class AuthorizedKeyManager:
 
     def _add_remote(self, host: str, user: str, key: Key):
         if self._shell.can_run_as(host, user):
-            rc, _ = self._shell.get_rc_and_error(
-                host, user,
-                f"grep '{key.public_key()}' ~{user}/.ssh/authorized_key > /dev/null",
-            )
-            if rc == 0:
-                return
-        if isinstance(key, KeyFile) and key.public_key_file() is not None:
+            shell_user = user
+        elif self._shell.can_run_as(host, 'root'):
+            shell_user = 'root'
+        else:
+            shell_user = None
+        if shell_user is not None:
+            cmd = self._add_by_editing_file(user, key)
+            rc, msg = self._shell.get_rc_and_error(host, shell_user, cmd)
+            if rc != 0:
+                raise Error(f'Failed configuring SSH passwordless with {user}@{host}: {msg}')
+        else:
             user_info = pwd.getpwnam(user)
-            if os.stat(key.public_key_file()).st_uid == user_info.pw_uid:
-                cmd = "ssh-copy-id -f -i '{}' '{}@{}' &> /dev/null".format(key.public_key_file(), user, host)
-                logger.info("Configuring SSH passwordless with %s@%s", user, host)
-                result = self._shell.local_shell.su_subprocess_run(self._shell.local_user, cmd, tty=True, preserve_env=['SSH_AUTH_SOCK'])
+            if isinstance(key, KeyFile) and key.public_key_file() is not None:
+                if os.stat(key.public_key_file()).st_uid == user_info.pw_uid:
+                    self._add_by_ssh_copy_id(user, host, key.public_key_file())
+                else:
+                    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.pub') as tmp:
+                        os.chown(tmp.fileno(), user_info.pw_uid, user_info.pw_gid)
+                        print(key.public_key(), file=tmp)
+                        tmp.flush()
+                        self._add_by_ssh_copy_id(user, host, tmp.name)
             else:
-                with tempfile.NamedTemporaryFile('w', encoding='utf-8') as tmp:
+                with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.pub') as tmp:
                     os.chown(tmp.fileno(), user_info.pw_uid, user_info.pw_gid)
                     print(key.public_key(), file=tmp)
-                    cmd = "ssh-copy-id -f -i '{}' '{}@{}' &> /dev/null".format(tmp.name, user, host)
-                    logger.info("Configuring SSH passwordless with %s@%s", user, host)
-                    result = self._shell.local_shell.su_subprocess_run(self._shell.local_user, cmd, tty=True)
-            if result.returncode != 0:
-                raise Error(f'Failed configuring SSH passwordless with {user}@{host}.')
-            # TODO: error handling
+                    tmp.flush()
+                    self._add_by_ssh_copy_id(user, host, tmp.name)
+
+    @classmethod
+    def _add_by_editing_file(cls, user: str, key: Key):
+        public_key = key.public_key()
+        dir = f'~{user}/.ssh'
+        file = f'{dir}/authorized_keys'
+        cmd = f'''if ! grep '{public_key}' {file} > /dev/null; then
+    if [ -s {file} ]; then
+        sed -i '$a {public_key}' {file}
+    else
+        mkdir -p {dir}
+        chmod 0700 {dir}
+        echo '{public_key}' > {file}
+        chmod 0600 {file}
+    fi
+fi'''
+        return cmd
+
+    def _add_by_ssh_copy_id(self, user, host, key_path):
+        cmd = "ssh-copy-id -f -i '{}' '{}@{}' &> /dev/null".format(key_path, user, host)
+        logger.info("Configuring SSH passwordless with %s@%s", user, host)
+        result = self._shell.local_shell.su_subprocess_run(
+            self._shell.local_user, cmd,
+            tty=True,
+        )
+        if result.returncode != 0:
+            raise Error(f'Failed configuring SSH passwordless with {user}@{host}.')
+
+
+class AgentClient:
+    def __init__(self, socket_path: typing.Optional[str] = None):
+        if socket_path is None:
+            if 'SSH_AUTH_SOCK' not in os.environ:
+                raise AgentNotAvailableError("ssh-agent is not available.")
+            self.socket_path = None
+        else:
+            self.socket_path = socket_path
+        self.shell = sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': self.socket_path} if self.socket_path else None)
+
+    def list(self) -> typing.List[Key]:
+        cmd = 'ssh-add -L'
+        rc, stdout, stderr = self.shell.get_rc_stdout_stderr(None, cmd)
+        if rc == 1:
+            raise NoKeysInAgentError(stderr)
+        elif rc == 2:
+            raise AgentNotAvailableError(stderr)
+        elif rc != 0:
+            raise sh.CommandFailure(cmd, None, None, stderr)
+        return [InMemoryPublicKey(line) for line in stdout.splitlines()]
+
+
+class KeyFileManager:
+    KNOWN_KEY_TYPES = ['rsa', 'ed25519', 'ecdsa']   # dsa is not listed here as it is not so secure
+    KNOWN_PUBLIC_KEY_FILENAME_PATTERN = re.compile('/id_(?:{})\\.pub$'.format('|'.join(KNOWN_KEY_TYPES)))
+
+    def __init__(self, shell: sh.ClusterShell):
+        self.cluster_shell = sh.ClusterShell(shell.local_shell, shell.user_of_host, raise_ssh_error=True)
+
+    def list_public_key_for_user(self, host: typing.Optional[str], user: str) -> typing.List[str]:
+        result = self.cluster_shell.subprocess_run_without_input(
+            host, user,
+            f'ls ~/.ssh/id_*.pub',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            return list()
+        return [
+            filename
+            for filename in sh.Utils.decode_str(result.stdout).splitlines()
+            if self.KNOWN_PUBLIC_KEY_FILENAME_PATTERN.search(filename)
+        ]
+
+    def load_public_keys_for_user(self, host: typing.Optional[str], user: str) -> typing.List[InMemoryPublicKey]:
+        filenames = self.list_public_key_for_user(host, user)
+        if not filenames:
+            return list()
+        cmd = f'cat ~{user}/.ssh/{{{",".join(filenames)}}}'
+        result = self.cluster_shell.subprocess_run_without_input(
+            host, user,
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            raise sh.CommandFailure(cmd, host, user, sh.Utils.decode_str(result.stderr).strip())
+        return [InMemoryPublicKey(line) for line in sh.Utils.decode_str(result.stdout).splitlines()]
+
+    def ensure_key_pair_exists_for_user(self, host: typing.Optional[str], user: str) -> typing.List[InMemoryPublicKey]:
+        script = '''if [ ! \\( {condition} \\) ]; then
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -C 'Cluster internal on {host}' -N '' <> /dev/null
+fi
+for file in ~/.ssh/id_{{{pattern}}}.pub; do
+    if [ -f "$file" ]; then cat "$file"; fi
+done
+'''.format(
+            condition=' -o '.join([f'-f ~/.ssh/id_{t}' for t in self.KNOWN_KEY_TYPES]),
+            host=host,
+            pattern=','.join(self.KNOWN_KEY_TYPES),
+        )
+        result = self.cluster_shell.subprocess_run_without_input(
+            host, user,
+            script,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        if result.returncode != 0:
+            print(script)
+            print(result.stdout)
+            raise sh.CommandFailure(f'Script({script[:16]}...) failed. rc = {result.returncode}', host, user, sh.Utils.decode_str(result.stderr).strip())
+        return [InMemoryPublicKey(line) for line in sh.Utils.decode_str(result.stdout).splitlines()]

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -238,7 +238,6 @@ done
             script,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            start_new_session=True,
         )
         if result.returncode != 0:
             print(script)

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -46,6 +46,12 @@ class KeyFile(Key):
                 self._public_key = f.read().strip()
             return self._public_key
 
+    def __eq__(self, other):
+        return isinstance(other, KeyFile) and self._path == other._path and self.public_key() == other.public_key()
+
+    def __repr__(self):
+        return f'KeyFile(path={self._path}, key={self.public_key()})'
+
 
 class InMemoryPublicKey(Key):
     def __init__(self, content: str):
@@ -53,6 +59,9 @@ class InMemoryPublicKey(Key):
 
     def public_key(self) -> str:
         return self.content
+
+    def __eq__(self, other):
+        return isinstance(other, InMemoryPublicKey) and self.content == other.content
 
 
 class AuthorizedKeyManager:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -63,7 +63,7 @@ def script_args(args):
 
 def get_cluster_name():
     cluster_name = None
-    if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
+    if not ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("corosync.service"):
         name = corosync.get_values('totem.cluster_name')
         if name:
             cluster_name = name[0]
@@ -381,6 +381,8 @@ Examples:
                             help="Skip csync2 initialization (an experimental option)")
         parser.add_argument("--no-overwrite-sshkey", action="store_true", dest="no_overwrite_sshkey",
                             help='Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is used (False by default; Deprecated)')
+        parser.add_argument('--use-ssh-agent', action='store_true', dest='use_ssh_agent',
+                            help="Use an existing key from ssh-agent instead of creating new key pairs")
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action=CustomAppendAction, choices=utils.interface_choice(), default=[],
@@ -450,7 +452,7 @@ Examples:
         boot_context.ui_context = context
         boot_context.stage = stage
         boot_context.args = args
-        boot_context.cluster_is_running = ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("pacemaker.service")
+        boot_context.cluster_is_running = ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("pacemaker.service")
         boot_context.type = "init"
         boot_context.initialize_qdevice()
         boot_context.validate_option()
@@ -497,6 +499,8 @@ Examples:
             "-c", "--cluster-node", metavar="[USER@]HOST", dest="cluster_node",
             help="User and host to login to an existing cluster node. The host can be specified with either a hostname or an IP.",
         )
+        network_group.add_argument('--use-ssh-agent', action='store_true', dest='use_ssh_agent',
+                            help="Use an existing key from ssh-agent instead of creating new key pairs")
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action=CustomAppendAction, choices=utils.interface_choice(), default=[],
                 help="Bind to IP address on interface IF. Use -i second time for second interface")
         options, args = parse_options(parser, args)
@@ -563,7 +567,7 @@ the config.core.force option.""",
         '''
         Rename the cluster.
         '''
-        if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
+        if not ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("corosync.service"):
             context.fatal_error("Can't rename cluster when cluster service is stopped")
         old_name = cib_factory.get_property('cluster-name')
         if old_name and new_name == old_name:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -735,6 +735,8 @@ to get the geo cluster configuration.""",
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         parser.add_argument("-c", "--cluster-node", metavar="[USER@]HOST", help="An already-configured geo cluster", dest="cluster_node")
+        parser.add_argument('--use-ssh-agent', action='store_true', dest='use_ssh_agent',
+                            help="Use an existing key from ssh-agent instead of creating new key pairs")
         options, args = parse_options(parser, args)
         if options is None or args is None:
             return

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -62,7 +62,7 @@ class Corosync(command.UI):
         '''
         Quick cluster health status. Corosync status or QNetd status
         '''
-        if not ServiceManager(sh.LocalOnlyClusterShell(sh.LocalShell())).service_is_active("corosync.service"):
+        if not ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("corosync.service"):
             logger.error("corosync.service is not running!")
             return False
 

--- a/crmsh/user_of_host.py
+++ b/crmsh/user_of_host.py
@@ -47,7 +47,7 @@ class UserOfHost:
         local_user = None
         remote_user = None
         try:
-            local_user = 'root' if self._use_ssh_agent() else self.user_of(self.this_node())
+            local_user = 'root' if self.use_ssh_agent() else self.user_of(self.this_node())
             remote_user = self.user_of(host)
             return local_user, remote_user
         except UserNotFoundError:
@@ -68,7 +68,7 @@ class UserOfHost:
                 return cached
 
     @staticmethod
-    def _use_ssh_agent() -> bool:
+    def use_ssh_agent() -> bool:
         return config.get_option('core', 'no_generating_ssh_key')
 
     @staticmethod

--- a/crmsh/user_of_host.py
+++ b/crmsh/user_of_host.py
@@ -47,7 +47,7 @@ class UserOfHost:
         local_user = None
         remote_user = None
         try:
-            local_user = self.user_of(self.this_node())
+            local_user = 'root' if self._use_ssh_agent() else self.user_of(self.this_node())
             remote_user = self.user_of(host)
             return local_user, remote_user
         except UserNotFoundError:
@@ -67,6 +67,9 @@ class UserOfHost:
             else:
                 return cached
 
+    @staticmethod
+    def _use_ssh_agent() -> bool:
+        return config.get_option('core', 'no_generating_ssh_key')
 
     @staticmethod
     def _get_user_of_host_from_config(host):

--- a/data-manifest
+++ b/data-manifest
@@ -85,6 +85,7 @@ test/features/qdevice_usercase.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
 test/features/resource_set.feature
+test/features/ssh_agent.feature
 test/features/steps/behave_agent.py
 test/features/steps/const.py
 test/features/steps/__init__.py

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -10,7 +10,7 @@ Feature: crmsh bootstrap process - options
       "-u":      Configure corosync to communicate over unicast
       "-U":      Configure corosync to communicate over multicast
   Tag @clean means need to stop cluster service if the service is available
-  Need nodes: hanode1 hanode2
+  Need nodes: hanode1 hanode2 hanode3
 
   @clean
   Scenario: Check help output
@@ -39,7 +39,7 @@ Feature: crmsh bootstrap process - options
   Scenario: Init whole cluster service on node "hanode1" using "--node" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -y --node "hanode1 hanode2"" on "hanode1"
+    When    Run "crm cluster init -y --node "hanode1 hanode2 hanode3"" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"

--- a/test/features/ssh_agent.feature
+++ b/test/features/ssh_agent.feature
@@ -36,6 +36,9 @@ Feature: ssh-agent support
     And     Run "test x1 == x$(awk 'END {print NR}' ~/.ssh/authorized_keys)" OK on "hanode3"
     And     Run "test x3 == x$(sudo awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK on "hanode3"
 
+  Scenario: crm report
+    Then    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm report" OK
+
   Scenario: Use qnetd
     Given   Run "crm cluster stop" OK on "hanode1,hanode2,hanode3"
     When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"

--- a/test/features/ssh_agent.feature
+++ b/test/features/ssh_agent.feature
@@ -7,39 +7,40 @@ Feature: ssh-agent support
   Scenario: Errors are reported when ssh-agent is not avaible
     When    Try "crm cluster init --use-ssh-agent -y" on "hanode1"
     Then    Expected "Environment variable SSH_AUTH_SOCK does not exist." in stderr
-    When    Try "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    When    Try "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
     Then    Expected "Environment variable SSH_AUTH_SOCK does not exist." not in stderr
 
   Scenario: Errors are reported when there are no keys in ssh-agent
-    Given   ssh-agent is started at "/root/ssh-auth-sock" on nodes ["hanode1", "hanode2", "hanode3"]
-    When    Try "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    Given   ssh-agent is started at "/tmp/ssh-auth-sock" on nodes ["hanode1", "hanode2", "hanode3"]
+    When    Try "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
     Then    Expected "ssh-add" in stderr
 
   Scenario: Skip creating ssh key pairs with --use-ssh-agent
-    Given   Run "mkdir /root/ssh_disabled && mv /root/.ssh/id_* /root/ssh_disabled" OK on "hanode1,hanode2,hanode3"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock ssh-add /root/ssh_disabled/id_rsa" on "hanode1,hanode2,hanode3"
-    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
-    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
-    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode3"
+    Given   Run "mkdir ~/ssh_disabled" OK on "hanode1,hanode2,hanode3"
+    And     Run "mv ~/.ssh/id_* ~/ssh_disabled" OK on "hanode1,hanode2,hanode3"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock ssh-add ~/ssh_disabled/id_rsa" on "hanode1,hanode2,hanode3"
+    And     Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
+    And     Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode3"
     Then    Cluster service is "started" on "hanode1"
     And     Online nodes are "hanode1 hanode2 hanode3"
     # check the number of keys in authorized_keys
-    And     Run "test x1 == x$(awk 'END {print NR}' ~root/.ssh/authorized_keys)" OK
-    And     Run "test x3 == x$(awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK
+    And     Run "test x1 == x$(awk 'END {print NR}' ~/.ssh/authorized_keys)" OK
+    And     Run "test x3 == x$(sudo awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK
 
   Scenario: Skip creating ssh key pairs with --use-ssh-agent and use -N
     Given   Run "crm cluster stop" OK on "hanode1,hanode2,hanode3"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 -N hanode3" on "hanode1"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 -N hanode3" on "hanode1"
     Then    Cluster service is "started" on "hanode3"
     And     Online nodes are "hanode1 hanode2 hanode3"
-    And     Run "test x1 == x$(awk 'END {print NR}' ~root/.ssh/authorized_keys)" OK on "hanode3"
-    And     Run "test x3 == x$(awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK on "hanode3"
+    And     Run "test x1 == x$(awk 'END {print NR}' ~/.ssh/authorized_keys)" OK on "hanode3"
+    And     Run "test x3 == x$(sudo awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK on "hanode3"
 
   Scenario: Use qnetd
     Given   Run "crm cluster stop" OK on "hanode1,hanode2,hanode3"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
-    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init qdevice --use-ssh-agent -y --qnetd-hostname qnetd-node" on "hanode1"
-    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init qdevice --use-ssh-agent -y --qnetd-hostname qnetd-node" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
     Then    Cluster service is "started" on "hanode1"
     And     Online nodes are "hanode1 hanode2"
     And     Service "corosync-qdevice" is "started" on "hanode1"
@@ -48,7 +49,7 @@ Feature: ssh-agent support
 
   Scenario: Use qnetd with -N
     Given   Run "crm cluster stop" OK on "hanode1,hanode2"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 --qnetd-hostname qnetd-node" on "hanode1"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 --qnetd-hostname qnetd-node" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Online nodes are "hanode1 hanode2"
     And     Service "corosync-qdevice" is "started" on "hanode1"
@@ -60,19 +61,19 @@ Feature: ssh-agent support
     And     Run "systemctl disable --now booth@booth" OK on "hanode1,hanode2,hanode3"
     And     Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init -y -n cluster1 --use-ssh-agent" on "hanode1"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init -y -n cluster1 --use-ssh-agent" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Run "crm configure primitive vip IPaddr2 params ip=@vip.0" on "hanode1"
 
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init -y -n cluster2 --use-ssh-agent" on "hanode2"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster init -y -n cluster2 --use-ssh-agent" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     When    Run "crm configure primitive vip IPaddr2 params ip=@vip.1" on "hanode2"
 
     When    Run "crm cluster geo_init -y --clusters "cluster1=@vip.0 cluster2=@vip.1" --tickets tickets-geo --arbitrator hanode3" on "hanode1"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster geo_join -y --use-ssh-agent --cluster-node hanode1 --clusters "cluster1=@vip.0 cluster2=@vip.1"" on "hanode2"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster geo_join -y --use-ssh-agent --cluster-node hanode1 --clusters "cluster1=@vip.0 cluster2=@vip.1"" on "hanode2"
 
     Given   Service "booth@booth" is "stopped" on "hanode3"
-    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster geo_init_arbitrator -y --use-ssh-agent --cluster-node hanode1" on "hanode3"
+    When    Run "SSH_AUTH_SOCK=/tmp/ssh-auth-sock crm cluster geo_init_arbitrator -y --use-ssh-agent --cluster-node hanode1" on "hanode3"
     Then    Service "booth@booth" is "started" on "hanode3"
     When    Run "crm resource start g-booth" on "hanode1"
     Then    Show cluster status on "hanode1"

--- a/test/features/ssh_agent.feature
+++ b/test/features/ssh_agent.feature
@@ -1,0 +1,70 @@
+# vim: sw=2 sts=2
+Feature: ssh-agent support
+
+  Test ssh-agent support for crmsh
+  Need nodes: hanode1 hanode2 hanode3 qnetd-node
+
+  Scenario: Skip creating ssh key pairs with --use-ssh-agent
+    Given   Run "mkdir /root/ssh_disabled && mv /root/.ssh/id_* /root/ssh_disabled" OK on "hanode1,hanode2,hanode3"
+    And     ssh-agent is started at "/root/ssh-auth-sock" on nodes ["hanode1", "hanode2", "hanode3"]
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock ssh-add /root/ssh_disabled/id_rsa" on "hanode1,hanode2,hanode3"
+    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
+    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode3"
+    Then    Cluster service is "started" on "hanode1"
+    And     Online nodes are "hanode1 hanode2 hanode3"
+    # check the number of keys in authorized_keys
+    And     Run "test x1 == x$(awk 'END {print NR}' ~root/.ssh/authorized_keys)" OK
+    And     Run "test x3 == x$(awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK
+
+  Scenario: Skip creating ssh key pairs with --use-ssh-agent and use -N
+    Given   Run "crm cluster stop" OK on "hanode1,hanode2,hanode3"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 -N hanode3" on "hanode1"
+    Then    Cluster service is "started" on "hanode3"
+    And     Online nodes are "hanode1 hanode2 hanode3"
+    And     Run "test x1 == x$(awk 'END {print NR}' ~root/.ssh/authorized_keys)" OK on "hanode3"
+    And     Run "test x3 == x$(awk 'END {print NR}' ~hacluster/.ssh/authorized_keys)" OK on "hanode3"
+
+  Scenario: Use qnetd
+    Given   Run "crm cluster stop" OK on "hanode1,hanode2,hanode3"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init qdevice --use-ssh-agent -y --qnetd-hostname qnetd-node" on "hanode1"
+    And     Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster join --use-ssh-agent -y -c hanode1" on "hanode2"
+    Then    Cluster service is "started" on "hanode1"
+    And     Online nodes are "hanode1 hanode2"
+    And     Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"
+
+  Scenario: Use qnetd with -N
+    Given   Run "crm cluster stop" OK on "hanode1,hanode2"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init --use-ssh-agent -y -N hanode2 --qnetd-hostname qnetd-node" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Online nodes are "hanode1 hanode2"
+    And     Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"
+
+  Scenario: GEO cluster setup with ssh-agent
+    Given   Run "crm cluster stop" OK on "hanode1,hanode2"
+    And     Run "systemctl disable --now booth@booth" OK on "hanode1,hanode2,hanode3"
+    And     Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init -y -n cluster1 --use-ssh-agent" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm configure primitive vip IPaddr2 params ip=@vip.0" on "hanode1"
+
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster init -y -n cluster2 --use-ssh-agent" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    When    Run "crm configure primitive vip IPaddr2 params ip=@vip.1" on "hanode2"
+
+    When    Run "crm cluster geo_init -y --clusters "cluster1=@vip.0 cluster2=@vip.1" --tickets tickets-geo --arbitrator hanode3" on "hanode1"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster geo_join -y --use-ssh-agent --cluster-node hanode1 --clusters "cluster1=@vip.0 cluster2=@vip.1"" on "hanode2"
+
+    Given   Service "booth@booth" is "stopped" on "hanode3"
+    When    Run "SSH_AUTH_SOCK=/root/ssh-auth-sock crm cluster geo_init_arbitrator -y --use-ssh-agent --cluster-node hanode1" on "hanode3"
+    Then    Service "booth@booth" is "started" on "hanode3"
+    When    Run "crm resource start g-booth" on "hanode1"
+    Then    Show cluster status on "hanode1"
+    When    Run "crm resource start g-booth" on "hanode2"
+    Then    Show cluster status on "hanode2"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -82,6 +82,8 @@ optional arguments:
   --no-overwrite-sshkey
                         Avoid "/root/.ssh/id_rsa" overwrite if "-y" option is
                         used (False by default; Deprecated)
+  --use-ssh-agent       Use an existing key from ssh-agent instead of creating
+                        new key pairs
 
 Network configuration:
   Options for configuring the network and messaging layer.
@@ -228,6 +230,8 @@ Network configuration:
                         User and host to login to an existing cluster node.
                         The host can be specified with either a hostname or an
                         IP.
+  --use-ssh-agent       Use an existing key from ssh-agent instead of creating
+                        new key pairs
   -i IF, --interface IF
                         Bind to IP address on interface IF. Use -i second time
                         for second interface
@@ -344,4 +348,6 @@ optional arguments:
   -q, --quiet           Be quiet (don't describe what's happening, just do it)
   -y, --yes             Answer "yes" to all prompts (use with caution)
   -c [USER@]HOST, --cluster-node [USER@]HOST
-                        An already-configured geo cluster'''
+                        An already-configured geo cluster
+  --use-ssh-agent       Use an existing key from ssh-agent instead of creating
+                        new key pairs'''

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -100,7 +100,7 @@ def step_impl(context, addr, iface):
 
 @given('Run "{cmd}" OK on "{addr}"')
 def step_impl(context, cmd, addr):
-    _, out, _ = run_command_local_or_remote(context, cmd, addr)
+    _, out, _ = run_command_local_or_remote(context, cmd, addr, True)
 
 @when('Run "{cmd}" on "{addr}"')
 def step_impl(context, cmd, addr):

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -98,6 +98,10 @@ def step_impl(context, addr, iface):
     assert bool(res) is True
 
 
+@given('Run "{cmd}" OK on "{addr}"')
+def step_impl(context, cmd, addr):
+    _, out, _ = run_command_local_or_remote(context, cmd, addr)
+
 @when('Run "{cmd}" on "{addr}"')
 def step_impl(context, cmd, addr):
     _, out, _ = run_command_local_or_remote(context, cmd, addr)
@@ -523,3 +527,10 @@ def step_impl(context, nodelist):
             assert bootstrap.is_nologin('hacluster') is False
         else:
             assert bootstrap.is_nologin('hacluster', node) is False
+
+
+@given('ssh-agent is started at "{path}" on nodes [{nodes:str+}]')
+def step_impl(context, path, nodes):
+    for node in nodes:
+        rc, _, _ = behave_agent.call(node, 1122, f"systemd-run -u ssh-agent /usr/bin/ssh-agent -D -a '{path}'", user='root')
+        assert 0 == rc

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -531,6 +531,9 @@ def step_impl(context, nodelist):
 
 @given('ssh-agent is started at "{path}" on nodes [{nodes:str+}]')
 def step_impl(context, path, nodes):
+    user =  userdir.get_sudoer()
+    if not user:
+        user = userdir.getuser()
     for node in nodes:
-        rc, _, _ = behave_agent.call(node, 1122, f"systemd-run -u ssh-agent /usr/bin/ssh-agent -D -a '{path}'", user='root')
+        rc, _, _ = behave_agent.call(node, 1122, f"systemd-run --uid '{user}' -u ssh-agent /usr/bin/ssh-agent -D -a '{path}'", user='root')
         assert 0 == rc

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -55,7 +55,7 @@ def _wrap_cmd_non_root(cmd):
     else:
         return cmd
     if re.search('cluster (:?join|geo_join|geo_init_arbitrator)', cmd) and "@" not in cmd:
-        cmd = re.sub(r'''((?:-c|-N|--qnetd-hostname|--cluster-node)(?:\s+|=)['"]?)(\S{2,}['"]?)''', f'\\1{user}@\\2', cmd)
+        cmd = re.sub(r'''((?:-c|-N|--qnetd-hostname|--cluster-node|--arbitrator)(?:\s+|=)['"]?)(\S{2,}['"]?)''', f'\\1{user}@\\2', cmd)
     elif "cluster init" in cmd and ("-N" in cmd or "--qnetd-hostname" in cmd) and "@" not in cmd:
         cmd = re.sub(r'''((?:-c|-N|--qnetd-hostname|--cluster-node)(?:\s+|=)['"]?)(\S{2,}['"]?)''', f'\\1{user}@\\2', cmd)
     elif "cluster init" in cmd and "--node" in cmd and "@" not in cmd:

--- a/test/unittests/test_sh.py
+++ b/test/unittests/test_sh.py
@@ -22,7 +22,7 @@ class TestLocalShell(unittest.TestCase):
             input=b'bar',
         )
         mock_run.assert_called_once_with(
-            ['su', 'alice', '--login', '-c', 'foo'],
+            ['su', 'alice', '--login', '-s', '/bin/sh', '-c', 'foo'],
             input=b'bar',
         )
 


### PR DESCRIPTION
Use Cases
=========

In a typical cloud-based deployment, a server may have password-based
authentication disabled for ssh, and an adminstrator's ssh public key
is added to authorized_keys during initialization.

For this case, it is impossible for crmsh to log into cluster node with
interactive authentication and create new key pairs for further
operations. Instead, crmsh can make use of the administrator's key, by
authenticating ssh session with ssh-agent forwarded form the
adminstrator's PC.

Usage Example
=============

```text
alice@alice-pc: ~> ssh -A root@node1
root@node1:~ # crm cluster init --use-ssh-agent -y
root@node1:~ # exit
alice@alice-pc: ~> ssh -A root@node2
root@node2:~ # crm cluster join --use-ssh-agent -c node1 -y
```