### PR TITLE
Dev: log: Set the log format for crmsh.log as rfc5424

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -228,7 +228,7 @@ LOGGING_CFG = {
         },
         "file": {
             "format": "%(asctime)s {} %(name)s: %(levelname)s: %(message)s".format(socket.gethostname()),
-            "datefmt": "%b %d %H:%M:%S",
+            "datefmt": "%Y-%m-%dT%H:%M:%S%z",
         }
     },
     "filters": {


### PR DESCRIPTION
So that the crmsh.log can include the year information.

See also: https://github.com/ClusterLabs/crmsh/pull/1295