### PR TITLE
Fix: bootstrap: Detect cluster service on init node before saving the canonical hostname (bsc#1222714)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1625,6 +1625,7 @@ def join_ssh_impl(local_user, seed_host, seed_user, ssh_public_keys: typing.List
     user_by_host.add(local_user, utils.this_node())
     user_by_host.set_no_generating_ssh_key(bool(ssh_public_keys))
     user_by_host.save_local()
+    detect_cluster_service_on_node(seed_host)
     user_by_host.add(seed_user, get_node_canonical_hostname(seed_host))
     user_by_host.save_local()
 
@@ -2204,6 +2205,17 @@ def bootstrap_add(context):
         print(out)
 
 
+def detect_cluster_service_on_node(peer_node):
+    service_manager = ServiceManager()
+    for _ in range(REJOIN_COUNT):
+        if service_manager.service_is_active("pacemaker.service", peer_node):
+            break
+        logger.warning("Cluster is inactive on %s. Retry in %d seconds", peer_node, REJOIN_INTERVAL)
+        sleep(REJOIN_INTERVAL)
+    else:
+        utils.fatal("Cluster is inactive on {}".format(peer_node))
+
+
 def bootstrap_join(context):
     """
     Join cluster process
@@ -2242,24 +2254,13 @@ def bootstrap_join(context):
         init_upgradeutil()
         remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
         utils.ping_node(cluster_node)
-
         join_ssh(cluster_node, remote_user)
         remote_user = utils.user_of(cluster_node)
-
-        service_manager = ServiceManager()
-        n = 0
-        while n < REJOIN_COUNT:
-            if service_manager.service_is_active("pacemaker.service", cluster_node):
-                break
-            n += 1
-            logger.warning("Cluster is inactive on %s. Retry in %d seconds", cluster_node, REJOIN_INTERVAL)
-            sleep(REJOIN_INTERVAL)
-        else:
-            utils.fatal("Cluster is inactive on {}".format(cluster_node))
 
         lock_inst = lock.RemoteLock(cluster_node)
         try:
             with lock_inst.lock():
+                service_manager = ServiceManager()
                 _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(cluster_node)
                 setup_passwordless_with_other_nodes(cluster_node, remote_user)
                 join_remote_auth(cluster_node, remote_user)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -577,6 +577,7 @@ class TestBootstrap(unittest.TestCase):
             bootstrap.join_ssh(None, None)
         mock_error.assert_called_once_with("No existing IP/hostname specified (use -c option)")
 
+    @mock.patch('crmsh.bootstrap.detect_cluster_service_on_node')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
     @mock.patch('crmsh.bootstrap.swap_public_ssh_key_for_secondary_user')
     @mock.patch('crmsh.bootstrap.change_user_shell')
@@ -588,6 +589,7 @@ class TestBootstrap(unittest.TestCase):
             self,
             mock_start_service, mock_config_ssh, mock_ssh_copy_id, mock_swap, mock_change, mock_swap_2,
             mock_get_node_cononical_hostname,
+            mock_detect_cluster_service_on_node
     ):
         bootstrap._context = mock.Mock(current_user="bob", default_nic="eth1", use_ssh_agent=False)
         mock_swap.return_value = None


### PR DESCRIPTION

```
# When cluster service is down on init node
# crm cluster join -c 15sp5-1 -y
WARNING: chronyd.service is not configured to start at system boot.
ERROR: cluster.join:
```
```
See crmsh.log:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 86, in run
    rv = self.execute_command() is not False
  File "/usr/lib/python3.6/site-packages/crmsh/ui_context.py", line 267, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib/python3.6/site-packages/crmsh/ui_cluster.py", line 543, in do_join
    bootstrap.bootstrap_join(join_context)
  File "/usr/lib/python3.6/site-packages/crmsh/bootstrap.py", line 2246, in bootstrap_join
    join_ssh(cluster_node, remote_user)
  File "/usr/lib/python3.6/site-packages/crmsh/bootstrap.py", line 1596, in join_ssh
    return join_ssh_impl(local_user, seed_host, seed_user, keys)
  File "/usr/lib/python3.6/site-packages/crmsh/bootstrap.py", line 1628, in join_ssh_impl
    user_by_host.add(seed_user, get_node_canonical_hostname(seed_host))
  File "/usr/lib/python3.6/site-packages/crmsh/bootstrap.py", line 468, in get_node_canonical_hostname
    utils.fatal(err)
  File "/usr/lib/python3.6/site-packages/crmsh/utils.py", line 2711, in fatal
    raise ValueError(error_msg)
ValueError

```


```
With this fix, when cluster service is down on init node

# crm cluster join -c 15sp5-1 -y
WARNING: chronyd.service is not configured to start at system boot.
INFO: A new ssh keypair is generated for user hacluster.
WARNING: Cluster is inactive on 15sp5-1. Retry in 10 seconds
WARNING: Cluster is inactive on 15sp5-1. Retry in 10 seconds
...
```