### PR TITLE
Add profile for AWS and GCP with recommended corosync token timeout

### DIFF
--- a/etc/profiles.yml
+++ b/etc/profiles.yml
@@ -29,3 +29,9 @@ knet-default:
 microsoft-azure:
   corosync.totem.token: 30000
   sbd.watchdog_timeout: 60
+
+amazon-web-services:
+  corosync.totem.token: 30000
+
+google-cloud-platform:
+  corosync.totem.token: 20000


### PR DESCRIPTION
Add profile for AWS and GCP with recommended corosync token timeout.

- https://docs.aws.amazon.com/sap/latest/sap-netweaver/sap-netweaver-ha-setup.html#sample-file
- https://documentation.suse.com/sbp/sap-12/html/SLES4SAP-hana-sr-guide-PerfOpt-12_AWS/index.html#id-1.12.6.5.6
- https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_file
