### PR TITLE
Dev: Change the RA name string format

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -490,8 +490,8 @@ CRM_MON_ONE_SHOT = "crm_mon -1"
 CRM_MON_XML_OUTPUT= "crm_mon --output-as=xml"
 STONITH_TIMEOUT_DEFAULT = 60
 PCMK_DELAY_MAX = 30
-DLM_CONTROLD_RA = "ocf::pacemaker:controld"
-LVMLOCKD_RA = "ocf::heartbeat:lvmlockd"
+DLM_CONTROLD_RA = "ocf:pacemaker:controld"
+LVMLOCKD_RA = "ocf:heartbeat:lvmlockd"
 HA_USER = "hacluster"
 HA_GROUP = "haclient"
 SCHEMA_MIN_VER_SUPPORT_OCF_1_1 = "pacemaker-3.7"

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -24,10 +24,10 @@ class TestCrmMonXmlParser(unittest.TestCase):
     <node name="tbw-2" id="1084783312" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member"/>
   </nodes>
   <resources>
-    <resource id="ocfs2-dlm" resource_agent="ocf::pacemaker:controld" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+    <resource id="ocfs2-dlm" resource_agent="ocf:pacemaker:controld" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
       <node name="tbw-2" id="1084783312" cached="true"/>
     </resource>
-    <resource id="ocfs2-clusterfs" resource_agent="ocf::heartbeat:Filesystem" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+    <resource id="ocfs2-clusterfs" resource_agent="ocf:heartbeat:Filesystem" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
       <node name="tbw-2" id="1084783312" cached="true"/>
     </resource>
   </resources>
@@ -46,7 +46,7 @@ class TestCrmMonXmlParser(unittest.TestCase):
 
     def test_is_resource_configured(self):
         assert self.parser_inst.is_resource_configured("test") is False
-        assert self.parser_inst.is_resource_configured("ocf::heartbeat:Filesystem") is True
+        assert self.parser_inst.is_resource_configured("ocf:heartbeat:Filesystem") is True
 
     def test_is_any_resource_running(self):
         assert self.parser_inst.is_any_resource_running() is True
@@ -54,8 +54,8 @@ class TestCrmMonXmlParser(unittest.TestCase):
     def test_is_resource_started(self):
         assert self.parser_inst.is_resource_started("test") is False
         assert self.parser_inst.is_resource_started("ocfs2-clusterfs") is True
-        assert self.parser_inst.is_resource_started("ocf::pacemaker:controld") is True
+        assert self.parser_inst.is_resource_started("ocf:pacemaker:controld") is True
 
     def test_get_resource_id_list_via_type(self):
         assert self.parser_inst.get_resource_id_list_via_type("test") == []
-        assert self.parser_inst.get_resource_id_list_via_type("ocf::pacemaker:controld")[0] == "ocfs2-dlm"
+        assert self.parser_inst.get_resource_id_list_via_type("ocf:pacemaker:controld")[0] == "ocfs2-dlm"


### PR DESCRIPTION
OCF resource agents will be displayed as ocf:PROVIDER:AGENT rather than ocf::PROVIDER:AGENT in crm_mon and crm_simulate output and pacemaker-schedulerd logs