### PR TITLE
Dev: qdevice: Add all nodes' keys to qnetd authorized_keys

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -74,7 +74,7 @@ FILES_TO_SYNC = (BOOTH_DIR, corosync.conf(), COROSYNC_AUTH, CSYNC2_CFG, CSYNC2_K
         "/etc/drbd.conf", "/etc/drbd.d", "/etc/ha.d/ldirectord.cf", "/etc/lvm/lvm.conf", "/etc/multipath.conf",
         "/etc/samba/smb.conf", SYSCONFIG_NFS, SYSCONFIG_PCMK, SYSCONFIG_SBD, PCMK_REMOTE_AUTH, WATCHDOG_CFG,
         PROFILES_FILE, CRM_CFG, SBD_SYSTEMD_DELAY_START_DIR)
-INIT_STAGES = ("ssh", "csync2", "csync2_remote", "corosync", "remote_auth", "sbd", "cluster", "ocfs2", "admin", "qdevice")
+INIT_STAGES = ("ssh", "csync2", "csync2_remote", "qnetd_remote", "corosync", "remote_auth", "sbd", "cluster", "ocfs2", "admin", "qdevice")
 
 
 class Context(object):
@@ -1183,6 +1183,18 @@ def init_csync2_remote():
         _context.quiet = was_quiet
 
 
+def init_qnetd_remote():
+    """
+    Triggered by join_cluster, this function adds the joining node's key to the qnetd's authorized_keys
+    """
+    local_user, remote_user, join_node = _select_user_pair_for_ssh_for_secondary_components(_context.cluster_node)
+    join_node_key_content = remote_public_key_from(remote_user, local_user, join_node, remote_user)
+    qnetd_host = corosync.get_value("quorum.device.net.host")
+    _, qnetd_user, qnetd_host = _select_user_pair_for_ssh_for_secondary_components(qnetd_host)
+    authorized_key_manager = ssh_key.AuthorizedKeyManager(sh.cluster_shell())
+    authorized_key_manager.add(qnetd_host, qnetd_user, ssh_key.InMemoryPublicKey(join_node_key_content))
+
+
 def init_corosync_auth():
     """
     Generate the corosync authkey
@@ -1527,6 +1539,14 @@ def init_qdevice():
                             args[i + 1] = f'{sudoer}@{qnetd_addr}'
                             msg += '\nOr, run "{}".'.format(' '.join(args))
             raise ValueError(msg)
+        else:
+            for node in cluster_node_list:
+                if node == utils.this_node():
+                    continue
+                local_user, remote_user, node = _select_user_pair_for_ssh_for_secondary_components(node)
+                remote_key_content = remote_public_key_from(remote_user, local_user, node, remote_user)
+                ssh_key.AuthorizedKeyManager(sh.cluster_shell()).add(qnetd_addr, ssh_user, ssh_key.InMemoryPublicKey(remote_key_content))
+
     user_by_host = utils.HostUserConfig()
     user_by_host.add(local_user, utils.this_node())
     user_by_host.add(ssh_user, qnetd_addr)
@@ -1880,6 +1900,13 @@ def join_cluster(seed_host, remote_user):
     if is_qdevice_configured and not ServiceManager().service_is_available("corosync-qdevice.service"):
         utils.fatal("corosync-qdevice.service is not available")
 
+    shell = sh.cluster_shell()
+
+    if is_qdevice_configured and not _context.use_ssh_agent:
+        # trigger init_qnetd_remote on init node
+        cmd = f"crm cluster init qnetd_remote {utils.this_node()} -y"
+        shell.get_stdout_or_raise_error(cmd, seed_host)
+
     shutil.copy(corosync.conf(), COROSYNC_CONF_ORIG)
 
     # check if use IPv6
@@ -1917,7 +1944,7 @@ def join_cluster(seed_host, remote_user):
     except corosync.IPAlreadyConfiguredError as e:
         logger.warning(e)
     sync_file(corosync.conf())
-    sh.cluster_shell().get_stdout_or_raise_error('sudo corosync-cfgtool -R', seed_host)
+    shell.get_stdout_or_raise_error('sudo corosync-cfgtool -R', seed_host)
 
     _context.sbd_manager.join_sbd(remote_user, seed_host)
 
@@ -2087,7 +2114,7 @@ def bootstrap_init(context):
     elif stage == "":
         if _context.cluster_is_running:
             utils.fatal("Cluster is currently active - can't run")
-    elif stage not in ("ssh", "csync2", "csync2_remote", "sbd", "ocfs2"):
+    elif stage not in ("ssh", "csync2", "csync2_remote", "qnetd_remote", "sbd", "ocfs2"):
         if _context.cluster_is_running:
             utils.fatal("Cluster is currently active - can't run %s stage" % (stage))
 
@@ -2095,15 +2122,15 @@ def bootstrap_init(context):
     _context.init_sbd_manager()
 
     # Need hostname resolution to work, want NTP (but don't block csync2_remote)
-    if stage not in ('csync2_remote',):
+    if stage not in ('csync2_remote', 'qnetd_remote'):
         check_tty()
         if not check_prereqs(stage):
             return
-    elif stage == 'csync2_remote':
+    else:
         args = _context.args
         logger_utils.log_only_to_file("args: {}".format(args))
         if len(args) != 2:
-            utils.fatal("Expected NODE argument to csync2_remote")
+            utils.fatal(f"Expected NODE argument to {stage} stage")
         _context.cluster_node = args[1]
 
     if stage and _context.cluster_is_running and \

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1500,23 +1500,8 @@ def configure_qdevice_interactive():
             is_stage=_context.stage == "qdevice")
 
 
-def init_qdevice():
-    """
-    Setup qdevice and qnetd service
-    """
-    if not _context.qdevice_inst:
-        configure_qdevice_interactive()
-    # If don't want to config qdevice, return
-    if not _context.qdevice_inst:
-        ServiceManager().disable_service("corosync-qdevice.service")
-        return
-    logger.info("""Configure Qdevice/Qnetd:""")
-    cluster_node_list = utils.list_cluster_nodes()
-    for node in cluster_node_list:
-        if not ServiceManager().service_is_available("corosync-qdevice.service", node):
-            utils.fatal("corosync-qdevice.service is not available on {}".format(node))
-    qdevice_inst = _context.qdevice_inst
-    local_user, ssh_user, qnetd_addr = _select_user_pair_for_ssh_for_secondary_components(_context.qnetd_addr_input)
+def _setup_passwordless_ssh_for_qnetd(cluster_node_list: typing.List[str]):
+    local_user, qnetd_user, qnetd_addr = _select_user_pair_for_ssh_for_secondary_components(_context.qnetd_addr_input)
     # Configure ssh passwordless to qnetd if detect password is needed
     if UserOfHost.instance().use_ssh_agent():
         logger.info("Adding public keys to authorized_keys for user root...")
@@ -1524,13 +1509,12 @@ def init_qdevice():
             ssh_key.AuthorizedKeyManager(sh.SSHShell(
                 sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': os.environ.get('SSH_AUTH_SOCK')}),
                 'root',
-            )).add(qnetd_addr, ssh_user, key)
-    elif utils.check_ssh_passwd_need(local_user, ssh_user, qnetd_addr):
-        configure_ssh_key(local_user)
-        if 0 != utils.ssh_copy_id_no_raise(local_user, ssh_user, qnetd_addr):
-            msg = f"Failed to login to {ssh_user}@{qnetd_addr}. Please check the credentials."
+            )).add(qnetd_addr, qnetd_user, key)
+    elif utils.check_ssh_passwd_need(local_user, qnetd_user, qnetd_addr):
+        if 0 != utils.ssh_copy_id_no_raise(local_user, qnetd_user, qnetd_addr):
+            msg = f"Failed to login to {qnetd_user}@{qnetd_addr}. Please check the credentials."
             sudoer = userdir.get_sudoer()
-            if sudoer and ssh_user != sudoer:
+            if sudoer and qnetd_user != sudoer:
                 args = ['sudo crm']
                 args += [x for x in sys.argv[1:]]
                 for i, arg in enumerate(args):
@@ -1540,27 +1524,47 @@ def init_qdevice():
                             msg += '\nOr, run "{}".'.format(' '.join(args))
             raise ValueError(msg)
         else:
+            cluster_shell = sh.cluster_shell()
+            # Add other nodes' public keys to qnetd's authorized_keys
             for node in cluster_node_list:
                 if node == utils.this_node():
                     continue
                 local_user, remote_user, node = _select_user_pair_for_ssh_for_secondary_components(node)
                 remote_key_content = remote_public_key_from(remote_user, local_user, node, remote_user)
-                ssh_key.AuthorizedKeyManager(sh.cluster_shell()).add(qnetd_addr, ssh_user, ssh_key.InMemoryPublicKey(remote_key_content))
+                in_memory_key = ssh_key.InMemoryPublicKey(remote_key_content)
+                ssh_key.AuthorizedKeyManager(cluster_shell).add(qnetd_addr, qnetd_user, in_memory_key)
 
     user_by_host = utils.HostUserConfig()
     user_by_host.add(local_user, utils.this_node())
-    user_by_host.add(ssh_user, qnetd_addr)
+    user_by_host.add(qnetd_user, qnetd_addr)
     user_by_host.save_remote(cluster_node_list)
-    # Start qdevice service if qdevice already configured
+
+
+def init_qdevice():
+    """
+    Setup qdevice and qnetd service
+    """
+    if not _context.qdevice_inst:
+        configure_qdevice_interactive()
+    if not _context.qdevice_inst:
+        ServiceManager().disable_service("corosync-qdevice.service")
+        return
+
+    logger.info("""Configure Qdevice/Qnetd:""")
+    cluster_node_list = utils.list_cluster_nodes()
+    for node in cluster_node_list:
+        if not ServiceManager().service_is_available("corosync-qdevice.service", node):
+            utils.fatal("corosync-qdevice.service is not available on {}".format(node))
+
+    _setup_passwordless_ssh_for_qnetd(cluster_node_list)
+
+    qdevice_inst = _context.qdevice_inst
     if corosync.is_qdevice_configured() and not confirm("Qdevice is already configured - overwrite?"):
         qdevice_inst.start_qdevice_service()
         return
     qdevice_inst.set_cluster_name()
-    # Validate qnetd node
     qdevice_inst.valid_qnetd()
-
     qdevice_inst.config_and_start_qdevice()
-
     if _context.stage == "qdevice":
         adjust_properties()
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -808,7 +808,7 @@ def _keys_from_ssh_agent() -> typing.List[ssh_key.Key]:
     try:
         keys = ssh_key.AgentClient().list()
         logger.info("Using public keys from ssh-agent...")
-    except Error:
+    except ssh_key.Error:
         logger.error("Cannot get a public key from ssh-agent.")
         raise
     return keys

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -146,12 +146,6 @@ def query_qnetd_status():
     if not qnetd_addr:
         raise ValueError("host for qnetd not configured!")
 
-    # Configure ssh passwordless to qnetd if detect password is needed
-    local_user, remote_user = utils.user_pair_for_ssh(qnetd_addr)
-    if utils.check_ssh_passwd_need(local_user, remote_user, qnetd_addr):
-        crmsh.bootstrap.configure_ssh_key(local_user)
-        utils.ssh_copy_id(local_user, remote_user, qnetd_addr)
-
     cmd = "corosync-qnetd-tool -lv -c {}".format(cluster_name)
     result = parallax.parallax_call([qnetd_addr], cmd)
     _, qnetd_result_stdout, _ = result[0][1]

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -74,7 +74,7 @@ class KeyFile(Key):
 
 class InMemoryPublicKey(Key):
     def __init__(self, content: str):
-        self.content = content
+        self.content = content.strip()
 
     def public_key(self) -> str:
         return self.content

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -949,6 +949,75 @@ class TestBootstrap(unittest.TestCase):
         bootstrap._context = mock.Mock(ipv6=None, nic_addr_list=[])
         bootstrap.init_network()
 
+    @mock.patch('crmsh.utils.HostUserConfig')
+    @mock.patch('crmsh.ssh_key.AuthorizedKeyManager')
+    @mock.patch('crmsh.sh.cluster_shell')
+    @mock.patch('crmsh.ssh_key.InMemoryPublicKey')
+    @mock.patch('crmsh.bootstrap.remote_public_key_from')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.utils.ssh_copy_id_no_raise')
+    @mock.patch('crmsh.utils.check_ssh_passwd_need')
+    @mock.patch('crmsh.bootstrap.UserOfHost.instance')
+    @mock.patch('crmsh.bootstrap._select_user_pair_for_ssh_for_secondary_components')
+    def test_setup_passwordless_ssh_for_qnetd_add_keys(self, mock_select, mock_user_of_host, mock_check_passwd, mock_ssh_copy_id, mock_this_node, mock_remote_public_key_from, mock_in_memory_public_key, mock_cluster_shell, mock_authorized_key_manager, mock_host_user_config_class):
+        bootstrap._context = mock.Mock(qnetd_addr_input="user@qnetd-node")
+        mock_select.side_effect = [("bob", "bob", "qnetd-node"), ("bob", "bob", "node2")]
+        mock_user_of_host_instance = mock.Mock()
+        mock_user_of_host.return_value = mock_user_of_host_instance
+        mock_user_of_host_instance.use_ssh_agent.return_value = False
+        mock_check_passwd.return_value = True
+        mock_ssh_copy_id.return_value = 0
+        mock_this_node.return_value = "node1"
+        mock_remote_public_key_from.return_value = "public_key"
+        mock_in_memory_public_key.return_value = "public_key"
+        mock_authorized_key_manager_instance = mock.Mock()
+        mock_authorized_key_manager.return_value = mock_authorized_key_manager_instance
+        mock_host_user_config_instance = mock.Mock()
+        mock_host_user_config_class.return_value = mock_host_user_config_instance
+
+        bootstrap._setup_passwordless_ssh_for_qnetd(["node1", "node2"])
+
+        mock_select.assert_has_calls([
+            mock.call(bootstrap._context.qnetd_addr_input),
+            mock.call('node2')
+            ])
+
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.utils.HostUserConfig')
+    @mock.patch('os.environ.get')
+    @mock.patch('crmsh.sh.SSHShell')
+    @mock.patch('crmsh.sh.LocalShell')
+    @mock.patch('crmsh.ssh_key.AuthorizedKeyManager')
+    @mock.patch('crmsh.ssh_key.AgentClient')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.bootstrap.UserOfHost.instance')
+    @mock.patch('crmsh.bootstrap._select_user_pair_for_ssh_for_secondary_components')
+    def test_setup_passwordless_ssh_for_qnetd_ssh_agent(self, mock_select, mock_user_of_host, mock_info, mock_agent, mock_authorized_key_manager, mock_local_shell, mock_ssh_shell, mock_get, mock_host_user_config_class, mock_this_node):
+        bootstrap._context = mock.Mock(qnetd_addr_input="user@qnetd-node")
+        mock_select.return_value = ("bob", "bob", "qnetd-node")
+        mock_user_of_host_instance = mock.Mock()
+        mock_user_of_host.return_value = mock_user_of_host_instance
+        mock_user_of_host_instance.use_ssh_agent.return_value = True
+        mock_agent_instance = mock.Mock()
+        mock_agent.return_value = mock_agent_instance
+        key_in_memory = mock.MagicMock(crmsh.ssh_key.InMemoryPublicKey)
+        mock_agent_instance.list.return_value = [key_in_memory]
+        mock_authorized_key_manager_instance = mock.Mock()
+        mock_authorized_key_manager.return_value = mock_authorized_key_manager_instance
+        mock_get.return_value = "/ssh-agent-path"
+        mock_local_shell_instance = mock.Mock()
+        mock_local_shell.return_value = mock_local_shell_instance
+        mock_ssh_shell_instance = mock.Mock()
+        mock_ssh_shell.return_value = mock_ssh_shell_instance
+        mock_this_node.return_value = "node1"
+        mock_host_uesr_config_instance = mock.Mock()
+        mock_host_user_config_class.return_value = mock_host_uesr_config_instance
+
+        bootstrap._setup_passwordless_ssh_for_qnetd(["node1", "node2"])
+
+        mock_info.assert_called_once_with("Adding public keys to authorized_keys for user root...")
+        mock_authorized_key_manager_instance.add.assert_called_once_with("qnetd-node", "bob", key_in_memory)
+
     @mock.patch('crmsh.service_manager.ServiceManager.disable_service')
     @mock.patch('logging.Logger.info')
     def test_init_qdevice_no_config(self, mock_status, mock_disable):
@@ -956,39 +1025,6 @@ class TestBootstrap(unittest.TestCase):
         bootstrap.init_qdevice()
         mock_status.assert_not_called()
         mock_disable.assert_called_once_with("corosync-qdevice.service")
-
-    @mock.patch('crmsh.bootstrap._select_user_pair_for_ssh_for_secondary_components')
-    @mock.patch('crmsh.utils.HostUserConfig')
-    @mock.patch('crmsh.user_of_host.UserOfHost.instance')
-    @mock.patch('crmsh.utils.list_cluster_nodes')
-    @mock.patch('crmsh.utils.ssh_copy_id_no_raise')
-    @mock.patch('crmsh.bootstrap.configure_ssh_key')
-    @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    @mock.patch('logging.Logger.info')
-    def test_init_qdevice_copy_ssh_key_failed(
-            self,
-            mock_status, mock_check_ssh_passwd_need,
-            mock_configure_ssh_key, mock_ssh_copy_id, mock_list_nodes, mock_user_of_host,
-            mock_host_user_config_class,
-            mock_select_user_pair_for_ssh,
-    ):
-        mock_list_nodes.return_value = []
-        bootstrap._context = mock.Mock(qdevice_inst=self.qdevice_with_ip, current_user="bob")
-        mock_check_ssh_passwd_need.return_value = True
-        mock_ssh_copy_id.return_value = 255
-        mock_user_of_host.return_value = mock.MagicMock(crmsh.user_of_host.UserOfHost)
-        mock_user_of_host.return_value.use_ssh_agent.return_value = False
-        mock_select_user_pair_for_ssh.return_value = ("bob", "bob", 'qnetd-node')
-
-        with self.assertRaises(ValueError):
-            bootstrap.init_qdevice()
-
-        mock_status.assert_has_calls([
-            mock.call("Configure Qdevice/Qnetd:"),
-        ])
-        mock_check_ssh_passwd_need.assert_called_once_with("bob", "bob", "qnetd-node")
-        mock_configure_ssh_key.assert_called_once_with('bob')
-        mock_ssh_copy_id.assert_called_once_with('bob', 'bob', 'qnetd-node')
 
     @mock.patch('crmsh.bootstrap._select_user_pair_for_ssh_for_secondary_components')
     @mock.patch('crmsh.utils.HostUserConfig')

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -178,18 +178,14 @@ def test_query_qnetd_status_no_host(mock_qdevice_configured, mock_get_value):
 
 @mock.patch('crmsh.utils.user_pair_for_ssh')
 @mock.patch("crmsh.parallax.parallax_call")
-@mock.patch("crmsh.utils.ssh_copy_id")
-@mock.patch('crmsh.bootstrap.configure_ssh_key')
-@mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.corosync.is_qdevice_configured")
 def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
-        mock_get_value, mock_check_passwd, mock_config_ssh_key, mock_ssh_copy_id, mock_parallax_call, mock_user_pair_for_ssh):
+        mock_get_value, mock_parallax_call, mock_user_pair_for_ssh):
     mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_parallax_call.side_effect = ValueError("Failed on 10.10.10.123: foo")
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
-    mock_check_passwd.return_value = True
     with pytest.raises(ValueError) as err:
         corosync.query_qnetd_status()
     assert err.value.args[0] == "Failed on 10.10.10.123: foo"
@@ -198,26 +194,19 @@ def test_query_qnetd_status_copy_id_failed(mock_qdevice_configured,
         mock.call("totem.cluster_name"),
         mock.call("quorum.device.net.host")
         ])
-    mock_check_passwd.assert_called_once_with("alice", "root", "10.10.10.123")
-    mock_config_ssh_key.assert_called_once_with('alice')
-    mock_ssh_copy_id.assert_called_once_with('alice', 'root', '10.10.10.123')
 
 
 @mock.patch('crmsh.utils.user_pair_for_ssh')
 @mock.patch("crmsh.utils.print_cluster_nodes")
 @mock.patch("crmsh.parallax.parallax_call")
-@mock.patch("crmsh.utils.ssh_copy_id")
-@mock.patch('crmsh.bootstrap.configure_ssh_key')
-@mock.patch("crmsh.utils.check_ssh_passwd_need")
 @mock.patch("crmsh.corosync.get_value")
 @mock.patch("crmsh.corosync.is_qdevice_configured")
 def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
-        mock_check_passwd, mock_config_ssh_key, mock_ssh_copy_id, mock_parallax_call, mock_print_nodes,
+        mock_parallax_call, mock_print_nodes,
         mock_user_pair_for_ssh):
     mock_user_pair_for_ssh.return_value = "alice", "root"
     mock_qdevice_configured.return_value = True
     mock_get_value.side_effect = ["hacluster", "10.10.10.123"]
-    mock_check_passwd.return_value = True
     mock_parallax_call.return_value = [("node1", (0, "data", None)), ]
 
     corosync.query_qnetd_status()
@@ -227,9 +216,6 @@ def test_query_qnetd_status_copy(mock_qdevice_configured, mock_get_value,
         mock.call("totem.cluster_name"),
         mock.call("quorum.device.net.host")
         ])
-    mock_check_passwd.assert_called_once_with("alice", "root", "10.10.10.123")
-    mock_config_ssh_key.assert_called_once_with('alice')
-    mock_ssh_copy_id.assert_called_once_with('alice', 'root', '10.10.10.123')
     mock_parallax_call.assert_called_once_with(["10.10.10.123"], "corosync-qnetd-tool -lv -c hacluster")
     mock_print_nodes.assert_called_once_with()
 


### PR DESCRIPTION
Currently, qdevice only adds the init node's key to qnetd. This patch adds all nodes' keys to qnetd authorized_keys. Then all cluster nodes can connect to qnetd without password.