### PR TITLE
[crmsh-4.6] Fix: ui_node: When `utils.list_cluster_nodes` return None, try to get ip list from corosync.conf

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -246,9 +246,12 @@ keep the node in standby after reboot. The life time defaults to
     # return local node
     if (not options.all and not args) or (len(args) == 1 and args[0] == utils.this_node()):
         return [utils.this_node()]
-    member_list = utils.list_cluster_nodes()
+    member_list = utils.list_cluster_nodes() or utils.get_address_list_from_corosync_conf()
     if not member_list:
         context.fatal_error("Cannot get the node list from cluster")
+    for node in args:
+        if node not in member_list:
+            context.fatal_error(f"Node '{node}' is not a member of the cluster")
 
     node_list = member_list if options.all else args
     for node in node_list:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1812,10 +1812,10 @@ def list_cluster_nodes(no_reg=False):
     else:
         cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
         if not os.path.isfile(cib_path):
-            return get_address_list_from_corosync_conf()
+            return None
         cib = xmlutil.file2cib_elem(cib_path)
     if cib is None:
-        return get_address_list_from_corosync_conf()
+        return None
 
     node_list = []
     for node in cib.xpath(constants.XML_NODE_PATH):

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -151,6 +151,9 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode1"
     Then    Cluster service is "started" on "hanode2"
 
+    When    Try "crm cluster start xxx"
+    Then    Except "ERROR: cluster.start: Node 'xxx' is not a member of the cluster"
+
   @clean
   Scenario: Can't stop all nodes' cluster service when local node's service is down(bsc#1213889)
     Given   Cluster service is "stopped" on "hanode1"

--- a/test/features/crm_report_normal.feature
+++ b/test/features/crm_report_normal.feature
@@ -105,4 +105,5 @@ Feature: crm report functional test for common cases
     When    Run "crm cluster stop --all" on "hanode1"
     When    Run "rm -f /var/lib/pacemaker/cib/cib*" on "hanode1"
     When    Run "rm -f /var/lib/pacemaker/cib/cib*" on "hanode2"
-    When    Run "crm report" OK
+    When    Try "crm report" on "hanode1"
+    Then    Expected "Could not figure out a list of nodes; is this a cluster node" in stderr

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1202,43 +1202,26 @@ Quorate:          Yes
     mock_run_inst.get_stdout_or_raise_error.assert_called_once_with("corosync-quorumtool -s", None, success_exit_status={0, 2})
 
 
-@mock.patch('crmsh.utils.get_address_list_from_corosync_conf')
 @mock.patch('crmsh.utils.etree.fromstring')
 @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
-def test_list_cluster_nodes_none(mock_run, mock_etree, mock_corosync):
+def test_list_cluster_nodes_none(mock_run, mock_etree):
     mock_run.return_value = (0, "data", None)
     mock_etree.return_value = None
-    mock_corosync.return_value = ["node1", "node2"]
     res = utils.list_cluster_nodes()
-    assert res == ["node1", "node2"]
+    assert res is None
     mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=False)
     mock_etree.assert_called_once_with("data")
 
 
-@mock.patch('crmsh.utils.get_address_list_from_corosync_conf')
-@mock.patch('crmsh.utils.etree.fromstring')
-@mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
-def test_list_cluster_nodes_none_no_reg(mock_run, mock_etree, mock_corosync):
-    mock_run.return_value = (0, "data", None)
-    mock_etree.return_value = None
-    mock_corosync.return_value = ["node1", "node2"]
-    res = utils.list_cluster_nodes(no_reg=True)
-    assert res == ["node1", "node2"]
-    mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=True)
-    mock_etree.assert_called_once_with("data")
-
-
-@mock.patch('crmsh.utils.get_address_list_from_corosync_conf')
 @mock.patch('os.path.isfile')
 @mock.patch('os.getenv')
 @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
-def test_list_cluster_nodes_cib_not_exist(mock_run, mock_env, mock_isfile, mock_corosync):
+def test_list_cluster_nodes_cib_not_exist(mock_run, mock_env, mock_isfile):
     mock_run.return_value = (1, None, None)
     mock_env.return_value = constants.CIB_RAW_FILE
     mock_isfile.return_value = False
-    mock_corosync.return_value = ["node1", "node2"]
     res = utils.list_cluster_nodes()
-    assert res == ["node1", "node2"]
+    assert res is None
     mock_run.assert_called_once_with(constants.CIB_QUERY, no_reg=False)
     mock_env.assert_called_once_with("CIB_file", constants.CIB_RAW_FILE)
     mock_isfile.assert_called_once_with(constants.CIB_RAW_FILE)


### PR DESCRIPTION
backport #1377 