### PR TITLE
Dev: ui_utils: Supports '=' when setting node/resource attributes

### DIFF
--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -49,6 +49,8 @@ def manage_attr(cmd, attr_ext_commands, rsc, subcmd, attr, value):
     '''
     try:
         attr_cmd = _get_attr_cmd(attr_ext_commands, subcmd)
+        if re.search("\w+=\w+", attr):
+            attr, value = attr.split('=')
         return _dispatch_attr_cmd(cmd, attr_cmd, rsc, subcmd, attr, value)
     except ValueError as msg:
         cmdline = [rsc, subcmd, attr]

--- a/test/features/configure_bugs.feature
+++ b/test/features/configure_bugs.feature
@@ -15,8 +15,11 @@ Feature: Functional test for configure sub level
     And     Online nodes are "hanode1 hanode2"
 
     # mask password by default
-    When    Run "crm node utilization hanode1 set password qwertyui" on "hanode1"
+    When    Run "crm node utilization hanode1 set password=qwertyui" on "hanode1"
     When    Try "crm configure show|grep password|grep qwertyui"
+    Then    Expected return code is "1"
+    When    Run "crm node utilization hanode2 set password testingpass" on "hanode1"
+    When    Try "crm configure show|grep password|grep testingpass"
     Then    Expected return code is "1"
     And     Show crm configure
 


### PR DESCRIPTION
Now supports both:

    crm node attribute <node> set <attr> <value>
    crm node attribute <node> set <attr>=<value>
    
    crm resource meta <rsc> set <attr> <value>
    crm resource meta <rsc> set <attr>=<value>
    
    crm resource param <rsc> set <param> <value>
    crm resource param <rsc> set <param>=<value>