### PR TITLE
 [crmsh-4.6] Fix: bootstrap: fix the owner and permission of file authorized_keys(bsc#1217279)

### DIFF
--- a/crmsh/healthcheck.py
+++ b/crmsh/healthcheck.py
@@ -147,6 +147,10 @@ class PasswordlessHaclusterAuthenticationFeature(Feature):
         remote_nodes = set(nodes)
         remote_nodes.remove(local_node)
         remote_nodes = list(remote_nodes)
+        crmsh.parallax.parallax_run(
+            nodes,
+            'chown hacluster: ~hacluster/.ssh/authorized_keys && chmod 0600 ~hacluster/.ssh/authorized_keys',
+        )
         crmsh.bootstrap.configure_ssh_key('hacluster')
         crmsh.bootstrap.swap_key_for_hacluster(remote_nodes)
         for node in remote_nodes:

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -140,10 +140,12 @@ class AuthorizedKeyManager:
         sed -i '$a {public_key}' {file}
     else
         mkdir -p {dir}
+        chown {user}: {dir}
         chmod 0700 {dir}
         echo '{public_key}' > {file}
         chmod 0600 {file}
     fi
+    chown {user}: {file}
 fi'''
         return cmd
 

--- a/test/unittests/test_prun.py
+++ b/test/unittests/test_prun.py
@@ -108,6 +108,43 @@ class TestPrun(unittest.TestCase):
         self.assertTrue(isinstance(results, typing.Dict))
         self.assertSetEqual({"host1", "host2"}, set(results.keys()))
 
+    @mock.patch("os.geteuid")
+    @mock.patch("crmsh.userdir.getuser")
+    @mock.patch("crmsh.prun.prun._is_local_host")
+    @mock.patch("crmsh.user_of_host.UserOfHost.user_pair_for_ssh")
+    @mock.patch("crmsh.prun.runner.Runner.run")
+    @mock.patch("crmsh.prun.runner.Runner.add_task")
+    def test_prun_localhost(
+            self,
+            mock_runner_add_task: mock.MagicMock,
+            mock_runner_run: mock.MagicMock,
+            mock_user_pair_for_ssh: mock.MagicMock,
+            mock_is_local_host: mock.MagicMock,
+            mock_getuser: mock.MagicMock,
+            mock_geteuid: mock.MagicMock,
+    ):
+        host_cmdline = {"host1": "foo"}
+        #mock_user_pair_for_ssh.return_value = "alice", "bob"
+        mock_is_local_host.return_value = True
+        mock_getuser.return_value = 'root'
+        mock_geteuid.return_value = 0
+        results = crmsh.prun.prun.prun(host_cmdline)
+        mock_user_pair_for_ssh.assert_not_called()
+        mock_is_local_host.assert_called_once_with('host1')
+        mock_runner_add_task.assert_called_once_with(
+            TaskArgumentsEq(
+                ['/bin/sh'],
+                b'foo',
+                stdout=crmsh.prun.runner.Task.Capture,
+                stderr=crmsh.prun.runner.Task.Capture,
+                context={"host": 'host1', "ssh_user": 'root'},
+            )
+        )
+        mock_user_pair_for_ssh.assert_not_called()
+        mock_runner_run.assert_called_once()
+        self.assertTrue(isinstance(results, typing.Dict))
+        self.assertSetEqual({"host1"}, set(results.keys()))
+
 
 class TaskArgumentsEq(crmsh.prun.runner.Task):
     def __eq__(self, other):


### PR DESCRIPTION
port

* #1277

Note: the fix of bsc#1217279 is implemented quite differently from crmsh-4.5.