### PR TITLE
Dev: bootstrap: Use the existing function to query cluster property

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1981,9 +1981,12 @@ def join_cluster(seed_host, remote_user):
     with logger_utils.status_long("Reloading cluster configuration"):
 
         # Ditch no-quorum-policy=ignore
-        _rc, outp = ShellUtils().get_stdout("crm configure show")
-        if re.search('no-quorum-policy=.*ignore', outp):
-            invoke("crm_attribute --attr-name no-quorum-policy --delete-attr")
+        no_quorum_policy = utils.get_property("no-quorum-policy")
+        if no_quorum_policy == "ignore":
+            logger.info("Ditching no-quorum-policy=ignore")
+            if not utils.delete_property("no-quorum-policy"):
+                logger.error("Failed to delete no-quorum-policy=ignore")
+
         invoke("crm cluster run 'crm corosync reload'")
 
     if is_qdevice_configured:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2779,6 +2779,17 @@ def get_property(name, property_type="crm_config", peer=None):
     return stdout if rc == 0 else None
 
 
+def delete_property(name, property_type="crm_config") -> bool:
+    cmd = f"crm_attribute -D -t {property_type} -n {name}"
+    rc, _, stderr = ShellUtils().get_stdout_stderr(cmd)
+    if rc == 0:
+        logger.info("Delete cluster property \"%s\" in %s", name, property_type)
+        return True
+    elif stderr:
+        logger.error(stderr)
+    return False
+
+
 def check_no_quorum_policy_with_dlm():
     """
     Give warning when no-quorum-policy not freeze while configured DLM

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -297,3 +297,15 @@ Feature: Regression test for bootstrap bugs
     And     Expected "hacluster:haclient" in stdout
     Then    Run "stat -c '%U:%G' ~hacluster/.ssh/authorized_keys" OK on "hanode2"
     And     Expected "hacluster:haclient" in stdout
+
+  @clean
+  Scenario: Ditch no-quorum-policy=ignore when joining
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    And     Run "crm configure property no-quorum-policy=ignore" on "hanode1"
+    And     Run "crm configure show" on "hanode1"
+    Then    Expected "no-quorum-policy=ignore" in stdout
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Run "crm configure show" on "hanode1"
+    Then    Expected "no-quorum-policy=ignore" not in stdout


### PR DESCRIPTION
The command `crm_attribute --attr-name no-quorum-policy --delete-attr` didn't work, will get
```
crm_attribute: Missing argument for --delete-attr
```

And adding a new function to delete the cluster property.
