### PR TITLE
[crmsh-4.6] Fix: ui_context: crm configure up prompt #1466

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -326,7 +326,7 @@ class Context(object):
         '''
         ok = True
         if len(self.stack) > 1:
-            if self.command_name and self.command_name not in constants.NON_FUNCTIONAL_COMMANDS:
+            if ServiceManager().service_is_active("pacemaker.service"):
                 ok = self.current_level().end_game(no_questions_asked=self._in_transit) is not False
             self.stack.pop()
             self.clear_readline_cache()


### PR DESCRIPTION
backport #1481

The regression was introduced in beb26f3e
Before beb26f3e it was like
$ crm(live/15sp5-1)configure# primitive d Dummy
$ crm(live/15sp5-1)configure# up
$ There are changes pending. Do you want to commit them (y/n)? After beb26f3e there is no prompt 'There are changes pending... (y/n)?' This change brings the prompt back.