### PR TITLE
[crmsh-4.6] Dev: log: log the backtrace of ValueError in log file and refactoring

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -12,8 +12,17 @@ from contextlib import contextmanager
 from . import options
 from . import constants
 
-
+DEBUG2 = logging.DEBUG + 5
 CRMSH_LOG_FILE = "/var/log/crmsh/crmsh.log"
+
+
+class DEBUG2Logger(logging.Logger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def debug2(self, msg, *args, **kwargs):
+        if self.isEnabledFor(DEBUG2):
+            self._log(DEBUG2, msg, args, **kwargs)
 
 
 class ConsoleCustomHandler(logging.StreamHandler):
@@ -208,14 +217,6 @@ class LoggerUtils(object):
         # used in regression test
         self.lineno = 0
         self.__save_lineno = 0
-
-    def set_debug2_level(self):
-        """
-        Create DEBUG2 level for verbosity
-        """
-        logging.DEBUG2 = logging.DEBUG + 5
-        logging.addLevelName(logging.DEBUG2, "DEBUG2")
-        self.logger.debug2 = lambda msg, *args: self.logger._log(logging.DEBUG2, msg, args)
 
     def get_handler(self, _type):
         """
@@ -459,6 +460,8 @@ def setup_logging(only_help=False):
     except (PermissionError, FileNotFoundError) as e:
         print('{}WARNING:{} Failed to open log file: {}'.format(constants.YELLOW, constants.END, e), file=sys.stderr)
         LOGGING_CFG["handlers"]["file"] = {'class': 'logging.NullHandler'}
+    logging.addLevelName(DEBUG2, "DEBUG2")
+    logging.setLoggerClass(DEBUG2Logger)
     logging.config.dictConfig(LOGGING_CFG)
 
 
@@ -480,5 +483,4 @@ def setup_report_logger(name):
     """
     logger = setup_logger(name)
     logger_utils = LoggerUtils(logger)
-    logger_utils.set_debug2_level()
     return logger

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -86,17 +86,6 @@ class LeveledFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-class FileCustomFormatter(logging.Formatter):
-    """
-    A custom formatter for file
-    """
-    FORMAT = "%(asctime)s {} %(name)s: %(levelname)s: %(message)s".format(socket.gethostname())
-    DATEFMT = "%b %d %H:%M:%S"
-
-    def __init__(self):
-        super().__init__(fmt=self.FORMAT, datefmt=self.DATEFMT)
-
-
 class DebugCustomFilter(logging.Filter):
     """
     A custom filter for debug message
@@ -162,7 +151,8 @@ LOGGING_CFG = {
             },
         },
         "file": {
-            "()": FileCustomFormatter
+            "format": "%(asctime)s {} %(name)s: %(levelname)s: %(message)s".format(socket.gethostname()),
+            "datefmt": "%b %d %H:%M:%S",
         }
     },
     "filters": {

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -257,19 +257,6 @@ class LoggerUtils(object):
         self.set_console_formatter(self.lineno)
 
     @contextmanager
-    def suppress_new_line(self):
-        """
-        Supress new line in console
-        """
-        console_handler = self.get_handler("console")
-        try:
-            console_handler.terminator = ""
-            yield
-        finally:
-            sys.stdout.flush()
-            console_handler.terminator = "\n"
-
-    @contextmanager
     def only_file(self):
         """
         Only log to file in bootstrap logger
@@ -482,5 +469,4 @@ def setup_report_logger(name):
     Get the logger for crm report
     """
     logger = setup_logger(name)
-    logger_utils = LoggerUtils(logger)
     return logger

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -86,16 +86,6 @@ class LeveledFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-class ConsoleReportFormatter(ConsoleColoredFormatter):
-    """
-    Custom formatter for crm report
-    """
-    FORMAT_REPORT = "{}: %(levelname)s: %(message)s".format(socket.gethostname())
-
-    def __init__(self):
-        super().__init__(fmt=self.FORMAT_REPORT)
-
-
 class FileCustomFormatter(logging.Formatter):
     """
     A custom formatter for file
@@ -156,7 +146,12 @@ LOGGING_CFG = {
     "disable_existing_loggers": "False",
     "formatters": {
         "console_report": {
-            "()": ConsoleReportFormatter
+            "()": LeveledFormatter,
+            "base_formatter_factory": ConsoleColoredFormatter,
+            "default_fmt": "{}: %(levelname)s: %(message)s".format(socket.gethostname()),
+            "level_fmt": {
+                DEBUG2: "{}: %(levelname)s: %(funcName)s: %(message)s".format(socket.gethostname()),
+            },
         },
         "console": {
             "()": LeveledFormatter,

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -94,9 +94,9 @@ class ConsoleCustomHandler(logging.StreamHandler):
 class ConsoleColoredFormatter(logging.Formatter):
     """Print levelname with colors"""
     COLORS = {
-        "WARNING": constants.YELLOW,
-        "INFO": constants.GREEN,
-        "ERROR": constants.RED
+        logging.WARNING: constants.YELLOW,
+        logging.INFO: constants.GREEN,
+        logging.ERROR: constants.RED
     }
     FORMAT = "%(levelname)s: %(message)s"
 
@@ -104,13 +104,13 @@ class ConsoleColoredFormatter(logging.Formatter):
         super().__init__(fmt)
         if not fmt:
             fmt = self.FORMAT
-        self._colored_formatter: typing.Mapping[str, logging.Formatter] = {
+        self._colored_formatter: typing.Mapping[int, logging.Formatter] = {
             level: logging.Formatter(fmt.replace('%(levelname)s', f'{color}%(levelname)s{constants.END}'))
             for level, color in self.COLORS.items()
         }
 
     def format(self, record):
-        colored_formatter = self._colored_formatter.get(record.levelname)
+        colored_formatter = self._colored_formatter.get(record.levelno)
         if colored_formatter is not None:
             return colored_formatter.format(record)
         else:
@@ -140,7 +140,7 @@ class DebugCustomFilter(logging.Filter):
     """
     def filter(self, record):
         from .config import core
-        if record.levelname == "DEBUG":
+        if record.levelno == logging.DEBUG:
             return core.debug
         else:
             return True
@@ -152,9 +152,9 @@ class ReportDebugCustomFilter(logging.Filter):
     """
     def filter(self, record):
         from .config import report
-        if record.levelname == "DEBUG":
+        if record.levelno == logging.DEBUG:
             return int(report.verbosity) >= 1
-        if record.levelname == "DEBUG2":
+        if record.levelno == DEBUG2:
             return int(report.verbosity) > 1
         else:
             return True

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -45,8 +45,8 @@ def load_rc(context, rcfile):
         try:
             if not context.run(inp):
                 raise ValueError("Error in RC file: " + rcfile)
-        except ValueError as msg:
-            logger.error(msg)
+        except ValueError as e:
+            logger.error(e, exc_info=e)
     f.close()
     sys.stdin = save_stdin
 
@@ -261,14 +261,16 @@ def main_input_loop(context, user_args):
             try:
                 if not context.run(inp):
                     rc = 1
-            except ValueError as msg:
+            except ValueError as e:
                 rc = 1
-                logger.error(msg)
+                logger.error(e, exc_info=e)
         except KeyboardInterrupt:
             if options.interactive and not options.batch:
                 print("Ctrl-C, leaving")
             context.quit(1)
-    return rc
+        except Exception as e:
+            logger.error(e, exc_info=e)
+            context.quit(1)
 
 
 def compgen():
@@ -374,11 +376,10 @@ def run():
             print("Ctrl-C, leaving")
             sys.exit(1)
     except ValueError as e:
-        if config.core.debug:
-            import traceback
-            traceback.print_exc()
-            sys.stdout.flush()
-        logger.error(str(e))
+        logger.error(e, exc_info=e)
         sys.exit(1)
+    except Exception as e:
+        logger.error(e, exc_info=e)
+        raise
 
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -84,12 +84,8 @@ class Context(object):
             if cmd:
                 utils.check_user_access(self.current_level().name)
                 rv = self.execute_command() is not False
-        except (ValueError, IOError) as msg:
-            if config.core.debug or options.regression_tests:
-                import traceback
-                traceback.print_exc()
-                sys.stdout.flush()
-            logger.error("%s: %s", self.get_qualified_name(), msg)
+        except (ValueError, IOError) as e:
+            logger.error("%s: %s", self.get_qualified_name(), e, exc_info=e)
             rv = False
         except utils.TerminateSubCommand:
             return False

--- a/scripts/health/collect.py
+++ b/scripts/health/collect.py
@@ -6,7 +6,11 @@ import pwd
 import hashlib
 import platform
 import crm_script
+
+import crmsh.log
+crmsh.log.setup_logging()
 from crmsh.report import utils
+
 data = crm_script.get_input()
 
 PACKAGES = ['booth', 'cluster-glue', 'corosync', 'crmsh', 'csync2', 'drbd',

--- a/test/evaltest.sh
+++ b/test/evaltest.sh
@@ -7,6 +7,7 @@
 CRM_NO_REG="$CRM"
 CRM="$CRM -R"
 export PYTHONUNBUFFERED=1
+export CRMSH_REGRESSION_TEST=1
 
 if [ "$1" = prof ]; then
 	CRM="$CRM -X regtest.profile"

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -83,29 +83,29 @@ ERROR: 29: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: modgroup g1 add p1
 ERROR: 1: syntax in group: child p1 listed more than once in group g1 parsing 'group g1 p1 p2 d3 p1'
 .INP: modgroup g1 remove st
+ERROR: 42: configure.modgroup: st is not member of g1
 Traceback (most recent call last):
     rv = self.execute_command() is not False
     rv = self.command_info.function(*arglist)
     context.fatal_error("%s is not member of %s" % (prim_id, group_id))
     raise ValueError(msg)
 ValueError: st is not member of g1
-ERROR: 42: configure.modgroup: st is not member of g1
 .INP: modgroup g1 remove c1
+ERROR: 43: configure.modgroup: c1 is not member of g1
 Traceback (most recent call last):
     rv = self.execute_command() is not False
     rv = self.command_info.function(*arglist)
     context.fatal_error("%s is not member of %s" % (prim_id, group_id))
     raise ValueError(msg)
 ValueError: c1 is not member of g1
-ERROR: 43: configure.modgroup: c1 is not member of g1
 .INP: modgroup g1 remove nosuch
+ERROR: 44: configure.modgroup: nosuch is not member of g1
 Traceback (most recent call last):
     rv = self.execute_command() is not False
     rv = self.command_info.function(*arglist)
     context.fatal_error("%s is not member of %s" % (prim_id, group_id))
     raise ValueError(msg)
 ValueError: nosuch is not member of g1
-ERROR: 44: configure.modgroup: nosuch is not member of g1
 .INP: modgroup g1 add c1
 ERROR: 45: a group may contain only primitives; c1 is clone
 .INP: modgroup g1 add nosuch

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -68,7 +68,7 @@ op_defaults op-options: \
 .INP: primitive d3 ocf:heartbeat:Dummy
 .INP: group g2 d1 d2
 .INP: filter "sed '/g2/s/d1/p1/;/g1/s/p1/d1/'"
-ERROR: Cannot create group:g1: Child primitive:d1 already in group:g2
+ERROR: 29: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: filter "sed '/g1/s/d1/p1/;/g2/s/p1/d1/'"
 .INP: filter "sed '$alocation loc-d1 d1 rule $id=r1 -inf: not_defined webserver rule $id=r2 webserver: defined webserver'"
 .INP: filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
@@ -107,9 +107,9 @@ Traceback (most recent call last):
 ValueError: nosuch is not member of g1
 ERROR: 44: configure.modgroup: nosuch is not member of g1
 .INP: modgroup g1 add c1
-ERROR: a group may contain only primitives; c1 is clone
+ERROR: 45: a group may contain only primitives; c1 is clone
 .INP: modgroup g1 add nosuch
-ERROR: g1 refers to missing object nosuch
+ERROR: 46: g1 refers to missing object nosuch
 .INP: filter "sed 's/^/# this is a comment\n/'" loc-d1
 .INP: rsc_defaults $id="rsc_options" failure-timeout=10m
 .INP: filter "sed 's/2m/60s/'" op-options

--- a/test/testcases/scripts.exp
+++ b/test/testcases/scripts.exp
@@ -240,13 +240,13 @@ sbd-device
 virtual-ip
 vmware
 .INP: list bogus
+ERROR: 7: script.list: Unexpected argument 'bogus': expected  [all|names]
 Traceback (most recent call last):
     rv = self.execute_command() is not False
     rv = self.command_info.function(*arglist)
     context.fatal_error("Unexpected argument '%s': expected  [all|names]" % (arg))
     raise ValueError(msg)
 ValueError: Unexpected argument 'bogus': expected  [all|names]
-ERROR: 7: script.list: Unexpected argument 'bogus': expected  [all|names]
 .INP: show mailto
 mailto (Basic)
 E-Mail

--- a/test/testcases/shadow.exp
+++ b/test/testcases/shadow.exp
@@ -11,13 +11,13 @@ INFO: 3: cib.reset: copied live CIB to regtest
 .EXT >/dev/null </dev/null crm_shadow -b -C 'regtest' --force
 INFO: 5: cib.commit: committed 'regtest' shadow CIB to the cluster
 .INP: delete regtest
+ERROR: 6: cib.delete: regtest shadow CIB is in use
 Traceback (most recent call last):
     rv = self.execute_command() is not False
     rv = self.command_info.function(*arglist)
     context.fatal_error("%s shadow CIB is in use" % name)
     raise ValueError(msg)
 ValueError: regtest shadow CIB is in use
-ERROR: 6: cib.delete: regtest shadow CIB is in use
 .INP: use
 .INP: delete regtest
 .EXT >/dev/null </dev/null crm_shadow -b -D 'regtest' --force


### PR DESCRIPTION
In previous versions, crmsh does not print backtrace for most  of exceptions to make the error message more readable. However, backtrace is important information to debug a problem happened in a production environment.

This pull request enable crmsh to print the backtrace in logfile and suppress it in console in the same time, by implement a custom LogFormatter for console.

And this pull request also contains these refactoring and improvements:

* Avoid modifying module `logging` in the standard library. Instead, subclass the classes in it to customize.
* Avoid modifying `LogRecord` in handlers and formatters as it is shared by multiple handlers and formatters.
* Use `levelno` instead `levelname` to filter the logs for better performance.
* Remove `ConsoleReportFormatter` as it does nothing different to `ConsoleCustomFormatter`.
* Remove `FileCustomFormatter` as it does nothing different to `logging.Formatter`.
* Move the implementation of `lineno` used in regression tests, from handler to logger, as the number is controlled manually by the caller of logger.