### PR TITLE
Fix: qnetd fails to start when TLS is disabled (bsc#1227649)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1491,7 +1491,7 @@ def configure_qdevice_interactive():
             valid_func=qdevice.QDevice.check_qdevice_algo)
     qdevice_tie_breaker = prompt_for_string("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest",
             valid_func=qdevice.QDevice.check_qdevice_tie_breaker)
-    qdevice_tls = prompt_for_string("Whether using TLS on QDevice/QNetd (on/off/required)", default="on",
+    qdevice_tls = prompt_for_string("Whether using TLS on QDevice (on/off/required)", default="on",
             valid_func=qdevice.QDevice.check_qdevice_tls)
     qdevice_heuristics = prompt_for_string("Heuristics COMMAND to run with absolute path; For multiple commands, use \";\" to separate",
             valid_func=qdevice.QDevice.check_qdevice_heuristics,

--- a/crmsh/prun/prun.py
+++ b/crmsh/prun/prun.py
@@ -12,6 +12,8 @@ from crmsh.sh import Utils
 
 _DEFAULT_CONCURRENCY = 32
 
+_SUDO_SFTP_SERVER = 'sudo PATH=/usr/lib/ssh:/usr/lib/openssh:/usr/libexec/ssh:/usr/libexec/openssh /bin/sh -c "exec sftp-server"'
+
 
 class ProcessResult:
     def __init__(self, returncode: int, stdout: bytes, stderr: bytes):
@@ -185,9 +187,10 @@ exec sudo -u {local_sudoer} ssh "$@"''')
 
 def _build_copy_task(ssh: str, script: str, host: str):
     _, remote_sudoer = UserOfHost.instance().user_pair_for_ssh(host)
-    cmd = "sftp {} {} -o BatchMode=yes -s 'sudo PATH=/usr/lib/ssh:/usr/libexec/ssh /bin/sh -c \"exec sftp-server\"' -b - {}@{}".format(
+    cmd = "sftp {} {} -o BatchMode=yes -s '{}' -b - {}@{}".format(
         ssh,
         crmsh.constants.SSH_OPTION,
+        _SUDO_SFTP_SERVER,
         remote_sudoer, _enclose_inet6_addr(host),
     )
     return Task(
@@ -249,9 +252,10 @@ def pfetch_from_remote(
 
 def _build_fetch_task( ssh: str, host: str, src: str, dst: str, flags: str) -> Task:
     _, remote_sudoer = UserOfHost.instance().user_pair_for_ssh(host)
-    cmd = "sftp {} {} -o BatchMode=yes -s 'sudo PATH=/usr/lib/ssh:/usr/libexec/ssh /bin/sh -c \"exec sftp-server\"' -b - {}@{}".format(
+    cmd = "sftp {} {} -o BatchMode=yes -s '{}' -b - {}@{}".format(
         ssh,
         crmsh.constants.SSH_OPTION,
+        _SUDO_SFTP_SERVER,
         remote_sudoer, _enclose_inet6_addr(host),
     )
     os.makedirs(f"{dst}/{host}", exist_ok=True)

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -97,28 +97,12 @@ def qnetd_lock_for_multi_cluster(func):
 
 
 class QDevice(object):
-    """
-    Class to manage qdevice configuration and services
+    """Class to manage qdevice configuration and services
 
-    Whole certification process:
-    For init
-    Step 2:  fetch_qnetd_crt_from_qnetd
-    Step 3:  copy_qnetd_crt_to_cluster
-    Step 4:  init_db_on_cluster
-    Step 5:  create_ca_request
-    Step 6:  copy_crq_to_qnetd
-    Step 7:  sign_crq_on_qnetd
-    Step 8:  fetch_cluster_crt_from_qnetd
-    Step 9:  import_cluster_crt
-    Step 10: copy_p12_to_cluster
-    Step 11: import_p12_on_cluster
-
-    For join
-    Step 1:  fetch_qnetd_crt_from_cluster
-    Step 2:  init_db_on_local
-    Step 3:  fetch_p12_from_cluster
-    Step 4:  import_p12_on_local
+    Call `certificate_process_on_init` to generate all of CA, server, and client certs.
+    Call `certificate_process_on_join` to generate a single client cert for the local node.
     """
+
     qnetd_service = "corosync-qnetd.service"
     qnetd_cacert_filename = "qnetd-cacert.crt"
     qdevice_crq_filename = "qdevice-net-node.crq"
@@ -344,31 +328,23 @@ class QDevice(object):
         cmd = "corosync-qnetd-certutil -i"
         parallax.parallax_call([self.qnetd_addr], cmd)
 
-    def fetch_qnetd_crt_from_qnetd(self):
-        """
-        Certificate process for init
-        Step 2
-        Fetch QNetd CA certificate(qnetd-cacert.crt) from QNetd server
-        """
+    def fetch_qnetd_crt_from_qnetd(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Fetch QNetd CA certificate(qnetd-cacert.crt) from QNetd server"""
         if os.path.exists(self.qnetd_cacert_on_local):
             return
 
-        desc = "Step 2: Fetch {} from {}".format(self.qnetd_cacert_filename, self.qnetd_addr)
-        QDevice.log_only_to_file(desc)
+        desc = "Fetch {} from {}".format(self.qnetd_cacert_filename, self.qnetd_addr)
+        log(desc)
         crmsh.parallax.parallax_slurp([self.qnetd_addr], self.qdevice_path, self.qnetd_cacert_on_qnetd)
 
-    def copy_qnetd_crt_to_cluster(self):
-        """
-        Certificate process for init
-        Step 3
-        Copy exported QNetd CA certificate (qnetd-cacert.crt) to every node
-        """
+    def copy_qnetd_crt_to_cluster(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Copy exported QNetd CA certificate (qnetd-cacert.crt) to every node"""
         node_list = utils.list_cluster_nodes_except_me()
         if not node_list:
             return
 
-        desc = "Step 3: Copy exported {} to {}".format(self.qnetd_cacert_filename, node_list)
-        QDevice.log_only_to_file(desc)
+        desc = "Copy exported {} to {}".format(self.qnetd_cacert_filename, node_list)
+        log(desc)
         self._copy_file_to_remote_hosts(
             os.path.dirname(self.qnetd_cacert_on_local),
             node_list, self.qdevice_path,
@@ -386,104 +362,77 @@ class QDevice(object):
     def _copy_file_to_remote_hosts(cls, local_file, remote_hosts: typing.Iterable[str], remote_path, recursive=False):
         crmsh.parallax.parallax_copy(remote_hosts, local_file, remote_path, recursive)
 
-    def init_db_on_cluster(self):
+    def init_db_on_cluster(self, log: typing.Callable[[str, typing.Optional[str]], None]):
         """
-        Certificate process for init
-        Step 4
         On one of cluster node initialize database by running
         /usr/sbin/corosync-qdevice-net-certutil -i -c qnetd-cacert.crt
         """
         node_list = utils.list_cluster_nodes()
         cmd = "corosync-qdevice-net-certutil -i -c {}".format(self.qnetd_cacert_on_local)
-        desc = "Step 4: Initialize database on {}".format(node_list)
-        QDevice.log_only_to_file(desc, cmd)
+        desc = "Initialize database on {}".format(node_list)
+        log(desc, cmd)
         crmsh.parallax.parallax_call(node_list, cmd)
 
-    def create_ca_request(self):
-        """
-        Certificate process for init
-        Step 5
-        Generate certificate request:
+    def create_ca_request(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Generate certificate request:
         /usr/sbin/corosync-qdevice-net-certutil -r -n Cluster
         (Cluster name must match cluster_name key in the corosync.conf)
         """
         cmd = "corosync-qdevice-net-certutil -r -n {}".format(self.cluster_name)
-        QDevice.log_only_to_file("Step 5: Generate certificate request {}".format(self.qdevice_crq_filename), cmd)
+        log("Generate certificate request {}".format(self.qdevice_crq_filename), cmd)
         sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
-    def copy_crq_to_qnetd(self):
-        """
-        Certificate process for init
-        Step 6
-        Copy exported CRQ to QNetd server
-        """
-        desc = "Step 6: Copy {} to {}".format(self.qdevice_crq_filename, self.qnetd_addr)
-        QDevice.log_only_to_file(desc)
+    def copy_crq_to_qnetd(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Copy exported CRQ to QNetd server"""
+        desc = "Copy {} to {}".format(self.qdevice_crq_filename, self.qnetd_addr)
+        log(desc)
         self._copy_file_to_remote_hosts(self.qdevice_crq_on_local, [self.qnetd_addr], self.qdevice_crq_on_qnetd)
 
-    def sign_crq_on_qnetd(self):
-        """
-        Certificate process for init
-        Step 7
-        On QNetd server sign and export cluster certificate by running
+    def sign_crq_on_qnetd(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """On QNetd server sign and export cluster certificate by running
         corosync-qnetd-certutil -s -c qdevice-net-node.crq -n Cluster
         """
-        desc = "Step 7: Sign and export cluster certificate on {}".format(self.qnetd_addr)
+        desc = "Sign and export cluster certificate on {}".format(self.qnetd_addr)
         cmd = "corosync-qnetd-certutil -s -c {} -n {}".\
                 format(self.qdevice_crq_on_qnetd, self.cluster_name)
-        QDevice.log_only_to_file(desc, cmd)
+        log(desc, cmd)
         parallax.parallax_call([self.qnetd_addr], cmd)
 
-    def fetch_cluster_crt_from_qnetd(self):
-        """
-        Certificate process for init
-        Step 8
-        Copy exported CRT to node where certificate request was created
-        """
-        desc = "Step 8: Fetch {} from {}".format(os.path.basename(self.qnetd_cluster_crt_on_qnetd), self.qnetd_addr)
-        QDevice.log_only_to_file(desc)
+    def fetch_cluster_crt_from_qnetd(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Copy exported CRT to node where certificate request was created"""
+        desc = "Fetch {} from {}".format(os.path.basename(self.qnetd_cluster_crt_on_qnetd), self.qnetd_addr)
+        log(desc)
         crmsh.parallax.parallax_slurp([self.qnetd_addr], self.qdevice_path, self.qnetd_cluster_crt_on_qnetd)
 
-    def import_cluster_crt(self):
-        """
-        Certificate process for init
-        Step 9
-        Import certificate on node where certificate request was created by
+    def import_cluster_crt(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Import certificate on node where certificate request was created by
         running /usr/sbin/corosync-qdevice-net-certutil -M -c cluster-Cluster.crt
         """
         cmd = "corosync-qdevice-net-certutil -M -c {}".format(self.qnetd_cluster_crt_on_local)
-        QDevice.log_only_to_file(
-                "Step 9: Import certificate file {} on local".format(os.path.basename(self.qnetd_cluster_crt_on_local)),
-                cmd)
+        log("Import certificate file {} on local".format(os.path.basename(self.qnetd_cluster_crt_on_local)), cmd)
         sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
-    def copy_p12_to_cluster(self):
-        """
-        Certificate process for init
-        Step 10
-        Copy output qdevice-net-node.p12 to all other cluster nodes
-        """
+    def copy_p12_to_cluster(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Copy output qdevice-net-node.p12 to all other cluster nodes"""
         node_list = utils.list_cluster_nodes_except_me()
         if not node_list:
             return
 
-        desc = "Step 10: Copy {} to {}".format(self.qdevice_p12_filename, node_list)
-        QDevice.log_only_to_file(desc)
+        desc = "Copy {} to {}".format(self.qdevice_p12_filename, node_list)
+        log(desc)
         self._copy_file_to_remote_hosts(self.qdevice_p12_on_local, node_list, self.qdevice_p12_on_local)
 
-    def import_p12_on_cluster(self):
-        """
-        Certificate process for init
-        Step 11
-        Import cluster certificate and key on all other cluster nodes:
+    def import_p12_on_cluster(self, log: typing.Callable[[str, typing.Optional[str]], None]):
+        """Import cluster certificate and key on all other cluster nodes:
         /usr/sbin/corosync-qdevice-net-certutil -m -c qdevice-net-node.p12
         """
         node_list = utils.list_cluster_nodes_except_me()
         if not node_list:
             return
 
-        desc = "Step 11: Import {} on {}".format(self.qdevice_p12_filename, node_list)
+        desc = "Import {} on {}".format(self.qdevice_p12_filename, node_list)
         cmd = "corosync-qdevice-net-certutil -m -c {}".format(self.qdevice_p12_on_local)
+        log(desc, cmd)
         QDevice.log_only_to_file(desc, cmd)
         parallax.parallax_call(node_list, cmd)
 
@@ -491,16 +440,19 @@ class QDevice(object):
         """
         The qdevice certificate process on init node
         """
-        self.fetch_qnetd_crt_from_qnetd()
-        self.copy_qnetd_crt_to_cluster()
-        self.init_db_on_cluster()
-        self.create_ca_request()
-        self.copy_crq_to_qnetd()
-        self.sign_crq_on_qnetd()
-        self.fetch_cluster_crt_from_qnetd()
-        self.import_cluster_crt()
-        self.copy_p12_to_cluster()
-        self.import_p12_on_cluster()
+        for i, step in enumerate([
+            self.fetch_qnetd_crt_from_qnetd,
+            self.copy_qnetd_crt_to_cluster,
+            self.init_db_on_cluster,
+            self.create_ca_request,
+            self.copy_crq_to_qnetd,
+            self.sign_crq_on_qnetd,
+            self.fetch_cluster_crt_from_qnetd,
+            self.import_cluster_crt,
+            self.copy_p12_to_cluster,
+            self.import_p12_on_cluster,
+        ]):
+            step(lambda s, cmd=None: self.log_only_to_file(f'Step {i+1}: {s}', cmd))
 
     def fetch_qnetd_crt_from_cluster(self):
         """

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -679,7 +679,7 @@ class QDevice(object):
         Wrap function to collect functions to config and start qdevice
         """
         QDevice.remove_qdevice_db()
-        if self.tls == "on":
+        if self.tls == "on" or self.tls == 'required':
             with logger_utils.status_long("Qdevice certification process"):
                 self.certificate_process_on_init()
         self.adjust_sbd_watchdog_timeout_with_qdevice()

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -102,7 +102,6 @@ class QDevice(object):
 
     Whole certification process:
     For init
-    Step 1:  init_db_on_qnetd
     Step 2:  fetch_qnetd_crt_from_qnetd
     Step 3:  copy_qnetd_crt_to_cluster
     Step 4:  init_db_on_cluster
@@ -293,27 +292,17 @@ class QDevice(object):
         """
         exception_msg = ""
         suggest = ""
-        duplicated_cluster_name = False
         shell = sh.cluster_shell()
         if not utils.package_is_installed("corosync-qnetd", remote_addr=self.qnetd_addr):
             exception_msg = "Package \"corosync-qnetd\" not installed on {}!".format(self.qnetd_addr)
             suggest = "install \"corosync-qnetd\" on {}".format(self.qnetd_addr)
-        elif ServiceManager().service_is_active("corosync-qnetd", remote_addr=self.qnetd_addr):
+        else:
+            self.init_tls_certs_on_qnetd()
+            self.start_qnetd()
             cmd = "corosync-qnetd-tool -l -c {}".format(self.cluster_name)
             if shell.get_stdout_or_raise_error(cmd, self.qnetd_addr):
-                duplicated_cluster_name = True
-        else:
-            cmd = "test -f {}".format(self.qnetd_cluster_crt_on_qnetd)
-            try:
-                shell.get_stdout_or_raise_error(cmd, self.qnetd_addr)
-            except ValueError:
-                # target file not exist
-                pass
-            else:
-                duplicated_cluster_name = True
-        if duplicated_cluster_name:
-            exception_msg = "This cluster's name \"{}\" already exists on qnetd server!".format(self.cluster_name)
-            suggest = "consider to use the different cluster-name property"
+                exception_msg = "This cluster's name \"{}\" already exists on qnetd server!".format(self.cluster_name)
+                suggest = "consider to use the different cluster-name property"
 
         if exception_msg:
             if self.is_stage:
@@ -341,24 +330,18 @@ class QDevice(object):
             raise ValueError("No cluster_name found in {}".format(corosync.conf()))
 
     @qnetd_lock_for_multi_cluster
-    def init_db_on_qnetd(self):
-        """
-        Certificate process for init
-        Step 1
-        Initialize database on QNetd server by running corosync-qnetd-certutil -i
-        """
+    def init_tls_certs_on_qnetd(self):
+        """Initialize NSS database and generates CA and server certs on QNetd server."""
         cmd = "test -f {}".format(self.qnetd_cacert_on_qnetd)
         try:
             parallax.parallax_call([self.qnetd_addr], cmd)
+            return
         except ValueError:
             # target file not exist
             pass
-        else:
-            return
 
+        logger.info('Generating QNetd CA and server certificates on %s', self.qnetd_addr)
         cmd = "corosync-qnetd-certutil -i"
-        desc = "Step 1: Initialize database on {}".format(self.qnetd_addr)
-        QDevice.log_only_to_file(desc, cmd)
         parallax.parallax_call([self.qnetd_addr], cmd)
 
     def fetch_qnetd_crt_from_qnetd(self):
@@ -508,7 +491,6 @@ class QDevice(object):
         """
         The qdevice certificate process on init node
         """
-        self.init_db_on_qnetd()
         self.fetch_qnetd_crt_from_qnetd()
         self.copy_qnetd_crt_to_cluster()
         self.init_db_on_cluster()

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -430,7 +430,7 @@ Examples:
         qdevice_group.add_argument("--qdevice-tie-breaker", dest="qdevice_tie_breaker", metavar="TIE_BREAKER", default="lowest",
                                    help="QNetd TIE_BREAKER (lowest/highest/valid_node_id, default:lowest)")
         qdevice_group.add_argument("--qdevice-tls", dest="qdevice_tls", metavar="TLS", default="on", choices=['on', 'off', 'required'],
-                                   help="Whether using TLS on QDevice/QNetd (on/off/required, default:on)")
+                                   help="Whether using TLS on QDevice (on/off/required, default:on)")
         qdevice_group.add_argument("--qdevice-heuristics", dest="qdevice_heuristics", metavar="COMMAND",
                                    help="COMMAND to run with absolute path. For multiple commands, use \";\" to separate (details about heuristics can see man 8 corosync-qdevice)")
         qdevice_group.add_argument("--qdevice-heuristics-mode", dest="qdevice_heuristics_mode", metavar="MODE", choices=['on', 'sync', 'off'],

--- a/test/features/qdevice_options.feature
+++ b/test/features/qdevice_options.feature
@@ -38,6 +38,7 @@ Feature: corosync qdevice/qnetd options
     When    Run "crm cluster init --qnetd-hostname=qnetd-node --qdevice-tls=off -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"
     And     Show corosync qdevice configuration
 
   @clean

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -31,11 +31,11 @@ Feature: Verify usercase master survive when split-brain
     And     Service "corosync-qnetd" is "started" on "qnetd-node"
     And     Show corosync qdevice configuration
     When    Run "crm corosync status qnetd" on "hanode1"
-    Then    Expected regrex "Heuristics:\s+Fail" in stdout
+    Then    Expected regex "Heuristics:\s+Fail" in stdout
     When    Run "touch /tmp/heuristics.txt" on "hanode1"
     When    Run "sleep 30" on "hanode1"
     When    Run "crm corosync status qnetd" on "hanode1"
-    Then    Expected regrex "Heuristics:\s+Pass" in stdout
+    Then    Expected regex "Heuristics:\s+Pass" in stdout
 
   @clean
   Scenario: Master survive when split-brain

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -84,7 +84,7 @@ Feature: corosync qdevice/qnetd options validate
     When    Run "crm cluster init -n cluster1 -y" on "hanode3"
     Then    Cluster service is "started" on "hanode3"
     When    Try "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode2,hanode3"
-    Then    Except "ERROR: cluster.init: Duplicated cluster name "cluster1"!"
+    Then    Expected regex "(?:Duplicated cluster name|cluster's name .* already exists)" in stderr
     When    Run "crm cluster stop" on "hanode2"
     When    Run "crm cluster stop" on "hanode3"
 

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -117,7 +117,7 @@ QDevice configuration:
   --qdevice-tie-breaker TIE_BREAKER
                         QNetd TIE_BREAKER (lowest/highest/valid_node_id,
                         default:lowest)
-  --qdevice-tls TLS     Whether using TLS on QDevice/QNetd (on/off/required,
+  --qdevice-tls TLS     Whether using TLS on QDevice (on/off/required,
                         default:on)
   --qdevice-heuristics COMMAND
                         COMMAND to run with absolute path. For multiple

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -169,7 +169,7 @@ def step_impl(context, msg):
     context.stderr = None
 
 
-@then('Expected regrex "{reg_str}" in stdout')
+@then('Expected regex "{reg_str}" in stdout')
 def step_impl(context, reg_str):
     res = re.search(reg_str, context.stdout)
     assert res is not None

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -176,6 +176,12 @@ def step_impl(context, reg_str):
     context.stdout = None
 
 
+@then('Expected regex "{reg_str}" in stderr')
+def step_impl(context, reg_str):
+    assert context.stderr is not None and re.search(reg_str, context.stderr)
+    context.stderr = None
+
+
 @then('Expected return code is "{num}"')
 def step_impl(context, num):
     assert context.return_code == int(num)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1179,7 +1179,7 @@ class TestBootstrap(unittest.TestCase):
                 valid_func=qdevice.QDevice.check_qdevice_algo),
             mock.call("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest",
                 valid_func=qdevice.QDevice.check_qdevice_tie_breaker),
-            mock.call("Whether using TLS on QDevice/QNetd (on/off/required)", default="on",
+            mock.call("Whether using TLS on QDevice (on/off/required)", default="on",
                 valid_func=qdevice.QDevice.check_qdevice_tls),
             mock.call("Heuristics COMMAND to run with absolute path; For multiple commands, use \";\" to separate",
                 valid_func=qdevice.QDevice.check_qdevice_heuristics,

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -323,11 +323,17 @@ class TestQDevice(unittest.TestCase):
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
 
     @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
-    @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
+    @mock.patch("crmsh.qdevice.QDevice.start_qnetd")
+    @mock.patch("crmsh.qdevice.QDevice.init_tls_certs_on_qnetd")
     @mock.patch("crmsh.utils.package_is_installed")
-    def test_valid_qnetd_duplicated_with_qnetd_running(self, mock_installed, mock_is_active, mock_run):
+    def test_valid_qnetd_duplicated_cluster_name(
+            self,
+            mock_installed,
+            mock_init_tls_certs_on_qnetd,
+            mock_start_qnetd,
+            mock_run,
+    ):
         mock_installed.return_value = True
-        mock_is_active.return_value = True
         mock_run.return_value = "data"
         excepted_err_string = "This cluster's name \"cluster1\" already exists on qnetd server!\nPlease consider to use the different cluster-name property."
         self.maxDiff = None
@@ -337,25 +343,8 @@ class TestQDevice(unittest.TestCase):
         self.assertEqual(excepted_err_string, str(err.exception))
 
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
-        mock_is_active.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
+        mock_init_tls_certs_on_qnetd.assert_called_once()
         mock_run.assert_called_once_with("corosync-qnetd-tool -l -c cluster1", "10.10.10.123")
-
-    @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
-    @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
-    @mock.patch("crmsh.utils.package_is_installed")
-    def test_valid_qnetd_duplicated_without_qnetd_running(self, mock_installed, mock_is_active, mock_run):
-        mock_installed.return_value = True
-        mock_is_active.return_value = False
-        excepted_err_string = "This cluster's name \"hacluster1\" already exists on qnetd server!\nCluster service already successfully started on this node except qdevice service.\nIf you still want to use qdevice, consider to use the different cluster-name property.\nThen run command \"crm cluster init\" with \"qdevice\" stage, like:\n  crm cluster init qdevice qdevice_related_options\nThat command will setup qdevice separately."
-        self.maxDiff = None
-
-        with self.assertRaises(ValueError) as err:
-            self.qdevice_with_cluster_name.valid_qnetd()
-        self.assertEqual(excepted_err_string, str(err.exception))
-
-        mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
-        mock_is_active.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
-        mock_run.assert_called_once_with("test -f /etc/corosync/qnetd/nssdb/cluster-hacluster1.crt", "10.10.10.123")
 
     @mock.patch("crmsh.service_manager.ServiceManager.enable_service")
     def test_enable_qnetd(self, mock_enable):
@@ -377,35 +366,32 @@ class TestQDevice(unittest.TestCase):
         self.qdevice_with_ip.stop_qnetd()
         mock_stop.assert_called_once_with("corosync-qnetd.service", remote_addr="10.10.10.123")
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.parallax.parallax_call")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_qnetd", new_callable=mock.PropertyMock)
-    def test_init_db_on_qnetd_already_exists(self, mock_qnetd_cacert, mock_call, mock_log):
+    def test_init_tls_certs_on_qnetd_already_exists(self, mock_qnetd_cacert, mock_call):
         mock_call.return_value = [("10.10.10.123", (0, None, None))]
         mock_qnetd_cacert.return_value = "/etc/corosync/qnetd/nssdb/qnetd-cacert.crt"
-        self.qdevice_with_ip.init_db_on_qnetd.__wrapped__(self.qdevice_with_ip)
+        self.qdevice_with_ip.init_tls_certs_on_qnetd.__wrapped__(self.qdevice_with_ip)
         mock_call.assert_called_once_with(["10.10.10.123"],
                                           "test -f {}".format(mock_qnetd_cacert.return_value))
         mock_qnetd_cacert.assert_called_once_with()
-        mock_log.assert_not_called()
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
+    @mock.patch("crmsh.qdevice.logger")
     @mock.patch("crmsh.parallax.parallax_call")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_qnetd", new_callable=mock.PropertyMock)
-    def test_init_db_on_qnetd(self, mock_qnetd_cacert, mock_call, mock_log):
+    def test_init_tls_certs_on_qnetd(self, mock_qnetd_cacert, mock_call, mock_logger):
         mock_call.side_effect = [ValueError(mock.Mock(), "Failed on 10.10.10.123: error happen"),
                                  [("10.10.10.123", (0, None, None))]]
         mock_qnetd_cacert.return_value = "/etc/corosync/qnetd/nssdb/qnetd-cacert.crt"
 
-        self.qdevice_with_ip.init_db_on_qnetd.__wrapped__(self.qdevice_with_ip)
+        self.qdevice_with_ip.init_tls_certs_on_qnetd.__wrapped__(self.qdevice_with_ip)
 
         mock_call.assert_has_calls([
             mock.call(["10.10.10.123"], "test -f {}".format(mock_qnetd_cacert.return_value)),
             mock.call(["10.10.10.123"], "corosync-qnetd-certutil -i")
         ])
         mock_qnetd_cacert.assert_called_once_with()
-        mock_log.assert_called_once_with("Step 1: Initialize database on 10.10.10.123",
-                'corosync-qnetd-certutil -i')
+        mock_logger.info.assert_called_once_with('Generating QNetd CA and server certificates on %s', '10.10.10.123')
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("os.path.exists")
@@ -639,14 +625,12 @@ class TestQDevice(unittest.TestCase):
     @mock.patch("crmsh.qdevice.QDevice.init_db_on_cluster")
     @mock.patch("crmsh.qdevice.QDevice.copy_qnetd_crt_to_cluster")
     @mock.patch("crmsh.qdevice.QDevice.fetch_qnetd_crt_from_qnetd")
-    @mock.patch("crmsh.qdevice.QDevice.init_db_on_qnetd")
-    def test_certificate_process_on_init(self, mock_init_db_on_qnetd, mock_fetch_qnetd_crt_from_qnetd,
+    def test_certificate_process_on_init(self, mock_fetch_qnetd_crt_from_qnetd,
             mock_copy_qnetd_crt_to_cluster, mock_init_db_on_cluster, mock_create_ca_request,
             mock_copy_crq_to_qnetd, mock_sign_crq_on_qnetd, mock_fetch_cluster_crt_from_qnetd,
             mock_import_cluster_crt, mock_copy_p12_to_cluster, mock_import_p12_on_cluster):
 
         self.qdevice_with_ip.certificate_process_on_init()
-        mock_init_db_on_qnetd.assert_called_once_with()
         mock_fetch_qnetd_crt_from_qnetd.assert_called_once_with()
         mock_copy_qnetd_crt_to_cluster.assert_called_once_with()
         mock_init_db_on_cluster.assert_called_once_with()

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -393,221 +393,221 @@ class TestQDevice(unittest.TestCase):
         mock_qnetd_cacert.assert_called_once_with()
         mock_logger.info.assert_called_once_with('Generating QNetd CA and server certificates on %s', '10.10.10.123')
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.parallax.parallax_slurp")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     def test_fetch_qnetd_crt_from_qnetd_exist(self, mock_qnetd_cacert_local,
-                                              mock_parallax_slurp, mock_exists, mock_log):
+                                              mock_parallax_slurp, mock_exists):
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_exists.return_value = True
 
-        self.qdevice_with_ip.fetch_qnetd_crt_from_qnetd()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.fetch_qnetd_crt_from_qnetd(mock_log)
 
         mock_exists.assert_called_once_with(mock_qnetd_cacert_local.return_value)
         mock_qnetd_cacert_local.assert_called_once_with()
         mock_parallax_slurp.assert_not_called()
         mock_log.assert_not_called()
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("os.path.exists")
     @mock.patch("crmsh.parallax.parallax_slurp")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     def test_fetch_qnetd_crt_from_qnetd(self, mock_qnetd_cacert_local,
-                                        mock_parallax_slurp, mock_exists, mock_log):
+                                        mock_parallax_slurp, mock_exists):
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_exists.return_value = False
 
-        self.qdevice_with_ip.fetch_qnetd_crt_from_qnetd()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.fetch_qnetd_crt_from_qnetd(mock_log)
 
         mock_exists.assert_called_once_with(mock_qnetd_cacert_local.return_value)
         mock_qnetd_cacert_local.assert_called_once_with()
-        mock_log.assert_called_once_with("Step 2: Fetch qnetd-cacert.crt from 10.10.10.123")
+        mock_log.assert_called_once_with("Fetch qnetd-cacert.crt from 10.10.10.123")
         mock_parallax_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net", "/etc/corosync/qnetd/nssdb/qnetd-cacert.crt")
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
     @mock.patch("crmsh.parallax.parallax_copy")
-    def test_copy_qnetd_crt_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes, mock_log):
+    def test_copy_qnetd_crt_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com"]
 
-        self.qdevice_with_ip.copy_qnetd_crt_to_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.copy_qnetd_crt_to_cluster(mock_log)
 
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
         mock_copy.assert_not_called()
         mock_log.assert_not_called()
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
     @mock.patch("crmsh.parallax.parallax_copy")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     @mock.patch("os.path.dirname")
     def test_copy_qnetd_crt_to_cluster(self, mock_dirname, mock_qnetd_cacert_local,
-                                       mock_copy, mock_this_node, mock_list_nodes, mock_log):
+                                       mock_copy, mock_this_node, mock_list_nodes):
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_dirname.return_value = "/etc/corosync/qdevice/net/10.10.10.123"
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com", "node2.com"]
 
-        self.qdevice_with_ip.copy_qnetd_crt_to_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.copy_qnetd_crt_to_cluster(mock_log)
 
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
-        mock_log.assert_called_once_with("Step 3: Copy exported qnetd-cacert.crt to ['node2.com']")
+        mock_log.assert_called_once_with("Copy exported qnetd-cacert.crt to ['node2.com']")
         mock_copy.assert_called_once_with(["node2.com"], mock_dirname.return_value,
                                           "/etc/corosync/qdevice/net", True)
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.parallax.parallax_call")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cacert_on_local", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.utils.list_cluster_nodes")
-    def test_init_db_on_cluster(self, mock_list_nodes, mock_qnetd_cacert_local, mock_call, mock_log):
+    def test_init_db_on_cluster(self, mock_list_nodes, mock_qnetd_cacert_local, mock_call):
         mock_list_nodes.return_value = ["node1", "node2"]
         mock_qnetd_cacert_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt"
         mock_call.return_value = [("node1", (0, None, None)), ("node2", (0, None, None))]
 
-        self.qdevice_with_ip.init_db_on_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.init_db_on_cluster(mock_log)
 
         mock_list_nodes.assert_called_once_with()
         mock_qnetd_cacert_local.assert_called_once_with()
-        mock_log.assert_called_once_with("Step 4: Initialize database on ['node1', 'node2']",
+        mock_log.assert_called_once_with("Initialize database on ['node1', 'node2']",
                 'corosync-qdevice-net-certutil -i -c /etc/corosync/qdevice/net/10.10.10.123/qnetd-cacert.crt')
         mock_call.assert_called_once_with(mock_list_nodes.return_value,
                                           "corosync-qdevice-net-certutil -i -c {}".format(mock_qnetd_cacert_local.return_value))
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
-    def test_create_ca_request(self, mock_stdout_stderr, mock_log):
+    def test_create_ca_request(self, mock_stdout_stderr):
         mock_stdout_stderr.return_value = (0, None, None)
 
-        self.qdevice_with_cluster_name.create_ca_request()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_cluster_name.create_ca_request(mock_log)
 
-        mock_log.assert_called_once_with("Step 5: Generate certificate request qdevice-net-node.crq",
+        mock_log.assert_called_once_with("Generate certificate request qdevice-net-node.crq",
                 'corosync-qdevice-net-certutil -r -n hacluster1')
         mock_stdout_stderr.assert_called_once_with("corosync-qdevice-net-certutil -r -n hacluster1")
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_crq_on_qnetd", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.qdevice.QDevice.qdevice_crq_on_local", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.parallax.parallax_copy")
     def test_copy_crq_to_qnetd(self, mock_copy, mock_qdevice_crq_local,
-                               mock_qdevice_crq_qnetd, mock_log):
+                               mock_qdevice_crq_qnetd):
         mock_qdevice_crq_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.crq"
         mock_qdevice_crq_qnetd.return_value = "/etc/corosync/qnetd/nssdb/qdevice-net-node.crq"
 
-        self.qdevice_with_ip.copy_crq_to_qnetd()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.copy_crq_to_qnetd(mock_log)
 
-        mock_log.assert_called_once_with("Step 6: Copy qdevice-net-node.crq to 10.10.10.123")
+        mock_log.assert_called_once_with("Copy qdevice-net-node.crq to 10.10.10.123")
         mock_copy.assert_called_once_with(["10.10.10.123"], mock_qdevice_crq_local.return_value,
                                           mock_qdevice_crq_qnetd.return_value, False)
         mock_qdevice_crq_local.assert_called_once_with()
         mock_qdevice_crq_qnetd.assert_called_once_with()
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.parallax.parallax_call")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_crq_on_qnetd", new_callable=mock.PropertyMock)
-    def test_sign_crq_on_qnetd(self, mock_qdevice_crq_qnetd, mock_call, mock_log):
+    def test_sign_crq_on_qnetd(self, mock_qdevice_crq_qnetd, mock_call):
         mock_qdevice_crq_qnetd.return_value = "/etc/corosync/qnetd/nssdb/qdevice-net-node.crq"
         mock_call.return_value = ["10.10.10.123", (0, None, None)]
 
+        mock_log = mock.MagicMock()
         self.qdevice_with_ip.cluster_name = "hacluster"
-        self.qdevice_with_ip.sign_crq_on_qnetd()
+        self.qdevice_with_ip.sign_crq_on_qnetd(mock_log)
 
-        mock_log.assert_called_once_with("Step 7: Sign and export cluster certificate on 10.10.10.123",
+        mock_log.assert_called_once_with("Sign and export cluster certificate on 10.10.10.123",
                 'corosync-qnetd-certutil -s -c /etc/corosync/qnetd/nssdb/qdevice-net-node.crq -n hacluster')
         mock_qdevice_crq_qnetd.assert_called_once_with()
         mock_call.assert_called_once_with(["10.10.10.123"],
                                           "corosync-qnetd-certutil -s -c {} -n hacluster".format(mock_qdevice_crq_qnetd.return_value))
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cluster_crt_on_qnetd", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.parallax.parallax_slurp")
-    def test_fetch_cluster_crt_from_qnetd(self, mock_parallax_slurp, mock_crt_on_qnetd, mock_log):
+    def test_fetch_cluster_crt_from_qnetd(self, mock_parallax_slurp, mock_crt_on_qnetd):
         mock_crt_on_qnetd.return_value = "/etc/corosync/qnetd/nssdb/cluster-hacluster.crt"
 
         self.qdevice_with_ip.cluster_name = "hacluster"
-        self.qdevice_with_ip.fetch_cluster_crt_from_qnetd()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.fetch_cluster_crt_from_qnetd(mock_log)
 
-        mock_log.assert_called_once_with("Step 8: Fetch cluster-hacluster.crt from 10.10.10.123")
+        mock_log.assert_called_once_with("Fetch cluster-hacluster.crt from 10.10.10.123")
         mock_crt_on_qnetd.assert_has_calls([mock.call(), mock.call()])
         mock_parallax_slurp.assert_called_once_with(["10.10.10.123"], "/etc/corosync/qdevice/net", mock_crt_on_qnetd.return_value)
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.sh.ClusterShell.get_stdout_or_raise_error")
     @mock.patch("crmsh.qdevice.QDevice.qnetd_cluster_crt_on_local", new_callable=mock.PropertyMock)
-    def test_import_cluster_crt(self, mock_crt_on_local, mock_stdout_stderr, mock_log):
+    def test_import_cluster_crt(self, mock_crt_on_local, mock_stdout_stderr):
         mock_crt_on_local.return_value = "/etc/corosync/qdevice/net/10.10.10.123/cluster-hacluster.crt"
 
-        self.qdevice_with_ip.import_cluster_crt()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.import_cluster_crt(mock_log)
 
-        mock_log.assert_called_once_with("Step 9: Import certificate file cluster-hacluster.crt on local",
+        mock_log.assert_called_once_with("Import certificate file cluster-hacluster.crt on local",
                 'corosync-qdevice-net-certutil -M -c /etc/corosync/qdevice/net/10.10.10.123/cluster-hacluster.crt')
         mock_crt_on_local.assert_has_calls([mock.call(), mock.call()])
         mock_stdout_stderr.assert_called_once_with("corosync-qdevice-net-certutil -M -c {}".format(mock_crt_on_local.return_value))
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
     @mock.patch("crmsh.parallax.parallax_copy")
-    def test_copy_p12_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes, mock_log):
+    def test_copy_p12_to_cluster_one_node(self, mock_copy, mock_this_node, mock_list_nodes):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com"]
 
-        self.qdevice_with_ip.copy_p12_to_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.copy_p12_to_cluster(mock_log)
 
         mock_log.assert_not_called()
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
         mock_copy.assert_not_called()
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.utils.this_node")
     @mock.patch("crmsh.parallax.parallax_copy")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_local", new_callable=mock.PropertyMock)
     def test_copy_p12_to_cluster(self, mock_p12_on_local,
-                                       mock_copy, mock_this_node, mock_list_nodes, mock_log):
+                                       mock_copy, mock_this_node, mock_list_nodes):
         mock_this_node.return_value = "node1.com"
         mock_list_nodes.return_value = ["node1.com", "node2.com"]
         mock_p12_on_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12"
 
-        self.qdevice_with_ip.copy_p12_to_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.copy_p12_to_cluster(mock_log)
 
-        mock_log.assert_called_once_with("Step 10: Copy qdevice-net-node.p12 to ['node2.com']")
+        mock_log.assert_called_once_with("Copy qdevice-net-node.p12 to ['node2.com']")
         mock_this_node.assert_called_once_with()
         mock_list_nodes.assert_called_once_with()
         mock_copy.assert_called_once_with(["node2.com"], mock_p12_on_local.return_value,
                                           mock_p12_on_local.return_value, False)
         mock_p12_on_local.assert_has_calls([mock.call(), mock.call()])
 
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.parallax.parallax_call")
     @mock.patch("crmsh.utils.list_cluster_nodes_except_me")
-    def test_import_p12_on_cluster_one_node(self, mock_list_nodes, mock_call, mock_log):
+    def test_import_p12_on_cluster_one_node(self, mock_list_nodes, mock_call):
         mock_list_nodes.return_value = []
 
-        self.qdevice_with_ip.import_p12_on_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.import_p12_on_cluster(mock_log)
 
         mock_log.assert_not_called()
         mock_list_nodes.assert_called_once_with()
         mock_call.assert_not_called()
 
     @mock.patch("crmsh.parallax.parallax_call")
-    @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("crmsh.qdevice.QDevice.qdevice_p12_on_local", new_callable=mock.PropertyMock)
     @mock.patch("crmsh.utils.list_cluster_nodes_except_me")
-    def test_import_p12_on_cluster(self, mock_list_nodes, mock_p12_on_local, mock_log, mock_call):
+    def test_import_p12_on_cluster(self, mock_list_nodes, mock_p12_on_local, mock_call):
         mock_list_nodes.return_value = ["node2", "node3"]
         mock_p12_on_local.return_value = "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12"
         mock_call.return_value = [("node2", (0, None, None)), ("node3", (0, None, None))]
 
-        self.qdevice_with_ip.import_p12_on_cluster()
+        mock_log = mock.MagicMock()
+        self.qdevice_with_ip.import_p12_on_cluster(mock_log)
 
-        mock_log.assert_called_once_with("Step 11: Import qdevice-net-node.p12 on ['node2', 'node3']",
+        mock_log.assert_called_once_with("Import qdevice-net-node.p12 on ['node2', 'node3']",
                 'corosync-qdevice-net-certutil -m -c /etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12')
         mock_list_nodes.assert_called_once_with()
         mock_call.assert_called_once_with(
@@ -631,16 +631,16 @@ class TestQDevice(unittest.TestCase):
             mock_import_cluster_crt, mock_copy_p12_to_cluster, mock_import_p12_on_cluster):
 
         self.qdevice_with_ip.certificate_process_on_init()
-        mock_fetch_qnetd_crt_from_qnetd.assert_called_once_with()
-        mock_copy_qnetd_crt_to_cluster.assert_called_once_with()
-        mock_init_db_on_cluster.assert_called_once_with()
-        mock_create_ca_request.assert_called_once_with()
-        mock_copy_crq_to_qnetd.assert_called_once_with()
-        mock_sign_crq_on_qnetd.assert_called_once_with()
-        mock_fetch_cluster_crt_from_qnetd.assert_called_once_with()
-        mock_import_cluster_crt.assert_called_once_with()
-        mock_copy_p12_to_cluster.assert_called_once_with()
-        mock_import_p12_on_cluster.assert_called_once_with()
+        mock_fetch_qnetd_crt_from_qnetd.assert_called_once()
+        mock_copy_qnetd_crt_to_cluster.assert_called_once()
+        mock_init_db_on_cluster.assert_called_once()
+        mock_create_ca_request.assert_called_once()
+        mock_copy_crq_to_qnetd.assert_called_once()
+        mock_sign_crq_on_qnetd.assert_called_once()
+        mock_fetch_cluster_crt_from_qnetd.assert_called_once()
+        mock_import_cluster_crt.assert_called_once()
+        mock_copy_p12_to_cluster.assert_called_once()
+        mock_import_p12_on_cluster.assert_called_once()
 
     @mock.patch("crmsh.qdevice.QDevice.log_only_to_file")
     @mock.patch("os.path.exists")


### PR DESCRIPTION
When TLS for qdevice/qnetd communication is disabled, the current implementation changes only the configuration on the client side (qdevice), and the server side (qnetd) still uses default value: "on". As a result, qnetd needs to be prepared for accepting incoming TLS connections. This requires CA and server certificates to be generated.

This pull request ensures CA and server certificates present on qnetd node and qnetd service started before starting to configure qdevice.