### PR TITLE
Import missing sys library in config.py

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -6,6 +6,7 @@ Holds user-configurable options.
 
 import os
 import re
+import sys
 import configparser
 from contextlib import contextmanager
 from typing import List


### PR DESCRIPTION
Failing to import sys will raise an exception when encountering a parsing failure of crm.conf. sys is used in def _disable_exception_traceback()

https://github.com/ClusterLabs/crmsh/blob/master/crmsh/config.py#L20-L23