### PR TITLE
[crmsh-4.6] Fix: ui_cluster: Can't start cluster with --all option if no cib (bsc#1219052)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -386,6 +386,9 @@ def collect_config(context: core.Context) -> None:
         logger.debug(f"Touch file 'RUNNING' in {utils.real_path(workdir)}")
     else:
         # TODO should determine offline node was ha node
+        if not os.path.isfile(os.path.join(context.cib_dir, constants.CIB_F)):
+            logger.warning(f"Cannot find cib.xml in {context.cib_dir}")
+            return
         shutil.copy2(os.path.join(context.cib_dir, constants.CIB_F), workdir)
         crmutils.str2file("", os.path.join(workdir, "STOPPED"))
         logger.debug(f"Touch file 'STOPPED' in {utils.real_path(workdir)}")

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -244,14 +244,11 @@ keep the node in standby after reboot. The life time defaults to
         context.fatal_error("Should either use --all or specific node(s)")
 
     # return local node
-    if not options.all and not args:
+    if (not options.all and not args) or (len(args) == 1 and args[0] == utils.this_node()):
         return [utils.this_node()]
     member_list = utils.list_cluster_nodes()
     if not member_list:
         context.fatal_error("Cannot get the node list from cluster")
-    for node in args:
-        if node not in member_list:
-            context.fatal_error("Node \"{}\" is not a cluster node".format(node))
 
     node_list = member_list if options.all else args
     for node in node_list:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1766,6 +1766,14 @@ def print_cluster_nodes():
         print("{}\n".format(out))
 
 
+def get_address_list_from_corosync_conf():
+    """
+    Return a list of addresses configured in corosync.conf
+    """
+    from . import corosync
+    return corosync.get_values("nodelist.node.ring0_addr")
+
+
 def list_cluster_nodes(no_reg=False):
     '''
     Returns a list of nodes in the cluster.
@@ -1780,10 +1788,10 @@ def list_cluster_nodes(no_reg=False):
     else:
         cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
         if not os.path.isfile(cib_path):
-            return None
+            return get_address_list_from_corosync_conf()
         cib = xmlutil.file2cib_elem(cib_path)
     if cib is None:
-        return None
+        return get_address_list_from_corosync_conf()
 
     node_list = []
     for node in cib.xpath(constants.XML_NODE_PATH):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1796,9 +1796,10 @@ def list_cluster_nodes(no_reg=False):
     node_list = []
     for node in cib.xpath(constants.XML_NODE_PATH):
         name = node.get('uname') or node.get('id')
+        # exclude remote node
         if node.get('type') == 'remote':
-            srv = cib.xpath("//primitive[@id='%s']/instance_attributes/nvpair[@name='server']" % (name))
-            if srv:
+            xpath = f"//primitive[@provider='pacemaker' and @type='remote']/instance_attributes/nvpair[@name='server' and @value='{name}']"
+            if cib.xpath(xpath):
                 continue
         node_list.append(name)
     return node_list

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -133,6 +133,25 @@ Feature: Regression test for bootstrap bugs
     Then    Service "corosync" is "stopped" on "hanode1"
 
   @clean
+  Scenario: Can't start cluster with --all option if no cib(bsc#1219052)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+
+    When    Run "crm cluster stop --all" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "rm -f /var/lib/pacemaker/cib/*" on "hanode1"
+    When    Run "rm -f /var/lib/pacemaker/cib/*" on "hanode2"
+    And     Run "crm cluster start --all" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    Then    Cluster service is "started" on "hanode2"
+
+  @clean
   Scenario: Can't stop all nodes' cluster service when local node's service is down(bsc#1213889)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"

--- a/test/features/crm_report_normal.feature
+++ b/test/features/crm_report_normal.feature
@@ -105,5 +105,4 @@ Feature: crm report functional test for common cases
     When    Run "crm cluster stop --all" on "hanode1"
     When    Run "rm -f /var/lib/pacemaker/cib/cib*" on "hanode1"
     When    Run "rm -f /var/lib/pacemaker/cib/cib*" on "hanode2"
-    When    Try "crm report" on "hanode1"
-    Then    Expected "Could not figure out a list of nodes; is this a cluster node" in stderr
+    When    Run "crm report" OK

--- a/test/unittests/test_report_utils.py
+++ b/test/unittests/test_report_utils.py
@@ -138,27 +138,16 @@ class TestSanitizer(unittest.TestCase):
     @mock.patch('glob.glob')
     def test_load_cib_from_work_dir_no_cib(self, mock_glob):
         mock_glob.return_value = []
-        with self.assertRaises(utils.ReportGenericError) as err:
-            self.s_inst._load_cib_from_work_dir()
-        self.assertEqual(f"CIB file {constants.CIB_F} was not collected", str(err.exception))
-
-    @mock.patch('glob.glob')
-    @mock.patch('crmsh.utils.read_from_file')
-    def test_load_cib_from_work_dir_empty(self, mock_read, mock_glob):
-        mock_glob.return_value = [f"/opt/node1/{constants.CIB_F}"]
-        mock_read.return_value = None
-        with self.assertRaises(utils.ReportGenericError) as err:
-            self.s_inst._load_cib_from_work_dir()
-        self.assertEqual(f"File /opt/node1/{constants.CIB_F} is empty", str(err.exception))
-        mock_read.assert_called_once_with(f"/opt/node1/{constants.CIB_F}")
+        res = self.s_inst._load_cib_from_work_dir()
+        self.assertIsNone(res)
 
     @mock.patch('glob.glob')
     @mock.patch('crmsh.utils.read_from_file')
     def test_load_cib_from_work_dir(self, mock_read, mock_glob):
         mock_glob.return_value = [f"/opt/node1/{constants.CIB_F}"]
         mock_read.return_value = "data"
-        self.s_inst._load_cib_from_work_dir()
-        self.assertEqual(self.s_inst.cib_data, "data")
+        res = self.s_inst._load_cib_from_work_dir()
+        self.assertEqual(res, "data")
         mock_read.assert_called_once_with(f"/opt/node1/{constants.CIB_F}")
 
     @mock.patch('crmsh.report.utils.logger', spec=crmsh.log.DEBUG2Logger)


### PR DESCRIPTION
## Issue
When setting up cluster via yast2-cluster,
- Can't start the cluster with --all option:
```
15sp5-1:~ # crm cluster start --all
ERROR: cluster.start: Cannot get the node list from cluster
```
- Can't start cluster on peer node
```
15sp5-1:~ # crm cluster start 15sp5-2
ERROR: cluster.start: Cannot get the node list from cluster
```
- Can't start cluster on local node
```
15sp5-1:~ # crm cluster start 15sp5-1
ERROR: cluster.start: Cannot get the node list from cluster
```
## Solution
- The --all option try to query the node list from `utils.list_cluster_nodes`, which should grab the address list from corosync.conf when there is no cib
- For the peer node case, stop compare with the return results from list_cluster_nodes, since it's hard to tell if the given name is not the alias name
- For the local node case, return itself immediately