### PR TITLE
Dev: ra: Guess stonith class type when using fence agents

### DIFF
--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -865,7 +865,10 @@ def disambiguate_ra_type(s):
     elif len(l) == 2:
         cl, tp = l
     else:
-        cl, tp = "ocf", l[0]
+        if l[0].startswith("fence_"):
+            cl, tp = "stonith", l[0]
+        else:
+            cl, tp = "ocf", l[0]
     pr = pick_provider(ra_providers(tp, cl)) if cl == 'ocf' else ''
     return cl, pr, tp
 


### PR DESCRIPTION
## Problem
When adding fence agent without giving `stonith` class, get an error while using Tab to get  parameters
```
crm(live/alp-1)configure# primitive stonith-sbd fence_sbd params ERROR: ocf:heartbeat:fence_sbd: got no meta-data, does this RA exist?
```
That is allowed when adding ocf RA without giving `ocf` class
```
crm(live/alp-1)configure# primitive d Dummy params 
fake=    state=
```
## Solution
In ra.disambiguate_ra_type function, return 'stonith' class type when RA starts with 'fence_'