### PR TITLE
[crmsh-4.6] Fix: doc/toolchain: fix missing anchor in generated AIO doc (#1409)

### DIFF
--- a/doc/toolchain/bin/adocxt
+++ b/doc/toolchain/bin/adocxt
@@ -10,7 +10,7 @@ import typing
 RE_FROM_CODE = re.compile(r'^\[\[([^,]+),[^,]*,From Code]]$')
 RE_TAG = re.compile('^cmdhelp_(.*)$')
 RE_SECTION_TITLE = re.compile('^=')
-RE_FROM_CODE_OR_SECTION_TITLE=re.compile(r'^(?:\[\[([^,]+),[^,]*,From Code]]$|=)')
+RE_ANCHOR_OR_SECTION_TITLE=re.compile(r'^(?:\[\[.*]]$|=)')
 
 TAG_EXCLUDES = {
     'cmdhelp_root_report',
@@ -86,7 +86,7 @@ def generate_include(stdin, stdout):
                             break
                         case _:
                             # waiting for next section
-                            found = RE_FROM_CODE_OR_SECTION_TITLE.match(line)
+                            found = RE_ANCHOR_OR_SECTION_TITLE.match(line)
                             if found:
                                 tag = None
                                 section_title = None

--- a/doc/website-v1/man-4.6.adoc
+++ b/doc/website-v1/man-4.6.adoc
@@ -1103,6 +1103,7 @@ Options:
 
 
 
+[[cmdhelp_cluster_health,Cluster health check]]
 ==== `health`
 
 Runs a larger set of tests and queries on all nodes in the cluster to
@@ -1363,6 +1364,7 @@ Options:
 
 
 
+[[cmdhelp_cluster_rename,Rename the cluster]]
 ==== `rename`
 
 Rename the cluster name 
@@ -1407,6 +1409,7 @@ Options:
 
 
 
+[[cmdhelp_cluster_status,Cluster status check]]
 ==== `status`
 
 Reports the status for the cluster messaging layer on the local
@@ -1433,6 +1436,7 @@ Options:
 
 
 
+[[cmdhelp_cluster_wait_for_startup,Wait for cluster to start]]
 ==== `wait_for_startup`
 
 Mostly useful in scripts or automated workflows, this command will
@@ -2493,6 +2497,7 @@ Options:
 
 
 
+[[cmdhelp_node_ready,put node into ready mode]]
 ==== `ready`
 
 Set the node's maintenance status to `off`. The node should be
@@ -2550,6 +2555,7 @@ Options:
 
 
 
+[[cmdhelp_node_status-attr,manage status attributes]]
 ==== `status-attr`
 
 Edit node attributes which are in the CIB status section, i.e.,


### PR DESCRIPTION
The start of next section should be detected with

```
[[...]]
= ...
```

instead of

```
[[...,From Code]]
= ...
```