### PR TITLE
Fix: codecov: use environ to pass CODECOV_TOKEN (#1472)

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -50,8 +50,9 @@ jobs:
         tox -v -e${{ matrix.python-version }}
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unit
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_crm_report_bugs:
     runs-on: ubuntu-24.04
@@ -66,8 +67,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_crm_report_normal:
     runs-on: ubuntu-24.04
@@ -82,8 +84,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_bugs:
     runs-on: ubuntu-24.04
@@ -98,8 +101,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_bugs_non_root:
     runs-on: ubuntu-24.04
@@ -114,8 +118,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_common:
     runs-on: ubuntu-24.04
@@ -130,8 +135,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_common_non_root:
     runs-on: ubuntu-24.04
@@ -146,8 +152,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_options:
     runs-on: ubuntu-24.04
@@ -162,8 +169,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_corosync_ui:
     runs-on: ubuntu-24.04
@@ -178,8 +186,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_bootstrap_options_non_root:
     runs-on: ubuntu-24.04
@@ -194,8 +203,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_setup_remove:
     runs-on: ubuntu-24.04
@@ -210,8 +220,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_setup_remove_non_root:
     runs-on: ubuntu-24.04
@@ -226,8 +237,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_options:
     runs-on: ubuntu-24.04
@@ -242,8 +254,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_validate:
     runs-on: ubuntu-24.04
@@ -258,8 +271,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_validate_non_root:
     runs-on: ubuntu-24.04
@@ -274,8 +288,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_qdevice_user_case:
     runs-on: ubuntu-24.04
@@ -290,8 +305,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_failcount:
     runs-on: ubuntu-24.04
@@ -306,8 +322,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_set:
     runs-on: ubuntu-24.04
@@ -322,8 +339,9 @@ jobs:
         $DOCKER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_resource_set_non_root:
     runs-on: ubuntu-24.04
@@ -338,8 +356,9 @@ jobs:
         $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_configure_sublevel:
     runs-on: ubuntu-24.04
@@ -354,8 +373,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_constraints_bugs:
     runs-on: ubuntu-24.04
@@ -370,8 +390,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_geo_cluster:
     runs-on: ubuntu-24.04
@@ -386,8 +407,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_healthcheck:
     runs-on: ubuntu-24.04
@@ -402,8 +424,9 @@ jobs:
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_cluster_api:
     runs-on: ubuntu-24.04
@@ -417,8 +440,9 @@ jobs:
         $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_user_access:
     runs-on: ubuntu-24.04
@@ -432,8 +456,9 @@ jobs:
         $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   functional_test_ssh_agent:
     runs-on: ubuntu-24.04
@@ -447,8 +472,9 @@ jobs:
         $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent` && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
     - uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         flags: integration
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   original_regression_test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
As shown in https://github.com/ClusterLabs/crmsh/actions/runs/9612091155/job/26512047071, codecov reports: Error: Codecov token not found. Please provide Codecov token with -t flag.

So try a different way to provide the token.