### PR TITLE
Fix: DC lost during wait

### DIFF
--- a/crmsh/prun/runner.py
+++ b/crmsh/prun/runner.py
@@ -55,7 +55,7 @@ class Runner:
         )
         if timeout_seconds > 0:
             awaitable = self._timeout_limit(timeout_seconds, awaitable)
-        return asyncio.get_event_loop().run_until_complete(awaitable)
+        return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(awaitable)
 
     async def _timeout_limit(self, timeout_seconds: int, awaitable: typing.Awaitable):
         assert timeout_seconds > 0

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -225,22 +225,6 @@ class Cluster(command.UI):
         return True
 
     @staticmethod
-    def _wait_for_dc(node=None):
-        """
-        Wait for the cluster's DC to become available
-        """
-        if not ServiceManager().service_is_active("pacemaker.service", remote_addr=node):
-            return
-
-        dc_deadtime = utils.get_property("dc-deadtime", peer=node) or str(constants.DC_DEADTIME_DEFAULT)
-        dc_timeout = int(dc_deadtime.strip('s')) + 5
-        try:
-            utils.check_function_with_timeout(utils.get_dc, wait_timeout=dc_timeout, peer=node)
-        except TimeoutError:
-            logger.error("No DC found currently, please wait if the cluster is still starting")
-            raise utils.TerminateSubCommand
-
-    @staticmethod
     def _set_dlm(node=None):
         """
         When dlm running and quorum is lost, before stop cluster service, should set
@@ -261,7 +245,7 @@ class Cluster(command.UI):
             return
         logger.debug(f"stop node list: {node_list}")
 
-        self._wait_for_dc(node_list[0])
+        utils.wait_for_dc(node_list[0])
 
         self._set_dlm(node_list[0])
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -862,7 +862,7 @@ class CibConfig(command.UI):
         argl = [x for x in argl if x not in ('-f', '--force')]
         if arg_force or config.core.force:
             if self._stop_if_running(argl) > 0:
-                utils.wait4dc(what="Stopping %s" % (", ".join(argl)))
+                utils.wait_dc_stable(what="Stopping %s" % (", ".join(argl)))
         cib_factory.ensure_cib_updated()
         return cib_factory.delete(*argl)
 

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -104,7 +104,7 @@ class Context(object):
 
         # wait for dc if wait flag set
         if self._wait_for_dc:
-            return utils.wait4dc(self.command_name, not options.batch)
+            return utils.wait_dc_stable(self.command_name, not options.batch)
         return rv
 
     def complete(self, line):

--- a/crmsh/ui_history.py
+++ b/crmsh/ui_history.py
@@ -158,7 +158,7 @@ class History(command.UI):
     def do_latest(self, context):
         "usage: latest"
         self._init_source()
-        if not utils.wait4dc("transition", not options.batch):
+        if not utils.wait_dc_stable("transition", not options.batch):
             return False
         self._set_source("live")
         crm_report().refresh_source()

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -325,7 +325,7 @@ class RscMgmt(command.UI):
         logger.info("ordering %s to stop", ", ".join(resources))
         if not self._commit_meta_attrs(context, resources, "target-role", "Stopped"):
             return False
-        if not utils.wait4dc("stop", not options.batch):
+        if not utils.wait_dc_stable("stop", not options.batch):
             return False
         logger.info("ordering %s to start", ", ".join(resources))
         return self._commit_meta_attrs(context, resources, "target-role", "Started")

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2937,22 +2937,6 @@ def detect_file(_file, remote=None):
     return rc
 
 
-def check_function_with_timeout(check_function, wait_timeout=30, interval=1, *args, **kwargs):
-    """
-    Run check_function in a loop
-    Return when check_function is true
-    Raise TimeoutError when timeout
-    """
-    current_time = int(time.time())
-    timeout = current_time + wait_timeout
-    while current_time <= timeout:
-        if check_function(*args, **kwargs):
-            return
-        time.sleep(interval)
-        current_time = int(time.time())
-    raise TimeoutError
-
-
 def retry_with_timeout(callable, timeout_sec: float, interval_sec=1):
     """Try callable repeatedly until it returns without raising an exception.
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -991,12 +991,12 @@ def append_file(dest, src):
 
 def get_dc(peer=None):
     cmd = "crmadmin -D -t 1"
-    rc, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(peer, cmd)
+    _, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(peer, cmd)
     if not out:
-        return (None, rc)
+        return None
     if not out.startswith("Designated"):
-        return (None, rc)
-    return (out.split()[-1], rc)
+        return None
+    return out.split()[-1]
 
 
 def wait_dc_stable(what="", show_progress=True):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -999,7 +999,7 @@ def get_dc(peer=None):
     return (out.split()[-1], rc)
 
 
-def wait4dc(what="", show_progress=True):
+def wait_dc_stable(what="", show_progress=True):
     '''
     Wait for the DC to get into the S_IDLE state. This should be
     invoked only after a CIB modification which would exercise

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -80,7 +80,7 @@ class TestCluster(unittest.TestCase):
         mock_qdevice_configured.assert_called_once_with()
         mock_info.assert_called_once_with("The cluster stack started on node1")
 
-    @mock.patch('crmsh.ui_cluster.Cluster._wait_for_dc')
+    @mock.patch('crmsh.utils.wait_for_dc')
     @mock.patch('crmsh.ui_cluster.Cluster._node_ready_to_stop_cluster_service')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     def test_do_stop_return(self, mock_parse_nodes, mock_node_ready_to_stop_cluster_service, mock_dc):
@@ -98,7 +98,7 @@ class TestCluster(unittest.TestCase):
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.ui_cluster.ServiceManager')
     @mock.patch('crmsh.ui_cluster.Cluster._set_dlm')
-    @mock.patch('crmsh.ui_cluster.Cluster._wait_for_dc')
+    @mock.patch('crmsh.utils.wait_for_dc')
     @mock.patch('crmsh.ui_cluster.Cluster._node_ready_to_stop_cluster_service')
     @mock.patch('crmsh.ui_cluster.parse_option_for_nodes')
     def test_do_stop(self, mock_parse_nodes, mock_node_ready_to_stop_cluster_service, mock_dc,


### PR DESCRIPTION
This is a refined version of #1475.

`crmsh.utils.wait4dc` traces DC transition until it gets stable. However, at certain steps during the transition, there will be no DCs in the cluster. wait4dc does not handle this situation and fails.