### PR TITLE
[crmsh-4.6] Dev: spec: Add setuptools as BuildRequires

### DIFF
--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package crmsh
 #
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -54,6 +54,7 @@ Requires:       python3 >= 3.4
 Requires:       python3-PyYAML
 Requires:       python3-lxml
 BuildRequires:  python3-lxml
+BuildRequires:  python3-setuptools
 BuildRequires:  python3-pip
 BuildRequires:  python3-wheel
 


### PR DESCRIPTION
Since the build will fail without it on openSUSE Tumbleweed

See https://build.opensuse.org/package/live_build_log/openSUSE:Factory/crmsh/standard/x86_64