### PR TITLE
[crmsh-4.6] Fix: cibconfig: Disable auto complete advised operation values when adding a rsc_template

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -793,7 +793,7 @@ def id_for_node(node, id_hint=None):
     return obj_id
 
 
-def postprocess_cli(node, oldnode=None, id_hint=None, complete_advised=False):
+def postprocess_cli(node, oldnode=None, id_hint=None, promotable_default_meta=False):
     """
     input: unprocessed but parsed XML
     output: XML, obj_type, obj_id
@@ -816,14 +816,14 @@ def postprocess_cli(node, oldnode=None, id_hint=None, complete_advised=False):
     resolve_references(node)
     if oldnode is not None:
         remove_id_used_attributes(oldnode)
-    if complete_advised:
-        complete_advised_meta(node)
+    if promotable_default_meta:
+        add_promotable_default_meta_attr(node)
     return node, obj_type, obj_id
 
 
-def complete_advised_meta(node):
+def add_promotable_default_meta_attr(node):
     """
-    Complete advised meta attributes
+    Add promotable default advised meta attributes
     """
     if node.tag != "clone":
         return
@@ -855,7 +855,8 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    complete_advised = False
+    default_op_values = False
+    default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
         utils.auto_convert_role = False
@@ -864,15 +865,17 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
-            complete_advised = False
+            default_op_values = False
+            default_promotable_meta = False
         else:
-            complete_advised = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete_advised)
+            default_op_values = True
+            default_promotable_meta = True
+        node = parse.parse(cli, comments=comments, ignore_empty=False, add_default_op_values=default_op_values)
     if node is False:
         return None, None, None
     elif node is None:
         return None, None, None
-    return postprocess_cli(node, oldnode, complete_advised=complete_advised)
+    return postprocess_cli(node, oldnode, promotable_default_meta=default_promotable_meta)
 
 #
 # cib element classes (CibObject the parent class)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -855,7 +855,7 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    complete = False
+    complete_advised = False
     comments = []
     if isinstance(cli, str):
         utils.auto_convert_role = False
@@ -863,13 +863,16 @@ def parse_cli_to_xml(cli, oldnode=None):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
-        complete = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete)
+        if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
+            complete_advised = False
+        else:
+            complete_advised = True
+        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete_advised)
     if node is False:
         return None, None, None
     elif node is None:
         return None, None, None
-    return postprocess_cli(node, oldnode, complete_advised=complete)
+    return postprocess_cli(node, oldnode, complete_advised=complete_advised)
 
 #
 # cib element classes (CibObject the parent class)

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,13 +170,13 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, complete_advised):
+    def do_parse(self, cmd, ignore_empty, add_default_op_values):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
         self.ignore_empty = ignore_empty
-        self.complete_advised = complete_advised
+        self.add_default_op_values = add_default_op_values
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -655,13 +655,13 @@ class BaseParser(object):
             else:
                 break
 
-        self.complete_advised_ops(out)
+        self.add_default_advised_ops(out)
 
-    def complete_advised_ops(self, out):
+    def add_default_advised_ops(self, out):
         """
-        Complete operation actions advised values
+        Add default operation actions advised values
         """
-        if not self.complete_advised or out.tag != "primitive":
+        if not self.add_default_op_values or out.tag != "primitive":
             return
         ra_inst = ra.RAInfo(out.get('class'), out.get('type'), out.get('provider'))
         ra_actions_dict = ra_inst.actions()
@@ -753,7 +753,7 @@ class BaseParser(object):
                     inst_attrs = xmlutil.child(container_node, name)
                     # set meaningful id for port-mapping and storage-mapping
                     # when the bundle is newly created
-                    if self.complete_advised:
+                    if self.add_default_op_values:
                         id_str = f"{bundle_id}_{name.replace('-', '_')}_{index}"
                         inst_attrs.set('id', id_str)
                     child_flag = True
@@ -1795,7 +1795,7 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None, ignore_empty=True, complete_advised=False):
+def parse(s, comments=None, ignore_empty=True, add_default_op_values=False):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1841,7 +1841,7 @@ def parse(s, comments=None, ignore_empty=True, complete_advised=False):
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, complete_advised)
+        ret = parser.do_parse(s, ignore_empty, add_default_op_values)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -171,3 +171,9 @@ Feature: Use "crm configure set" to update attributes and operations
       INFO: Testing on hanode1: d vip
       INFO: Testing on hanode2: d vip
       """
+
+  @clean
+  Scenario: Use rsc_template
+    When    Run "crm configure rsc_template dummy_template ocf:pacemaker:Dummy op monitor interval=12s" on "hanode1"
+    And     Try "crm configure primitive d8 @dummy_template params passwd=123" on "hanode1"
+    Then    Expected "got no meta-data, does this RA exist" not in stderr


### PR DESCRIPTION
backport from #1454 