### PR TITLE
[crmsh-4.6] Dev: github-actions: update to v4 (#1431)

### DIFF
--- a/.github/workflows/crmsh-cd.yml
+++ b/.github/workflows/crmsh-cd.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: delivery process
       run: |
         docker pull "${CONTAINER_IMAGE}"
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: submit process
       run: |
         docker pull "${CONTAINER_IMAGE}"

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -61,6 +61,8 @@ jobs:
         index=`$GET_INDEX_OF crm_report_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_crm_report_normal:
     runs-on: ubuntu-20.04
@@ -74,6 +76,8 @@ jobs:
         index=`$GET_INDEX_OF crm_report_normal`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-20.04
@@ -87,6 +91,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_bugs_non_root:
     runs-on: ubuntu-20.04
@@ -100,6 +106,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_common:
     runs-on: ubuntu-20.04
@@ -113,6 +121,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_common_non_root:
     runs-on: ubuntu-20.04
@@ -126,6 +136,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_options:
     runs-on: ubuntu-20.04
@@ -139,6 +151,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_options_non_root:
     runs-on: ubuntu-20.04
@@ -152,6 +166,8 @@ jobs:
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-20.04
@@ -165,6 +181,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_setup_remove_non_root:
     runs-on: ubuntu-20.04
@@ -178,6 +196,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_options:
     runs-on: ubuntu-20.04
@@ -191,6 +211,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_options`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_validate:
     runs-on: ubuntu-20.04
@@ -204,6 +226,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_validate_non_root:
     runs-on: ubuntu-20.04
@@ -217,6 +241,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-20.04
@@ -230,6 +256,8 @@ jobs:
         index=`$GET_INDEX_OF qdevice_usercase`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_failcount:
     runs-on: ubuntu-20.04
@@ -243,6 +271,8 @@ jobs:
         index=`$GET_INDEX_OF resource_failcount`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_set:
     runs-on: ubuntu-20.04
@@ -256,6 +286,8 @@ jobs:
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_set_non_root:
     runs-on: ubuntu-20.04
@@ -269,6 +301,8 @@ jobs:
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-20.04
@@ -282,6 +316,8 @@ jobs:
         index=`$GET_INDEX_OF configure_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_constraints_bugs:
     runs-on: ubuntu-20.04
@@ -295,6 +331,8 @@ jobs:
         index=`$GET_INDEX_OF constraints_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_geo_cluster:
     runs-on: ubuntu-20.04
@@ -308,6 +346,8 @@ jobs:
         index=`$GET_INDEX_OF geo_setup`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_healthcheck:
     runs-on: ubuntu-20.04
@@ -321,6 +361,8 @@ jobs:
         index=`$GET_INDEX_OF healthcheck`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_cluster_api:
     runs-on: ubuntu-20.04
@@ -333,6 +375,8 @@ jobs:
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_user_access:
     runs-on: ubuntu-20.04
@@ -345,6 +389,8 @@ jobs:
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_ssh_agent:
     runs-on: ubuntu-20.04
@@ -357,6 +403,8 @@ jobs:
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent` && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
     - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   original_regression_test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -48,6 +48,10 @@ jobs:
     - name: Test with pytest in tox
       run: |
         tox -v -e${{ matrix.python-version }}
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unit
 
   functional_test_crm_report_bugs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -16,7 +16,7 @@ jobs:
   general_check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: check data-manifest
       run: |
         ./update-data-manifest.sh
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for crm_report bugs
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for crm_report normal
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap bugs
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap bugs, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap common
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap common, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap options
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for bootstrap options, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice setup and remove
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice setup and remove, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice options
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice validate
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice validate, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for qdevice user case
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for resource failcount
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for resource set
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for resource set, under non root user
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for configure sublevel bugs
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for constraints bugs
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for geo cluster
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -353,7 +353,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for healthcheck
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -368,7 +368,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for cluster api
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for user access
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: functional test for ssh agent
       run:  |
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
@@ -410,7 +410,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: original regression test
       run:  |
         $DOCKER_SCRIPT `$GET_INDEX_OF "regression test"`

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -63,6 +63,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_crm_report_normal:
     runs-on: ubuntu-20.04
@@ -78,6 +79,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-20.04
@@ -93,6 +95,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_bugs_non_root:
     runs-on: ubuntu-20.04
@@ -108,6 +111,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_common:
     runs-on: ubuntu-20.04
@@ -123,6 +127,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_common_non_root:
     runs-on: ubuntu-20.04
@@ -138,6 +143,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_options:
     runs-on: ubuntu-20.04
@@ -153,6 +159,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_bootstrap_options_non_root:
     runs-on: ubuntu-20.04
@@ -168,6 +175,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-20.04
@@ -183,6 +191,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_setup_remove_non_root:
     runs-on: ubuntu-20.04
@@ -198,6 +207,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_options:
     runs-on: ubuntu-20.04
@@ -213,6 +223,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_validate:
     runs-on: ubuntu-20.04
@@ -228,6 +239,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_validate_non_root:
     runs-on: ubuntu-20.04
@@ -243,6 +255,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-20.04
@@ -258,6 +271,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_resource_failcount:
     runs-on: ubuntu-20.04
@@ -273,6 +287,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_resource_set:
     runs-on: ubuntu-20.04
@@ -288,6 +303,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_resource_set_non_root:
     runs-on: ubuntu-20.04
@@ -303,6 +319,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-20.04
@@ -318,6 +335,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_constraints_bugs:
     runs-on: ubuntu-20.04
@@ -333,6 +351,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_geo_cluster:
     runs-on: ubuntu-20.04
@@ -348,6 +367,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_healthcheck:
     runs-on: ubuntu-20.04
@@ -363,6 +383,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_cluster_api:
     runs-on: ubuntu-20.04
@@ -377,6 +398,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_user_access:
     runs-on: ubuntu-20.04
@@ -391,6 +413,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   functional_test_ssh_agent:
     runs-on: ubuntu-20.04
@@ -405,6 +428,7 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration
 
   original_regression_test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -60,7 +60,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF crm_report_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -75,7 +75,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF crm_report_normal`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -105,7 +105,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -120,7 +120,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -135,7 +135,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -150,7 +150,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -165,7 +165,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -180,7 +180,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -195,7 +195,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -210,7 +210,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_options`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -225,7 +225,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -240,7 +240,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -255,7 +255,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_usercase`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -270,7 +270,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_failcount`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -285,7 +285,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -300,7 +300,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
         $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -315,7 +315,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF configure_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -330,7 +330,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF constraints_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -345,7 +345,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF geo_setup`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -360,7 +360,7 @@ jobs:
         sudo systemctl restart docker.service
         index=`$GET_INDEX_OF healthcheck`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -374,7 +374,7 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -388,7 +388,7 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -402,7 +402,7 @@ jobs:
         echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent` && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,9 +8,9 @@ coverage:
         threshold: 0.35%
 codecov: 
   notify:
-    after_n_builds: 23
+    after_n_builds: 27
 comment:
-  after_n_builds: 23
+  after_n_builds: 27
 
 ignore:
   - "crmsh/report"

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ coverage:
       default:
         threshold: 0.35%
 codecov: 
-  token: 16b01c29-3b23-4923-b33a-4d26a49d80c4
   notify:
     after_n_builds: 23
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ codecov:
     after_n_builds: 27
 comment:
   after_n_builds: 27
+  layout: "condensed_header, flags, files, condensed_footer"
 
 ignore:
   - "crmsh/report"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ changedir = test/unittests
 deps =
     pytest
     pytest-cov
-commands = py.test -vv --cov=crmsh --cov-config .coveragerc --cov-report term --cov-report html {posargs}
+commands = pytest -vv --cov=crmsh --cov-config .coveragerc --cov-report term --cov-report xml {posargs}
 
 [testenv]
 changedir = {[base]changedir}


### PR DESCRIPTION
backport:

* #1436

difference:

* use ubuntu 20.04 as python 3.6 is removed in 24.04
* the number of reports are different
* no badge in README.md