### PR TITLE
[crmsh-4.6] Dev: ui_resource: Improve completers for 'crm resource' command

### DIFF
--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -50,21 +50,15 @@ def resources(args=None):
         return []
     nodes = xmlutil.get_interesting_nodes(cib_el, [])
     rsc_id_list = [x.get("id") for x in nodes if xmlutil.is_resource(x)]
-    if args and args[0] in ['promote', 'demote']:
-        return [item for item in rsc_id_list if xmlutil.RscState().is_ms_or_promotable_clone(item)]
-    if args and args[0] == "started":
-        return [item for item in rsc_id_list if xmlutil.RscState().is_running(item)]
-    if args and args[0] == "stopped":
-        return [item for item in rsc_id_list if not xmlutil.RscState().is_running(item)]
+    if args:
+        if args[0] in ('promote', 'demote'):
+            rsc_id_list = [item for item in rsc_id_list if xmlutil.RscState().is_ms_or_promotable_clone(item)]
+        elif args[0] == "start":
+            rsc_id_list = [item for item in rsc_id_list if not xmlutil.RscState().is_running(item)]
+        elif args[0] == "stop":
+            rsc_id_list = [item for item in rsc_id_list if xmlutil.RscState().is_running(item)]
+        rsc_id_list = [item for item in rsc_id_list if item not in args]
     return rsc_id_list
-
-
-def resources_started(args=None):
-    return resources(["started"])
-
-
-def resources_stopped(args=None):
-    return resources(["stopped"])
 
 
 def primitives(args):

--- a/crmsh/crash_test/check.py
+++ b/crmsh/crash_test/check.py
@@ -305,8 +305,8 @@ def check_resources():
     """
     task_inst = task.TaskCheck("Checking resources")
     with task_inst.run():
-        started_list = completers.resources_started()
-        stopped_list = completers.resources_stopped()
+        started_list = completers.resources(["stop"])
+        stopped_list = completers.resources(["start"])
         # TODO need suitable method to get failed resources list
         failed_list = []
         if started_list:

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -257,7 +257,7 @@ class RscMgmt(command.UI):
         return True
 
     @command.alias('show', 'list')
-    @command.completers(compl.resources)
+    @command.completers_repeating(compl.resources)
     def do_status(self, context, *resources):
         "usage: status [<rsc> ...]"
         if len(resources) > 0:
@@ -303,7 +303,7 @@ class RscMgmt(command.UI):
         return rc
 
     @command.wait
-    @command.completers(compl.resources_stopped)
+    @command.completers_repeating(compl.resources)
     def do_start(self, context, *resources):
         "usage: start <rsc> [<rsc> ...]"
         if len(resources) == 0:
@@ -311,7 +311,7 @@ class RscMgmt(command.UI):
         return self._commit_meta_attrs(context, resources, "target-role", "Started")
 
     @command.wait
-    @command.completers(compl.resources_started)
+    @command.completers_repeating(compl.resources)
     def do_stop(self, context, *resources):
         "usage: stop <rsc> [<rsc> ...]"
         if len(resources) == 0:
@@ -319,7 +319,7 @@ class RscMgmt(command.UI):
         return self._commit_meta_attrs(context, resources, "target-role", "Stopped")
 
     @command.wait
-    @command.completers(compl.resources)
+    @command.completers_repeating(compl.resources)
     def do_restart(self, context, *resources):
         "usage: restart <rsc> [<rsc> ...]"
         logger.info("ordering %s to stop", ", ".join(resources))
@@ -351,7 +351,7 @@ class RscMgmt(command.UI):
         else:
             context.fatal_error("Need crm_simulate or ptest in path to display scores")
 
-    @command.completers(compl.resources)
+    @command.completers_repeating(compl.resources)
     def do_locate(self, context, *resources):
         "usage: locate <rsc> [<rsc> ...]"
         if len(resources) == 0:

--- a/test/unittests/test_crashtest_check.py
+++ b/test/unittests/test_crashtest_check.py
@@ -463,16 +463,14 @@ Active Resources:
             mock.call("Node 15sp2-2 is UNCLEAN!")
             ])
 
-    @mock.patch('crmsh.crash_test.check.completers.resources_stopped')
-    @mock.patch('crmsh.crash_test.check.completers.resources_started')
+    @mock.patch('crmsh.crash_test.check.completers.resources')
     @mock.patch('crmsh.crash_test.task.TaskCheck')
-    def test_check_resources(self, mock_task, mock_started, mock_stopped):
+    def test_check_resources(self, mock_task, mock_resources):
         mock_task_inst = mock.Mock()
         mock_task.return_value = mock_task_inst
         mock_task_inst.run.return_value.__enter__ = mock.Mock()
         mock_task_inst.run.return_value.__exit__ = mock.Mock()
-        mock_started.return_value = ["r1", "r2"]
-        mock_stopped.return_value = ["r3", "r4"]
+        mock_resources.side_effect = [["r1", "r2"], ["r3", "r4"]]
 
         check.check_resources()
 


### PR DESCRIPTION
- Use 'completers_repeating' instead of 'completers' for start/stop/restart/status/locate commands to get multiple complete results
- Filter out duplicated complete results

backport #1443 