### PR TITLE
[crmsh-4.6] Dev: doc: implement help2adoc (#1374)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 doc/website-v1/gen
 Makefile.in
 autom4te.cache
-Makefile
+./Makefile
 aclocal.m4
 autoconf
 autoheader

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+generated-sources/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean subdirs
 
-all: subdirs generated-sources/crm.8.adoc
+all: subdirs crm.8.html
 
 generated-sources:
 	mkdir -p $@
@@ -14,5 +14,11 @@ subdirs: generated-sources/Makefile
 generated-sources/crm.8.adoc: crm.8.adoc generated-sources
 	adocxt gen-include < $< > $@
 
+generated-sources/profiles.adoc: profiles.adoc generated-sources
+	cp $< $@
+
+crm.8.html: generated-sources/crm.8.adoc generated-sources/profiles.adoc subdirs
+	asciidoctor $<
+
 clean:
-	$(RM) -r generated-sources
+	$(RM) -r generated-sources crm.8.html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all clean subdirs
+
+all: subdirs generated-sources/crm.8.adoc
+
+generated-sources:
+	mkdir -p $@
+
+generated-sources/Makefile: crm.8.adoc generated-sources
+	adocxt gen-makefile < $< > $@
+
+subdirs: generated-sources/Makefile
+	$(MAKE) -C generated-sources all
+
+generated-sources/crm.8.adoc: crm.8.adoc generated-sources
+	adocxt gen-include < $< > $@
+
+clean:
+	$(RM) -r generated-sources

--- a/doc/toolchain/Containerfile
+++ b/doc/toolchain/Containerfile
@@ -1,0 +1,14 @@
+FROM docker.io/alpine:3.19.0
+
+RUN apk add --no-cache \
+    py3-lxml \
+    py3-yaml \
+    py3-dateutil
+RUN apk add --no-cache \
+    bash \
+    make
+
+env PYTHONPATH=/opt/crmsh
+env PATH=/opt/crmsh/bin:/opt/crmsh/doc/toolchain/bin:"${PATH}"
+
+CMD cd /opt/crmsh/doc && make

--- a/doc/toolchain/Containerfile
+++ b/doc/toolchain/Containerfile
@@ -1,12 +1,14 @@
 FROM docker.io/alpine:3.19.0
 
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 RUN apk add --no-cache \
     py3-lxml \
     py3-yaml \
-    py3-dateutil
-RUN apk add --no-cache \
+    py3-dateutil\
     bash \
-    make
+    make \
+    asciidoctor
+
 
 env PYTHONPATH=/opt/crmsh
 env PATH=/opt/crmsh/bin:/opt/crmsh/doc/toolchain/bin:"${PATH}"

--- a/doc/toolchain/bin/adocxt
+++ b/doc/toolchain/bin/adocxt
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+
+import re
+import shlex
+import sys
+import typing
+
+
+RE_FROM_CODE = re.compile(r'^\[\[([^,]+),[^,]*,From Code]]$')
+RE_TAG = re.compile('^cmdhelp_(.*)$')
+
+TAG_EXCLUDES = {
+    'cmdhelp_node_online',
+    'cmdhelp_node_standby',
+    'cmdhelp_root_report',
+}
+
+
+def main(stdin, stdout):
+    tags = list()
+    for line in stdin:
+        found = RE_FROM_CODE.match(line)
+        if found:
+            tag = found.group(1)
+            if tag in TAG_EXCLUDES:
+                continue
+            command = extract_command(tag)
+            tags.append(tag)
+            stdout.write(tag)
+            stdout.write('.txt:\n\t')
+            stdout.write(shlex.join(command))
+            stdout.write(' > "$@"\n\n')
+    end(tags, stdout)
+
+
+def extract_command(tag: str) -> typing.Sequence[str]:
+    found = RE_TAG.match(tag)
+    if not found:
+        raise RuntimeError(f'Invalid tag {tag}')
+    args = ['crm']
+    args.extend(found.group(1).split('_', 1))
+    args.append('--help-without-redirect')
+    return args
+
+
+def end(tags: typing.Sequence[str], stdout):
+    stdout.write(
+        '%.adoc: %.txt\n\thelp2adoc "$<"\n\n'
+    )
+    stdout.write(
+        '.PHONY: clean all\n\nclean:\n\t$RM *.txt *.adoc\n\nall: '
+    )
+    for tag in tags:
+        stdout.write(tag)
+        stdout.write('.adoc ')
+    stdout.write('\n\n')
+
+
+
+if __name__ == '__main__':
+    main(sys.stdin, sys.stdout)

--- a/doc/toolchain/bin/adocxt
+++ b/doc/toolchain/bin/adocxt
@@ -9,6 +9,8 @@ import typing
 
 RE_FROM_CODE = re.compile(r'^\[\[([^,]+),[^,]*,From Code]]$')
 RE_TAG = re.compile('^cmdhelp_(.*)$')
+RE_SECTION_TITLE = re.compile('^=')
+RE_FROM_CODE_OR_SECTION_TITLE=re.compile(r'^(?:\[\[([^,]+),[^,]*,From Code]]$|=)')
 
 TAG_EXCLUDES = {
     'cmdhelp_node_online',
@@ -17,7 +19,7 @@ TAG_EXCLUDES = {
 }
 
 
-def main(stdin, stdout):
+def generate_makefile(stdin, stdout):
     tags = list()
     for line in stdin:
         found = RE_FROM_CODE.match(line)
@@ -46,7 +48,7 @@ def extract_command(tag: str) -> typing.Sequence[str]:
 
 def end(tags: typing.Sequence[str], stdout):
     stdout.write(
-        '%.adoc: %.txt\n\thelp2adoc "$<"\n\n'
+        '%.adoc: %.txt\n\thelp2adoc "$<" > "$*".adoc\n\n'
     )
     stdout.write(
         '.PHONY: clean all\n\nclean:\n\t$RM *.txt *.adoc\n\nall: '
@@ -57,6 +59,54 @@ def end(tags: typing.Sequence[str], stdout):
     stdout.write('\n\n')
 
 
+def generate_include(stdin, stdout):
+    tag = None
+    section_title = None
+    for line in stdin:
+        go_next_line = False
+        while not go_next_line:
+            match tag:
+                case None:
+                    # initial state
+                    found = RE_FROM_CODE.match(line)
+                    if found:
+                        found_tag = found.group(1)
+                        if found_tag not in TAG_EXCLUDES:
+                            tag = found_tag
+                    stdout.write(line)
+                    go_next_line = True
+                case _:
+                    # found a tag
+                    match section_title:
+                        case None:
+                            # waiting a section title
+                            found = RE_SECTION_TITLE.match(line)
+                            if found:
+                                section_title = line
+                                stdout.write(section_title)
+                                print(f'include::{tag}.adoc[]\n', file=stdout)
+                            break
+                        case _:
+                            # waiting for next section
+                            found = RE_FROM_CODE_OR_SECTION_TITLE.match(line)
+                            if found:
+                                tag = None
+                                section_title = None
+                            else:
+                                go_next_line = True
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f'Usage: {sys.argv[0]} gen-makefile|gen-include', file=sys.stderr)
+        return 1
+    match sys.argv[1]:
+        case 'gen-makefile':
+            generate_makefile(sys.stdin, sys.stdout)
+        case 'gen-include':
+            generate_include(sys.stdin, sys.stdout)
+    
+
 
 if __name__ == '__main__':
-    main(sys.stdin, sys.stdout)
+    sys.exit(main())

--- a/doc/toolchain/bin/help2adoc
+++ b/doc/toolchain/bin/help2adoc
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+export PYTHONPATH=$(readlink -f "${SCRIPT_DIR}"/../lib)
+python3 -m help2adoc.main "$@"

--- a/doc/toolchain/lib/help2adoc/generator.py
+++ b/doc/toolchain/lib/help2adoc/generator.py
@@ -1,0 +1,51 @@
+from .parser import Parser
+
+import typing
+import re
+
+
+class AsciiDocGenerator(Parser):
+    USAGE_RE = re.compile('^usage:\\s*')
+
+    def __init__(self, output: typing.Callable[[str], None]):
+        self.output = output
+
+    def on_usage(self, text: str):
+        usage = text[self.USAGE_RE.match(text).end():]
+        self.output('Usage:\n\n ')
+        self.output(usage)
+        self.output('\n\n')
+
+    def on_paragraph(self, text: str):
+        self.output(self.escape(text))
+        self.output('\n\n')
+
+    def enter_options(self):
+        self.output('Options:\n\n')
+
+    def exit_options(self):
+        self.output('\n')
+
+    def on_option(self, option: str, help: str):
+        self.output('* `+++')
+        self.output(option)
+        self.output('+++`: ')
+        self.output(self.escape(help))
+        self.output('\n\n')
+
+    def enter_option_group(self, name: str):
+        self.output(name)
+        self.output(':\n\n')
+
+    def exit_option_group(self, name: str):
+        self.output('\n')
+
+    def enter_description(self):
+        pass
+
+    def exit_description(self):
+        pass
+
+    def escape(self, text: str):
+        # TODO
+        return text

--- a/doc/toolchain/lib/help2adoc/main.py
+++ b/doc/toolchain/lib/help2adoc/main.py
@@ -1,0 +1,28 @@
+from .parser import lexer, LookAheadIterator
+from .generator import AsciiDocGenerator
+
+from argparse import ArgumentParser
+import sys
+
+def main():
+    ap = ArgumentParser('help2adoc')
+    ap.add_argument('file')
+    args = ap.parse_args()
+    with open(args.file, 'r') as f:
+        tokens = LookAheadIterator(lexer(f))
+        AsciiDocGenerator(sys.stdout.write).parse_help(tokens)
+        token = tokens.lookahead()
+        if token is None:
+            return
+        epilog_start = token.lineno
+        f.seek(0)
+        for i in range(epilog_start):
+            next(f)
+        print('....')
+        for line in f:
+            print(line, end='')
+        print('....')
+
+
+if __name__ == '__main__':
+    main()

--- a/doc/toolchain/lib/help2adoc/parser.py
+++ b/doc/toolchain/lib/help2adoc/parser.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+import typing
+import re
+import io
+
+
+class Token:
+    def __init__(self, lineno: int, tpe: str, text: str):
+        self.tpe = tpe
+        self.lineno = lineno
+        self.text = text
+
+    def __str__(self):
+        return f'Token(tpe={self.tpe}, text={self.text})'
+
+
+class EmptyLineToken(Token):
+    def __init__(self, lineno: int):
+        super().__init__(lineno, 'emptyline', '')
+
+
+class TextToken(Token):
+    def __init__(self, lineno: int, indent: int, text: str):
+        super().__init__(lineno, 'text', text)
+        self.indent = indent
+
+
+class LogToken(Token):
+    def __init__(self, lineno: int, text: str):
+        super().__init__(lineno, 'log', text)
+
+
+class UsageToken(Token):
+    def __init__(self, lineno: int, text: str):
+        super().__init__(lineno, 'usage', text)
+
+
+class OptionsToken(Token):
+    def __init__(self, lineno: int, text: str):
+        super().__init__(lineno, 'options', text)
+
+
+class OptionToken(Token):
+    def __init__(self, lineno: int, text: str):
+        super().__init__(lineno, 'option', text)
+
+
+def lexer(lines: typing.Iterator[str]):
+    for lineno, line in enumerate(lines):
+        line = line.rstrip()
+        if not line:
+            yield EmptyLineToken(lineno)
+        elif re.match('(?:\033\\[\\d+m)?(?:INFO|ERROR)(?:\033\\[0m)?: ', line):
+            pass
+        elif re.match('usage: ', line):
+            yield UsageToken(lineno, line)
+        elif re.match('options:', line):
+            yield OptionsToken(lineno, line)
+        elif re.match('\\s+-', line):
+            yield OptionToken(lineno, line)
+        else:
+            indent = re.search('\\S', line).start()
+            yield TextToken(lineno, indent, line)
+
+
+T = typing.TypeVar('T')
+
+
+class LookAheadIterator(typing.Generic[T]):
+    def __init__(self, it: typing.Iterator[T]):
+        self._it = it
+        self._lookahead_buffer = list()
+        self._lookahead_index = -1
+
+    def lookahead(self):
+        if self._lookahead_index + 1 == len(self._lookahead_buffer):
+            try:
+                ret = next(self._it)
+                self._lookahead_index += 1
+                self._lookahead_buffer.append(ret)
+                return ret
+            except StopIteration:
+                return None
+        else:
+            self._lookahead_index += 1
+            return self._lookahead_buffer[self._lookahead_index]
+
+    def consume(self):
+        self._lookahead_buffer = self._lookahead_buffer[self._lookahead_index+1:]
+        self._lookahead_index = -1
+
+    def rollback(self):
+        self._lookahead_index -= 1
+
+    def reset(self):
+        self._lookahead_index = -1
+
+
+class SyntaxErrorException(Exception):
+    pass
+
+
+class Parser:
+    def on_usage(self, text: str):
+        print('<usage/>')
+
+    def enter_description(self):
+        print('<description>')
+
+    def exit_description(self):
+        print('</description>')
+
+    def on_paragraph(self, text: str):
+        print(f'<paragraph>{text}</paragraph>')
+
+    def enter_options(self):
+        print('<options>')
+
+    def exit_options(self):
+        print('</options>')
+
+    def enter_option_group(self, name: str):
+        print(f'<option_group name={name}>')
+
+    def exit_option_group(self, name: str):
+        print(f'</option_group name={name}>')
+
+    def on_option(self, option: str, help: str):
+        print(f'<option name={option}/>')
+
+    def parse_help(self, tokens: LookAheadIterator[Token]):
+        self.parse_usage(tokens)
+        self.parse_description(tokens)
+        self.parse_options(tokens)
+        tokens.reset()
+
+    class MatchFailure(Exception):
+        pass
+
+    def parse_usage(self, tokens: LookAheadIterator[Token]):
+        token = tokens.lookahead()
+        self.assert_token_tpe('usage', token)
+        buf = io.StringIO()
+        buf.write(token.text)
+        while True:
+            token = tokens.lookahead()
+            if token is None:
+                tokens.consume()
+                self.on_usage(buf.getvalue())
+            elif token.tpe == 'text':
+                buf.write(' ')
+                buf.write(token.text[token.indent:])
+            else:
+                self.assert_token_tpe('emptyline', token)
+                tokens.rollback()
+                self.parse_emptyline(tokens)
+                self.on_usage(buf.getvalue())
+                break
+
+    def parse_description(self, tokens: LookAheadIterator[Token]):
+        result = self.parse_paragraph(tokens)
+        if result is not None:
+            indent, paragraph = result
+            self.enter_description()
+            tokens.consume()
+            self.on_paragraph(paragraph)
+            while True:
+                ret = self.parse_paragraph(tokens)
+                if ret is None:
+                    self.exit_description()
+                    return
+                indent, text = ret
+                tokens.consume()
+                self.on_paragraph(text)
+
+
+    def parse_options(self, tokens: LookAheadIterator[Token]):
+        token = tokens.lookahead()
+        if token.tpe != 'options':
+            return
+        else:
+            self.enter_options()
+            self.parse_option_group(tokens)
+            while self.parse_named_option_group(tokens):
+                pass
+            self.exit_options()
+
+    def parse_option_group(self, tokens: LookAheadIterator[Token]):
+        while True:
+            ret = self.parse_option(tokens)
+            if ret is None:
+                break
+            option, help = ret
+            self.on_option(option, help)
+
+    def parse_option(self, tokens: LookAheadIterator[Token]):
+        token = tokens.lookahead()
+        if token is not None and token.tpe == 'option':
+            match = re.match(
+                '\\s+((?:-[a-zA-Z]|--[-a-zA-Z0-9]+)(?:\\s[^, ]+)?(?:,\\s+--[-a-zA-Z0-9]+(?:\\s[^, ]+)?)?)\\s*',
+                token.text,
+            )
+            if match is None:
+                tokens.rollback()
+                return None
+            option = match.group(1)
+            buf = io.StringIO()
+            buf.write(token.text[match.end():])
+            while True:
+                token = tokens.lookahead()
+                if token is None:
+                    tokens.consume()
+                    break
+                elif token.tpe != 'text':
+                    tokens.rollback()
+                    break
+                else:
+                    tokens.consume()
+                    if buf.tell() != 0:
+                        buf.write(' ')
+                    buf.write(token.text[token.indent:])
+            return option, buf.getvalue()
+
+    def parse_named_option_group(self, tokens: LookAheadIterator[Token]):
+        token = tokens.lookahead()
+        if token is None:
+            tokens.rollback()
+            return
+        elif token.tpe == 'emptyline':
+            tokens.rollback()
+            self.parse_emptyline(tokens)
+        if token.tpe == 'text' and token.indent == 0 and token.text[-1] == ':':
+            group_name = token.text[:-1]
+            description = list()
+            while True:
+                ret = self.parse_paragraph(tokens)
+                if ret is None:
+                    break
+                indent, text = ret
+                description.append(text)
+            ret = self.parse_option(tokens)
+            if ret is None:
+                tokens.reset()
+                return
+            else:
+                self.enter_option_group(group_name)
+                for paragraph in description:
+                    self.on_paragraph(paragraph)
+                option, help = ret
+                self.on_option(option, help)
+                tokens.consume()
+                while True:
+                    ret = self.parse_option(tokens)
+                    if ret is None:
+                        break
+                    option, help = ret
+                    self.on_option(option, help)
+                    tokens.consume()
+                self.parse_emptyline(tokens)
+                self.exit_option_group(group_name)
+                tokens.consume()
+            return True
+        else:
+            tokens.rollback()
+            return False
+
+    @classmethod
+    def assert_token_tpe(cls, tpe: str, token: Token):
+        if token.tpe != tpe:
+            raise SyntaxErrorException(f'Expected: <{tpe}>. Actural: {token.text}')
+
+    def parse_log(self, tokens: LookAheadIterator[Token]):
+        # TODO: remove me
+        while True:
+            token = tokens.lookahead()
+            if token.tpe == 'log':
+                tokens.consume()
+            else:
+                return
+
+    def parse_paragraph(self, tokens: LookAheadIterator[Token]):
+        buf = io.StringIO()
+        indent = -1
+        while True:
+            token = tokens.lookahead()
+            if token is None:
+                tokens.consume()
+                break
+            if token.tpe != 'text':
+                tokens.rollback()
+                break
+            new_indent = token.indent
+            if indent == -1:
+                indent = new_indent
+                buf.write(token.text[indent:])
+            elif new_indent == indent:
+                buf.write(' ')
+                buf.write(token.text[indent:])
+            else:
+                tokens.rollback()
+                break
+        if indent == -1:
+            return None
+        else:
+            token = tokens.lookahead()
+            if token is not None:
+                tokens.rollback()
+                self.parse_emptyline(tokens)
+            return indent, buf.getvalue()
+
+    def parse_emptyline(self, tokens: LookAheadIterator[Token]):
+        while True:
+            token = tokens.lookahead()
+            if token.tpe != 'emptyline':
+                tokens.rollback()
+                break
+
+
+def main():
+    import sys
+    stdin = sys.stdin
+    with open(3, buffering=1) as stdin:
+        tokens = LookAheadIterator(lexer(stdin))
+        Parser().parse_help(tokens)
+        print('epilog starts at line {}'.format(tokens.lookahead().lineno))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request includes:

1. a tool `help2adoc` to convert the help text generated by python `argparse` module to asciidoc
2. a series of helper scripts, makefiles, containers to automatic the process to combine the asciidocs generated by `help2adoc` and `crm.8.adoc` to generated a complete document

Usage:

```shell
$ cd doc/toolchain
$ podman build -t local/crmsh-doc-builder .
$ cd ..
$ make clean
$ podman run --rm -ti -v ..:/opt/crmsh local/crmsh-doc-builder:latest
```

The final results is `doc/generated-sources/crm.8.adoc` and `doc/generated-sources/crm.8.html`

Part of #1374.