### PR TITLE
Dev: Hide 'configure ms' command (jsc#PED-8550)

### DIFF
--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -11,6 +11,7 @@ import re
 from . import help as help_module
 from . import ui_utils
 from . import log
+from . import constants
 
 
 logger = log.setup_logger(__name__)
@@ -423,7 +424,9 @@ Examples:
         '''
         return tab completions
         '''
-        return [x for x in self._children.keys() if x not in self._aliases]
+        return [x for x in self._children.keys() if
+                x not in self._aliases and
+                x not in constants.HIDDEN_COMMANDS]
 
     def get_child(self, child):
         '''

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -525,4 +525,7 @@ COROSYNC_PORT = 5405
 CSYNC2_PORT = 30865
 HAWK_PORT = 7630
 DLM_PORT = 21064
+
+# Commands that are deprecated and hidden from UI
+HIDDEN_COMMANDS = {'ms'}
 # vim:ts=4:sw=4:et:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3264,25 +3264,6 @@ clone disk1 drbd1 \
 ...............
 ****************************
 
-.Note on `id-ref` usage
-****************************
-Instance or meta attributes (`params` and `meta`) may contain
-a reference to another set of attributes. In that case, no other
-attributes are allowed. Since attribute sets' ids, though they do
-exist, are not shown in the `crm`, it is also possible to
-reference an object instead of an attribute set. `crm` will
-automatically replace such a reference with the right id:
-
-...............
-crm(live)configure# primitive a2 www-2 meta $id-ref=a1
-crm(live)configure# show a2
-primitive a2 apache \
-    meta $id-ref=a1-meta_attributes
-    [...]
-...............
-It is advisable to give meaningful names to attribute sets which
-are going to be referenced.
-****************************
 
 [[cmdhelp_configure_node,define a cluster node]]
 ==== `node`
@@ -3470,6 +3451,26 @@ primitive A ocf:pacemaker:Dummy \
     op_meta 2: rule #ra-version version:gt 1.0 timeout=120s \
     op_meta 1: timeout=60s
 ...............
+
+.Note on `id-ref` usage
+****************************
+Instance or meta attributes (`params` and `meta`) may contain
+a reference to another set of attributes. In that case, no other
+attributes are allowed. Since attribute sets' ids, though they do
+exist, are not shown in the `crm`, it is also possible to
+reference an object instead of an attribute set. `crm` will
+automatically replace such a reference with the right id:
+
+...............
+crm(live)configure# primitive a2 www-2 meta $id-ref=a1
+crm(live)configure# show a2
+primitive a2 apache \
+    meta $id-ref=a1-meta_attributes
+    [...]
+...............
+It is advisable to give meaningful names to attribute sets which
+are going to be referenced.
+****************************
 
 [[cmdhelp_configure_property,set a cluster property]]
 ==== `property`

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2531,7 +2531,6 @@ Commands for resources are:
 - `monitor`
 - `group`
 - `clone` (promotable clones)
-- `ms`/`master` (master-slave) (deprecated)
 
 In order to streamline large configurations, it is possible to
 define a template which can later be referenced in primitives:
@@ -2869,7 +2868,7 @@ edit [xml] changed
 ****************************
 The edit command sometimes cannot properly handle modifying
 element ids. In particular for elements which belong to group or
-ms resources. Group and ms resources themselves also cannot be
+promotable resources. Group and promotable resources themselves also cannot be
 renamed. Please use the `rename` command instead.
 ****************************
 
@@ -3230,39 +3229,6 @@ monitor apcfence 60m:60s
 
 Note that after executing the command, the monitor operation may
 be shown as part of the primitive definition.
-
-[[cmdhelp_configure_ms,define a master-slave resource (deprecated)]]
-==== `ms` (`master`)
-
-The `ms` command creates a master/slave resource type. It may contain a
-single primitive resource or one group of resources.
-
-Usage:
-...............
-ms <name> <rsc>
-  [description=<description>]
-  [meta attr_list]
-  [params attr_list]
-
-attr_list :: [$id=<id>] <attr>=<val> [<attr>=<val>...] | $id-ref=<id>
-...............
-Example:
-...............
-ms disk1 drbd1 \
-  meta notify=true globally-unique=false
-...............
-
-.Note on `ms` deprecated
-****************************
-From Pacemaker-2.0, the resource type referred to as "master/slave",
-"stateful", or "multi-state" is no longer a separate resource type,
-but a variation of clone now referred to as a "promotable clone".
-For backward compatibility, above configurations are also accepted.
-...............
-clone disk1 drbd1 \
-  meta promotable=true notify=true globally-unique=false
-...............
-****************************
 
 
 [[cmdhelp_configure_node,define a cluster node]]
@@ -3709,7 +3675,7 @@ The order of resources is significant: it is assumed that later
 resources depend on earlier ones.
 
 If a resource is multi-state, it is assumed that the role on
-which later resources depend is master.
+which later resources depend is Promoted.
 
 Tests are run sequentially to prevent running the same resource
 on two or more nodes. Tests are carried out only if none of the
@@ -3870,7 +3836,7 @@ show [xml] [<id>
            | obscure:<glob>
            ...]
 
-type :: node | primitive | group | clone | ms | rsc_template
+type :: node | primitive | group | clone | rsc_template
       | location | colocation | order
       | rsc_ticket
       | property | rsc_defaults | op_defaults
@@ -4790,7 +4756,7 @@ refresh [force]
 Show actions and any failures that happened on all specified
 resources on all nodes. Normally, one gives resource names as
 arguments, but it is also possible to use extended regular
-expressions. Note that neither groups nor clones or master/slave
+expressions. Note that neither groups nor clones or promotable clone
 names are ever logged. The resource command is going to expand
 all of these appropriately, so that clone instances or resources
 which are part of a group are shown.


### PR DESCRIPTION
Changes include:
- Hide 'configure ms' command from UI; crmsh still supports to interpret the old syntax, but not recommend to use it
- Move 'id-ref' usage into help primitive section
- Drop help info of 'configure ms' command