### PR TITLE
Dev: Parsing resource meta attributes dynamically

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -25,7 +25,7 @@ from . import cibstatus
 from . import crm_gv
 from . import ui_utils
 from . import userdir
-from .ra import get_ra, get_properties_list, get_pe_meta, get_properties_meta, RAInfo
+from .ra import get_ra, get_properties_list, get_pe_meta, get_properties_meta, RAInfo, get_resource_meta_list
 from .utils import ext_cmd, safe_open_w, pipe_string, safe_close_w, crm_msec
 from .utils import ask, lines2cli, olist
 from .utils import page_string, str2tmp, ensure_sudo_readable
@@ -1571,7 +1571,7 @@ class CibPrimitive(CibObject):
         if self.node is None:  # eh?
             logger.error("%s: no xml (strange)", self.obj_id)
             return utils.get_check_rc()
-        rc3 = sanity_check_meta(self.obj_id, self.node, constants.rsc_meta_attributes)
+        rc3 = sanity_check_meta(self.obj_id, self.node, get_resource_meta_list())
         if self.obj_type == "primitive":
             r_node = reduce_primitive(self.node)
             if r_node is None:
@@ -1681,7 +1681,7 @@ class CibContainer(CibObject):
         if self.node is None:  # eh?
             logger.error("%s: no xml (strange)", self.obj_id)
             return utils.get_check_rc()
-        l = constants.rsc_meta_attributes
+        l = get_resource_meta_list()
         if self.obj_type == "clone":
             l += constants.clone_meta_attributes
         elif self.obj_type == "ms":
@@ -2045,7 +2045,7 @@ class CibProperty(CibObject):
         elif self.obj_type == "op_defaults":
             l = schema.get('attr', 'op', 'a')
         elif self.obj_type == "rsc_defaults":
-            l = constants.rsc_meta_attributes
+            l = get_resource_meta_list()
         rc = sanity_check_nvpairs(self.obj_id, self.node, l)
         return rc
 

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -228,6 +228,23 @@ def get_properties_list():
         return []
 
 
+@utils.memoize
+def get_resource_meta():
+    resource_meta = utils.get_resource_metadata()
+    if resource_meta:
+        return RAInfo("resource_meta", None, meta_string=resource_meta)
+    return None
+
+
+@utils.memoize
+def get_resource_meta_list():
+    try:
+        return list(get_resource_meta().params().keys())
+    # use legacy code to get the resource metadata list
+    except:
+        return constants.rsc_meta_attributes
+
+
 def prog_meta(prog):
     '''
     Do external program metadata.

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -238,9 +238,14 @@ def _prim_meta_completer(agent, args):
     completing = args[-1]
     if completing == 'meta':
         return ['meta']
+    if completing.endswith('='):
+        if len(completing) > 1 and options.interactive:
+            topic = completing[:-1]
+            CompletionHelp.help(topic, agent.meta_parameter(topic), args)
+        return []
     if '=' in completing:
         return []
-    return utils.filter_keys(constants.rsc_meta_attributes, args)
+    return utils.filter_keys(ra.get_resource_meta_list(), args)
 
 
 def _prim_op_completer(agent, args):
@@ -304,6 +309,11 @@ def _property_completer(args):
     return _prim_params_completer(agent, args)
 
 
+def _rsc_meta_completer(args):
+    agent = ra.get_resource_meta()
+    return _prim_meta_completer(agent, args)
+
+
 def primitive_complete_complex(args):
     '''
     This completer depends on the content of the line, i.e. on
@@ -334,6 +344,8 @@ def primitive_complete_complex(args):
     if last_keyw is None:
         return []
 
+    if last_keyw == 'meta':
+        agent = ra.get_resource_meta()
     complete_results = completers_set[last_keyw](agent, args)
     if len(args) > 4 and '=' in args[-1]:
         return complete_results + keywords
@@ -1125,7 +1137,7 @@ class CibConfig(command.UI):
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('administrator')
-    @command.completers_repeating(_prim_meta_completer)
+    @command.completers_repeating(_rsc_meta_completer)
     def do_rsc_defaults(self, context, *args):
         "usage: rsc_defaults [$id=<set_id>] <option>=<value>"
         return self.__conf_object(context.get_command_name(), *args)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -194,6 +194,15 @@ def get_cluster_option_metadata(show_xml=True) -> str:
     return None
 
 
+def get_resource_metadata(show_xml=True) -> str:
+    output_type = "xml" if show_xml else "text"
+    cmd = f"crm_resource --list-options=primitive --all --output-as={output_type}"
+    rc, out, _ = ShellUtils().get_stdout_stderr(cmd)
+    if rc == 0 and out:
+        return out
+    return None
+
+
 def pacemaker_20_daemon(new, old):
     "helper to discover renamed pacemaker daemons"
     if is_program(new):

--- a/test/testcases/acl.exp
+++ b/test/testcases/acl.exp
@@ -23,6 +23,7 @@
 .INP: _test
 .INP: verify
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: show
 node node1
 primitive d0 ocf:pacemaker:Dummy \

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -62,6 +62,7 @@ clone cl-p5 p5 \
        meta interleave=true
 colocation c2 inf: ( p1 p2 ) p3 p4
 .INP: commit
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: _test
 .INP: verify
 .INP: show
@@ -153,6 +154,7 @@ op_defaults op-options: \
 .INP: commit
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: _test
 .INP: verify
 .TRY Unknown properties
@@ -176,6 +178,7 @@ primitive st stonith:null \
 property SAPHanaSR: \
 	hana_ha1_site_lss_WDF1=4
 .INP: commit
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: _test
 .INP: verify
 .INP: property SAPHanaSR_2:     hana_ha1_site_iss_WDF1=cde     hana_ha1_site_bss_WDF1=abc
@@ -211,5 +214,6 @@ INFO: 6: pulling in template virtual-ip
 .EXT crm_resource --list-ocf-alternatives IPaddr
 .INP: up
 .INP: commit
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: _test
 .INP: verify

--- a/test/testcases/bundle.exp
+++ b/test/testcases/bundle.exp
@@ -19,6 +19,7 @@
 .INP: _test
 .INP: verify
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: show
 node node1 \
        attributes mem=16G

--- a/test/testcases/commit.exp
+++ b/test/testcases/commit.exp
@@ -8,6 +8,7 @@
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .INP: commit
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 WARNING: 7: st: unknown attribute 'yoyo-meta'
 .INP: node node1 	attributes mem=16G
 .INP: primitive p1 ocf:heartbeat:Dummy 	op monitor interval=60m 	op monitor interval=120m OCF_CHECK_LEVEL=10

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -68,6 +68,7 @@ INFO: 37: "collocation" is accepted as "colocation"
 .INP: set d2.mondelay 45
 .INP: _test
 .INP: verify
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 WARNING: 53: c2: resource d1 is grouped, constraints should apply to the group
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
 .INP: show

--- a/test/testcases/delete.exp
+++ b/test/testcases/delete.exp
@@ -117,6 +117,7 @@ primitive st stonith:ssh \
 	op stop timeout=15s interval=0s
 location d1-pref d1 100: node1
 .INP: verify
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: # delete a group which is in a clone
 .INP: primitive d2 ocf:pacemaker:Dummy
 .INP: group g1 d2 d1

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -202,6 +202,7 @@ rsc_defaults rsc_options: \
 op_defaults op-options: \
 	timeout=60s
 .INP: commit
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
 .INP: _test
 .INP: verify

--- a/test/testcases/file.exp
+++ b/test/testcases/file.exp
@@ -37,6 +37,7 @@ op_defaults op-options: \
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .EXT sed -i 's/60s/2m/' sample.txt
 .EXT sed -i '8a # comment' sample.txt
 .TRY Load update

--- a/test/testcases/newfeatures.exp
+++ b/test/testcases/newfeatures.exp
@@ -76,4 +76,5 @@ alert notify_9 "/usr/share/pacemaker/alerts/alert_snmp.sh" \
 .INP: _test
 .INP: verify
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: commit

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -9,6 +9,7 @@ node1: member
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -25,6 +26,7 @@ node1: member
 </cib>
 
 .TRY configure group g0 p5
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -589,6 +589,7 @@ INFO: Stop tracing p0 for operation stop
 </cib>
 
 .TRY configure group g p0 p3
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -778,6 +779,7 @@ INFO: Stop tracing p0 for operation stop
 </cib>
 
 .TRY configure clone cg g
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -1125,12 +1127,14 @@ INFO: Stop tracing p0 for operation stop
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY configure primitive p3 Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY resource stop p3
 .TRY resource start p3
 .TRY resource stop p3
@@ -1139,6 +1143,7 @@ WARNING: This command 'rm' is deprecated, please use 'delete'
 INFO: "rm" is accepted as "delete"
 .TRY configure ms msg g
 WARNING: "ms" is deprecated. Please use "clone msg g meta promotable=true"
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY resource scores
 .EXT crm_simulate -sUL
 2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
@@ -1180,7 +1185,9 @@ Remaining: node1 capacity:
 .EXT stonithd metadata
 .EXT crm_resource --show-metadata ocf:pacemaker:Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Delay
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY configure group g1 p5
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY resource manage p5
 .SETENV showobj=p5
 .TRY -F resource maintenance p5 on

--- a/test/testcases/rset.exp
+++ b/test/testcases/rset.exp
@@ -40,6 +40,7 @@ colocation c3 inf: d3 d1
 order o1 Serialize: d1 d3
 .INP: _test
 .INP: verify
+.EXT crm_resource --list-options=primitive --all --output-as=xml
 .INP: show
 node node1
 primitive d1 ocf:pacemaker:Dummy \


### PR DESCRIPTION
With the latest pacemaker version (since 2.1.8),
crmsh can get the resource meta attributes by parsing the output of `crm_resource --list-options=primitive --output-as=xml` command.

The benefit of this approach:
- Avoid hardcoding the resource meta attributes
- Provide help info at interactive mode for each meta attribute

```
crm(live/alp-1)configure# rsc_defaults maintenance=
maintenance (boolean, [false]): If true, the cluster will not schedule any actions involving the resource
    If true, the cluster will not start, stop, promote, or demote the resource on any node, and will pause any recurring monitors (except those specifying role as "Stopped"). If false, a true value for the maintenance-mode cluster option or maintenance node attribute overrides this.

crm(live/alp-1)configure# primitive d Dummy meta  allow-migrate= 
allow-migrate (boolean): Whether the cluster should try to "live migrate" this resource when it needs to be moved
    Whether the cluster should try to "live migrate" this resource when it needs to be moved. The default is true for ocf:pacemaker:remote resources, and false otherwise.
```

Note: This PR also supports original way for resource meta if pacemaker doesn't have such option