### PR TITLE
Fix: ui_context: crm configure delete autocompletion #1403 #1460

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -11,6 +11,7 @@ from . import userdir
 from . import constants
 from . import log
 from . import main
+from .service_manager import ServiceManager
 
 
 logger = log.setup_logger(__name__)
@@ -255,6 +256,9 @@ class Context(object):
         self._in_transit = True
 
         entry = level()
+        if ServiceManager().service_is_active("pacemaker.service"):
+            if 'requires' in dir(entry) and not entry.requires():
+                self.fatal_error("Missing requirements")
         self.stack.append(entry)
         self.clear_readline_cache()
 


### PR DESCRIPTION
If you type
  $ crm configure delete
of do it interactively
  $ crm configure
  crm(live/node1)configure# delete
and then double press tab it, should propose possible resource options. And this commit makes it working again.