### PR TITLE
Dev: utils: Add info when property is newly added

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2795,11 +2795,12 @@ def set_property(property_name, property_value, property_type="crm_config", cond
     origin_value = get_property(property_name, property_type)
     if origin_value and str(origin_value) == str(property_value):
         return
-    if conditional:
-        if crm_msec(origin_value) >= crm_msec(property_value):
-            return
+    if conditional and crm_msec(origin_value) >= crm_msec(property_value):
+        return
+    if not origin_value and property_value:
+        logger.info("Set property \"%s\" in %s to %s", property_name, property_type, property_value)
     if origin_value and str(origin_value) != str(property_value):
-        logger.warning("\"{}\" in {} is set to {}, it was {}".format(property_name, property_type, property_value, origin_value))
+        logger.warning("\"%s\" in %s is set to %s, it was %s", property_name, property_type, property_value, origin_value)
     property_sub_cmd = "property" if property_type == "crm_config" else property_type
     cmd = "crm configure {} {}={}".format(property_sub_cmd, property_name, property_value)
     sh.cluster_shell().get_stdout_or_raise_error(cmd)

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1151,7 +1151,7 @@ def test_set_property(mock_get, mock_run, mock_warn):
     mock_get.return_value = "start"
     utils.set_property("no-quorum-policy", "stop")
     mock_run.assert_called_once_with("crm configure property no-quorum-policy=stop")
-    mock_warn.assert_called_once_with('"no-quorum-policy" in crm_config is set to stop, it was start')
+    mock_warn.assert_called_once_with('"%s" in %s is set to %s, it was %s', 'no-quorum-policy', 'crm_config', 'stop', 'start')
 
 
 @mock.patch('crmsh.utils.get_property')


### PR DESCRIPTION
case 1
```
# first node init
no 'priority' property

# then the second node join
set 'priority=1' with no warning/info to show this behavior
```
case 2
```
# two-node cluster running
# remove the second node
show:
WARNING: "priority" in rsc_defaults is set to 0, it was 1
```
case 3
```
# removed node re-join
show:
WARNING: "priority" in rsc_defaults is set to 1, it was 0
```

This PR adds info when the property is newly added, for case 1