### PR TITLE
Dev: unittest: disable python 3.10 in test matrix

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
       fail-fast: false
     timeout-minutes: 5
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py310, py311, py312
+envlist = py311, py312
 skip_missing_interpreters = true
 
 [base]
@@ -11,11 +11,6 @@ deps =
 commands = py.test -vv --cov=crmsh --cov-config .coveragerc --cov-report term --cov-report html {posargs}
 
 [testenv]
-changedir = {[base]changedir}
-deps = {[base]deps}
-commands = {[base]commands}
-
-[testenv:3.10]
 changedir = {[base]changedir}
 deps = {[base]deps}
 commands = {[base]commands}


### PR DESCRIPTION
As ALP is now targeting 3.11.