### PR TITLE
[crmsh-4.6] Fix: utils: A workaround for the truncating issue (bsc#1205925)

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -499,6 +499,7 @@ SCHEMA_MIN_VER_SUPPORT_OCF_1_1 = "pacemaker-3.7"
 REJOIN_COUNT = 60
 REJOIN_INTERVAL = 10
 DC_DEADTIME_DEFAULT = 20
+TERMINAL_MAX_WIDTH = '500'
 
 ADVISED_ACTION_LIST = ['monitor', 'start', 'stop', 'promote', 'demote']
 ADVISED_KEY_LIST = ['timeout', 'interval', 'role']

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -779,7 +779,9 @@ def ext_cmd(cmd, shell=True):
     if options.regression_tests:
         print(".EXT", cmd)
     logger.debug("invoke: %s", cmd)
-    return subprocess.call(cmd, shell=shell)
+    env = os.environ.copy()
+    env["COLORTERM"] = constants.TERMINAL_MAX_WIDTH
+    return subprocess.call(cmd, shell=shell, env=env)
 
 
 def ext_cmd_nosudo(cmd, shell=True):


### PR DESCRIPTION
When python program calling cibsecret with a small terminal width, the command `ps -ef | grep '[p]acemaker-controld'` will return 1

>>> cmd = "ps -ef | grep '[p]acemaker-controld' >/dev/null"
>>> # When terminal width is small
>>> subprocess.call(cmd, shell=True)
1
>>> # When terminal is big enough
>>> subprocess.call(cmd, shell=True)
0

Set a large terminal width could be a workaround

See also: https://github.com/ClusterLabs/pacemaker/pull/3384