### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -49,7 +49,7 @@ def crm_resource(opts):
 
 @utils.memoize
 def can_use_lrmadmin():
-    from distutils import version
+    from setuptools._distutils import version
     # after this glue release all users can get meta-data and
     # similar from lrmd
     minimum_glue = "1.0.10"

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -34,7 +34,7 @@ from . import userdir
 from . import constants
 from . import options
 from . import term
-from distutils.version import LooseVersion
+from setuptools._distutils.version import LooseVersion
 from .constants import SSH_OPTION
 from . import log
 from .prun import prun

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 PyYAML
 python-dateutil
+setuptools

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import os
 import socket
 import re
-import imp
+import importlib
 import subprocess
 import unittest
 import pytest
@@ -24,7 +24,7 @@ def setup_function():
     utils._ip_for_cloud = None
     # Mock memoize method and reload the module under test later with imp
     mock.patch('crmsh.utils.memoize', lambda x: x).start()
-    imp.reload(utils)
+    importlib.reload(utils)
 
 
 @mock.patch("crmsh.utils.get_stdout_stderr")


### PR DESCRIPTION
See #1324 for description of the problem.

I don't know what solution you would prefer regarding the `LooseVersion` problem:
* there is this current implement that uses a kinda hidden code in `setuptools`
  *pros*: `setuptools`  is widely distributed everywhere, so that code is already broadly available
  *cons*: as it's a kinda of "hidden" part of the API, I don't know how this will be maintained in the future
* another solution is to use the specific [looseversion](https://github.com/effigies/looseversion) package
  *pros*: that package's only purpose is to provide the `LooseVersion` API, so it won't change even in the distant future
  *cons*: that package is recent and not broadly available yet. It's available in Fedora, but not in Debian, for example, making the packaging of new version of `crmsh` in distributions more difficult.
