### PR TITLE
Dev: spec: bump python requirement to >= 3.10

### DIFF
--- a/crmsh.spec.in
+++ b/crmsh.spec.in
@@ -50,7 +50,7 @@ Requires(pre):  pacemaker
 %endif
 Requires:       %{name}-scripts >= %{version}-%{release}
 Requires:       /usr/bin/which
-Requires:       python3 >= 3.4
+Requires:       python3 >= 3.10
 Requires:       python3-PyYAML
 Requires:       python3-lxml
 Requires:       python3-packaging


### PR DESCRIPTION
as pattern matching(PEP-636) is used in corosync_config_format.py