### PR TITLE
[crmsh-4.6] Fix: report: Unable to gather log files that are in the syslog format (bsc#1218491)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,6 @@ codecov:
     after_n_builds: 23
 comment:
   after_n_builds: 23
+
+ignore:
+  - "crmsh/report"

--- a/data-manifest
+++ b/data-manifest
@@ -155,6 +155,7 @@ test/unittests/corosync.conf.2
 test/unittests/corosync.conf.3
 test/unittests/__init__.py
 test/unittests/pacemaker.log
+test/unittests/pacemaker.log.2
 test/unittests/pacemaker_unicode.log
 test/unittests/schemas/acls-1.1.rng
 test/unittests/schemas/acls-1.2.rng

--- a/test/unittests/pacemaker.log.2
+++ b/test/unittests/pacemaker.log.2
@@ -1,0 +1,3 @@
+Jan 03 11:03:31 15sp1-1 pacemaker-fenced    [1944] (pcmk_cpg_membership)        info: Group event stonith-ng.3: node 2 joined
+Jan 03 11:03:41 15sp1-1 pacemaker-fenced    [1944] (pcmk_cpg_membership)        info: Group event stonith-ng.3: node 1 (15sp1-1) is member
+Jan 03 11:03:51 15sp1-1 pacemaker-fenced    [1944] (corosync_node_name)         info: Unable to get node name for nodeid 2


### PR DESCRIPTION
Logs in syslog format lack year information, making it challenging to determine the year a line was recorded. Therefore, when encountering a future timestamp, we must estimate the year