### PR TITLE
[crmsh-4.6] Fix: report: use ClusterShell for ssh (bsc#1220170)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -189,16 +189,6 @@ def collect_ratraces(context: core.Context) -> None:
     """
     Collect ra trace file from default /var/lib/heartbeat/trace_ra and custom one
     """
-    # since the "trace_dir" attribute been removed from cib after untrace
-    # need to parse crmsh log file to extract custom trace ra log directory on each node
-    if crmsh.user_of_host.instance().use_ssh_agent():
-        shell = sh.ClusterShell(
-            sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': os.environ.get('SSH_AUTH_SOCK', '')}),
-            crmsh.user_of_host.instance(),
-            forward_ssh_agent=True,
-        )
-    else:
-        shell = sh.cluster_shell()
     trace_dir_str = ' '.join(context.trace_dir_list)
     if not trace_dir_str:
         return

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -199,11 +199,7 @@ def collect_ratraces(context: core.Context) -> None:
         )
     else:
         shell = sh.cluster_shell()
-    log_contents = ""
-    cmd = f"grep 'INFO: Trace for .* is written to ' {log.CRMSH_LOG_FILE}*|grep -v 'collect'"
-    for node in context.node_list:
-        log_contents += shell.get_rc_stdout_stderr_without_input(node, cmd)[1] + "\n"
-    trace_dir_str = ' '.join(list(set(re.findall("written to (.*)/.*", log_contents))))
+    trace_dir_str = ' '.join(context.trace_dir_list)
     if not trace_dir_str:
         return
 

--- a/crmsh/report/sh.py
+++ b/crmsh/report/sh.py
@@ -1,0 +1,82 @@
+import subprocess
+import typing
+
+import crmsh.pyshim
+import crmsh.sh
+import crmsh.userdir
+
+import os
+
+
+class Shell:
+    @classmethod
+    def local_shell(cls):
+        if 'SSH_AUTH_SOCK' in os.environ:
+            return crmsh.sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': os.environ.get('SSH_AUTH_SOCK')})
+        else:
+            return crmsh.sh.LocalShell()
+
+    @classmethod
+    def find_shell(cls, cluster_shell: crmsh.sh.ClusterShell, host: str, user: typing.Optional[str]):
+        if cluster_shell.can_run_as(host, 'root'):
+            return ClusterShellAdaptor(cluster_shell, host)
+        local_shell = cls.local_shell()
+        if user:
+            ret = cls._try_create_report_shell(local_shell, host, user)
+            if ret:
+                return ret
+        sudoer = crmsh.userdir.get_sudoer()
+        if sudoer and sudoer != user:
+            ret = cls._try_create_report_shell(local_shell, host, sudoer)
+            if ret:
+                return ret
+        current_user = crmsh.userdir.getuser()
+        if current_user != sudoer and current_user != user:
+            ret = cls._try_create_report_shell(local_shell, host, current_user)
+            if ret:
+                return ret
+        return None
+
+    @staticmethod
+    def _try_create_report_shell(local_shell: crmsh.sh.LocalShell, host: str, user: str):
+        ssh_shell = crmsh.sh.SSHShell(local_shell, user)
+        # call can_run_as here to populate know_hosts
+        if not ssh_shell.can_run_as(host, user):
+            return None
+        # check for root privilege
+        ret = ssh_shell.subprocess_run_without_input(
+                host, user,
+                'true' if user == 'root' else 'sudo true',
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+        )
+        if ret.returncode == 0:
+            return Shell(local_shell, host, user)
+        else:
+            return None
+
+    def __init__(self, local_shell: crmsh.sh.LocalShell, host: str, user: str):
+        self.local_shell = local_shell
+        self._host = host
+        self._user = user
+
+    def subprocess_run_without_input(self, cmd: str, **kwargs):
+        if self._user == self.local_shell.get_effective_user_name():
+            args = ['/bin/sh']
+        else:
+            args = ['sudo', '-H', '-u', self._user, '/bin/sh']
+        return subprocess.run(
+            args,
+            input=cmd.encode('utf-8'),
+            **kwargs,
+        )
+
+
+class ClusterShellAdaptor:
+    def __init__(self, cluster_shell: crmsh.sh.ClusterShell, host):
+        self.cluster_shell = cluster_shell
+        self._host = host
+
+    def subprocess_run_without_input(self, cmd: str, **kwargs):
+        return self.cluster_shell.subprocess_run_without_input(self._host, None, cmd, **kwargs)

--- a/data-manifest
+++ b/data-manifest
@@ -205,6 +205,7 @@ test/unittests/test_qdevice.py
 test/unittests/test_ratrace.py
 test/unittests/test_report_collect.py
 test/unittests/test_report_core.py
+test/unittests/test_report_sh.py
 test/unittests/test_report_utils.py
 test/unittests/test_sbd.py
 test/unittests/test_scripts.py

--- a/test/unittests/test_report_core.py
+++ b/test/unittests/test_report_core.py
@@ -301,13 +301,14 @@ class TestRun(unittest.TestCase):
 
     @mock.patch('crmsh.report.core.process_results')
     @mock.patch('crmsh.report.core.collect_for_nodes')
+    @mock.patch('crmsh.report.core.load_context_trace_dir_list')
     @mock.patch('crmsh.report.core.find_ssh_user')
     @mock.patch('crmsh.report.core.setup_workdir')
     @mock.patch('crmsh.report.core.load_context_attributes')
     @mock.patch('crmsh.report.core.parse_arguments')
     @mock.patch('crmsh.report.core.is_collector')
     @mock.patch('crmsh.report.core.Context')
-    def test_run_impl(self, mock_context, mock_collector, mock_parse, mock_load, mock_setup, mock_find_ssh, mock_collect, mock_process_results):
+    def test_run_impl(self, mock_context, mock_collector, mock_parse, mock_load, mock_setup, mock_find_ssh, mock_load_context_trace_dir_list, mock_collect, mock_process_results):
         mock_context.return_value = mock.Mock()
         mock_ctx_inst = mock_context.return_value
         mock_collector.side_effect = [False, False]
@@ -320,6 +321,7 @@ class TestRun(unittest.TestCase):
         mock_load.assert_called_once_with(mock_ctx_inst)
         mock_setup.assert_called_once_with(mock_ctx_inst)
         mock_find_ssh.assert_called_once_with(mock_ctx_inst)
+        mock_load_context_trace_dir_list.assert_called_once_with(mock_ctx_inst)
         mock_collect.assert_called_once_with(mock_ctx_inst)
         mock_process_results.assert_called_once_with(mock_ctx_inst)
 

--- a/test/unittests/test_report_sh.py
+++ b/test/unittests/test_report_sh.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest import mock
+
+import crmsh.report.sh
+import crmsh.sh
+
+import subprocess
+
+
+class TestFindShell(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_cluster_shell = mock.Mock(crmsh.sh.ClusterShell)
+        self.patcher_local_shell = mock.patch('crmsh.report.sh.Shell.local_shell')
+        self.patcher_try_create_report_shell = mock.patch('crmsh.report.sh.Shell._try_create_report_shell')
+        self.mock_local_shell = self.patcher_local_shell.start()
+        self.mock_local_shell.return_value = mock.Mock(crmsh.sh.LocalShell)
+        self.mock_try_create_report_shell = self.patcher_try_create_report_shell.start()
+
+    def tearDown(self) -> None:
+        self.patcher_local_shell.stop()
+        self.patcher_try_create_report_shell.stop()
+
+    def test_cluster_shell_available(self):
+        self.mock_cluster_shell.can_run_as.return_value = True
+        self.assertIsInstance(
+                crmsh.report.sh.Shell.find_shell(self.mock_cluster_shell, 'node1', None),
+                crmsh.report.sh.ClusterShellAdaptor,
+        )
+        self.assertIsInstance(
+                crmsh.report.sh.Shell.find_shell(self.mock_cluster_shell, 'node1', 'alice'),
+                crmsh.report.sh.ClusterShellAdaptor,
+        )
+
+    def test_specified_user_work(self):
+        self.mock_cluster_shell.can_run_as.return_value = False
+        self.mock_try_create_report_shell.return_value = mock.Mock(crmsh.report.sh.Shell)
+        ret = crmsh.report.sh.Shell.find_shell(self.mock_cluster_shell, 'node1', 'alice')
+        self.mock_local_shell.assert_called_once()
+        self.mock_try_create_report_shell.assert_called_once_with(
+            self.mock_local_shell.return_value,
+            'node1', 'alice',
+        )
+        self.assertIs(ret, self.mock_try_create_report_shell.return_value)
+
+class TestTryCreateReportShell(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_local_shell = mock.Mock(crmsh.sh.LocalShell)
+        self.patcher_ssh_shell = mock.patch('crmsh.sh.SSHShell')
+        self.mock_ssh_shell = self.patcher_ssh_shell.start().return_value
+
+    def tearDown(self) -> None:
+        self.patcher_ssh_shell.stop()
+
+    def test_success(self):
+        self.mock_ssh_shell.can_run_as.return_value = True
+        self.mock_ssh_shell.subprocess_run_without_input.return_value = mock.Mock(returncode=0)
+        ret = crmsh.report.sh.Shell._try_create_report_shell(self.mock_local_shell, 'node1', 'alice')
+        self.mock_ssh_shell.can_run_as.assert_called_once_with('node1', 'alice')
+        self.mock_ssh_shell.subprocess_run_without_input.assert_called_once_with(
+            'node1', 'alice',
+            'sudo true',
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertIsInstance(ret, crmsh.report.sh.Shell)
+
+    def test_failure_no_sudoer(self):
+        self.mock_ssh_shell.can_run_as.return_value = True
+        self.mock_ssh_shell.subprocess_run_without_input.return_value = mock.Mock(returncode=1)
+        ret = crmsh.report.sh.Shell._try_create_report_shell(self.mock_local_shell, 'node1', 'alice')
+        self.mock_ssh_shell.can_run_as.assert_called_once_with('node1', 'alice')
+        self.mock_ssh_shell.subprocess_run_without_input.assert_called_once_with(
+            'node1', 'alice',
+            'sudo true',
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertIsNone(ret)
+
+    def test_failure_no_ssh(self):
+        self.mock_ssh_shell.can_run_as.return_value = False
+        ret = crmsh.report.sh.Shell._try_create_report_shell(self.mock_local_shell, 'node1', 'alice')
+        self.mock_ssh_shell.can_run_as.assert_called_once_with('node1', 'alice')
+        self.mock_ssh_shell.subprocess_run_without_input.assert_not_called()
+        self.assertIsNone(ret)


### PR DESCRIPTION
The current ssh implementation in crm.report will use a wrong user when using root + ssh-agent + sudo.

This patch change to use try to ClusterShell first, providing consistent behavior with other parts of crmsh. And fallback to interactive authentication when ClusterShell does not work.