### PR TITLE
testcases update

### DIFF
--- a/test/testcases/bugs
+++ b/test/testcases/bugs
@@ -6,7 +6,7 @@ configure
 erase
 primitive st stonith:null \
 	params hostlist='node1' \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m
 primitive p4 Dummy
 primitive p3 Dummy
@@ -44,7 +44,7 @@ configure
 erase
 primitive st stonith:null \
 	params hostlist='node1' \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m
 property SAPHanaSR: \
     hana_ha1_site_lss_WDF1=4
@@ -66,7 +66,7 @@ erase
 node node1
 primitive st stonith:null \
 	params hostlist='node1' \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m
 template
 new vip virtual-ip params ip=10.10.10.123

--- a/test/testcases/bugs.exp
+++ b/test/testcases/bugs.exp
@@ -6,7 +6,7 @@ INFO: 2: "sort_elements" is accepted as "sort-elements"
 .INP: up
 .INP: configure
 .INP: erase
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.INP: primitive st stonith:null 	params hostlist='node1' 	meta requires=nothing 	op monitor interval=60m
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .INP: primitive p4 Dummy
@@ -30,7 +30,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 node node1
 primitive st stonith:null \
 	params hostlist=node1 \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m timeout=20s \
         op start timeout=20s interval=0s \
         op stop timeout=15s interval=0s
@@ -69,7 +69,7 @@ colocation c2 inf: ( p1 p2 ) p3 p4
 node node1
 primitive st stonith:null \
 	params hostlist=node1 \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m timeout=20s \
         op start timeout=20s interval=0s \
         op stop timeout=15s interval=0s
@@ -163,7 +163,7 @@ op_defaults op-options: \
 INFO: 2: constraint colocation:c2 updated
 INFO: 2: constraint colocation:c2 updated
 INFO: 2: modified location:loc1 from g1 to gr2
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.INP: primitive st stonith:null 	params hostlist='node1' 	meta requires=nothing 	op monitor interval=60m
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .INP: property SAPHanaSR:     hana_ha1_site_lss_WDF1=4
@@ -171,7 +171,7 @@ INFO: 2: modified location:loc1 from g1 to gr2
 node node1
 primitive st stonith:null \
 	params hostlist=node1 \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m timeout=20s \
         op start timeout=20s interval=0s \
         op stop timeout=15s interval=0s
@@ -186,7 +186,7 @@ property SAPHanaSR: \
 node node1
 primitive st stonith:null \
 	params hostlist=node1 \
-	meta description="some description here" requires=nothing \
+	meta requires=nothing \
 	op monitor interval=60m timeout=20s \
         op start timeout=20s interval=0s \
         op stop timeout=15s interval=0s
@@ -202,7 +202,7 @@ property SAPHanaSR_2: \
 .INP: configure
 .INP: erase
 .INP: node node1
-.INP: primitive st stonith:null 	params hostlist='node1' 	meta description="some description here" requires=nothing 	op monitor interval=60m
+.INP: primitive st stonith:null 	params hostlist='node1' 	meta requires=nothing 	op monitor interval=60m
 .EXT crm_resource --show-metadata stonith:null
 .EXT stonithd metadata
 .INP: template

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -67,9 +67,9 @@ location l6 m5 \
 location l7 m5 \
 	rule $id-ref=l2
 colocation c1 inf: m6 m5
-colocation c2 inf: m5:Promoted d1:Started
+colocation c2 inf: m5:Promoted g1:Started
 order o1 Mandatory: m5 m6
-order o2 Optional: d1:start m5:promote
+order o2 Optional: g1:start m5:promote
 order o3 Serialize: m5 m6
 order o4 Mandatory: m5 m6
 rsc_ticket ticket-A_m6 ticket-A: m6

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -54,12 +54,14 @@ location l3 m5 \
 location l4 m5 \
 	rule -inf: not_defined pingd or pingd lte 0
 location l5 m5 \
-	rule -inf: not_defined pingd or pingd lte 0 \
-	rule inf: #uname eq node1 and pingd gt 0 \
-	rule inf: date lt "2009-05-26" and \
-		date in start="2009-05-26" end="2009-07-26" and \
-		date in start="2009-05-26" years="2009" and \
-		date spec years="2009" hours="09-17"
+	rule -inf: not_defined pingd or pingd lte 0
+location l8 m5 \
+	rule inf: #uname eq node1 and \
+	pingd gt 0 and \
+	date lt "2009-05-26" and \
+	date in start="2009-05-26" end="2009-07-26" and \
+	date in start="2009-05-26" years="2009" and \
+	date spec years="2009" hours="09-17"
 location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \

--- a/test/testcases/confbasic
+++ b/test/testcases/confbasic
@@ -26,15 +26,13 @@ primitive d3 ocf:pacemaker:Dummy
 clone c d3 \
 	meta clone-max=1
 primitive d4 ocf:pacemaker:Dummy
-ms m d4
-delete m
-master m d4
+clone m d4 meta promotable=true
 primitive s5 ocf:pacemaker:Stateful \
 	operations $id-ref=d1-ops
 primitive s6 ocf:pacemaker:Stateful \
 	operations $id-ref=d1
-ms m5 s5
-ms m6 s6
+clone m5 s5 meta promotable=true
+clone m6 s6 meta promotable=true
 primitive d7 Dummy \
 	params rule inf: #uname eq node1 fake=1 \
 	params rule inf: #uname eq node2 fake=2 \
@@ -66,15 +64,15 @@ location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \
 	rule $id-ref=l2
-collocation c1 inf: m6 m5
-collocation c2 inf: m5:Master d1:Started
+colocation c1 inf: m6 m5
+colocation c2 inf: m5:Promoted d1:Started
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6
 order o4 Mandatory: m5 m6
 rsc_ticket ticket-A_m6 ticket-A: m6
 rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
-rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence
+rsc_ticket ticket-C_master ticket-C: m6 m5:Promoted loss-policy=fence
 fencing_topology st st2
 property stonith-enabled=true
 property $id=cpset2 maintenance-mode=true

--- a/test/testcases/confbasic-xml
+++ b/test/testcases/confbasic-xml
@@ -26,15 +26,13 @@ primitive d3 ocf:pacemaker:Dummy
 clone c d3 \
 	meta clone-max=1
 primitive d4 ocf:pacemaker:Dummy
-ms m d4
-delete m
-master m d4
+clone m d4 meta promotable=true
 primitive s5 ocf:pacemaker:Stateful \
 	operations $id-ref=d1-ops
 primitive s6 ocf:pacemaker:Stateful \
 	operations $id-ref=d1
-ms m5 s5
-ms m6 s6
+clone m5 s5 meta promotable=true
+clone m6 s6 meta promotable=true
 location l1 g1 100: node1
 location l2 c \
 	rule $id=l2-rule1 100: #uname eq node1
@@ -53,15 +51,15 @@ location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \
 	rule $id-ref=l2
-collocation c1 inf: m6 m5
-collocation c2 inf: m5:Master d1:Started
+colocation c1 inf: m6 m5
+colocation c2 inf: m5:Promoted d1:Started
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6
 order o4 Mandatory: m5 m6
 rsc_ticket ticket-A_m6 ticket-A: m6
 rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
-rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence
+rsc_ticket ticket-C_master ticket-C: m6 m5:Promoted loss-policy=fence
 fencing_topology st st2
 property stonith-enabled=true
 property $id=cpset2 maintenance-mode=true

--- a/test/testcases/confbasic-xml
+++ b/test/testcases/confbasic-xml
@@ -41,12 +41,14 @@ location l3 m5 \
 location l4 m5 \
 	rule -inf: not_defined pingd or pingd lte 0
 location l5 m5 \
-	rule -inf: not_defined pingd or pingd lte 0 \
-	rule inf: #uname eq node1 and pingd gt 0 \
-	rule inf: date lt 2009-05-26 and \
-		date in start=2009-05-26 end=2009-07-26 and \
-		date in start=2009-05-26 years=2009 and \
-		date spec years=2009 hours=09-17
+	rule -inf: not_defined pingd or pingd lte 0
+location l8 m5 \
+	rule inf: #uname eq node1 and \
+	pingd gt 0 and \
+	date lt 2009-05-26 and \
+	date in start=2009-05-26 end=2009-07-26 and \
+	date in start=2009-05-26 years=2009 and \
+	date spec years=2009 hours=09-17
 location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \

--- a/test/testcases/confbasic-xml.exp
+++ b/test/testcases/confbasic-xml.exp
@@ -75,7 +75,7 @@
       <clone id="c">
         <meta_attributes id="c-meta_attributes">
           <nvpair name="clone-max" value="1" id="c-meta_attributes-clone-max"/>
-          <nvpair name="interleave" value="true" id="c-meta_attributes-interleave"/>
+          <nvpair id="c-meta_attributes-interleave" name="interleave" value="true"/>
         </meta_attributes>
         <primitive id="d3" class="ocf" provider="pacemaker" type="Dummy">
           <operations>
@@ -85,7 +85,11 @@
           </operations>
         </primitive>
       </clone>
-      <master id="m">
+      <clone id="m">
+        <meta_attributes id="m-meta_attributes">
+          <nvpair name="promotable" value="true" id="m-meta_attributes-promotable"/>
+          <nvpair id="m-meta_attributes-interleave" name="interleave" value="true"/>
+        </meta_attributes>
         <primitive id="d4" class="ocf" provider="pacemaker" type="Dummy">
           <operations>
             <op name="monitor" timeout="20s" interval="10s" id="d4-monitor-10s"/>
@@ -93,8 +97,12 @@
             <op name="stop" timeout="20s" interval="0s" id="d4-stop-0s"/>
           </operations>
         </primitive>
-      </master>
-      <master id="m5">
+      </clone>
+      <clone id="m5">
+        <meta_attributes id="m5-meta_attributes">
+          <nvpair name="promotable" value="true" id="m5-meta_attributes-promotable"/>
+          <nvpair id="m5-meta_attributes-interleave" name="interleave" value="true"/>
+        </meta_attributes>
         <primitive id="s5" class="ocf" provider="pacemaker" type="Stateful">
           <operations id-ref="d1-ops">
             <op name="monitor" timeout="20s" interval="10s" role="Promoted" id="s5-monitor-10s"/>
@@ -105,8 +113,12 @@
             <op name="demote" timeout="10s" interval="0s" id="s5-demote-0s"/>
           </operations>
         </primitive>
-      </master>
-      <master id="m6">
+      </clone>
+      <clone id="m6">
+        <meta_attributes id="m6-meta_attributes">
+          <nvpair name="promotable" value="true" id="m6-meta_attributes-promotable"/>
+          <nvpair id="m6-meta_attributes-interleave" name="interleave" value="true"/>
+        </meta_attributes>
         <primitive id="s6" class="ocf" provider="pacemaker" type="Stateful">
           <operations id-ref="d1-ops">
             <op name="monitor" timeout="20s" interval="10s" role="Promoted" id="s6-monitor-10s"/>
@@ -117,7 +129,7 @@
             <op name="demote" timeout="10s" interval="0s" id="s6-demote-0s"/>
           </operations>
         </primitive>
-      </master>
+      </clone>
     </resources>
     <constraints>
       <rsc_location id="l1" rsc="g1" score="100" node="node1"/>

--- a/test/testcases/confbasic-xml.exp
+++ b/test/testcases/confbasic-xml.exp
@@ -155,18 +155,18 @@
           <expression operation="not_defined" attribute="pingd" id="l5-rule-expression"/>
           <expression operation="lte" attribute="pingd" value="0" id="l5-rule-expression-0"/>
         </rule>
-        <rule score="INFINITY" id="l5-rule-0">
-          <expression operation="eq" attribute="#uname" value="node1" id="l5-rule-0-expression"/>
-          <expression operation="gt" attribute="pingd" value="0" id="l5-rule-0-expression-0"/>
-        </rule>
-        <rule score="INFINITY" id="l5-rule-1">
-          <date_expression operation="lt" end="2009-05-26" id="l5-rule-1-expression"/>
-          <date_expression operation="in_range" start="2009-05-26" end="2009-07-26" id="l5-rule-1-expression-0"/>
-          <date_expression operation="in_range" start="2009-05-26" id="l5-rule-1-expression-1">
-            <duration years="2009" id="l5-rule-1-expression-1-duration"/>
+      </rsc_location>
+      <rsc_location id="l8" rsc="m5">
+        <rule score="INFINITY" id="l8-rule">
+          <expression operation="eq" attribute="#uname" value="node1" id="l8-rule-expression"/>
+          <expression operation="gt" attribute="pingd" value="0" id="l8-rule-expression-0"/>
+          <date_expression operation="lt" end="2009-05-26" id="l8-rule-expression-1"/>
+          <date_expression operation="in_range" start="2009-05-26" end="2009-07-26" id="l8-rule-expression-2"/>
+          <date_expression operation="in_range" start="2009-05-26" id="l8-rule-expression-3">
+            <duration years="2009" id="l8-rule-expression-3-duration"/>
           </date_expression>
-          <date_expression operation="date_spec" id="l5-rule-1-expression-2">
-            <date_spec years="2009" hours="09-17" id="l5-rule-1-expression-2-date_spec"/>
+          <date_expression operation="date_spec" id="l8-rule-expression-4">
+            <date_spec years="2009" hours="09-17" id="l8-rule-expression-4-date_spec"/>
           </date_expression>
         </rule>
       </rsc_location>

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -40,9 +40,9 @@
 .INP: location l6 m5 	rule $id-ref=l2-rule1
 .INP: location l7 m5 	rule $id-ref=l2
 .INP: colocation c1 inf: m6 m5
-.INP: colocation c2 inf: m5:Promoted d1:Started
+.INP: colocation c2 inf: m5:Promoted g1:Started
 .INP: order o1 Mandatory: m5 m6
-.INP: order o2 Optional: d1:start m5:promote
+.INP: order o2 Optional: g1:start m5:promote
 .INP: order o3 Serialize: m5 m6
 .INP: order o4 Mandatory: m5 m6
 .INP: rsc_ticket ticket-A_m6 ticket-A: m6
@@ -58,7 +58,6 @@
 .INP: _test
 .INP: verify
 .EXT crm_resource --list-options=primitive --all --output-as=xml
-WARNING: 53: c2: resource d1 is grouped, constraints should apply to the group
 .EXT crm_attribute --list-options=cluster --all --output-as=xml
 .INP: show
 node node1 \
@@ -143,7 +142,7 @@ clone m7 d8 \
 	meta promoted-node-max=1
 tag t1 m5 m6
 colocation c1 inf: m6 m5
-colocation c2 inf: m5:Promoted d1:Started
+colocation c2 inf: m5:Promoted g1:Started
 location l1 g1 100: node1
 location l2 c \
 	rule $id=l2-rule1 100: #uname eq node1
@@ -160,7 +159,7 @@ location l7 m5 \
 location l8 m5 \
 	rule #uname eq node1 and pingd gt 0 and date lt 2009-05-26 and date in start=2009-05-26 end=2009-07-26 and date in start=2009-05-26 years=2009 and date spec years=2009 hours=09-17
 order o1 Mandatory: m5 m6
-order o2 Optional: d1:start m5:promote
+order o2 Optional: g1:start m5:promote
 order o3 Serialize: m5 m6
 order o4 Mandatory: m5 m6
 fencing_topology st st2
@@ -177,7 +176,6 @@ op_defaults opsdef2: \
 	rule 100: #uname eq node1 \
 	record-pending=true
 .INP: commit
-WARNING: 55: c2: resource d1 is grouped, constraints should apply to the group
 .TRY -F node maintenance node1
 .TRY -F resource maintenance g1 off
 .TRY -F resource maintenance d1

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -35,7 +35,8 @@
 .INP: location l2 c 	rule $id=l2-rule1 100: #uname eq node1
 .INP: location l3 m5 	rule inf: #uname eq node1 and pingd gt 0
 .INP: location l4 m5 	rule -inf: not_defined pingd or pingd lte 0
-.INP: location l5 m5 	rule -inf: not_defined pingd or pingd lte 0 	rule inf: #uname eq node1 and pingd gt 0 	rule inf: date lt "2009-05-26" and 		date in start="2009-05-26" end="2009-07-26" and 		date in start="2009-05-26" years="2009" and 		date spec years="2009" hours="09-17"
+.INP: location l5 m5 	rule -inf: not_defined pingd or pingd lte 0
+.INP: location l8 m5 	rule inf: #uname eq node1 and         pingd gt 0 and 	date lt "2009-05-26" and 	date in start="2009-05-26" end="2009-07-26" and 	date in start="2009-05-26" years="2009" and 	date spec years="2009" hours="09-17"
 .INP: location l6 m5 	rule $id-ref=l2-rule1
 .INP: location l7 m5 	rule $id-ref=l2
 .INP: colocation c1 inf: m6 m5
@@ -151,13 +152,13 @@ location l3 m5 \
 location l4 m5 \
 	rule -inf: not_defined pingd or pingd lte 0
 location l5 m5 \
-	rule -inf: not_defined pingd or pingd lte 0 \
-	rule #uname eq node1 and pingd gt 0 \
-	rule date lt 2009-05-26 and date in start=2009-05-26 end=2009-07-26 and date in start=2009-05-26 years=2009 and date spec years=2009 hours=09-17
+	rule -inf: not_defined pingd or pingd lte 0
 location l6 m5 \
 	rule $id-ref=l2-rule1
 location l7 m5 \
 	rule $id-ref=l2-rule1
+location l8 m5 \
+	rule #uname eq node1 and pingd gt 0 and date lt 2009-05-26 and date in start=2009-05-26 end=2009-07-26 and date in start=2009-05-26 years=2009 and date spec years=2009 hours=09-17
 order o1 Mandatory: m5 m6
 order o2 Optional: d1:start m5:promote
 order o3 Serialize: m5 m6

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -21,20 +21,12 @@
 .INP: primitive d3 ocf:pacemaker:Dummy
 .INP: clone c d3 	meta clone-max=1
 .INP: primitive d4 ocf:pacemaker:Dummy
-.INP: ms m d4
-WARNING: 19: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
-.INP: delete m
-.INP: master m d4
-WARNING: 21: This command 'master' is deprecated, please use 'ms'
-INFO: 21: "master" is accepted as "ms"
-WARNING: 21: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
+.INP: clone m d4 meta promotable=true
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
-.INP: ms m5 s5
-WARNING: 24: "ms" is deprecated. Please use "clone m5 s5 meta promotable=true"
-.INP: ms m6 s6
-WARNING: 25: "ms" is deprecated. Please use "clone m6 s6 meta promotable=true"
+.INP: clone m5 s5 meta promotable=true
+.INP: clone m6 s6 meta promotable=true
 .INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive d8 ocf:pacemaker:Dummy
@@ -46,21 +38,15 @@ WARNING: 25: "ms" is deprecated. Please use "clone m6 s6 meta promotable=true"
 .INP: location l5 m5 	rule -inf: not_defined pingd or pingd lte 0 	rule inf: #uname eq node1 and pingd gt 0 	rule inf: date lt "2009-05-26" and 		date in start="2009-05-26" end="2009-07-26" and 		date in start="2009-05-26" years="2009" and 		date spec years="2009" hours="09-17"
 .INP: location l6 m5 	rule $id-ref=l2-rule1
 .INP: location l7 m5 	rule $id-ref=l2
-.INP: collocation c1 inf: m6 m5
-WARNING: 36: This command 'collocation' is deprecated, please use 'colocation'
-INFO: 36: "collocation" is accepted as "colocation"
-.INP: collocation c2 inf: m5:Master d1:Started
-WARNING: 37: This command 'collocation' is deprecated, please use 'colocation'
-INFO: 37: "collocation" is accepted as "colocation"
-INFO: 37: Convert deprecated "Master" to "Promoted"
+.INP: colocation c1 inf: m6 m5
+.INP: colocation c2 inf: m5:Promoted d1:Started
 .INP: order o1 Mandatory: m5 m6
 .INP: order o2 Optional: d1:start m5:promote
 .INP: order o3 Serialize: m5 m6
 .INP: order o4 Mandatory: m5 m6
 .INP: rsc_ticket ticket-A_m6 ticket-A: m6
 .INP: rsc_ticket ticket-B_m6_m5 ticket-B: m6 m5 loss-policy=fence
-.INP: rsc_ticket ticket-C_master ticket-C: m6 m5:Master loss-policy=fence
-INFO: 44: Convert deprecated "Master" to "Promoted"
+.INP: rsc_ticket ticket-C_master ticket-C: m6 m5:Promoted loss-policy=fence
 .INP: fencing_topology st st2
 .INP: property stonith-enabled=true
 .INP: property $id=cpset2 maintenance-mode=true
@@ -142,11 +128,14 @@ primitive st2 stonith:ssh \
 	op start timeout=20s interval=0s \
 	op stop timeout=15s interval=0s
 group g1 d1 d2
-ms m d4
-ms m5 s5
-ms m6 s6
 clone c d3 \
 	meta clone-max=1 interleave=true
+clone m d4 \
+	meta promotable=true interleave=true
+clone m5 s5 \
+	meta promotable=true interleave=true
+clone m6 s6 \
+	meta promotable=true interleave=true
 clone m7 d8 \
 	meta promotable=true interleave=true \
 	meta promoted-max=1 \

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -31,11 +31,12 @@ primitive d3 ocf:heartbeat:Dummy
 group g2 d1 d2
 filter "sed '/g2/s/d1/p1/;/g1/s/p1/d1/'"
 filter "sed '/g1/s/d1/p1/;/g2/s/p1/d1/'"
-filter "sed '$alocation loc-d1 d1 rule $id=r1 -inf: not_defined webserver rule $id=r2 webserver: defined webserver'"
-filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
-filter "sed 's/ or mem number:lte 0//'" loc-d1
-filter "sed 's/not_defined webserver/& rule -inf: not_defined a2/'" loc-d1
-filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
+location loc-d1 d1 \
+	rule -inf: not_defined webserver or \
+	mem number:lte 0 or \
+	not_defined a2
+location loc-d1-2 d1 \
+	rule webserver: defined webserver
 modgroup g1 add d3
 modgroup g1 remove p1
 modgroup g1 add p1 after p2

--- a/test/testcases/edit
+++ b/test/testcases/edit
@@ -43,7 +43,6 @@ modgroup g1 add p1 after p2
 modgroup g1 remove p1
 modgroup g1 add p1 before p2
 modgroup g1 add p1
-modgroup g1 remove st
 modgroup g1 remove c1
 modgroup g1 remove nosuch
 modgroup g1 add c1

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -70,11 +70,8 @@ op_defaults op-options: \
 .INP: filter "sed '/g2/s/d1/p1/;/g1/s/p1/d1/'"
 ERROR: 29: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: filter "sed '/g1/s/d1/p1/;/g2/s/p1/d1/'"
-.INP: filter "sed '$alocation loc-d1 d1 rule $id=r1 -inf: not_defined webserver rule $id=r2 webserver: defined webserver'"
-.INP: filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
-.INP: filter "sed 's/ or mem number:lte 0//'" loc-d1
-.INP: filter "sed 's/not_defined webserver/& rule -inf: not_defined a2/'" loc-d1
-.INP: filter "sed 's/not_defined webserver/& or mem number:lte 0/'" loc-d1
+.INP: location loc-d1 d1 	rule -inf: not_defined webserver or 	mem number:lte 0 or 	not_defined a2
+.INP: location loc-d1-2 d1 	rule webserver: defined webserver
 .INP: modgroup g1 add d3
 .INP: modgroup g1 remove p1
 .INP: modgroup g1 add p1 after p2
@@ -191,8 +188,8 @@ clone c1 g1
 tag t-d45 d4 d5
 location l1 p3 100: node1
 location loc-d1 d1 \
-	rule -inf: not_defined webserver or mem number:lte 0 \
-	rule -inf: not_defined a2 \
+	rule -inf: not_defined webserver or mem number:lte 0 or not_defined a2
+location loc-d1-2 d1 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
 order o1 Mandatory: p3 c1
@@ -320,8 +317,8 @@ clone c1 g1
 tag t-d45 d4 d5
 location l1 p3 100: node1
 location loc-d1 d1 \
-	rule -inf: not_defined webserver or mem number:lte 0 \
-	rule -inf: not_defined a2 \
+	rule -inf: not_defined webserver or mem number:lte 0 or not_defined a2
+location loc-d1-2 d1 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
 order o1 Mandatory: p3 c1
@@ -427,8 +424,8 @@ clone c1 g1
 tag t-d45 d4 d5
 location l1 p3 100: node1
 location loc-d1 d1 \
-	rule -inf: not_defined webserver or mem number:lte 0 \
-	rule -inf: not_defined a2 \
+	rule -inf: not_defined webserver or mem number:lte 0 or not_defined a2
+location loc-d1-2 d1 \
 	rule webserver: defined webserver
 order o-d456 d4 d5 d6
 order o1 Mandatory: p3 c1

--- a/test/testcases/edit.exp
+++ b/test/testcases/edit.exp
@@ -79,18 +79,8 @@ ERROR: 29: Cannot create group:g1: Child primitive:d1 already in group:g2
 .INP: modgroup g1 add p1 before p2
 .INP: modgroup g1 add p1
 ERROR: 1: syntax in group: child p1 listed more than once in group g1 parsing 'group g1 p1 p2 d3 p1'
-.INP: modgroup g1 remove st
-ERROR: 42: configure.modgroup: st is not member of g1
-Traceback (most recent call last):
-    rv = self.execute_command() is not False
-         ^^^^^^^^^^^^^^^^^^^^^^
-    rv = self.command_info.function(*arglist)
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    context.fatal_error("%s is not member of %s" % (prim_id, group_id))
-    raise ValueError(msg)
-ValueError: st is not member of g1
 .INP: modgroup g1 remove c1
-ERROR: 43: configure.modgroup: c1 is not member of g1
+ERROR: 39: configure.modgroup: c1 is not member of g1
 Traceback (most recent call last):
     rv = self.execute_command() is not False
          ^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +90,7 @@ Traceback (most recent call last):
     raise ValueError(msg)
 ValueError: c1 is not member of g1
 .INP: modgroup g1 remove nosuch
-ERROR: 44: configure.modgroup: nosuch is not member of g1
+ERROR: 40: configure.modgroup: nosuch is not member of g1
 Traceback (most recent call last):
     rv = self.execute_command() is not False
          ^^^^^^^^^^^^^^^^^^^^^^
@@ -110,9 +100,9 @@ Traceback (most recent call last):
     raise ValueError(msg)
 ValueError: nosuch is not member of g1
 .INP: modgroup g1 add c1
-ERROR: 45: a group may contain only primitives; c1 is clone
+ERROR: 41: a group may contain only primitives; c1 is clone
 .INP: modgroup g1 add nosuch
-ERROR: 46: g1 refers to missing object nosuch
+ERROR: 42: g1 refers to missing object nosuch
 .INP: filter "sed 's/^/# this is a comment\n/'" loc-d1
 .INP: rsc_defaults $id="rsc_options" failure-timeout=10m
 .INP: filter "sed 's/2m/60s/'" op-options
@@ -328,8 +318,8 @@ rsc_defaults rsc_options: \
 op_defaults op-options: \
 	timeout=60s
 .INP: commit
-INFO: 89: apparently there is nothing to commit
-INFO: 89: try changing something first
+INFO: 85: apparently there is nothing to commit
+INFO: 85: try changing something first
 .INP: _test
 .INP: verify
 .INP: show
@@ -435,5 +425,5 @@ rsc_defaults rsc_options: \
 op_defaults op-options: \
 	timeout=60s
 .INP: commit
-INFO: 93: apparently there is nothing to commit
-INFO: 93: try changing something first
+INFO: 89: apparently there is nothing to commit
+INFO: 89: try changing something first

--- a/test/testcases/ra.exp
+++ b/test/testcases/ra.exp
@@ -67,8 +67,7 @@ livedangerously (enum): Live Dangerously!!
     setting this parameter to yes makes it an even worse idea.
     Viva la Vida Loca!
 
-pcmk_host_argument (string, [port]): An alternate parameter to supply instead of 'port'
-    *** Advanced Use Only ***
+pcmk_host_argument (string, [port]): *** Advanced Use Only *** An alternate parameter to supply instead of 'port'
     Some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of "none" can be used to tell the cluster not to supply any additional parameters.
 
 pcmk_host_map (string): A mapping of node names to port numbers for devices that do not support node names.
@@ -78,7 +77,7 @@ pcmk_host_list (string): Nodes targeted by this device
     Comma-separated list of nodes that can be targeted by this device (for example, "node1,node2,node3"). If pcmk_host_check is "static-list", either this or pcmk_host_map must be set.
 
 pcmk_host_check (select): How to determine which nodes can be targeted by the device
-    Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. The default value is "static-list" if pcmk_host_map or pcmk_host_list is set; otherwise "dynamic-list" if the device supports the list operation; otherwise "status" if the device supports the status operation; otherwise "none"
+    Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. The default value is "static-list" if pcmk_host_map or pcmk_host_list is set; otherwise "dynamic-list" if the device supports the list operation; otherwise "status" if the device supports the status operation; otherwise "none"  Allowed values: dynamic-list, static-list, status, none
     Allowed values: dynamic-list, static-list, status, none
 
 pcmk_delay_max (time, [0s]): Enable a delay of no more than the time specified before executing fencing actions.
@@ -90,76 +89,58 @@ pcmk_delay_base (string, [0s]): Enable a base delay for fencing actions and spec
 pcmk_action_limit (integer, [1]): The maximum number of actions can be performed in parallel on this device
     Cluster property concurrent-fencing="true" needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.
 
-pcmk_reboot_action (string, [reboot]): An alternate command to run instead of 'reboot'
-    *** Advanced Use Only ***
+pcmk_reboot_action (string, [reboot]): *** Advanced Use Only *** An alternate command to run instead of 'reboot'
     Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'reboot' action.
 
-pcmk_reboot_timeout (time, [60s]): Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_reboot_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'reboot' actions.
 
-pcmk_reboot_retries (integer, [2]): The maximum number of times to try the 'reboot' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_reboot_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'reboot' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'reboot' action before giving up.
 
-pcmk_off_action (string, [off]): An alternate command to run instead of 'off'
-    *** Advanced Use Only ***
+pcmk_off_action (string, [off]): *** Advanced Use Only *** An alternate command to run instead of 'off'
     Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'off' action.
 
-pcmk_off_timeout (time, [60s]): Specify an alternate timeout to use for 'off' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_off_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'off' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'off' actions.
 
-pcmk_off_retries (integer, [2]): The maximum number of times to try the 'off' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_off_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'off' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'off' action before giving up.
 
-pcmk_on_action (string, [on]): An alternate command to run instead of 'on'
-    *** Advanced Use Only ***
+pcmk_on_action (string, [on]): *** Advanced Use Only *** An alternate command to run instead of 'on'
     Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'on' action.
 
-pcmk_on_timeout (time, [60s]): Specify an alternate timeout to use for 'on' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_on_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'on' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'on' actions.
 
-pcmk_on_retries (integer, [2]): The maximum number of times to try the 'on' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_on_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'on' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'on' action before giving up.
 
-pcmk_list_action (string, [list]): An alternate command to run instead of 'list'
-    *** Advanced Use Only ***
+pcmk_list_action (string, [list]): *** Advanced Use Only *** An alternate command to run instead of 'list'
     Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'list' action.
 
-pcmk_list_timeout (time, [60s]): Specify an alternate timeout to use for 'list' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_list_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'list' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'list' actions.
 
-pcmk_list_retries (integer, [2]): The maximum number of times to try the 'list' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_list_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'list' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'list' action before giving up.
 
-pcmk_monitor_action (string, [monitor]): An alternate command to run instead of 'monitor'
-    *** Advanced Use Only ***
+pcmk_monitor_action (string, [monitor]): *** Advanced Use Only *** An alternate command to run instead of 'monitor'
     Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'monitor' action.
 
-pcmk_monitor_timeout (time, [60s]): Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_monitor_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'monitor' actions.
 
-pcmk_monitor_retries (integer, [2]): The maximum number of times to try the 'monitor' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_monitor_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'monitor' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'monitor' action before giving up.
 
-pcmk_status_action (string, [status]): An alternate command to run instead of 'status'
-    *** Advanced Use Only ***
+pcmk_status_action (string, [status]): *** Advanced Use Only *** An alternate command to run instead of 'status'
     Some devices do not support the standard commands or may provide additional ones.Use this to specify an alternate, device-specific, command that implements the 'status' action.
 
-pcmk_status_timeout (time, [60s]): Specify an alternate timeout to use for 'status' actions instead of stonith-timeout
-    *** Advanced Use Only ***
+pcmk_status_timeout (time, [60s]): *** Advanced Use Only *** Specify an alternate timeout to use for 'status' actions instead of stonith-timeout
     Some devices need much more/less time to complete than normal.Use this to specify an alternate, device-specific, timeout for 'status' actions.
 
-pcmk_status_retries (integer, [2]): The maximum number of times to try the 'status' command within the timeout period
-    *** Advanced Use Only ***
+pcmk_status_retries (integer, [2]): *** Advanced Use Only *** The maximum number of times to try the 'status' command within the timeout period
     Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'status' action before giving up.
 
 Operations' defaults (advisory minimum):

--- a/test/testcases/resource
+++ b/test/testcases/resource
@@ -50,7 +50,7 @@ resource stop p3
 resource start p3
 resource stop p3
 configure rm cg
-configure ms msg g
+configure clone msg g meta promotable=true
 resource scores
 %setenv showobj=
 configure primitive p5 Dummy

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1141,8 +1141,7 @@ INFO: Stop tracing p0 for operation stop
 .TRY configure rm cg
 WARNING: This command 'rm' is deprecated, please use 'delete'
 INFO: "rm" is accepted as "delete"
-.TRY configure ms msg g
-WARNING: "ms" is deprecated. Please use "clone msg g meta promotable=true"
+.TRY configure clone msg g meta promotable=true
 .EXT crm_resource --list-options=primitive --all --output-as=xml
 .TRY resource scores
 .EXT crm_simulate -sUL

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -8,9 +8,9 @@ RUN zypper refresh && \
         make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables cpio gawk \
         python3 python3-pip python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave python3-coverage python3-packaging \
         csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
-RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Unstable/15.4/ repo_corosync3 && \
+RUN zypper ar -f -G https://download.opensuse.org/repositories/network:/ha-clustering:/Unstable/openSUSE_Tumbleweed/ repo_corosync3 && \
     zypper --non-interactive refresh && \
-    zypper --non-interactive up --allow-vendor-change -y corosync corosync-qdevice corosync-qnetd && \
+    zypper --non-interactive up --allow-vendor-change -y corosync corosync-qdevice corosync-qnetd pacemaker && \
     zypper --non-interactive in libknet1-*
 
 RUN ssh-keygen -t rsa -f /root/.ssh/id_rsa -N '' && \


### PR DESCRIPTION
After upgrading pacemaker version to 2.1.7+20240530.09c4d6d2e in docker image for CI, the original testcases need to do these changes:
- Convert 'ms' or 'master' command into promotable clone
- Avoid multiple rule in a location constraint
- Apply constraints to the group instead of the grouped resource
- Remove unknown resource meta attribute
- New output of pacemaker-fenced metadata