### PR TITLE
Dev: ui_configure: Complete required parameters first

### DIFF
--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -8,6 +8,8 @@
 
 import inspect
 import re
+import ctypes
+import ctypes.util
 from . import help as help_module
 from . import ui_utils
 from . import log
@@ -569,6 +571,10 @@ class ChildInfo(object):
         '''
         ret = []
         if self.completer is not None:
+            if sort_completion_inst is not None and sort_completion_inst.value == 0:
+                # Restore the original value of rl_sort_completion_matches
+                # before calling the completer again
+                sort_completion_inst.value = orig_sort_completion_value
             specs = inspect.getfullargspec(self.completer)
             if 'context' in specs.args:
                 ret = self.completer([self.name] + args, context)
@@ -594,3 +600,16 @@ def _check_args(fn, expected):
     if argnames != expected:
         raise ValueError(fn.__name__ +
                          ": Expected method with signature " + repr(expected))
+
+
+readline_path = ctypes.util.find_library('readline')
+sort_completion_inst = None
+if readline_path:
+    # Inspired by
+    # https://stackoverflow.com/questions/31229708/python-gnu-readline-bindings-keep-my-sort-order
+    # Python readline module sort the completion result by
+    # alphabetical order by default. To archive the custom
+    # sort order, need to disable the sort_completion_matches
+    rl = ctypes.cdll.LoadLibrary(readline_path)
+    sort_completion_inst = ctypes.c_ulong.in_dll(rl, 'rl_sort_completion_matches')
+    orig_sort_completion_value = sort_completion_inst.value

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -357,7 +357,7 @@ class RAInfo(object):
         self.broken_ra = False
         return self.ra_elem
 
-    def params(self, completion=False):
+    def params(self):
         '''
         Construct a dict of dicts: parameters are keys and
         dictionary of attributes/values are values. Cached too.
@@ -365,12 +365,6 @@ class RAInfo(object):
         completion:
         If true, filter some (advanced) parameters out.
         '''
-        if completion:
-            if self.mk_ra_node() is None:
-                return None
-            return [c.get("name")
-                    for c in self.ra_elem.xpath("//parameters/parameter")
-                    if c.get("name") and c.get("name") not in self.excluded_from_completion]
         ident = "ra_params-%s" % self
         if cache.is_cached(ident):
             return cache.retrieve(ident)
@@ -379,7 +373,7 @@ class RAInfo(object):
         d = {}
         for c in self.ra_elem.xpath("//parameters/parameter"):
             name = c.get("name")
-            if not name:
+            if not name or name in self.excluded_from_completion:
                 continue
             required = c.get("required") if not (c.get("deprecated") or c.get("obsoletes")) else "0"
             unique = c.get("unique")

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -390,6 +390,10 @@ class RAInfo(object):
                 "type": typ,
                 "default": default,
             }
+        items = list(d.items())
+        # Sort the dictionary by required and then alphabetically
+        items.sort(key=lambda item: (item[1]["required"] != '1', item[0]))
+        d = dict(items)
         return cache.store(ident, d)
 
     def actions(self):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -234,7 +234,7 @@ def _prim_params_completer(agent, args):
     if command.sort_completion_inst is not None:
         # Set the value to 0 to use the costum sort order
         command.sort_completion_inst.value = 0
-    return utils.filter_keys(agent.params(completion=True), args)
+    return utils.filter_keys(agent.params(), args)
 
 
 def _prim_meta_completer(agent, args):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -231,6 +231,9 @@ def _prim_params_completer(agent, args):
         return []
     elif '=' in completing:
         return []
+    if command.sort_completion_inst is not None:
+        # Set the value to 0 to use the costum sort order
+        command.sort_completion_inst.value = 0
     return utils.filter_keys(agent.params(completion=True), args)
 
 

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -228,7 +228,7 @@ class Context(object):
             ret = None
         # logging.debug("line:%s, text:%s, ret:%s, state:%s", repr(line), repr(text), ret, state)
         if not text or (ret and line.split()[-1].endswith(ret)):
-            if ret == "id=":
+            if ret.endswith('='):
                 return ret
             return ret + ' '
         return ret


### PR DESCRIPTION
When adding an RA, if that RA has required parameters, 
sort the completion results by required parameters and then alphabetically
```
crm(live/alp-1)configure# primitive vip IPaddr2 params 
ip=                        arp_count_refresh=         broadcast=                 flush_routes=              lvs_ipv6_addrlabel_value=  network_namespace=         noprefixroute=             send_arp_opts=
arp_bg=                    arp_interval=              cidr_netmask=              iflabel=                   lvs_support=               nic=                       preferred_lft=             unique_clone_address=
arp_count=                 arp_sender=                clusterip_hash=            lvs_ipv6_addrlabel=        mac=                       nodad=                     run_arping=                
crm(live/alp-1)configure# primitive fs Filesystem params 
device=             fstype=             force_clones=       kill_signals=       run_fsck=           statusfile_prefix=  
directory=          fast_stop=          force_unmount=      options=            signal_delay=       term_signals=
```