### PR TITLE
[crmsh-4.6] Dev: utils: Return empty list if corosync.conf does not exist

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1771,6 +1771,8 @@ def get_address_list_from_corosync_conf():
     Return a list of addresses configured in corosync.conf
     """
     from . import corosync
+    if not os.path.exists(corosync.conf()):
+        return []
     return corosync.get_values("nodelist.node.ring0_addr")
 
 


### PR DESCRIPTION
To fix a minor regression introduced by #1312 , when the second node is joining 

```
# crm cluster join -c 15sp5-1 -y
ERROR: When reading file "/etc/corosync/corosync.conf": [Errno 2] No such file or directory: '/etc/corosync/corosync.conf'
```

That is because `utils.list_cluster_nodes` was called by `upgrade_if_needed`, at very beginning, when there is no corosync.conf exist