### PR TITLE
[crmsh-4.6] Fix: report: Show different perspectives of cluster status with multiple 'crm_mon' options (bsc#1204273)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -329,8 +329,26 @@ def dump_runtime_state(workdir: str) -> None:
     Dump runtime state files
     """
     cluster_shell_inst = sh.cluster_shell()
+
+    # Dump the output of 'crm_mon' command with multiple options
+    out = ""
+    for option, desc in [
+        ("-r1", "inactive resources"),
+        ("-n1", "resources grouped by node"),
+        ("-rf1", "resource fail counts"),
+        ("-rnt1", "resource operation history with timing details"),
+    ]:
+        cmd = f"crm_mon {option}"
+        out += f"\n#### Display cluster state and {desc}: {cmd} ####\n"
+        out += cluster_shell_inst.get_stdout_or_raise_error(cmd)
+        out += "\n\n"
+
+    target_f = os.path.join(workdir, constants.CRM_MON_F)
+    crmutils.str2file(out, target_f)
+    logger.debug(f"Dump crm_mon state into {utils.real_path(target_f)}")
+
+    # Dump other runtime state files
     for cmd, f, desc in [
-        ("crm_mon -1", constants.CRM_MON_F, "cluster state"),
         ("cibadmin -Ql", constants.CIB_F, "CIB contents"),
         ("crm_node -p", constants.MEMBERSHIP_F, "members of this partition")
     ]:

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -548,12 +548,19 @@ id            0x19041a12
         ]
         mock_run_inst = mock.Mock()
         mock_run.return_value = mock_run_inst
-        mock_run_inst.get_stdout_or_raise_error.side_effect = ["crm_mon_data", "cib_data", "crm_node_data"]
+        mock_run_inst.get_stdout_or_raise_error.side_effect = [
+                "crm_mon_data_r1",
+                "crm_mon_data_n1",
+                "crm_mon_data_rf1",
+                "crm_mon_data_rnt1",
+                "cib_data",
+                "crm_node_data"
+                ]
         mock_get_dc.return_value = "node1"
         mock_this_node.return_value = "node1"
         collect.dump_runtime_state("/opt/workdir")
         mock_debug.assert_has_calls([
-            mock.call(f"Dump cluster state into {constants.CRM_MON_F}"),
+            mock.call(f"Dump crm_mon state into {constants.CRM_MON_F}"),
             mock.call(f"Dump CIB contents into {constants.CIB_F}"),
             mock.call(f"Dump members of this partition into {constants.MEMBERSHIP_F}"),
             mock.call(f"Current DC is node1; Touch file 'DC' in workdir")


### PR DESCRIPTION
backport #1346 