### PR TITLE
[crmsh-4.6] Dev: bootstrap: Assign hosts with _context.node_list_in_cluster in jo…

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1914,10 +1914,7 @@ def join_ssh_merge(cluster_node, remote_user):
     """
     logger.info("Merging known_hosts")
 
-    hosts = utils.list_cluster_nodes()
-    if hosts is None:
-        hosts = list()
-    hosts.append(cluster_node)
+    hosts = _context.node_list_in_cluster
 
     shell = sh.cluster_shell()
     # create local entry in known_hosts


### PR DESCRIPTION
…in_ssh_merge

Instead of invoking `utils.list_cluster_nodes`, consider the following:
If the cluster service on the current node is not running, it will read
from `cib.xml`. If `cib.xml` contains an original node that is no longer
available, the join process at ssh_merge stage will fail;
    
`_context.node_list_in_cluster` is a list of node names that are fetched
from the init node, queried by `crm_node -l`