### PR TITLE
[crmsh-4.6] Dev: ui_context: make help subcommands to exit with 0 (#1374)

### DIFF
--- a/crmsh/crash_test/main.py
+++ b/crmsh/crash_test/main.py
@@ -168,7 +168,7 @@ For each --kill-* testcase, report directory: {}'''.format(context.logfile,
     args = parser.parse_args()
     if args.help or len(sys.argv) == 1:
         parser.print_help()
-        raise crmshutils.TerminateSubCommand
+        raise crmshutils.TerminateSubCommand(success=True)
 
     for arg in vars(args):
         setattr(context, arg, getattr(args, arg))

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -25,17 +25,19 @@ from . import constants
 
 
 from . import log
+from .utils import TerminateSubCommand
+
 logger = log.setup_logger(__name__)
 
 
 def parse_options(parser, args):
     try:
         options, args = parser.parse_known_args(list(args))
-    except:
+    except Exception:
         return None, None
     if hasattr(options, 'help') and options.help:
         parser.print_help()
-        return None, None
+        raise TerminateSubCommand(success=True)
     utils.check_empty_option_value(options)
     return options, args
 

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -87,8 +87,11 @@ class Context(object):
         except (ValueError, IOError) as e:
             logger.error("%s: %s", self.get_qualified_name(), e, exc_info=e)
             rv = False
-        except utils.TerminateSubCommand:
-            return False
+        except utils.TerminateSubCommand as terminate:
+            if terminate.success:
+                rv = True
+            else:
+                return False
         if cmd or (rv is False):
             rv = self._back_out() and rv
 

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -237,7 +237,7 @@ keep the node in standby after reboot. The life time defaults to
     options, args = parser.parse_known_args(args)
     if options.help:
         parser.print_help()
-        raise utils.TerminateSubCommand
+        raise utils.TerminateSubCommand(success=True)
     if options is None or args is None:
         raise utils.TerminateSubCommand
     if options.all and args:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -52,6 +52,8 @@ class TerminateSubCommand(Exception):
     """
     This is an exception to jump out of subcommand when meeting errors while staying interactive shell
     """
+    def __init__(self, success=False):
+        self.success = success
 
 
 def to_ascii(input_str):


### PR DESCRIPTION
It is not a failure.

Part of #1374.