### PR TITLE
Setup bootstrap stages dependency

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -595,7 +595,7 @@ def my_hostname_resolves():
         return False
 
 
-def check_prereqs(stage):
+def check_prereqs():
     warned = False
 
     if not my_hostname_resolves():
@@ -2149,17 +2149,16 @@ def bootstrap_init(context):
     _context.load_profiles()
     _context.init_sbd_manager()
 
-    # Need hostname resolution to work, want NTP (but don't block csync2_remote)
-    if stage not in ('csync2_remote', 'qnetd_remote'):
-        check_tty()
-        if not check_prereqs(stage):
-            return
-    else:
+    if stage in ('csync2_remote', 'qnetd_remote'):
         args = _context.args
-        logger_utils.log_only_to_file("args: {}".format(args))
+        logger_utils.log_only_to_file(f"args: {args}")
         if len(args) != 2:
-            utils.fatal(f"Expected NODE argument to {stage} stage")
+            utils.fatal(f"Expected NODE argument for '{stage}' stage")
         _context.cluster_node = args[1]
+    else:
+        check_tty()
+        if not check_prereqs():
+            return
 
     if stage and _context.cluster_is_running and \
             not ServiceManager(shell=sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active(CSYNC2_SERVICE):
@@ -2245,7 +2244,7 @@ def bootstrap_join(context):
 
     check_tty()
 
-    if not check_prereqs("join"):
+    if not check_prereqs():
         return
 
     if _context.stage != "":

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -46,6 +46,7 @@ from .sh import ShellUtils
 from .ui_node import NodeMgmt
 from . import conf_parser
 from .user_of_host import UserOfHost, UserNotFoundError
+import crmsh.healthcheck
 
 
 logger = log.setup_logger(__name__)
@@ -1663,6 +1664,9 @@ def join_ssh_impl(local_user, seed_host, seed_user, ssh_public_keys: typing.List
     change_user_shell('hacluster')
     swap_public_ssh_key_for_secondary_user(sh.cluster_shell(), seed_host, 'hacluster')
 
+    if _context.stage:
+        setup_passwordless_with_other_nodes(seed_host, seed_user)
+
 
 def join_ssh_with_ssh_agent(
         local_shell: sh.LocalShell,
@@ -2136,6 +2140,69 @@ def remove_node_from_cluster(node):
     invoke("corosync-cfgtool -R")
 
 
+def ssh_stage_finished():
+    """
+    Dectect if the ssh stage is finished
+    """
+    feature_check = crmsh.healthcheck.PasswordlessHaclusterAuthenticationFeature()
+    return feature_check.check_quick() and feature_check.check_local([utils.this_node()])
+
+
+def csync2_stage_finished():
+    """
+    Dectect if the csync2 stage is finished
+    """
+    return ServiceManager().service_is_active(CSYNC2_SERVICE)
+
+
+def corosync_stage_finished():
+    """
+    Dectect if the corosync stage is finished
+    """
+    try:
+        conf_parser.ConfParser.verify_config_file()
+    except ValueError as e:
+        logger.error(e)
+        return False
+    return True
+
+
+INIT_STAGE_CHECKER = {
+        # stage: (function, is_internal)
+        "ssh": (ssh_stage_finished, False),
+        "csync2": (csync2_stage_finished, False),
+        "corosync": (corosync_stage_finished, False),
+        "remote_auth": (init_remote_auth, True),
+        "sbd": (lambda: True, False),
+        "upgradeutil": (init_upgradeutil, True),
+        "cluster": (is_online, False)
+}
+
+
+JOIN_STAGE_CHECKER = {
+        # stage: (function, is_internal)
+        "ssh": (ssh_stage_finished, False),
+        "csync2": (csync2_stage_finished, False),
+        "ssh_merge": (lambda: True, False),
+        "cluster": (is_online, False)
+}
+
+
+def check_stage_dependency(stage):
+    stage_checker = INIT_STAGE_CHECKER if _context.type == "init" else JOIN_STAGE_CHECKER
+    if stage not in stage_checker:
+        return
+    stage_order = list(stage_checker.keys())
+    for stage_name in stage_order:
+        if stage == stage_name:
+            break
+        func, is_internal = stage_checker[stage_name]
+        if is_internal:
+            func()
+        elif not func():
+            utils.fatal(f"Please run '{stage_name}' stage first")
+
+
 def bootstrap_init(context):
     """
     Init cluster process
@@ -2168,6 +2235,7 @@ def bootstrap_init(context):
         _context.node_list_in_cluster = [utils.this_node()]
 
     if stage != "":
+        check_stage_dependency(stage)
         globals()["init_" + stage]()
     else:
         init_ssh()
@@ -2249,6 +2317,8 @@ def bootstrap_join(context):
 
     if _context.stage != "":
         remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
+        init_upgradeutil()
+        check_stage_dependency(_context.stage)
         globals()["join_" + _context.stage](cluster_node, remote_user)
     else:
         if not _context.yes_to_all and _context.cluster_node is None:

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2263,7 +2263,6 @@ def bootstrap_join(context):
                 service_manager = ServiceManager()
                 _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(cluster_node)
                 setup_passwordless_with_other_nodes(cluster_node, remote_user)
-                join_remote_auth(cluster_node, remote_user)
                 _context.skip_csync2 = not service_manager.service_is_active(CSYNC2_SERVICE, cluster_node)
                 if _context.skip_csync2:
                     service_manager.stop_service(CSYNC2_SERVICE, disable=True)
@@ -2291,14 +2290,6 @@ def join_ocfs2(peer_host, peer_user):
     """
     ocfs2_inst = ocfs2.OCFS2Manager(_context)
     ocfs2_inst.join_ocfs2(peer_host)
-
-
-def join_remote_auth(node, user):
-    if os.path.exists(PCMK_REMOTE_AUTH):
-        utils.rmfile(PCMK_REMOTE_AUTH)
-    pcmk_remote_dir = os.path.dirname(PCMK_REMOTE_AUTH)
-    utils.mkdirs_owned(pcmk_remote_dir, mode=0o750, gid="haclient")
-    utils.touch(PCMK_REMOTE_AUTH)
 
 
 def remove_qdevice() -> None:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -329,12 +329,6 @@ class Cluster(command.UI):
         '''
         Initialize a cluster.
         '''
-        def looks_like_hostnames(lst):
-            sectionlist = bootstrap.INIT_STAGES
-            return all(not (l.startswith('-') or l in sectionlist) for l in lst)
-        if len(args) > 0:
-            if '--dry-run' in args or looks_like_hostnames(args):
-                args = ['--yes', '--nodes'] + [arg for arg in args if arg != '--dry-run']
         parser = ArgumentParser(description="""
 Initialize a cluster from scratch. This command configures
 a complete cluster, and can also add additional cluster

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -457,8 +457,6 @@ Examples:
         stage = ""
         if len(args):
             stage = args[0]
-        if stage not in bootstrap.INIT_STAGES and stage != "":
-            parser.error("Invalid stage (%s)" % (stage))
 
         if options.qnetd_addr_input:
             if not ServiceManager().service_is_available("corosync-qdevice.service"):
@@ -531,12 +529,11 @@ Examples:
         stage = ""
         if len(args) == 1:
             stage = args[0]
-        if stage not in ("ssh", "csync2", "ssh_merge", "cluster", ""):
-            parser.error("Invalid stage (%s)" % (stage))
 
         join_context = bootstrap.Context.set_context(options)
         join_context.ui_context = context
         join_context.stage = stage
+        join_context.cluster_is_running = ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("pacemaker.service")
         join_context.type = "join"
         join_context.validate_option()
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -477,14 +477,6 @@ def chmod(path, mod):
             fatal("Failed to chmod {}: {}".format(path, err))
 
 
-def touch(file_name):
-    rc, out, err = ShellUtils().get_stdout_stderr("touch " + file_name, no_reg=True)
-    if rc != 0:
-        rc, out, err = ShellUtils().get_stdout_stderr("sudo touch " + file_name, no_reg=True)
-        if rc != 0:
-            fatal("Failed create file {}: {}".format(file_name, err))
-
-
 def copy_local_file(src, dest):
     try:
         shutil.copyfile(src, dest)

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -37,6 +37,15 @@ Feature: crmsh bootstrap process - options
     Then    Expected "Can't use -N/--nodes option and stage(sbd) together" in stderr
 
   @clean
+  Scenario: Stage validation
+    When    Try "crm cluster init fdsf -y" on "hanode1"
+    Then    Expected "Invalid stage: fdsf(available stages: ssh, csync2, corosync, sbd, cluster, ocfs2, admin, qdevice)" in stderr
+    When    Try "crm cluster join fdsf -y" on "hanode1"
+    Then    Expected "Invalid stage: fdsf(available stages: ssh, csync2, ssh_merge, cluster)" in stderr
+    When    Try "crm cluster join ssh -y" on "hanode1"
+    Then    Expected "Can't use stage(ssh) without specifying cluster node" in stderr
+
+  @clean
   Scenario: Init whole cluster service on node "hanode1" using "--node" option
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
@@ -45,6 +54,9 @@ Feature: crmsh bootstrap process - options
     And     Cluster service is "started" on "hanode2"
     And     Online nodes are "hanode1 hanode2"
     And     Show cluster status on "hanode1"
+
+    When    Try "crm cluster init cluster -y" on "hanode1"
+    Then    Expected "Cluster is active, can't run 'cluster' stage" in stderr
 
   @clean
   Scenario: Bind specific network interface using "-i" option
@@ -88,6 +100,9 @@ Feature: crmsh bootstrap process - options
     Then    Cluster service is "started" on "hanode2"
     And     IP "@hanode2.ip.default" is used by corosync on "hanode2"
     And     IP "@hanode2.ip.0" is used by corosync on "hanode2"
+
+    When    Try "crm cluster join cluster -c hanode1 -y" on "hanode2"
+    Then    Expected "Cluster is active, can't run 'cluster' stage" in stderr
 
   @clean
   Scenario: Using "-i" option with IP address

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -110,7 +110,7 @@ Feature: corosync qdevice/qnetd options validate
   Scenario: Run qdevice stage on inactive cluster node
     Given   Cluster service is "stopped" on "hanode1"
     When    Try "crm cluster init qdevice --qnetd-hostname=qnetd-node"
-    Then    Except "ERROR: cluster.init: Cluster is inactive - can't run qdevice stage"
+    Then    Except "ERROR: cluster.init: Cluster is inactive, can't run 'qdevice' stage"
 
   @clean
   Scenario: Run qdevice stage but miss "--qnetd-hostname" option

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -591,7 +591,7 @@ class TestBootstrap(unittest.TestCase):
             mock_get_node_cononical_hostname,
             mock_detect_cluster_service_on_node
     ):
-        bootstrap._context = mock.Mock(current_user="bob", default_nic="eth1", use_ssh_agent=False)
+        bootstrap._context = mock.Mock(current_user="bob", default_nic="eth1", use_ssh_agent=False, stage=None)
         mock_swap.return_value = None
         mock_ssh_copy_id.return_value = 0
         mock_get_node_cononical_hostname.return_value='node1'


### PR DESCRIPTION
## Changes
- Stages dependency on init side
```
15sp5-1:~ # crm cluster init cluster -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
ERROR: cluster.init: Please run 'ssh' stage first

15sp5-1:~ # crm cluster init ssh -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
INFO: A new ssh keypair is generated for user root.
INFO: A new ssh keypair is generated for user hacluster.
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp5-1:~ # crm cluster init cluster -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
ERROR: cluster.init: Please run 'csync2' stage first

15sp5-1:~ # crm cluster init csync2 -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
INFO: Configuring csync2
INFO: Starting csync2.socket service on 15sp5-1
INFO: BEGIN csync2 checking files
INFO: END csync2 checking files
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp5-1:~ # crm cluster init cluster -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
ERROR: File "/etc/corosync/corosync.conf" not exist
ERROR: cluster.init: Please run 'corosync' stage first

15sp5-1:~ # crm cluster init corosync -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
INFO: Configuring corosync(knet)
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp5-1:~ # crm cluster init cluster -y
INFO: Loading "default" profile from /etc/crm/profiles.yml
INFO: Loading "knet-default" profile from /etc/crm/profiles.yml
INFO: Hawk cluster interface is now running. To see cluster status, open:
INFO:   https://192.168.122.29:7630/
INFO: Log in with username 'hacluster', password 'linux'
WARNING: You should change the hacluster password to something more secure!
INFO: BEGIN Waiting for cluster
...........                                                                                                                                                                                                                                                   INFO: END Waiting for cluster
INFO: Loading initial cluster configuration
INFO: Done (log saved to /var/log/crmsh/crmsh.log)
```

- Stages dependency on join side
```
15sp5-2:~ # crm cluster join cluster -y
ERROR: cluster.join: Can't use stage(cluster) without specifying cluster node

15sp5-2:~ # crm cluster join cluster -c 15sp5-1 -y
ERROR: cluster.join: Please run 'ssh' stage first

15sp5-2:~ # crm cluster join ssh -c 15sp5-1 -y
WARNING: chronyd.service is not configured to start at system boot.
INFO: A new ssh keypair is generated for user root.
INFO: Configuring SSH passwordless with root@15sp5-1
Password: 
INFO: A new ssh keypair is generated for user hacluster.
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp5-2:~ # crm cluster join cluster -c 15sp5-1 -y
ERROR: cluster.join: Please run 'csync2' stage first

15sp5-2:~ # crm cluster join csync2 -c 15sp5-1 -y
WARNING: chronyd.service is not configured to start at system boot.
INFO: Configuring csync2
INFO: Starting csync2.socket service
INFO: BEGIN csync2 syncing files in cluster
INFO: END csync2 syncing files in cluster
INFO: Done (log saved to /var/log/crmsh/crmsh.log)

15sp5-2:~ # crm cluster join cluster -c 15sp5-1 -y
INFO: Hawk cluster interface is now running. To see cluster status, open:
INFO:   https://192.168.122.91:7630/
INFO: Log in with username 'hacluster', password 'linux'
INFO: BEGIN Waiting for cluster
..                                                                                                                                                                                                                                                            INFO: END Waiting for cluster
INFO: BEGIN Reloading cluster configuration
INFO: END Reloading cluster configuration
INFO: Done (log saved to /var/log/crmsh/crmsh.log)
```
- Dev: bootstrap: Remove unused function join_remote_auth
    
    Since /etc/pacemaker/authkey will be synced from init node
- Dev: bootstrap: Enhance stage validation
    
    - All stages on join side require -c option to specify cluster node
    - Move stange validation to a separate function
   
- Remove unused codes