### PR TITLE
[crmsh-4.6] Dev: ui_context: Skip querying CIB when in a sublevel or help command

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -511,4 +511,6 @@ RSC_ROLE_UNPROMOTED = "Unpromoted"
 RSC_ROLE_PROMOTED_LEGACY = "Master"
 RSC_ROLE_UNPROMOTED_LEGACY = "Slave"
 PCMK_VERSION_DEFAULT = "2.0.0"
+
+NON_FUNCTIONAL_COMMANDS = ('help', 'cd', 'ls', 'quit', 'up')
 # vim:ts=4:sw=4:et:

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -14,6 +14,7 @@ Feature: crmsh bootstrap process - options
 
   @clean
   Scenario: Check help output
+    When    Run "crm configure help primitive" OK		
     When    Run "crm -h" on "hanode1"
     Then    Output is the same with expected "crm" help output
     When    Run "crm cluster init -h" on "hanode1"


### PR DESCRIPTION
When cluster service is not running, entering some crm sublevel requires live cib, such as:
```
# crm configure
ERROR: running cibadmin -Ql: Could not connect to the CIB: Transport endpoint is not connected
Init failed, could not perform requested operations

ERROR: configure: Missing requirements
```

And it will fail to show the help info under this sublevel, like:
```
# crm configure help primitive
ERROR: running cibadmin -Ql: Could not connect to the CIB: Transport endpoint is not connected
Init failed, could not perform requested operations

ERROR: configure: Missing requirements
```

To fix that, should skip querying cib when the current stack is just level, or when the current command is the non functional command (like help, ls, cd, up, quit)