### PR TITLE
[crmsh-4.5] Fix: bootstrap: fix the owner and permission of file authorized_keys(bsc#1217279)

### DIFF
--- a/crmsh/prun/prun.py
+++ b/crmsh/prun/prun.py
@@ -96,15 +96,25 @@ def prun_multimap(
 
 
 def _build_run_task(remote: str, cmdline: str) -> Task:
-    local_sudoer, remote_sudoer = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(remote)
     if _is_local_host(remote):
         if 0 == os.geteuid():
             args = ['/bin/sh']
-        elif local_sudoer == crmsh.userdir.getuser():
-            args = ['sudo', '/bin/sh']
+            remote_sudoer = 'root'
         else:
-            raise AssertionError('trying to run sudo as a non-root user')
+            remote_sudoer = crmsh.userdir.get_sudoer()
+            if remote_sudoer == crmsh.userdir.getuser():
+                args = ['sudo', '/bin/sh']
+            else:
+                raise AssertionError('trying to run sudo as a non-root user')
+        return Task(
+            args,
+            cmdline.encode('utf-8'),
+            stdout=Task.Capture,
+            stderr=Task.Capture,
+            context={"host": remote, "ssh_user": remote_sudoer},
+        )
     else:
+        local_sudoer, remote_sudoer = crmsh.utils.UserOfHost.instance().user_pair_for_ssh(remote)
         shell = 'ssh {} {}@{} sudo -H /bin/sh'.format(crmsh.constants.SSH_OPTION, remote_sudoer, remote)
         if local_sudoer == crmsh.userdir.getuser():
             args = ['/bin/sh', '-c', shell]
@@ -112,13 +122,13 @@ def _build_run_task(remote: str, cmdline: str) -> Task:
             args = ['su', local_sudoer, '--login', '-c', shell]
         else:
             raise AssertionError('trying to run su as a non-root user')
-    return Task(
-        args,
-        cmdline.encode('utf-8'),
-        stdout=Task.Capture,
-        stderr=Task.Capture,
-        context={"host": remote, "ssh_user": remote_sudoer},
-    )
+        return Task(
+            args,
+            cmdline.encode('utf-8'),
+            stdout=Task.Capture,
+            stderr=Task.Capture,
+            context={"host": remote, "ssh_user": remote_sudoer},
+        )
 
 
 def _handle_run_result(task: Task, interceptor: PRunInterceptor = PRunInterceptor()):

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -533,7 +533,7 @@ class TestBootstrap(unittest.TestCase):
             mock.call("/test/.ssh/authorized_keys")
             ])
         mock_append_unique.assert_called_once_with("/test/.ssh/id_rsa.pub", "/test/.ssh/authorized_keys", "test")
-        mock_su.assert_called_once_with('touch /test/.ssh/authorized_keys', user="test")
+        mock_su.assert_called_once_with('touch /test/.ssh/authorized_keys && chmod 0600 /test/.ssh/authorized_keys', user="test")
 
     @mock.patch('crmsh.bootstrap.append_to_remote_file')
     @mock.patch('crmsh.utils.check_file_content_included')


### PR DESCRIPTION
File authorized_keys created for user hacluster in previous version is owned incorrectly by root. This prevents current verison of crmsh reading/writing it as user hacluster.

Fix by setting its owner and permission after create it and before trying to read/write it.

Also fix a problem of prun trying to detect ssh availability to localhost.