### PR TITLE
[crmsh-4.5] Fix: github-actions: should pass secrets to reusable workflows

### DIFF
--- a/.github/workflows/crmsh-cd.yml
+++ b/.github/workflows/crmsh-cd.yml
@@ -18,6 +18,7 @@ jobs:
   integration:
     if: github.repository == 'ClusterLabs/crmsh' && github.ref_name == 'crmsh-4.6'
     uses: ./.github/workflows/crmsh-ci.yml
+    secrets: inherit
 
   delivery:
     if: github.repository == 'ClusterLabs/crmsh' && github.ref_name == 'crmsh-4.6'


### PR DESCRIPTION
backport:

* #1474