### PR TITLE
[crmsh-4.4] Fix: log: Redirect debug messages into stderr (bsc#1208991)

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -19,12 +19,12 @@ class ConsoleCustomHandler(logging.StreamHandler):
     """
     A custom handler for console
 
-    Redirect ERROR message to sys.stderr
-    Redirect INFO/WARNING/DEBUG message to sys.stdout
+    Redirect ERROR/WARNING/DEBUG message to sys.stderr
+    Redirect INFO message to sys.stdout
     """
 
     def emit(self, record):
-        if record.levelno < logging.ERROR:
+        if record.levelno == logging.INFO:
             stream = sys.stdout
         else:
             stream = sys.stderr

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -360,7 +360,7 @@ def run():
             options.batch = True
         user_args = parse_options()
         if config.core.debug:
-            print(utils.debug_timestamp())
+            logger.debug(utils.debug_timestamp())
         term.init()
         if options.profile:
             return profile_run(context, user_args)

--- a/data-manifest
+++ b/data-manifest
@@ -107,6 +107,7 @@ test/testcases/confbasic
 test/testcases/confbasic.exp
 test/testcases/confbasic-xml
 test/testcases/confbasic-xml.exp
+test/testcases/confbasic-xml.filter
 test/testcases/delete
 test/testcases/delete.exp
 test/testcases/edit

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -5,7 +5,7 @@ import time
 
 
 def get_online_nodes():
-    _, out, _ = utils.get_stdout_stderr('crm_node -l')
+    _, out, _ = utils.get_stdout_stderr('sudo crm_node -l')
     if out:
         return re.findall(r'[0-9]+ (.*) member', out)
     else:
@@ -13,7 +13,7 @@ def get_online_nodes():
 
 
 def resource_cleanup():
-    utils.get_stdout_stderr('crm resource cleanup')
+    utils.get_stdout_stderr('sudo crm resource cleanup')
 
 
 def before_step(context, step):
@@ -31,4 +31,4 @@ def before_tag(context, tag):
                 time.sleep(1)
                 if utils.get_dc():
                     break
-            utils.get_stdout_or_raise_error("crm cluster stop --all")
+            utils.get_stdout_or_raise_error("sudo crm cluster stop --all")

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -131,7 +131,7 @@ Feature: corosync qdevice/qnetd options validate
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode1"
-    Then    Expected "WARNING: To use qdevice service, need to restart cluster service manually on each node" in stdout
+    Then    Expected "WARNING: To use qdevice service, need to restart cluster service manually on each node" in stderr
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
     When    Run "crm cluster restart" on "hanode1"
     Then    Service "corosync-qdevice" is "started" on "hanode1"
@@ -153,7 +153,7 @@ Feature: corosync qdevice/qnetd options validate
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     When    Run "crm cluster remove --qdevice -y" on "hanode1"
-    Then    Expected "WARNING: To remove qdevice service, need to restart cluster service manually on each node" in stdout
+    Then    Expected "WARNING: To remove qdevice service, need to restart cluster service manually on each node" in stderr
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
     When    Run "crm cluster restart" on "hanode1"

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -107,13 +107,13 @@ Feature: Use "crm configure set" to update attributes and operations
   @clean
   Scenario: operation warning
     When    Run "crm configure primitive id=d2 Dummy op start interval=5s" on "hanode1"
-    Then    Expected "WARNING: d2: Specified interval for start is 5s, it must be 0" in stdout
+    Then    Expected "WARNING: d2: Specified interval for start is 5s, it must be 0" in stderr
     When    Run "crm configure primitive id=d3 Dummy op monitor interval=0" on "hanode1"
-    Then    Expected "WARNING: d3: interval in monitor should be larger than 0, advised is 10s" in stdout
+    Then    Expected "WARNING: d3: interval in monitor should be larger than 0, advised is 10s" in stderr
     When    Run "crm configure primitive s2 ocf:pacemaker:Stateful op monitor role=Promoted interval=3s op monitor role=Unpromoted interval=3s" on "hanode1"
-    Then    Expected "WARNING: s2: interval in monitor must be unique, advised is 11s" in stdout
+    Then    Expected "WARNING: s2: interval in monitor must be unique, advised is 11s" in stderr
     When    Run "crm configure primitive id=d4 Dummy op start timeout=10s" on "hanode1"
-    Then    Expected "WARNING: d4: specified timeout 10s for start is smaller than the advised 20s" in stdout
+    Then    Expected "WARNING: d4: specified timeout 10s for start is smaller than the advised 20s" in stderr
 
   @clean
   Scenario: Add promotable=true and interleave=true automatically (bsc#1205522)

--- a/test/features/steps/utils.py
+++ b/test/features/steps/utils.py
@@ -1,3 +1,4 @@
+import getpass
 import difflib
 import tarfile
 import glob
@@ -35,8 +36,15 @@ def me():
     return socket.gethostname()
 
 
+def add_sudo(cmd):
+    user = getpass.getuser()
+    if user != 'root':
+        cmd = "sudo {}".format(cmd)
+    return cmd
+
+
 def run_command(context, cmd, err_record=False):
-    rc, out, err = utils.get_stdout_stderr(cmd)
+    rc, out, err = utils.get_stdout_stderr(add_sudo(cmd))
     if rc != 0 and err:
         if err_record:
             res = re.sub(r'\x1b\[[0-9]+m', '', err)
@@ -50,6 +58,7 @@ def run_command(context, cmd, err_record=False):
 
 
 def run_command_local_or_remote(context, cmd, addr, err_record=False):
+    cmd = add_sudo(cmd)
     if addr == me():
         _, out = run_command(context, cmd, err_record)
         return out

--- a/test/testcases/confbasic-xml.filter
+++ b/test/testcases/confbasic-xml.filter
@@ -1,0 +1,2 @@
+#!/bin/bash
+grep -v "WARNING"


### PR DESCRIPTION
If keep debug and info messages all in stdout, then some scripts that need to handle or analyze the output of the crm command might be messy.

Also redirect warning messages into stderr

backport from #1127