### PR TITLE
[crmsh-4.6] Fix: sh: pass env to child process explicitly (bsc#1205925)

### DIFF
--- a/crmsh/report/sh.py
+++ b/crmsh/report/sh.py
@@ -69,6 +69,7 @@ class Shell:
         return subprocess.run(
             args,
             input=cmd.encode('utf-8'),
+            env=os.environ,  # bsc#1205925
             **kwargs,
         )
 

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -1068,7 +1068,9 @@ def _check_control_persist():
         print((".EXT", cmd))
     cmd = subprocess.Popen(cmd,
                            stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
+                           stderr=subprocess.PIPE,
+                           env=os.environ,  # bsc#1205925
+                           )
     (out, err) = cmd.communicate()
     return "Bad configuration option" not in err
 
@@ -1138,7 +1140,11 @@ def _cleanup_local(workdir):
     if workdir and os.path.isdir(workdir):
         cleanscript = os.path.join(workdir, 'crm_clean.py')
         if os.path.isfile(cleanscript):
-            if subprocess.call([cleanscript, workdir], shell=False) != 0:
+            if subprocess.call(
+                    [cleanscript, workdir],
+                    shell=False,
+                    env=os.environ,  # bsc#1205925
+            ) != 0:
                 shutil.rmtree(workdir)
         else:
             shutil.rmtree(workdir)

--- a/crmsh/term.py
+++ b/crmsh/term.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import os
 import sys
 import re
 # from: http://code.activestate.com/recipes/475116/
@@ -151,6 +151,7 @@ def init():
     from . import config
     if not _term_stream.isatty() and 'color-always' not in config.color.style:
         return
+    _ignore_environ()
     # Check the terminal type.  If we fail, then assume that the
     # terminal has no capabilities.
     try:
@@ -176,5 +177,13 @@ def render(template):
 def is_color(s):
     return hasattr(colors, s.upper())
 
+
+def _ignore_environ():
+    """Ignore environment variable COLUMNS and ROWS"""
+    # See https://bugzilla.suse.com/show_bug.cgi?id=1205925
+    # and https://gitlab.com/procps-ng/procps/-/blob/c415fc86452c933716053a50ab1777a343190dcc/src/ps/global.c#L279
+    for name in ["COLUMNS", "ROWS"]:
+        if name in os.environ:
+            del os.environ[name]
 
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import os
 import re
 import copy
 import subprocess
@@ -550,10 +550,13 @@ class NodeMgmt(command.UI):
         'usage: delete <node>'
         logger.warning('`crm node delete` is deprecated and will very likely be dropped in the near future. It is auto-replaced as `crm cluster remove -c {}`.'.format(node))
         if config.core.force:
-            rc = subprocess.call(['crm', 'cluster', 'remove', '-F', '-c', node])
+            args = ['crm', 'cluster', 'remove', '-F', '-c', node]
         else:
-            rc = subprocess.call(['crm', 'cluster', 'remove', '-c', node])
-        return rc == 0
+            args = ['crm', 'cluster', 'remove', '-c', node]
+        return 0 == subprocess.call(
+            args,
+            env=os.environ,  # bsc#1205925
+        )
 
     @command.wait
     @command.completers(compl.nodes, compl.choice(['set', 'delete', 'show']), _find_attr)

--- a/crmsh/user_of_host.py
+++ b/crmsh/user_of_host.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import socket
 import subprocess
 import typing
@@ -107,6 +108,7 @@ class UserOfHost:
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=os.environ,  # bsc#1205925
         )
         if rc == 0:
             user = userdir.getuser()

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -523,7 +523,12 @@ def pipe_string(cmd, s):
     logger.debug("piping string to %s", cmd)
     if options.regression_tests:
         print(".EXT", cmd)
-    p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE)
+    p = subprocess.Popen(
+        cmd,
+        shell=True,
+        stdin=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
+    )
     try:
         # communicate() expects encoded bytes
         if isinstance(s, str):
@@ -552,7 +557,9 @@ def filter_string(cmd, s, stderr_on=True, shell=True):
                          shell=shell,
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
-                         stderr=stderr)
+                         stderr=stderr,
+                         env=os.environ,  # bsc#1205925
+                         )
     try:
         # bytes expected here
         if isinstance(s, str):
@@ -770,7 +777,9 @@ def show_dot_graph(dotfile, keep_file=False, desc="transition graph"):
     if options.regression_tests:
         print(".EXT", cmd)
     subprocess.Popen(cmd, shell=True, bufsize=0,
-                     stdin=None, stdout=None, stderr=None, close_fds=True)
+                     stdin=None, stdout=None, stderr=None, close_fds=True,
+                     env=os.environ,  # bsc#1205925
+                     )
     logger.info("starting %s to show %s", config.core.dotty, desc)
 
 
@@ -779,13 +788,21 @@ def ext_cmd(cmd, shell=True):
     if options.regression_tests:
         print(".EXT", cmd)
     logger.debug("invoke: %s", cmd)
-    return subprocess.call(cmd, shell=shell)
+    return subprocess.call(
+        cmd,
+        shell=shell,
+        env=os.environ,  # bsc#1205925
+    )
 
 
 def ext_cmd_nosudo(cmd, shell=True):
     if options.regression_tests:
         print(".EXT", cmd)
-    return subprocess.call(cmd, shell=shell)
+    return subprocess.call(
+        cmd,
+        shell=shell,
+        env=os.environ,  # bsc#1205925
+    )
 
 
 def rmdir_r(d):
@@ -918,7 +935,9 @@ def pipe_cmd_nosudo(cmd):
     proc = subprocess.Popen(cmd,
                             shell=True,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+                            stderr=subprocess.PIPE,
+                            env=os.environ,  # bsc#1205925
+                            )
     (outp, err_outp) = proc.communicate()
     proc.wait()
     rc = proc.returncode

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -150,13 +150,14 @@ _cib_in_use = ''
 
 
 def set_cib_in_use(name):
-    os.putenv(_cib_shadow, name)
+    os.environ[_cib_shadow] = name
     global _cib_in_use
     _cib_in_use = name
 
 
 def clear_cib_in_use():
-    os.unsetenv(_cib_shadow)
+    if _cib_shadow in os.environ:
+        del os.environ[_cib_shadow]
     global _cib_in_use
     _cib_in_use = ''
 

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -91,7 +91,11 @@ def sudocall(cmd):
     cmd = add_sudo(cmd)
     if options.regression_tests:
         print(".EXT", cmd)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        cmd, shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
+    )
     try:
         outp, errp = p.communicate()
         p.wait()

--- a/test/unittests/test_sh.py
+++ b/test/unittests/test_sh.py
@@ -13,8 +13,9 @@ class TestLocalShell(unittest.TestCase):
         self.local_shell.geteuid = mock.Mock(self.local_shell.geteuid)
         self.local_shell.hostname = mock.Mock(self.local_shell.hostname)
 
+    @mock.patch('os.environ')
     @mock.patch('subprocess.run')
-    def test_su_subprocess_run(self, mock_run: mock.MagicMock):
+    def test_su_subprocess_run(self, mock_run: mock.MagicMock, mock_environ: mock.MagicMock):
         self.local_shell.get_effective_user_name.return_value = 'root'
         self.local_shell.geteuid.return_value = 0
         self.local_shell.su_subprocess_run(
@@ -24,10 +25,12 @@ class TestLocalShell(unittest.TestCase):
         mock_run.assert_called_once_with(
             ['su', 'alice', '--login', '-s', '/bin/sh', '-c', 'foo'],
             input=b'bar',
+            env=mock_environ,
         )
 
+    @mock.patch('os.environ')
     @mock.patch('subprocess.run')
-    def test_su_subprocess_run_as_root(self, mock_run: mock.MagicMock):
+    def test_su_subprocess_run_as_root(self, mock_run: mock.MagicMock, mock_environ: mock.MagicMock):
         self.local_shell.get_effective_user_name.return_value = 'root'
         self.local_shell.geteuid.return_value = 0
         self.local_shell.su_subprocess_run(
@@ -37,6 +40,7 @@ class TestLocalShell(unittest.TestCase):
         mock_run.assert_called_once_with(
             ['/bin/sh', '-c', 'foo'],
             input=b'bar',
+            env=mock_environ,
         )
 
     @mock.patch('subprocess.run')
@@ -124,8 +128,9 @@ class TestSSHShell(unittest.TestCase):
             )
         self.ssh_shell.local_shell.su_subprocess_run.assert_not_called()
 
+    @mock.patch('os.environ')
     @mock.patch('subprocess.run')
-    def test_subprocess_run_without_input_local(self, mock_run):
+    def test_subprocess_run_without_input_local(self, mock_run, mock_environ: mock.MagicMock):
         self.ssh_shell.subprocess_run_without_input(
             'node1', 'bob',
             'foo',
@@ -138,6 +143,7 @@ class TestSSHShell(unittest.TestCase):
             input=b'foo',
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=mock_environ,
         )
 
 


### PR DESCRIPTION
A bug in python stardard library, python/cpython#100516, make
environment variables, `COLUMNS` and `ROWS` to be added at fork. These
environment variables may make some of the commands called by crmsh to
truncate its output even if those commands are not writing to the
terminal.

Passing argument `env` explicitly is a workaround for the python bug.
