### PR TITLE
[crmsh-4.5] Fix: report: Escape special characters in pattern (bsc#1220022)

### DIFF
--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -1594,8 +1594,10 @@ def sub_sensitive_string(data):
     """
     result = data
     if constants.SANITIZE_VALUE_RAW:
-        result = re.sub(r'\b({})\b'.format('|'.join(constants.SANITIZE_VALUE_RAW)), "******", data)
+        patt = '|'.join([re.escape(s) for s in constants.SANITIZE_VALUE_RAW])
+        result = re.sub(r'\b({})\b'.format(patt), "******", data)
     if constants.SANITIZE_VALUE_CIB:
-        result = re.sub('({})({})'.format('|'.join(constants.SANITIZE_KEY_CIB), '|'.join(constants.SANITIZE_VALUE_CIB)), '\\1******', result)
+        patt = '|'.join([re.escape(s) for s in constants.SANITIZE_VALUE_CIB])
+        result = re.sub('({})({})'.format('|'.join(constants.SANITIZE_KEY_CIB), patt), '\\1******', result)
     return result
 # vim:ts=4:sw=4:et:

--- a/test/features/crm_report_bugs.feature
+++ b/test/features/crm_report_bugs.feature
@@ -105,6 +105,15 @@ Feature: crm report functional test for verifying bugs
     Then    Expected return code is "1"
     When    Run "rm -rf report.tar.bz2 report" on "hanode1"
 
+    # bsc#1220022 with special characters
+    When    Run "crm node utilization hanode2 set password "xin!(liang8e"" on "hanode1"
+    When    Run "crm report report" on "hanode1"
+    When    Run "tar jxf report.tar.bz2" on "hanode1"
+    And     Try "grep -F -R 'xin!(liang8e' report"
+    # No password here
+    Then    Expected return code is "1"
+    When    Run "rm -rf report.tar.bz2 report" on "hanode1"
+
     # disable sanitize
     When    Run "sed -i 's/; \[report\]/[report]/' /etc/crm/crm.conf" on "hanode1"
     And     Run "sed -i 's/sanitize_rule = .*$/sanitize_rule = /g' /etc/crm/crm.conf" on "hanode1"


### PR DESCRIPTION
backport #1329 