### PR TITLE
Dev: workflows: Remove the redundant stage condition

### DIFF
--- a/.github/workflows/crmsh-cd.yml
+++ b/.github/workflows/crmsh-cd.yml
@@ -20,7 +20,6 @@ jobs:
     uses: ./.github/workflows/crmsh-ci.yml
 
   delivery:
-    if: github.repository == 'ClusterLabs/crmsh' && github.ref_name == 'master'
     needs: integration
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -38,7 +37,6 @@ jobs:
           /bin/bash -c "cp -r /package ~/package && cd ~/package && /scripts/upload.sh"
 
   submit:
-    if: github.repository == 'ClusterLabs/crmsh' && github.ref_name == 'master'
     needs: delivery
     runs-on: ubuntu-20.04
     timeout-minutes: 10


### PR DESCRIPTION
Since the condition to check the branch is already in the 'integration' stage (https://github.com/ClusterLabs/crmsh/blob/4a0937c33154b631a341d16c69880d1ceedd8731/.github/workflows/crmsh-cd.yml#L19), we don't need to check it again in the subsequent stages.