### PR TITLE
Dev: ui_context: make help subcommands to exit with 0

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -357,8 +357,8 @@ class ConfParser(object):
             try:
                 with open(self._config_file, 'r', encoding='utf-8') as f:
                     self._dom = corosync_config_format.DomParser(f).dom()
-            except OSError:
-                self._dom = dict()
+            except OSError as e:
+                raise ValueError(str(e)) from None
 
         self._dom_query = corosync_config_format.DomQuery(self._dom)
 

--- a/crmsh/crash_test/main.py
+++ b/crmsh/crash_test/main.py
@@ -168,7 +168,7 @@ For each --kill-* testcase, report directory: {}'''.format(context.logfile,
     args = parser.parse_args()
     if args.help or len(sys.argv) == 1:
         parser.print_help()
-        raise crmshutils.TerminateSubCommand
+        raise crmshutils.TerminateSubCommand(success=True)
 
     for arg in vars(args):
         setattr(context, arg, getattr(args, arg))

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -25,17 +25,19 @@ from . import constants
 
 
 from . import log
+from .utils import TerminateSubCommand
+
 logger = log.setup_logger(__name__)
 
 
 def parse_options(parser, args):
     try:
         options, args = parser.parse_known_args(list(args))
-    except:
+    except Exception:
         return None, None
     if hasattr(options, 'help') and options.help:
         parser.print_help()
-        return None, None
+        raise TerminateSubCommand(success=True)
     utils.check_empty_option_value(options)
     return options, args
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -172,6 +172,7 @@ class Cluster(command.UI):
         '''
         Starts the cluster stack on all nodes or specific node(s)
         '''
+        node_list = parse_option_for_nodes(context, *args)
         service_check_list = ["pacemaker.service"]
         start_qdevice = False
         if corosync.is_qdevice_configured():
@@ -179,7 +180,6 @@ class Cluster(command.UI):
             service_check_list.append("corosync-qdevice.service")
 
         service_manager = ServiceManager()
-        node_list = parse_option_for_nodes(context, *args)
         for node in node_list[:]:
             if all([service_manager.service_is_active(srv, remote_addr=node) for srv in service_check_list]):
                 logger.info("The cluster stack already started on {}".format(node))

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -92,8 +92,11 @@ class Context(object):
         except (ValueError, IOError) as e:
             logger.error("%s: %s", self.get_qualified_name(), e, exc_info=e)
             rv = False
-        except utils.TerminateSubCommand:
-            return False
+        except utils.TerminateSubCommand as terminate:
+            if terminate.success:
+                rv = True
+            else:
+                return False
         if cmd or (rv is False):
             rv = self._back_out() and rv
 

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -237,7 +237,7 @@ keep the node in standby after reboot. The life time defaults to
     options, args = parser.parse_known_args(args)
     if options.help:
         parser.print_help()
-        raise utils.TerminateSubCommand
+        raise utils.TerminateSubCommand(success=True)
     if options is None or args is None:
         raise utils.TerminateSubCommand
     if options.all and args:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -53,6 +53,8 @@ class TerminateSubCommand(Exception):
     """
     This is an exception to jump out of subcommand when meeting errors while staying interactive shell
     """
+    def __init__(self, success=False):
+        self.success = success
 
 
 def to_ascii(input_str):


### PR DESCRIPTION
port:

* #1375

revert:

* 9148684b980b30291de91d9e203980ee08a610d9 which is merged by mistake

and

* make `ui_clsuter.do_start` to parse cmdline args before doing any other check