### PR TITLE
[crmsh-4.6] Fix: bootstrap: ssh key of the init node is duplicated in the authorized_keys files of other node (bsc#1218940)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1829,8 +1829,9 @@ def swap_public_ssh_key(
 
     if add:
         public_key = generate_ssh_key_pair_on_remote(local_sudoer, remote_node, remote_sudoer, remote_user_to_swap)
-        _, _, local_authorized_file = key_files(local_user_to_swap).values()
-        sh.LocalShell().get_stdout_or_raise_error(local_user_to_swap, "sed -i '$a {}' '{}'".format(public_key, local_authorized_file))
+        ssh_key.AuthorizedKeyManager(sh.SSHShell(sh.LocalShell(), local_user_to_swap)).add(
+            None, local_user_to_swap, ssh_key.InMemoryPublicKey(public_key),
+        )
         return public_key
     else:
         try:

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -135,7 +135,7 @@ class AuthorizedKeyManager:
         public_key = key.public_key()
         dir = f'~{user}/.ssh'
         file = f'{dir}/authorized_keys'
-        cmd = f'''if ! grep '{public_key}' {file} > /dev/null; then
+        cmd = f'''if ! grep -F '{public_key}' {file} > /dev/null; then
     if [ -s {file} ]; then
         sed -i '$a {public_key}' {file}
     else


### PR DESCRIPTION
When a cluster is bootstrap with 'crm cluster init -N', the public key of the init node is added for mutiple times to the authorized_key files of other nodes.

Fix by reusing `AuthorizedKeyManager.add` in swap_public_ssh_key.