### PR TITLE
[crmsh-4.5] Fix: bootstrap: Remove unused -i option when calling csync2_remote and ssh_remote stage (bsc#1212080) 

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1702,8 +1702,8 @@ def join_ssh(seed_host, seed_user):
     # user has done manual initial setup without the assistance of
     # ha-cluster-init).
     utils.su_get_stdout_or_raise_error(
-        "ssh {} {}@{} sudo crm cluster init -i {} ssh_remote".format(
-            SSH_OPTION, seed_user, seed_host, _context.default_nic_list[0],
+        "ssh {} {}@{} sudo crm cluster init ssh_remote".format(
+            SSH_OPTION, seed_user, seed_host
         ),
         local_user,
     )
@@ -1786,7 +1786,7 @@ def join_csync2(seed_host, remote_user):
 
     # If we *were* updating /etc/hosts, the next line would have "\"$hosts_line\"" as
     # the last arg (but this requires re-enabling this functionality in ha-cluster-init)
-    cmd = "crm cluster init -i {} csync2_remote {}".format(_context.default_nic_list[0], utils.this_node())
+    cmd = "crm cluster init csync2_remote {}".format(utils.this_node())
     utils.get_stdout_or_raise_error(cmd, seed_host)
 
     # This is necessary if syncing /etc/hosts (to ensure everyone's got the

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -571,7 +571,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.configure_ssh_key')
     @mock.patch('crmsh.utils.start_service')
     def test_join_ssh(self, mock_start_service, mock_config_ssh, mock_ssh_copy_id, mock_swap, mock_invoke, mock_change):
-        bootstrap._context = mock.Mock(current_user="bob", user_list=["alice"], node_list=['node1'], default_nic_list=["eth1"])
+        bootstrap._context = mock.Mock(current_user="bob", user_list=["alice"], node_list=['node1'])
         mock_invoke.return_value = ''
         mock_swap.return_value = None
         mock_ssh_copy_id.return_value = 0
@@ -589,7 +589,7 @@ class TestBootstrap(unittest.TestCase):
                 mock.call("node1", "hacluster", "hacluster", "bob", "alice", add=True),
         ])
         mock_invoke.assert_called_once_with(
-            "ssh {} alice@node1 sudo crm cluster init -i eth1 ssh_remote".format(constants.SSH_OPTION),
+            "ssh {} alice@node1 sudo crm cluster init ssh_remote".format(constants.SSH_OPTION),
             "bob",
         )
 


### PR DESCRIPTION
backport #1347 