### PR TITLE
Enhance completion at non-interactive mode

### DIFF
--- a/contrib/bash_completion.sh
+++ b/contrib/bash_completion.sh
@@ -149,7 +149,7 @@ __crmcompadd ()
 	for x in $1; do
 		if [[ "$x" == "$3"* ]]; then
                     if [[ "$x" =~ .*(=|:)$ ]];then
-                        if [[ "$x" =~ ^id=$ ]];then
+                        if [[ "$x" =~ ^id=$ ]] && [ "$x" == "$3" ];then
                             :
                         else
 			    COMPREPLY[i++]="$2$x"

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -345,10 +345,10 @@ def profile_run(context, user_args):
 
 def run():
     try:
+        envsetup()
         if len(sys.argv) >= 2 and sys.argv[1] == '--compgen':
             compgen()
             return 0
-        envsetup()
         userdir.mv_user_files()
 
         ui = ui_root.Root()

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3481,9 +3481,7 @@ primitive A ocf:pacemaker:Dummy \
 [[cmdhelp_configure_property,set a cluster property]]
 ==== `property`
 
-Set cluster configuration properties. To list the
-available cluster configuration properties, use the
-<<cmdhelp_ra_info,`ra info`>> command with +cluster+ as arguments.
+Set cluster configuration properties.
 When setting the +maintenance-mode+ property, it will
 inform the user if there are nodes or resources that
 have the +maintenance+ property.


### PR DESCRIPTION
Related issue #1390 

'id=' completion
```
# crm configure primitive id=
```

property completion
```
# crm configure property 
batch-limit=                join-finalization-timeout=  pe-error-series-max=        stonith-enabled=
cluster-delay=              join-integration-timeout=   pe-input-series-max=        stonith-max-attempts=
cluster-ipc-limit=          load-threshold=             pe-warn-series-max=         stonith-timeout=
cluster-name=               maintenance-mode=           placement-strategy=         stonith-watchdog-timeout=
cluster-recheck-interval=   migration-limit=            priority-fencing-delay=     stop-all-resources=
concurrent-fencing=         node-action-limit=          remove-after-stop=          stop-orphan-actions=
dc-deadtime=                node-health-base=           shutdown-escalation=        stop-orphan-resources=
election-timeout=           node-health-green=          shutdown-lock=              symmetric-cluster=
enable-acl=                 node-health-red=            shutdown-lock-limit=        transition-delay=
enable-startup-probes=      node-health-strategy=       start-failure-is-fatal=     
fence-reaction=             node-health-yellow=         startup-fencing=            
have-watchdog=              no-quorum-policy=           stonith-action=
```