### PR TITLE
[crmsh-4.5] Fix: sh: pass env to child process explicitly (bsc#1205925)

### DIFF
--- a/crmsh/report/utillib.py
+++ b/crmsh/report/utillib.py
@@ -778,7 +778,11 @@ def get_command_info_timeout(cmd, timeout=5):
     # Python 101: How to timeout a subprocess
     def kill(process):
         process.kill()
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
+    )
     my_timer = Timer(timeout, kill, [proc])
     try:
         my_timer.start()

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -1067,7 +1067,9 @@ def _check_control_persist():
         print((".EXT", cmd))
     cmd = subprocess.Popen(cmd,
                            stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
+                           stderr=subprocess.PIPE,
+                           env=os.environ,  # bsc#1205925
+                           )
     (out, err) = cmd.communicate()
     return "Bad configuration option" not in err
 
@@ -1137,7 +1139,11 @@ def _cleanup_local(workdir):
     if workdir and os.path.isdir(workdir):
         cleanscript = os.path.join(workdir, 'crm_clean.py')
         if os.path.isfile(cleanscript):
-            if subprocess.call([cleanscript, workdir], shell=False) != 0:
+            if subprocess.call(
+                    [cleanscript, workdir],
+                    shell=False,
+                    env=os.environ,  # bsc#1205925
+            ) != 0:
                 shutil.rmtree(workdir)
         else:
             shutil.rmtree(workdir)

--- a/crmsh/term.py
+++ b/crmsh/term.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import os
 import sys
 import re
 # from: http://code.activestate.com/recipes/475116/
@@ -151,6 +151,7 @@ def init():
     from . import config
     if not _term_stream.isatty() and 'color-always' not in config.color.style:
         return
+    _ignore_environ()
     # Check the terminal type.  If we fail, then assume that the
     # terminal has no capabilities.
     try:
@@ -176,5 +177,13 @@ def render(template):
 def is_color(s):
     return hasattr(colors, s.upper())
 
+
+def _ignore_environ():
+    """Ignore environment variable COLUMNS and ROWS"""
+    # See https://bugzilla.suse.com/show_bug.cgi?id=1205925
+    # and https://gitlab.com/procps-ng/procps/-/blob/c415fc86452c933716053a50ab1777a343190dcc/src/ps/global.c#L279
+    for name in ["COLUMNS", "ROWS"]:
+        if name in os.environ:
+            del os.environ[name]
 
 # vim:ts=4:sw=4:et:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import os
 import re
 import copy
 import subprocess
@@ -550,10 +550,13 @@ class NodeMgmt(command.UI):
         'usage: delete <node>'
         logger.warning('`crm node delete` is deprecated and will very likely be dropped in the near future. It is auto-replaced as `crm cluster remove -c {}`.'.format(node))
         if config.core.force:
-            rc = subprocess.call(['crm', 'cluster', 'remove', '-F', '-c', node])
+            args = ['crm', 'cluster', 'remove', '-F', '-c', node]
         else:
-            rc = subprocess.call(['crm', 'cluster', 'remove', '-c', node])
-        return rc == 0
+            args = ['crm', 'cluster', 'remove', '-c', node]
+        return 0 == subprocess.call(
+            args,
+            env=os.environ,  # bsc#1205925
+        )
 
     @command.wait
     @command.completers(compl.nodes, compl.choice(['set', 'delete', 'show']), _find_attr)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1079,7 +1079,9 @@ def get_stdout(cmd, input_s=None, stderr_on=True, shell=True, raw=False):
                             shell=shell,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
-                            stderr=stderr)
+                            stderr=stderr,
+                            env=os.environ,  # bsc#1205925
+                            )
     stdout_data, stderr_data = proc.communicate(input_s)
     if raw:
         return proc.returncode, stdout_data
@@ -1096,7 +1098,9 @@ def get_stdout_stderr(cmd, input_s=None, shell=True, raw=False, no_reg=False):
                             shell=shell,
                             stdin=input_s and subprocess.PIPE or None,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+                            stderr=subprocess.PIPE,
+                            env=os.environ,  # bsc#1205925
+                            )
     stdout_data, stderr_data = proc.communicate(input_s)
     if raw:
         return proc.returncode, stdout_data, stderr_data
@@ -1115,6 +1119,7 @@ def su_get_stdout_stderr(user, cmd, input_s=None, raw=False):
         input=input_s.encode('utf-8') if (input_s is not None and not raw) else input_s,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
     )
     if raw:
         return result.returncode, result.stdout, result.stderr
@@ -2932,6 +2937,7 @@ def get_stdout_or_raise_error(cmd, remote=None, success_val_list=[0], no_raise=F
             input=cmd.encode('utf-8'),
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL if no_raise else subprocess.PIPE,
+            env=os.environ,  # bsc#1205925
         )
     else:
         result = subprocess_run_auto_ssh_no_input(
@@ -2958,6 +2964,7 @@ def subprocess_run_auto_ssh_no_input(cmd, remote=None, user=None, **kwargs):
         return subprocess.run(
             args,
             input=cmd.encode('utf-8'),
+            env=os.environ,  # bsc#1205925
             **kwargs,
         )
     else:
@@ -2983,7 +2990,8 @@ def su_get_stdout_or_raise_error(cmd, user, success_values={0}, no_raise=False):
     result = subprocess.run(
         args,
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL if no_raise else subprocess.PIPE
+        stderr=subprocess.DEVNULL if no_raise else subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
     )
     if no_raise or result.returncode in success_values:
         return result.stdout
@@ -3001,7 +3009,11 @@ def su_subprocess_run(user: str, cmd: str, tty=False, **kwargs):
             args = ['su', user, '--login', '-c', cmd]
     else:
         raise AssertionError('trying to run su as a non-root user')
-    return subprocess.run(args, **kwargs)
+    return subprocess.run(
+        args,
+        env=os.environ,  # bsc#1205925
+        **kwargs,
+    )
 
 
 def get_quorum_votes_dict(remote=None):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -242,13 +242,14 @@ _cib_in_use = ''
 
 
 def set_cib_in_use(name):
-    os.putenv(_cib_shadow, name)
+    os.environ[_cib_shadow] = name
     global _cib_in_use
     _cib_in_use = name
 
 
 def clear_cib_in_use():
-    os.unsetenv(_cib_shadow)
+    if _cib_shadow in os.environ:
+        del os.environ[_cib_shadow]
     global _cib_in_use
     _cib_in_use = ''
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -615,7 +615,12 @@ def pipe_string(cmd, s):
     logger.debug("piping string to %s", cmd)
     if options.regression_tests:
         print(".EXT", cmd)
-    p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE)
+    p = subprocess.Popen(
+        cmd,
+        shell=True,
+        stdin=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
+    )
     try:
         # communicate() expects encoded bytes
         if isinstance(s, str):
@@ -644,7 +649,9 @@ def filter_string(cmd, s, stderr_on=True, shell=True):
                          shell=shell,
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
-                         stderr=stderr)
+                         stderr=stderr,
+                         env=os.environ,  # bsc#1205925
+                         )
     try:
         # bytes expected here
         if isinstance(s, str):
@@ -872,7 +879,9 @@ def show_dot_graph(dotfile, keep_file=False, desc="transition graph"):
     if options.regression_tests:
         print(".EXT", cmd)
     subprocess.Popen(cmd, shell=True, bufsize=0,
-                     stdin=None, stdout=None, stderr=None, close_fds=True)
+                     stdin=None, stdout=None, stderr=None, close_fds=True,
+                     env=os.environ,  # bsc#1205925
+                     )
     logger.info("starting %s to show %s", config.core.dotty, desc)
 
 
@@ -881,13 +890,21 @@ def ext_cmd(cmd, shell=True):
     if options.regression_tests:
         print(".EXT", cmd)
     logger.debug("invoke: %s", cmd)
-    return subprocess.call(cmd, shell=shell)
+    return subprocess.call(
+        cmd,
+        shell=shell,
+        env=os.environ,  # bsc#1205925
+    )
 
 
 def ext_cmd_nosudo(cmd, shell=True):
     if options.regression_tests:
         print(".EXT", cmd)
-    return subprocess.call(cmd, shell=shell)
+    return subprocess.call(
+        cmd,
+        shell=shell,
+        env=os.environ,  # bsc#1205925
+    )
 
 
 def rmdir_r(d):
@@ -1020,7 +1037,9 @@ def pipe_cmd_nosudo(cmd):
     proc = subprocess.Popen(cmd,
                             shell=True,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+                            stderr=subprocess.PIPE,
+                            env=os.environ,  # bsc#1205925
+                            )
     (outp, err_outp) = proc.communicate()
     proc.wait()
     rc = proc.returncode

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -90,7 +90,11 @@ def sudocall(cmd):
     cmd = add_sudo(cmd)
     if options.regression_tests:
         print(".EXT", cmd)
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        cmd, shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=os.environ,  # bsc#1205925
+    )
     try:
         outp, errp = p.communicate()
         p.wait()


### PR DESCRIPTION
backport

* #1356