### PR TITLE
[crmsh-4.6] Update the operation id after the monitor interval changed

### DIFF
--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -12,7 +12,7 @@ from .ra import disambiguate_ra_type, ra_type_validate
 from . import schema
 from .utils import keyword_cmp, verify_boolean, lines2cli
 from .utils import get_boolean, olist, canonical_boolean
-from .utils import handle_role_for_ocf_1_1, compatible_role
+from .utils import handle_role_for_ocf_1_1, compatible_role, add_time_unit_if_needed
 from . import xmlutil
 from . import log
 
@@ -700,9 +700,9 @@ class BaseParser(object):
                         constants.DEFAULT_INTERVAL_IN_ACTION
                 adv_timeout = extract_advised_value(action_advised_attr_dict, action, 'timeout', op_node.get('role'))
                 if op_node.get('interval') is None:
-                    op_node.set('interval', adv_interval)
+                    op_node.set('interval', add_time_unit_if_needed(adv_interval))
                 if op_node.get('timeout') is None and adv_timeout:
-                    op_node.set('timeout', adv_timeout)
+                    op_node.set('timeout', add_time_unit_if_needed(adv_timeout))
                 configured_action_list.append(action)
 
         for action in action_advised_attr_dict:
@@ -717,9 +717,15 @@ class BaseParser(object):
                     for k, v in v_dict.items():
                         # set normal attributes
                         if k in constants.ADVISED_KEY_LIST:
+                            if k in ('interval', 'timeout'):
+                                v = add_time_unit_if_needed(v)
                             op_node.set(k, handle_role_for_ocf_1_1(v))
                     operations_node.append(op_node)
             else:
+                for k, v in value.items():
+                    if k in ('interval', 'timeout'):
+                        v = add_time_unit_if_needed(v)
+                        value.update({k: v})
                 op_node = xmlutil.new('op', name=action, **value)
                 operations_node.append(op_node)
 
@@ -774,10 +780,14 @@ class BaseParser(object):
         valid_attrs = validator.op_attributes()
         inst_attrs = None
         for nvp in all_attrs:
-            if nvp.get('name') in valid_attrs:
+            name = nvp.get('name')
+            if name in valid_attrs:
                 if inst_attrs is not None:
-                    self.err("Attribute order error: {} must appear before any instance attribute".format(nvp.get('name')))
-                node.set(nvp.get('name'), nvp.get('value'))
+                    self.err(f"Attribute order error: {name} must appear before any instance attribute")
+                value = nvp.get('value')
+                if name in ('interval', 'timeout'):
+                    value = add_time_unit_if_needed(value)
+                node.set(name, value)
             else:
                 if inst_attrs is None:
                     inst_attrs = xmlutil.child(node, 'instance_attributes')

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -648,20 +648,22 @@ class CibConfig(command.UI):
                 context.fatal_error("Operation \"{}\" not found for resource {}".format(op_type, obj_id))
             if len(op_res) > 1:
                 context.fatal_error("Should specify interval of {}".format(op_type))
+            if name in ('interval', 'timeout'):
+                value = utils.add_time_unit_if_needed(value)
             if name == 'interval':
-                value = value if value.endswith('s') else value + 's'
                 op_res[0].set('id', f'{obj_id}-{op_type}-{value}')
             op_res[0].set(name, value)
 
         # Use case for: set id.op_type.interval.name value
         if len(other_path_list) == 3:
             op_type, iv, name = other_path_list
-            iv = iv[:-1] if iv.endswith('s') else iv
+            iv = iv[:-1] if utils.time_value_with_unit(iv) else iv
+            # Search for IDs both with and without the associated time unit
             op_res = rsc.node.xpath(f".//operations/op[@id='{obj_id}-{op_type}-{iv}' or @id='{obj_id}-{op_type}-{iv}s']")
             if not op_res:
                 context.fatal_error(f"Operation \"{op_type}\" interval \"{iv}s\" not found for resource {obj_id}")
             if name == 'interval':
-                value = value if value.endswith('s') else value + 's'
+                value = utils.add_time_unit_if_needed(value)
                 op_res[0].set('id', f'{obj_id}-{op_type}-{value}')
             op_res[0].set(name, value)
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -648,14 +648,21 @@ class CibConfig(command.UI):
                 context.fatal_error("Operation \"{}\" not found for resource {}".format(op_type, obj_id))
             if len(op_res) > 1:
                 context.fatal_error("Should specify interval of {}".format(op_type))
+            if name == 'interval':
+                value = value if value.endswith('s') else value + 's'
+                op_res[0].set('id', f'{obj_id}-{op_type}-{value}')
             op_res[0].set(name, value)
 
         # Use case for: set id.op_type.interval.name value
         if len(other_path_list) == 3:
             op_type, iv, name = other_path_list
-            op_res = rsc.node.xpath(".//operations/op[@id='{}-{}-{}']".format(obj_id, op_type, iv))
+            iv = iv[:-1] if iv.endswith('s') else iv
+            op_res = rsc.node.xpath(f".//operations/op[@id='{obj_id}-{op_type}-{iv}' or @id='{obj_id}-{op_type}-{iv}s']")
             if not op_res:
-                context.fatal_error("Operation \"{}\" interval \"{}\" not found for resource {}".format(op_type, iv, obj_id))
+                context.fatal_error(f"Operation \"{op_type}\" interval \"{iv}s\" not found for resource {obj_id}")
+            if name == 'interval':
+                value = value if value.endswith('s') else value + 's'
+                op_res[0].set('id', f'{obj_id}-{op_type}-{value}')
             op_res[0].set(name, value)
 
         rsc.set_updated()

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3147,4 +3147,18 @@ def read_from_file(infile: str) -> str:
         return ""
 
     return data
+
+
+def add_time_unit_if_needed(time_value):
+    """
+    Add time unit if needed
+    """
+    return "{}s".format(time_value) if not time_value_with_unit(time_value) else time_value
+
+
+def time_value_with_unit(time_value):
+    """
+    Check if the time value contains unit
+    """
+    return re.search(r'^\d+[a-z]+$', time_value) is not None
 # vim:ts=4:sw=4:et:

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -29,7 +29,7 @@ Feature: Use "crm configure set" to update attributes and operations
     When    Try "crm configure set d.name value"
     Then    Except "ERROR: configure.set: Attribute not found: d.name"
     When    Try "crm configure set d.monitor.100.timeout 10"
-    Then    Except "ERROR: configure.set: Operation "monitor" interval "100" not found for resource d"
+    Then    Except "ERROR: configure.set: Operation "monitor" interval "100s" not found for resource d"
     When    Try "crm configure set s.monitor.interval 20"
     Then    Except "ERROR: configure.set: Should specify interval of monitor"
 
@@ -43,6 +43,25 @@ Feature: Use "crm configure set" to update attributes and operations
     When    Run "crm configure set s.monitor.5s.interval 20s" on "hanode1"
     And     Run "crm configure show s" on "hanode1"
     Then    Expected "interval=20s" in stdout
+    When    Run "crm configure set s.monitor.20s.interval 60s" on "hanode1"
+    And     Run "crm configure show s" on "hanode1"
+    Then    Expected "interval=60s" in stdout
+    When    Run "crm configure set s.monitor.60.interval 50" on "hanode1"
+    And     Run "crm configure show s" on "hanode1"
+    Then    Expected "interval=50s" in stdout
+
+    When    Run "crm configure primitive d2 Dummy op monitor interval=10 timeout=20 op start timeout=66" on "hanode1"
+    And     Run "crm configure show d2" on "hanode1"
+    Then    Expected "monitor interval=10s timeout=20s" in stdout
+    When    Run "crm configure show d2" on "hanode1"
+    Then    Expected "start timeout=66s" in stdout
+    When    Run "crm configure set d2.monitor.interval 33" on "hanode1"
+    And     Run "crm configure show d2" on "hanode1"
+    Then    Expected "interval=33s" in stdout
+    When    Run "crm configure set d2.monitor.33s.interval 50" on "hanode1"
+    And     Run "crm configure show d2" on "hanode1"
+    Then    Expected "interval=50s" in stdout
+
     When    Run "crm configure set op-options.timeout 101" on "hanode1"
     And     Run "crm configure show op-options" on "hanode1"
     Then    Expected "timeout=101" in stdout

--- a/test/testcases/acl.exp
+++ b/test/testcases/acl.exp
@@ -40,7 +40,7 @@ primitive st stonith:ssh \
 	meta target-role=Started requires=nothing \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 property cib-bootstrap-options: \
 	enable-acl=true
 role basic-read \

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -31,9 +31,9 @@ node node1
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-        op start timeout=20 interval=0s \
-        op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+        op start timeout=20s interval=0s \
+        op stop timeout=15s interval=0s
 primitive p4 Dummy \
         op monitor timeout=20s interval=10s \
         op start timeout=20s interval=0s \
@@ -69,9 +69,9 @@ node node1
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-        op start timeout=20 interval=0s \
-        op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+        op start timeout=20s interval=0s \
+        op stop timeout=15s interval=0s
 primitive p4 Dummy \
         op monitor timeout=20s interval=10s \
         op start timeout=20s interval=0s \
@@ -170,9 +170,9 @@ node node1
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-        op start timeout=20 interval=0s \
-        op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+        op start timeout=20s interval=0s \
+        op stop timeout=15s interval=0s
 property SAPHanaSR: \
 	hana_ha1_site_lss_WDF1=4
 .INP: commit
@@ -184,9 +184,9 @@ node node1
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-        op start timeout=20 interval=0s \
-        op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+        op start timeout=20s interval=0s \
+        op stop timeout=15s interval=0s
 property SAPHanaSR: \
 	hana_ha1_site_lss_WDF1=4
 property SAPHanaSR_2: \

--- a/test/testcases/bundle.exp
+++ b/test/testcases/bundle.exp
@@ -28,7 +28,7 @@ node node2 \
        utilization cpu=4
 primitive dummy Dummy \
 	meta target-role=Stopped \
-	op monitor interval=10 timeout=20s \
+	op monitor interval=10s timeout=20s \
 	op start timeout=20s interval=0s \
 	op stop timeout=20s interval=0s
 primitive st stonith:ssh \
@@ -36,12 +36,12 @@ primitive st stonith:ssh \
 	meta target-role=Started requires=nothing \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 primitive st2 stonith:ssh \
 	params hostlist="node1 node2" \
-	op monitor timeout=20 interval=3600 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor timeout=20s interval=3600s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 bundle bundle-test1 \
 	docker image=test \
 	network ip-range-start=10.10.10.123 port-mapping id=port1 port=80 \

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -75,9 +75,9 @@ primitive p3 Dummy \
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta yoyo-meta="yoyo 2" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group g1 d1 p2
 group g2 d3
 colocation cl1 inf: g1 p3

--- a/test/testcases/confbasic-xml.exp
+++ b/test/testcases/confbasic-xml.exp
@@ -33,7 +33,7 @@
         <operations>
           <op name="start" timeout="60s" interval="0s" id="st-start-0s"/>
           <op name="monitor" interval="60m" timeout="60s" id="st-monitor-60m"/>
-          <op name="stop" timeout="15" interval="0s" id="st-stop-0s"/>
+          <op name="stop" timeout="15s" interval="0s" id="st-stop-0s"/>
         </operations>
       </primitive>
       <primitive id="st2" class="stonith" type="ssh">
@@ -41,9 +41,9 @@
           <nvpair name="hostlist" value="node1 node2" id="st2-instance_attributes-hostlist"/>
         </instance_attributes>
         <operations>
-          <op name="monitor" timeout="20" interval="3600" id="st2-monitor-3600"/>
-          <op name="start" timeout="20" interval="0s" id="st2-start-0s"/>
-          <op name="stop" timeout="15" interval="0s" id="st2-stop-0s"/>
+          <op name="monitor" timeout="20s" interval="3600s" id="st2-monitor-3600s"/>
+          <op name="start" timeout="20s" interval="0s" id="st2-start-0s"/>
+          <op name="stop" timeout="15s" interval="0s" id="st2-stop-0s"/>
         </operations>
       </primitive>
       <group id="g1">

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -102,7 +102,7 @@ primitive d4 ocf:pacemaker:Dummy \
 primitive d7 Dummy \
 	params rule #uname eq node1 fake=1 \
 	params rule #uname eq node2 fake=2 \
-	op start interval=0 timeout=60s \
+	op start interval=0s timeout=60s \
 	op_params 2: rule #uname eq node1 op_param=dummy \
 	op_params 1: op_param=smart \
 	op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m \
@@ -134,12 +134,12 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 primitive st2 stonith:ssh \
 	params hostlist="node1 node2" \
-	op monitor timeout=20 interval=3600 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor timeout=20s interval=3600s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group g1 d1 d2
 ms m d4
 ms m5 s5

--- a/test/testcases/delete.exp
+++ b/test/testcases/delete.exp
@@ -27,7 +27,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-        op stop timeout=15 interval=0s
+        op stop timeout=15s interval=0s
 location d1-pref d1 100: node1
 .INP: _test
 .INP: rename d1 p1
@@ -47,7 +47,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-        op stop timeout=15 interval=0s
+        op stop timeout=15s interval=0s
 location d1-pref p1 100: node1
 .INP: # delete primitive
 .INP: delete d2
@@ -63,7 +63,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 location d1-pref p1 100: node1
 .INP: # delete primitive with constraint
 .INP: delete p1
@@ -76,7 +76,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 .INP: primitive d1 ocf:pacemaker:Dummy
 .INP: location d1-pref d1 100: node1
 .INP: _test
@@ -97,7 +97,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 group g1 d1
 location d1-pref g1 100: node1
 .INP: _test
@@ -114,7 +114,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 location d1-pref d1 100: node1
 .INP: verify
 .INP: # delete a group which is in a clone
@@ -141,7 +141,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 location d1-pref d2 100: node1
 .INP: _test
 .INP: group g1 d2 d1
@@ -168,7 +168,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 location d1-pref d2 100: node1
 .INP: _test
 .INP: group g1 d2 d1
@@ -187,7 +187,7 @@ primitive st stonith:ssh \
 	meta target-role=Started \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 .INP: _test
 .INP: # verify
 .INP: verify

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -25,9 +25,9 @@ primitive p2 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group g1 p1 p2
 op_defaults op-options: \
 	timeout=2m
@@ -46,9 +46,9 @@ primitive p3 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group g1 p1 p3
 op_defaults op-options: \
 	timeout=2m
@@ -176,9 +176,9 @@ primitive p3 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group g1 p1 p2 d3
 group g2 d1 d2
 clone c1 g1
@@ -305,9 +305,9 @@ primitive p3 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
 group g1 p1 p2 d3
 group g2 d1 d2
@@ -412,9 +412,9 @@ primitive p3 Dummy
 primitive st stonith:null \
 	params hostlist=node1 \
 	meta description="some description here" requires=nothing \
-	op monitor interval=60m timeout=20 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+	op monitor interval=60m timeout=20s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 group as a0 a1 a9 a2 a3 a4 a5 a6 a7 a8 aErr
 group g1 p1 p2 d3
 group g2 d1 d2

--- a/test/testcases/file.exp
+++ b/test/testcases/file.exp
@@ -20,9 +20,9 @@ primitive p3 ocf:pacemaker:Dummy \
         op stop timeout=20s interval=0s
 primitive st stonith:null \
 	params hostlist=node1 \
-        op monitor timeout=20 interval=3600 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+        op monitor timeout=20s interval=3600s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 clone c1 p1 \
        meta interleave=true
 clone m1 p2 \
@@ -65,9 +65,9 @@ primitive p3 ocf:pacemaker:Dummy \
         op stop timeout=20s interval=0s
 primitive st stonith:null \
 	params hostlist=node1 \
-        op monitor timeout=20 interval=3600 \
-	op start timeout=20 interval=0s \
-	op stop timeout=15 interval=0s
+        op monitor timeout=20s interval=3600s \
+	op start timeout=20s interval=0s \
+	op stop timeout=15s interval=0s
 property cib-bootstrap-options: \
 	cluster-recheck-interval=10m
 rsc_defaults build-resource-defaults: \

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -55,7 +55,7 @@ primitive st stonith:ssh \
 	meta target-role=Started requires=nothing \
 	op start timeout=60s interval=0s \
 	op monitor interval=60m timeout=60s \
-	op stop timeout=15 interval=0s
+	op stop timeout=15s interval=0s
 tag ones l1 p1
 tag tag1 p0 p1 p2
 tag tag2 p0 p1 p2

--- a/test/testcases/rset-xml.exp
+++ b/test/testcases/rset-xml.exp
@@ -12,8 +12,8 @@
         </instance_attributes>
         <operations>
           <op name="start" timeout="60s" interval="0s" id="st-start-0s"/>
-          <op name="monitor" timeout="20" interval="3600" id="st-monitor-3600"/>
-          <op name="stop" timeout="15" interval="0s" id="st-stop-0s"/>
+          <op name="monitor" timeout="20s" interval="3600s" id="st-monitor-3600s"/>
+          <op name="stop" timeout="15s" interval="0s" id="st-stop-0s"/>
         </operations>
       </primitive>
       <primitive id="d1" class="ocf" provider="pacemaker" type="Dummy">

--- a/test/testcases/rset.exp
+++ b/test/testcases/rset.exp
@@ -57,8 +57,8 @@ primitive d5 Dummy \
 primitive st stonith:ssh \
 	params hostlist=node1 \
 	op start timeout=60s interval=0s \
-	op monitor timeout=20 interval=3600 \
-	op stop timeout=15 interval=0s
+	op monitor timeout=20s interval=3600s \
+	op stop timeout=15s interval=0s
 colocation c1 inf: ( d1 d3 )
 colocation c2 inf: d3 d1
 colocation c3 inf: d3 d1

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -322,7 +322,7 @@ def test_pengine_test():
           </rule>
         </instance_attributes>
         <operations>
-          <op id="rsc1-monitor-10" interval="10" name="monitor"/>
+          <op id="rsc1-monitor-10s" interval="10s" name="monitor"/>
         </operations>
       </primitive>'''
     data = etree.fromstring(xml)
@@ -330,7 +330,7 @@ def test_pengine_test():
     assert obj is not None
     data = obj.repr_cli(format_mode=-1)
     print("OUTPUT:", data)
-    exp = 'primitive rsc1 ocf:pacemaker:Dummy params rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" op monitor interval=10'
+    exp = 'primitive rsc1 ocf:pacemaker:Dummy params rule 0: #cluster-name eq clusterA state="/var/run/Dummy-rsc1-clusterA" params rule 0: #cluster-name eq clusterB state="/var/run/Dummy-rsc1-clusterB" op monitor interval=10s'
     assert data == exp
     assert obj.cli_use_validate()
 
@@ -349,7 +349,7 @@ def test_tagset():
 def test_op_role():
     xml = '''<primitive class="ocf" id="rsc2" provider="pacemaker" type="Dummy">
         <operations>
-          <op id="rsc2-monitor-10" interval="10" name="monitor" role="Stopped"/>
+          <op id="rsc2-monitor-10s" interval="10s" name="monitor" role="Stopped"/>
         </operations>
       </primitive>'''
     data = etree.fromstring(xml)
@@ -357,7 +357,7 @@ def test_op_role():
     assert obj is not None
     data = obj.repr_cli(format_mode=-1)
     print("OUTPUT:", data)
-    exp = 'primitive rsc2 ocf:pacemaker:Dummy op monitor interval=10 role=Stopped'
+    exp = 'primitive rsc2 ocf:pacemaker:Dummy op monitor interval=10s role=Stopped'
     assert data == exp
     assert obj.cli_use_validate()
 

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -125,9 +125,9 @@ def test_idresolve():
 def test_ordering():
     xml = """<primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy"> \
   <operations> \
-    <op name="start" timeout="60" interval="0" id="dummy-start-0"/> \
-    <op name="stop" timeout="60" interval="0" id="dummy-stop-0"/> \
-    <op name="monitor" interval="60" timeout="30" id="dummy-monitor-60"/> \
+    <op name="start" timeout="60s" interval="0s" id="dummy-start-0s"/> \
+    <op name="stop" timeout="60s" interval="0s" id="dummy-stop-0s"/> \
+    <op name="monitor" interval="60s" timeout="30s" id="dummy-monitor-60s"/> \
   </operations> \
   <meta_attributes id="dummy-meta_attributes"> \
     <nvpair id="dummy-meta_attributes-target-role" name="target-role"
@@ -139,7 +139,7 @@ value="Stopped"/> \
     assert_is_not_none(obj)
     data = obj.repr_cli(format_mode=-1)
     print(data)
-    exp = 'primitive dummy ocf:pacemaker:Dummy op start timeout=60 interval=0 op stop timeout=60 interval=0 op monitor interval=60 timeout=30 meta target-role=Stopped'
+    exp = 'primitive dummy ocf:pacemaker:Dummy op start timeout=60s interval=0s op stop timeout=60s interval=0s op monitor interval=60s timeout=30s meta target-role=Stopped'
     assert exp == data
     assert obj.cli_use_validate()
 
@@ -151,9 +151,9 @@ def test_ordering2():
 value="Stopped"/> \
   </meta_attributes> \
   <operations> \
-    <op name="start" timeout="60" interval="0" id="dummy2-start-0"/> \
-    <op name="stop" timeout="60" interval="0" id="dummy2-stop-0"/> \
-    <op name="monitor" interval="60" timeout="30" id="dummy2-monitor-60"/> \
+    <op name="start" timeout="60s" interval="0s" id="dummy2-start-0s"/> \
+    <op name="stop" timeout="60s" interval="0s" id="dummy2-stop-0s"/> \
+    <op name="monitor" interval="60s" timeout="30s" id="dummy2-monitor-60s"/> \
   </operations> \
 </primitive>"""
     data = etree.fromstring(xml)
@@ -162,8 +162,8 @@ value="Stopped"/> \
     data = obj.repr_cli(format_mode=-1)
     print(data)
     exp = 'primitive dummy2 ocf:pacemaker:Dummy meta target-role=Stopped ' \
-          'op start timeout=60 interval=0 op stop timeout=60 interval=0 ' \
-          'op monitor interval=60 timeout=30'
+          'op start timeout=60s interval=0s op stop timeout=60s interval=0s ' \
+          'op monitor interval=60s timeout=30s'
     assert exp == data
     assert obj.cli_use_validate()
 
@@ -235,7 +235,7 @@ def test_param_rules():
 
 def test_operation_rules():
     roundtrip('primitive test Dummy ' +
-              'op start interval=0 '
+              'op start interval=0s '
               'op_params 2: rule #uname eq node1 fake=fake ' +
               'op_params 1: fake=real ' +
               'op_meta 2: rule #ra-version version:gt 1.0 timeout=120s ' +


### PR DESCRIPTION
The monitor operation's ID is constructed as
'<resource_id>-monitor-<interval_value>'. Therefore, when the monitor
interval is altered by configure.set, the ID should also be updated to
reflect the latest interval. If not, configure.set cannot update the
value based on the current path, which is identified by
id.[op_type.][interval.]name.
    
See the issue https://github.com/ClusterLabs/crmsh/issues/826