### PR TITLE
Fix: ui_node: prevent traceback on node standby

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -436,6 +436,8 @@ class NodeMgmt(command.UI):
             return
 
         cib = xmlutil.cibdump2elem()
+        if cib is None:
+            return False
         # IMPORTANT: Do NOT call cibdump2elem twice, or you risk a race.
         # Really use the same xml as "original" and basis for the changes.
         # Thus the "deepcopy" here; see also do_standby().

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -376,6 +376,8 @@ class NodeMgmt(command.UI):
             xml_query_path_oppsite = constants.XML_NODE_QUERY_STANDBY_PATH
 
         cib = xmlutil.cibdump2elem()
+        if cib is None:
+            return False
         # IMPORTANT:
         # Do NOT call cibdump2elem twice, or you risk a race where the
         # resulting diff will contain more changes than the values for


### PR DESCRIPTION
Crm throws traceback on `crm node standby` if cluster (corosync/pacemaker) stopped.

```
[root@es-3-virt1 ~]# rpm -qa | grep crmsh
crmsh-4.5.1-1.el8.noarch
crmsh-scripts-4.5.1-1.el8.noarch
crmsh-test-4.5.1-1.el8.noarch

[root@es-3-virt1 ~]# crm cluster stop
WARNING: crmsh configuration is inconsistent in cluster.
INFO: The cluster stack already stopped on es-3-virt1

[root@es-3-virt1 ~]# crm node standby
WARNING: crmsh configuration is inconsistent in cluster.
ERROR: running cibadmin -Ql: Could not connect to the CIB: Transport endpoint is not connected
Init failed, could not perform requested operations

Traceback (most recent call last):
  File "/usr/sbin/crm", line 53, in <module>
    rc = main.run()
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 369, in run
    return main_input_loop(context, user_args)
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 247, in main_input_loop
    rc = handle_noninteractive_use(context, user_args)
  File "/usr/lib/python3.6/site-packages/crmsh/main.py", line 204, in handle_noninteractive_use
    if context.run(' '.join(l)):
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 86, in run
    rv = self.execute_command() is not False
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 271, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib/python3.6/site-packages/crmsh/ui_node.py", line 397, in do_standby
    xml_item_list = cib.xpath(xml_path)
AttributeError: 'NoneType' object has no attribute 'xpath'

[root@es-3-virt1 ~]# echo $?
1

[root@es-3-virt1 ~]# cp /usr/lib/python3.6/site-packages/crmsh/ui_node.py{,.orig}
[root@es-3-virt1 ~]# vim /usr/lib/python3.6/site-packages/crmsh/ui_node.py
[root@es-3-virt1 ~]# diff -Naru /usr/lib/python3.6/site-packages/crmsh/ui_node.py.orig /usr/lib/python3.6/site-packages/crmsh/ui_node.py
--- /usr/lib/python3.6/site-packages/crmsh/ui_node.py.orig      2024-01-08 14:43:49.166728433 +0000
+++ /usr/lib/python3.6/site-packages/crmsh/ui_node.py   2024-01-08 14:44:50.942622070 +0000
@@ -376,6 +376,8 @@
             xml_query_path_oppsite = constants.XML_NODE_QUERY_STANDBY_PATH

         cib = xmlutil.cibdump2elem()
+        if cib is None:
+            return False
         # IMPORTANT:
         # Do NOT call cibdump2elem twice, or you risk a race where the
         # resulting diff will contain more changes than the values for

[root@es-3-virt1 ~]# crm node standby ; echo $?
WARNING: crmsh configuration is inconsistent in cluster.
ERROR: running cibadmin -Ql: Could not connect to the CIB: Transport endpoint is not connected
Init failed, could not perform requested operations

1
```