### PR TITLE
Fix Improper Method Call (Close file descriptors to prevent leaks)

### DIFF
--- a/crmsh/cibstatus.py
+++ b/crmsh/cibstatus.py
@@ -237,6 +237,7 @@ class CibStatus(object):
         if config.core.dotty and not nograph:
             fd, dotfile = mkstemp()
             cmd = "%s -D %s" % (cmd, dotfile)
+            os.close(fd)
         else:
             dotfile = None
         rc = ext_cmd(cmd % self.source_file())

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -175,7 +175,7 @@ def pull_configuration(from_node):
     Copy the configuration from the given node to this node
     '''
     local_path = conf()
-    _, fname = tmpfiles.create()
+    fd, fname = tmpfiles.create()
     print("Retrieving %s:%s..." % (from_node, local_path))
     cmd = ['scp', '-qC',
            '-o', 'PasswordAuthentication=no',
@@ -196,6 +196,7 @@ def pull_configuration(from_node):
         local_file = open(local_path, 'w')
         local_file.write(data)
         local_file.close()
+        os.close(fd)
     else:
         raise ValueError("Failed to retrieve %s from %s" % (local_path, from_node))
 

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -553,8 +553,8 @@ class TaskFixSBD(Task):
         self.description = "Replace SBD_DEVICE with candidate {}".format(self.new)
         self.conf = config.SBD_CONF
         super(self.__class__, self).__init__(self.description, flush=True)
-        self.bak = tempfile.mkstemp()[1]
-        self.edit = tempfile.mkstemp()[1]
+        self.bakfd, self.bak = tempfile.mkstemp()
+        self.editfd, self.edit = tempfile.mkstemp()
         self.force = force
 
         sbd_options = crmshutils.parse_sysconfig(self.conf)
@@ -619,7 +619,13 @@ New SBD device:      {}
             shutil.copymode(self.conf, self.edit)
             os.remove(self.conf)
             shutil.move(self.edit, self.conf)
+            if self.editfd:
+                os.close(self.editfd)
+                self.editfd = None
             os.remove(self.bak)
+            if self.bakfd:
+                os.close(self.bakfd)
+                self.bakfd = None
             self.bak = None
         except:
             raise TaskError("Fail to modify file {}".format(self.conf))

--- a/crmsh/ui_cib.py
+++ b/crmsh/ui_cib.py
@@ -63,6 +63,7 @@ class CibShadow(command.UI):
             fd, fname = tmpfiles.create(directory=xmlutil.cib_shadow_dir(), prefix="shadow.crmsh_")
             name = os.path.basename(fname).replace("shadow.", "")
             constants.tmp_cib = True
+            os.close(fd)
 
         if "empty" in opt_l:
             new_cmd = "%s -e '%s'" % (self.extcmd, name)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -679,6 +679,7 @@ def str2tmp(_str, suffix=".pcmk"):
     if not s.endswith('\n'):
         f.write("\n")
     f.close()
+    os.close(fd)
     return tmp
 
 
@@ -1235,6 +1236,7 @@ def run_ptest(graph_s, nograph, scores, utilization, actions, verbosity):
     if config.core.dotty and not nograph:
         fd, dotfile = mkstemp()
         ptest = "%s -D %s" % (ptest, dotfile)
+        os.close(fd)
     else:
         dotfile = None
     # ptest prints to stderr

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -679,7 +679,6 @@ def str2tmp(_str, suffix=".pcmk"):
     if not s.endswith('\n'):
         f.write("\n")
     f.close()
-    os.close(fd)
     return tmp
 
 


### PR DESCRIPTION
## Details
While triaging your project, we found that your project had used `mkstemp()` method in several places to create temporary files. However, it came to our attention that the file descriptors that were generated by the method weren't being closed at all. This can lead to a [file descriptor leak](https://cwe.mitre.org/data/definitions/775.html) which should be prevented. It is suggested that file descriptors should be closed after use.


### Proof of Concept
For the file descriptor leak related proof, one can execute the following script:
```py
from tempfile import mkstemp

for i in range(10000):
    print(f"Opening file descriptor for {i}-th time")
    fd, name = mkstemp()
    print(f"FD: {fd}")
```
During execution, the program is going to face an error/exception, since in Linux, each processes are allowed to have 1024 file descriptors associated with them. Among them, file descriptor 0, 1, 2 are assigned to `stdin`, `stdout`, and `stderr` respectively.


## Changes
- As a prevention, I have used `os.close()` method to close the file descriptors after their use.

Suggestions related to these changes are welcomed.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
