### PR TITLE
Dev: log an error when fencing node without stonith device configured and running

### DIFF
--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -108,6 +108,9 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
             self.get_fence_info()
             if not self.fence_enabled:
                 raise TaskError("Require stonith enabled")
+            if not self.fence_configured:
+                raise TaskError("Require stonith device configured and running")
+
 
     def get_fence_info(self):
         """
@@ -115,6 +118,7 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
         """
         fence_info_inst = utils.FenceInfo()
         self.fence_enabled = fence_info_inst.fence_enabled
+        self.fence_configured = fence_info_inst.fence_configured
         self.fence_action = fence_info_inst.fence_action
         self.fence_timeout = fence_info_inst.fence_timeout
 

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -111,6 +111,10 @@ class FenceInfo(object):
         return True
 
     @property
+    def fence_configured(self):
+        return crmshutils.has_stonith_running()
+
+    @property
     def fence_action(self):
         action_result = crmshutils.get_property("stonith-action")
         if action_result is None or action_result not in ["off", "poweroff", "reboot"]:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -484,6 +484,9 @@ class NodeMgmt(command.UI):
         'usage: fence <node>'
         if not utils.is_name_sane(node):
             return False
+        if not utils.has_stonith_running():
+            logger.error("fence command requires stonith device configured and running")
+            return False
         if not config.core.force and \
                 not utils.ask("Fencing %s will shut down the node and migrate any resources that are running on it! Do you want to fence %s?" % (node, node)):
             return False


### PR DESCRIPTION
When running `crm node fence` or `crm cluster crash_test --fence-node`, should check if stonith device configured and running, if not, log an error and return False