### PR TITLE
Dev: refine change detection for `crm configure` (#1466)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2769,14 +2769,18 @@ class CibFactory(object):
                 # no need to warn, user can see the object displayed as XML
                 logger.debug("object %s cannot be represented in the CLI notation", obj.obj_id)
 
-    def initialize(self, cib=None):
+    def initialize(self, cib=None, no_side_effects=False):
         if self.cib_elem is not None:
             return True
         if cib is None:
-            cib = read_cib(cibdump2elem)
+            cib_element = read_cib(lambda x: cibdump2elem(x, no_side_effects=no_side_effects))
+            if cib_element is None and no_side_effects:
+                return False
         elif isinstance(cib, str):
-            cib = text2elem(cib)
-        if not self._import_cib(cib):
+            cib_element = text2elem(cib)
+        else:
+            cib_element = cib
+        if not self._import_cib(cib_element):
             return False
         self.cib_orig = copy.deepcopy(self.cib_elem)
         sanitize_cib_for_patching(self.cib_orig)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3308,9 +3308,13 @@ class CibFactory(object):
         return not self.get_elems_on_type("type:primitive")
 
     def has_cib_changed(self):
-        if not self.is_cib_sane():
+        if self.cib_elem is None:
+            # cib is not loaded, so it is also not changed
             return False
-        return self.modified_elems() or self.remove_queue
+        elif not self.is_cib_sane():
+            return False
+        else:
+            return self.modified_elems() or self.remove_queue
 
     def ensure_cib_updated(self):
         if options.interactive and not self.has_cib_changed():

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -443,8 +443,6 @@ If a nic name is provided, the first IP of that nic will be used.
 Use multiple -i for more links. Note: Only one link is allowed for the non knet transport type
 """
 
-NON_FUNCTIONAL_COMMANDS = {'help', 'cd', 'ls', 'quit', 'up'}
-NON_FUNCTIONAL_OPTIONS = {'--help', '--help-without-redirect'}
 COROSYNC_STATUS_TYPES = ("ring", "quorum", "qdevice", "qnetd", "cpg")
 
 COROSYNC_PORT = 5405

--- a/crmsh/ui_assist.py
+++ b/crmsh/ui_assist.py
@@ -29,7 +29,8 @@ class Assist(command.UI):
         command.UI.__init__(self)
 
     def requires(self):
-        return cib_factory.initialize()
+        cib_factory.initialize(no_side_effects=True)
+        return True
 
     @command.skill_level('administrator')
     @command.completers_repeating(compl.call(cib_factory.prim_id_list))

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -512,8 +512,8 @@ class CibConfig(command.UI):
         # immediately so that tab completion works
 
     def requires(self):
-        if not cib_factory.initialize():
-            return False
+        if not cib_factory.initialize(no_side_effects=True):
+            return True
         # see the configure ptest/simulate command
         has_ptest = utils.is_program('ptest')
         has_simulate = utils.is_program('crm_simulate')

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -17,6 +17,8 @@ from .service_manager import ServiceManager
 logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
+_NON_FUNCTIONAL_COMMANDS = {'help', 'cd', 'ls', 'quit', 'up'}
+_NON_FUNCTIONAL_OPTIONS = {'--help', '--help-without-redirect'}
 
 class Context(object):
     """
@@ -83,8 +85,8 @@ class Context(object):
                     cmd = True
                     break
             if cmd:
-                if self.command_name not in constants.NON_FUNCTIONAL_COMMANDS\
-                        and all(arg not in constants.NON_FUNCTIONAL_OPTIONS for arg in self.command_args):
+                if self.command_name not in _NON_FUNCTIONAL_COMMANDS\
+                        and all(arg not in _NON_FUNCTIONAL_OPTIONS for arg in self.command_args):
                     entry = self.current_level()
                     if 'requires' in dir(entry) and not entry.requires():
                         self.fatal_error("Missing requirements")

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -326,8 +326,7 @@ class Context(object):
         '''
         ok = True
         if len(self.stack) > 1:
-            if ServiceManager().service_is_active("pacemaker.service"):
-                ok = self.current_level().end_game(no_questions_asked=self._in_transit) is not False
+            ok = self.current_level().end_game(no_questions_asked=self._in_transit) is not False
             self.stack.pop()
             self.clear_readline_cache()
         return ok
@@ -348,9 +347,7 @@ class Context(object):
         '''
         Exit from the top level
         '''
-        ok = True
-        if self.command_name and self.command_name not in constants.NON_FUNCTIONAL_COMMANDS:
-            ok = self.current_level().end_game()
+        ok = self.current_level().end_game()
         if options.interactive and not options.batch:
             if constants.need_reset:
                 utils.ext_cmd("reset")

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -11,7 +11,6 @@ from . import userdir
 from . import constants
 from . import log
 from . import main
-from .service_manager import ServiceManager
 
 
 logger = log.setup_logger(__name__)
@@ -258,9 +257,8 @@ class Context(object):
         self._in_transit = True
 
         entry = level()
-        if ServiceManager().service_is_active("pacemaker.service"):
-            if 'requires' in dir(entry) and not entry.requires():
-                self.fatal_error("Missing requirements")
+        if 'requires' in dir(entry) and not entry.requires():
+            self.fatal_error("Missing requirements")
         self.stack.append(entry)
         self.clear_readline_cache()
 

--- a/crmsh/ui_maintenance.py
+++ b/crmsh/ui_maintenance.py
@@ -26,7 +26,8 @@ class Maintenance(command.UI):
         command.UI.__init__(self)
 
     def requires(self):
-        return cib_factory.initialize()
+        cib_factory.initialize(no_side_effects=True)
+        return True
 
     def _onoff(self, resource, onoff):
         if resource is not None:

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -134,7 +134,7 @@ def text2elem(text):
         return None
 
 
-def cibdump2elem(section=None):
+def cibdump2elem(section=None, no_side_effects=False):
     if section:
         cmd = "%s -o %s" % (cib_dump, section)
     else:
@@ -142,7 +142,7 @@ def cibdump2elem(section=None):
     rc, outp, errp = sudocall(cmd)
     if rc == 0:
         return text2elem(outp)
-    else:
+    elif not no_side_effects:
         logger.error("running %s: %s", cmd, errp)
     return None
 


### PR DESCRIPTION
#1300 tried to remove unnecessary dependencies on a running pacemaker service when crmsh is not actually going to call the service. However, it removed the call to `end_game()` from `up()` and `quit()` incorrectly. This made sublevel `configure` not to have a chance to check uncommitted changes anymore, leading to a regression described in #1466.

#1481 tried to fix this regression by adding the call to `end_game()` back to `up()`, and check if pacemaker service is running before calling `end_game()`. This is not optimal as `up()` is a common method used for all sublevels and the status of pacemaker service is only related sublevel `configure`. Checking the status of pacemaker service when using other sublevels does not make sense.

This pull request uses a more straightforward method to fix the problem: improve how to detect uncommitted changes in `has_cib_changes()`.

The original implementation is to check if there is any elements in change queue. This requires the in memory representation of cib to be populated, leading to an indirect dependency to pacemaker service. However, we can take advantage of a property: the in memory cib needs to be populated before doing any changes. So in the implementation can be optimized: if the in memory cib is not populated, we will know there is not any change.