### PR TITLE
[crmsh-4.6] Dev: ui_configure: verify all cib objects even if there is no primitive resource configured

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -913,8 +913,7 @@ class CibConfig(command.UI):
         rc1 = True
         if replace and not force:
             rc1 = cib_factory.is_current_cib_equal()
-        rc2 = cib_factory.has_no_primitives() or \
-            self._verify(mkset_obj("xml", "changed"), mkset_obj("xml"))
+        rc2 = self._verify(mkset_obj("xml", "changed"), mkset_obj("xml"))
         if rc1 and rc2:
             return cib_factory.commit(replace=replace)
         if force or config.core.force:


### PR DESCRIPTION
To ensure consistent behavior for warnings, see
https://github.com/ClusterLabs/crmsh/issues/861#issuecomment-1022779253
That is, the warning will be raised when there is no RA added in cluster