### PR TITLE
[crmsh-4.6] Dev: ui_cluster: Move --use-ssh-agent to optional arguments

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -528,14 +528,14 @@ Examples:
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")
         parser.add_argument("-y", "--yes", help='Answer "yes" to all prompts (use with caution)', action="store_true", dest="yes_to_all")
         parser.add_argument("-w", "--watchdog", dest="watchdog", metavar="WATCHDOG", help="Use the given watchdog device")
+        parser.add_argument('--use-ssh-agent', action='store_true', dest='use_ssh_agent',
+                            help="Use an existing key from ssh-agent instead of creating new key pairs")
 
         network_group = parser.add_argument_group("Network configuration", "Options for configuring the network and messaging layer.")
         network_group.add_argument(
             "-c", "--cluster-node", metavar="[USER@]HOST", dest="cluster_node",
             help="User and host to login to an existing cluster node. The host can be specified with either a hostname or an IP.",
         )
-        network_group.add_argument('--use-ssh-agent', action='store_true', dest='use_ssh_agent',
-                            help="Use an existing key from ssh-agent instead of creating new key pairs")
         network_group.add_argument("-i", "--interface", dest="nic_list", metavar="IF", action=CustomAppendAction, choices=utils.interface_choice(), default=[],
                 help="Bind to IP address on interface IF. Use -i second time for second interface")
         options, args = parse_options(parser, args)

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -222,6 +222,8 @@ optional arguments:
   -y, --yes             Answer "yes" to all prompts (use with caution)
   -w WATCHDOG, --watchdog WATCHDOG
                         Use the given watchdog device
+  --use-ssh-agent       Use an existing key from ssh-agent instead of creating
+                        new key pairs
 
 Network configuration:
   Options for configuring the network and messaging layer.
@@ -230,8 +232,6 @@ Network configuration:
                         User and host to login to an existing cluster node.
                         The host can be specified with either a hostname or an
                         IP.
-  --use-ssh-agent       Use an existing key from ssh-agent instead of creating
-                        new key pairs
   -i IF, --interface IF
                         Bind to IP address on interface IF. Use -i second time
                         for second interface


### PR DESCRIPTION
Move --use-ssh-agent from network arguments to optional arguments (only for join side)