### PR TITLE
interface network option improvement

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1923,8 +1923,10 @@ def join_cluster(seed_host, remote_user):
 
     link_number = corosync.get_link_number()
     join_link_number = len(_context.default_ip_list)
-    if link_number != join_link_number:
-        utils.fatal(f"knet transport of all cluster nodes need {link_number} links via '-i' options, but provided {join_link_number}")
+    # the join link number can't be greater than the peer's link number
+    # or less than the peer's link number if -y is set
+    if join_link_number > link_number or (_context.yes_to_all and join_link_number < link_number):
+        utils.fatal(f"Node {seed_host} has {link_number} links, but provided {join_link_number}")
 
     detect_mountpoint(seed_host)
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1325,15 +1325,23 @@ def get_address_list() -> typing.List[str]:
     else:
         valid_func = Validation.valid_ucast_ip
 
+    if _context.yes_to_all or _context.nic_addr_list:
+        loop_count = len(_context.default_ip_list)
+    else:
+        # interative mode and without -i option specified
+        loop_count = min(Context.MAX_LINK_NUM, len(_context.interfaces_inst.nic_list))
+
     ringXaddr_list = []
-    loop_count = min(Context.MAX_LINK_NUM, len(_context.default_ip_list))
     for i in range(loop_count):
         addr = prompt_for_string("Address for ring{}".format(i),
                 default=pick_default_value(_context.default_ip_list, ringXaddr_list),
                 valid_func=valid_func,
                 prev_value=ringXaddr_list)
         ringXaddr_list.append(addr)
-        if i < (loop_count - 1) and not confirm("\nAdd another ring?"):
+        # only confirm when not the last loop and without -i option specified
+        if not _context.nic_addr_list and \
+                i < (loop_count - 1) and \
+                not confirm("\nAdd another ring?"):
             break
 
     return ringXaddr_list

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2332,7 +2332,7 @@ class InterfacesInfo(object):
                 self._input_nic_list.append(nic)
                 self._input_addr_list.append(item)
             else:
-                raise ValueError(f"Invalid value '{item}' for -i/--interface option")
+                raise ValueError(f"Invalid value '{item}' for -i/--interface option, should be {', '.join(self.nic_list)} or {', '.join(self.ip_list)}")
 
     @property
     def nic_list(self):

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -200,6 +200,6 @@ Feature: crmsh bootstrap process - options
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "stopped" on "hanode2"
-    And     Except "knet transport of all cluster nodes need 2 links via '-i' options, but provided 1" in stderr
+    And     Except "Node hanode1 has 2 links, but provided 1" in stderr
     When    Run "crm cluster join -c hanode1 -i eth0 -i eth1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"


### PR DESCRIPTION
-  Give valid value list for the -i option when the value is invalid
```
# crm cluster init -i xxx
ERROR: cluster.init: Invalid value 'xxx' for -i/--interface option

# After applying this PR

# crm cluster init -i xxx
ERROR: cluster.init: Invalid value 'xxx' for -i/--interface option, should be enp1s0, enp7s0, enp8s0 or 192.168.122.189, 10.10.10.61, 20.20.20.61
```
-  On join side, adjust the condition of comparing the link number
```
# on init node
# crm cluster init -i 10.10.10.61 -i 20.20.20.61 -y

# on join node
# crm cluster join
# ...
# ERROR: cluster.join: knet transport of all cluster nodes need 2 links via '-i' options, but provided 1

# After applying this PR

# crm cluster join
# ...
# Address for ring0 [192.168.122.145]
# Address for ring1 []10.10.10.62
```

- Minor refactoring of the get_address_list function
```
# no way to add another ring on interactive mode
# crm cluster init
...
Address for ring0 [192.168.122.189]
INFO: Configure SBD:

# After applying this PR
# crm cluster init
...
Address for ring0 [192.168.122.145]

Add another ring (y/n)?
```

```
# no need to ask for confirm for each -i option
# crm cluster init -i enp7s0 -i enp8s0
...
Address for ring0 [10.10.10.61]

Add another ring (y/n)?

# After applying this PR
 # crm cluster init -i enp7s0 -i enp8s0
...
Address for ring0 [10.10.10.62]
Address for ring1 [20.20.20.62]
INFO: Configure SBD:
```