### PR TITLE
Add 'crm sbd' sub-level (jsc#PED-8256)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -793,6 +793,7 @@ def start_pacemaker(node_list=[], enable_flag=False):
             except ValueError as err:
                 node_list.remove(node)
                 logger.error(err)
+    logger.info("Starting %s on %s", constants.PCMK_SERVICE, ', '.join(node_list) or utils.this_node())
     return service_manager.start_service("pacemaker.service", enable=enable_flag, node_list=node_list)
 
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -212,12 +212,19 @@ class Context(object):
         Validate sbd options
         """
         from .sbd import SBDUtils
+        with_sbd_option = self.sbd_devices or self.diskless_sbd
+        sbd_installed = utils.package_is_installed("sbd")
+
+        if with_sbd_option and not sbd_installed:
+            utils.fatal(SBDManager.SBD_NOT_INSTALLED_MSG)
         if self.sbd_devices and self.diskless_sbd:
             utils.fatal("Can't use -s and -S options together")
         if self.sbd_devices:
             SBDUtils.verify_sbd_device(self.sbd_devices)
         if self.stage == "sbd":
-            if not self.sbd_devices and not self.diskless_sbd and self.yes_to_all:
+            if not sbd_installed:
+                utils.fatal(SBDManager.SBD_NOT_INSTALLED_MSG)
+            if not with_sbd_option and self.yes_to_all:
                 utils.fatal("Stage sbd should specify sbd device by -s or diskless sbd by -S option")
             if ServiceManager().service_is_active(constants.SBD_SERVICE) and not config.core.force:
                 utils.fatal("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -775,10 +775,8 @@ def start_pacemaker(node_list=[], enable_flag=False):
             utils.package_is_installed("sbd") and \
             ServiceManager().service_is_enabled(constants.SBD_SERVICE) and \
             SBDTimeout.is_sbd_delay_start():
-        target_dir = "/run/systemd/system/sbd.service.d/"
-        cmd1 = "mkdir -p {}".format(target_dir)
-        target_file = "{}sbd_delay_start_disabled.conf".format(target_dir)
-        cmd2 = "echo -e '[Service]\nUnsetEnvironment=SBD_DELAY_START' > {}".format(target_file)
+        cmd1 = f"mkdir -p {SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_DIR}"
+        cmd2 = f"echo -e '[Service]\nUnsetEnvironment=SBD_DELAY_START' > {SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE}"
         cmd3 = "systemctl daemon-reload"
         for cmd in [cmd1, cmd2, cmd3]:
             parallax.parallax_call(node_list, cmd)

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1400,7 +1400,7 @@ def init_sbd():
     """
     import crmsh.sbd
     if _context.stage == "sbd":
-        crmsh.sbd.clean_up_existing_sbd_resource()
+        crmsh.sbd.cleanup_existing_sbd_resource()
     _context.sbd_manager.init_and_deploy_sbd()
 
 

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -453,6 +453,4 @@ NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mo
 
 PCMK_SERVICE = "pacemaker.service"
 SBD_SERVICE = "sbd.service"
-
-SHOW_SBD_START_TIMEOUT_CMD = "systemctl show -p TimeoutStartUSec sbd.service --value"
 # vim:ts=4:sw=4:et:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -453,4 +453,6 @@ NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mo
 
 PCMK_SERVICE = "pacemaker.service"
 SBD_SERVICE = "sbd.service"
+
+SHOW_SBD_START_TIMEOUT_CMD = "systemctl show -p TimeoutStartUSec sbd.service --value"
 # vim:ts=4:sw=4:et:

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -450,4 +450,7 @@ DLM_PORT = 21064
 HIDDEN_COMMANDS = {'ms'}
 
 NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mode."
+
+PCMK_SERVICE = "pacemaker.service"
+SBD_SERVICE = "sbd.service"
 # vim:ts=4:sw=4:et:

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -612,15 +612,15 @@ class QDevice(object):
         """
         Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice and diskless SBD
         """
-        from .sbd import SBDManager, SBDTimeout
+        from .sbd import SBDManager, SBDTimeout, SBDUtils
         utils.check_all_nodes_reachable()
-        self.using_diskless_sbd = SBDManager.is_using_diskless_sbd()
+        self.using_diskless_sbd = SBDUtils.is_using_diskless_sbd()
         # add qdevice after diskless sbd started
         if self.using_diskless_sbd:
-            res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
+            res = SBDUtils.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
             if not res or int(res) < SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
                 sbd_watchdog_timeout_qdevice = SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
-                SBDManager.update_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
+                SBDManager.update_sbd_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
                 utils.set_property("stonith-timeout", SBDTimeout.get_stonith_timeout())
 
     @qnetd_lock_for_same_cluster_name

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -15,6 +15,7 @@ from . import bootstrap
 from . import lock
 from . import log
 from .service_manager import ServiceManager
+from .sbd import SBDManager, SBDTimeout, SBDUtils
 
 
 logger = log.setup_logger(__name__)
@@ -612,7 +613,6 @@ class QDevice(object):
         """
         Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice and diskless SBD
         """
-        from .sbd import SBDManager, SBDTimeout, SBDUtils
         utils.check_all_nodes_reachable()
         self.using_diskless_sbd = SBDUtils.is_using_diskless_sbd()
         # add qdevice after diskless sbd started

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -378,11 +378,16 @@ def collect_sbd_info(context: core.Context) -> None:
         return
 
     sbd_f = os.path.join(context.work_dir, constants.SBD_F)
-    cmd = ". {};export SBD_DEVICE;{};{}".format(constants.SBDCONF, "sbd dump", "sbd list")
+    cmd_list = [
+        f". {constants.SBDCONF};export SBD_DEVICE;sbd dump;sbd list",
+        "crm sbd configure show",
+        "crm sbd status"
+    ]
     with open(sbd_f, "w") as f:
-        f.write("\n\n#=====[ Command ] ==========================#\n")
-        f.write(f"# {cmd}\n")
-        f.write(utils.get_cmd_output(cmd))
+        for cmd in cmd_list:
+            f.write("\n\n#=====[ Command ] ==========================#\n")
+            f.write(f"# {cmd}\n")
+            f.write(utils.get_cmd_output(cmd))
 
     logger.debug(f"Dump SBD config file into {utils.real_path(sbd_f)}")
 

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -758,7 +758,7 @@ def get_cmd_output(cmd: str, timeout: int = None) -> str:
         out_str += f"{out}\n"
     if err:
         out_str += f"{err}\n"
-    return out_str
+    return crmutils.strip_ansi_escape_sequences(out_str)
 
 
 def get_timespan_str(context: core.Context) -> str:

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -177,6 +177,7 @@ class SBDTimeout(object):
     SBD_WATCHDOG_TIMEOUT_DEFAULT_S390 = 15
     SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE = 35
     QDEVICE_SYNC_TIMEOUT_MARGIN = 5
+    SHOW_SBD_START_TIMEOUT_CMD = "systemctl show -p TimeoutStartUSec sbd.service --value"
 
     def __init__(self, context=None):
         '''
@@ -363,7 +364,7 @@ class SBDTimeout(object):
 
     @staticmethod
     def get_sbd_systemd_start_timeout() -> int:
-        out = sh.cluster_shell().get_stdout_or_raise_error(constants.SHOW_SBD_START_TIMEOUT_CMD)
+        out = sh.cluster_shell().get_stdout_or_raise_error(SBDTimeout.SHOW_SBD_START_TIMEOUT_CMD)
         return utils.get_systemd_timeout_start_in_sec(out)
 
     def adjust_systemd_start_timeout(self):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -324,8 +324,7 @@ class SBDTimeout(object):
 
     @staticmethod
     def get_sbd_systemd_start_timeout() -> int:
-        cmd = "systemctl show -p TimeoutStartUSec sbd --value"
-        out = sh.cluster_shell().get_stdout_or_raise_error(cmd)
+        out = sh.cluster_shell().get_stdout_or_raise_error(constants.SHOW_SBD_START_TIMEOUT_CMD)
         return utils.get_systemd_timeout_start_in_sec(out)
 
     def adjust_systemd_start_timeout(self):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -87,12 +87,24 @@ class SBDUtils:
         return res.split(';') if res else []
 
     @staticmethod
+    def _is_sbd_running_with_device():
+        if not ServiceManager().service_is_active(constants.SBD_SERVICE):
+            return False
+        return bool(SBDUtils.get_sbd_device_from_config())
+
+    @staticmethod
     def is_using_diskless_sbd():
         '''
         Check if using diskless SBD
         '''
-        dev_list = SBDUtils.get_sbd_device_from_config()
-        return not dev_list and ServiceManager().service_is_active(constants.SBD_SERVICE)
+        return not SBDUtils._is_sbd_running_with_device()
+
+    @staticmethod
+    def is_using_disk_based_sbd():
+        '''
+        Check if using disk-based SBD
+        '''
+        return SBDUtils._is_sbd_running_with_device()
 
     @staticmethod
     def has_sbd_device_already_initialized(dev) -> bool:

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -555,11 +555,14 @@ class SBDManager:
         '''
         if self.diskless_sbd:
             utils.set_property("stonith-watchdog-timeout", SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT)
-        elif not xmlutil.CrmMonXmlParser().is_resource_configured(self.SBD_RA):
-            all_device_list = SBDUtils.get_sbd_device_from_config()
-            devices_param_str = f"params devices=\"{','.join(all_device_list)}\""
-            cmd = f"crm configure primitive {self.SBD_RA_ID} {self.SBD_RA} {devices_param_str}"
-            sh.cluster_shell().get_stdout_or_raise_error(cmd)
+        else:
+            if utils.get_property("stonith-watchdog-timeout", get_default=False):
+                utils.delete_property("stonith-watchdog-timeout")
+            if not xmlutil.CrmMonXmlParser().is_resource_configured(self.SBD_RA):
+                all_device_list = SBDUtils.get_sbd_device_from_config()
+                devices_param_str = f"params devices=\"{','.join(all_device_list)}\""
+                cmd = f"crm configure primitive {self.SBD_RA_ID} {self.SBD_RA} {devices_param_str}"
+                sh.cluster_shell().get_stdout_or_raise_error(cmd)
         utils.set_property("stonith-enabled", "true")
 
     def _warn_diskless_sbd(self, peer=None):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -87,24 +87,22 @@ class SBDUtils:
         return res.split(';') if res else []
 
     @staticmethod
-    def _is_sbd_running_with_device():
-        if not ServiceManager().service_is_active(constants.SBD_SERVICE):
-            return False
-        return bool(SBDUtils.get_sbd_device_from_config())
-
-    @staticmethod
     def is_using_diskless_sbd():
         '''
         Check if using diskless SBD
         '''
-        return not SBDUtils._is_sbd_running_with_device()
+        if not ServiceManager().service_is_active(constants.SBD_SERVICE):
+            return False
+        return not bool(SBDUtils.get_sbd_device_from_config())
 
     @staticmethod
     def is_using_disk_based_sbd():
         '''
         Check if using disk-based SBD
         '''
-        return SBDUtils._is_sbd_running_with_device()
+        if not ServiceManager().service_is_active(constants.SBD_SERVICE):
+            return False
+        return bool(SBDUtils.get_sbd_device_from_config())
 
     @staticmethod
     def has_sbd_device_already_initialized(dev) -> bool:
@@ -414,7 +412,6 @@ class SBDManager:
         timeout_dict: typing.Dict[str, int] | None = None,
         update_dict: typing.Dict[str, str] | None = None,
         no_overwrite_dev_map: typing.Dict[str, bool] | None = None,
-        new_config: bool = False,
         diskless_sbd: bool = False,
         bootstrap_context: 'bootstrap.Context | None' = None
     ):
@@ -428,7 +425,6 @@ class SBDManager:
         self.cluster_is_running = ServiceManager().service_is_active(constants.PCMK_SERVICE)
         self.bootstrap_context = bootstrap_context
         self.no_overwrite_dev_map = no_overwrite_dev_map or {}
-        self.new_config = new_config
 
         # From bootstrap init or join process, override the values
         if self.bootstrap_context:
@@ -464,7 +460,7 @@ class SBDManager:
         '''
         if not self.update_dict:
             return
-        if (self.bootstrap_context and self.bootstrap_context.type == "init") or self.new_config:
+        if self.bootstrap_context and self.bootstrap_context.type == "init":
             utils.copy_local_file(self.SYSCONFIG_SBD_TEMPLATE, self.SYSCONFIG_SBD)
 
         for key, value in self.update_dict.items():

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1,5 +1,6 @@
 import os
 import re
+import typing
 from . import utils, sh
 from . import bootstrap
 from .bootstrap import SYSCONFIG_SBD, SBD_SYSTEMD_DELAY_START_DIR
@@ -7,17 +8,131 @@ from . import log
 from . import constants
 from . import corosync
 from . import xmlutil
+from . import watchdog
 from .service_manager import ServiceManager
 from .sh import ShellUtils
 
 logger = log.setup_logger(__name__)
-logger_utils = log.LoggerUtils(logger)
+
+
+class SBDUtils:
+    '''
+    Consolidate sbd related utility methods
+    '''
+    @staticmethod
+    def get_sbd_device_metadata(dev, timeout_only=False, remote=None) -> dict:
+        '''
+        Extract metadata from sbd device header
+        '''
+        sbd_info = {}
+        try:
+            out = sh.cluster_shell().get_stdout_or_raise_error(f"sbd -d {dev} dump", remote)
+        except Exception:
+            return sbd_info
+
+        pattern = r"UUID\s+:\s+(\S+)|Timeout\s+\((\w+)\)\s+:\s+(\d+)"
+        matches = re.findall(pattern, out)
+        for uuid, timeout_type, timeout_value in matches:
+            if uuid and not timeout_only:
+                sbd_info["uuid"] = uuid
+            elif timeout_type and timeout_value:
+                sbd_info[timeout_type] = int(timeout_value)
+        return sbd_info
+
+    @staticmethod
+    def get_device_uuid(dev, node=None):
+        '''
+        Get UUID for specific device and node
+        '''
+        res = SBDUtils.get_sbd_device_metadata(dev, remote=node).get("uuid")
+        if not res:
+            raise ValueError(f"Cannot find sbd device UUID for {dev}")
+        return res
+
+    @staticmethod
+    def compare_device_uuid(dev, node_list):
+        '''
+        Compare local sbd device UUID with other node's sbd device UUID
+        '''
+        if not node_list:
+            return
+        local_uuid = SBDUtils.get_device_uuid(dev)
+        for node in node_list:
+            remote_uuid = SBDUtils.get_device_uuid(dev, node)
+            if local_uuid != remote_uuid:
+                raise ValueError(f"Device {dev} doesn't have the same UUID with {node}")
+
+    @staticmethod
+    def verify_sbd_device(dev_list, compare_node_list=[]):
+        if len(dev_list) > SBDManager.SBD_DEVICE_MAX:
+            raise ValueError(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}")
+        for dev in dev_list:
+            if not utils.is_block_device(dev):
+                raise ValueError(f"{dev} doesn't look like a block device")
+            SBDUtils.compare_device_uuid(dev, compare_node_list)
+        utils.detect_duplicate_device_path(dev_list)
+
+    @staticmethod
+    def get_sbd_value_from_config(key):
+        '''
+        Get value from /etc/sysconfig/sbd
+        '''
+        return utils.parse_sysconfig(SYSCONFIG_SBD).get(key)
+
+    @staticmethod
+    def get_sbd_device_from_config():
+        '''
+        Get sbd device list from config
+        '''
+        res = SBDUtils.get_sbd_value_from_config("SBD_DEVICE")
+        return res.split(';') if res else []
+
+    @staticmethod
+    def is_using_diskless_sbd():
+        '''
+        Check if using diskless SBD
+        '''
+        dev_list = SBDUtils.get_sbd_device_from_config()
+        return not dev_list and ServiceManager().service_is_active(constants.SBD_SERVICE)
+
+    @staticmethod
+    def has_sbd_device_already_initialized(dev) -> bool:
+        '''
+        Check if sbd device already initialized
+        '''
+        cmd = "sbd -d {} dump".format(dev)
+        rc, _, _ = ShellUtils().get_stdout_stderr(cmd)
+        return rc == 0
+
+    @staticmethod
+    def no_overwrite_device_check(dev) -> bool:
+        '''
+        Check if device already initialized and ask if need to overwrite
+        '''
+        initialized = SBDUtils.has_sbd_device_already_initialized(dev)
+        return initialized and \
+                not bootstrap.confirm(f"{dev} has already been initialized by SBD, do you want to overwrite it?")
+
+    @staticmethod
+    def check_devices_metadata_consistent(dev_list) -> bool:
+        '''
+        Check if all devices have the same metadata
+        '''
+        consistent = True
+        if len(dev_list) < 2:
+            return consistent
+        first_dev_metadata = SBDUtils.get_sbd_device_metadata(dev_list[0], timeout_only=True)
+        for dev in dev_list[1:]:
+            if SBDUtils.get_sbd_device_metadata(dev, timeout_only=True) != first_dev_metadata:
+                logger.warning(f"Device {dev} doesn't have the same metadata as {dev_list[0]}")
+                consistent = False
+        return consistent
 
 
 class SBDTimeout(object):
-    """
+    '''
     Consolidate sbd related timeout methods and constants
-    """
+    '''
     STONITH_WATCHDOG_TIMEOUT_DEFAULT = -1
     SBD_WATCHDOG_TIMEOUT_DEFAULT = 5
     SBD_WATCHDOG_TIMEOUT_DEFAULT_S390 = 15
@@ -25,15 +140,14 @@ class SBDTimeout(object):
     QDEVICE_SYNC_TIMEOUT_MARGIN = 5
 
     def __init__(self, context=None):
-        """
+        '''
         Init function
-        """
+        '''
         self.context = context
         self.sbd_msgwait = None
         self.stonith_timeout = None
         self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT
         self.stonith_watchdog_timeout = self.STONITH_WATCHDOG_TIMEOUT_DEFAULT
-        self.sbd_delay_start = None
         self.two_node_without_qdevice = False
 
     def initialize_timeout(self):
@@ -44,10 +158,10 @@ class SBDTimeout(object):
             self._set_sbd_msgwait()
 
     def _set_sbd_watchdog_timeout(self):
-        """
+        '''
         Set sbd_watchdog_timeout from profiles.yml if exists
         Then adjust it if in s390 environment
-        """
+        '''
         if "sbd.watchdog_timeout" in self.context.profiles_dict:
             self.sbd_watchdog_timeout = int(self.context.profiles_dict["sbd.watchdog_timeout"])
         if self.context.is_s390 and self.sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390:
@@ -55,10 +169,10 @@ class SBDTimeout(object):
             self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390
 
     def _set_sbd_msgwait(self):
-        """
+        '''
         Set sbd msgwait from profiles.yml if exists
         Default is 2 * sbd_watchdog_timeout
-        """
+        '''
         sbd_msgwait_default = 2 * self.sbd_watchdog_timeout
         sbd_msgwait = sbd_msgwait_default
         if "sbd.msgwait" in self.context.profiles_dict:
@@ -68,10 +182,25 @@ class SBDTimeout(object):
                 sbd_msgwait = sbd_msgwait_default
         self.sbd_msgwait = sbd_msgwait
 
+    @classmethod
+    def get_advised_sbd_timeout(cls, diskless=False) -> typing.Tuple[int, int]:
+        '''
+        Get suitable sbd_watchdog_timeout and sbd_msgwait
+        '''
+        ctx = bootstrap.Context()
+        ctx.diskless_sbd = diskless
+        ctx.load_profiles()
+        time_inst = cls(ctx)
+        time_inst.initialize_timeout()
+
+        sbd_watchdog_timeout = time_inst.sbd_watchdog_timeout
+        sbd_msgwait = None if diskless else time_inst.sbd_msgwait
+        return sbd_watchdog_timeout, sbd_msgwait
+
     def _adjust_sbd_watchdog_timeout_with_diskless_and_qdevice(self):
-        """
+        '''
         When using diskless SBD with Qdevice, adjust value of sbd_watchdog_timeout
-        """
+        '''
         # add sbd after qdevice started
         if corosync.is_qdevice_configured() and ServiceManager().service_is_active("corosync-qdevice.service"):
             qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
@@ -87,44 +216,42 @@ class SBDTimeout(object):
 
     @staticmethod
     def get_sbd_msgwait(dev):
-        """
+        '''
         Get msgwait for sbd device
-        """
-        out = sh.cluster_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev))
-        # Format like "Timeout (msgwait)  : 30"
-        res = re.search(r"\(msgwait\)\s+:\s+(\d+)", out)
+        '''
+        res = SBDUtils.get_sbd_device_metadata(dev).get("msgwait")
         if not res:
-            raise ValueError("Cannot get sbd msgwait for {}".format(dev))
-        return int(res.group(1))
+            raise ValueError(f"Cannot get sbd msgwait for {dev}")
+        return res
 
     @staticmethod
     def get_sbd_watchdog_timeout():
-        """
+        '''
         Get SBD_WATCHDOG_TIMEOUT from /etc/sysconfig/sbd
-        """
-        res = SBDManager.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
+        '''
+        res = SBDUtils.get_sbd_value_from_config("SBD_WATCHDOG_TIMEOUT")
         if not res:
             raise ValueError("Cannot get the value of SBD_WATCHDOG_TIMEOUT")
         return int(res)
 
     @staticmethod
     def get_stonith_watchdog_timeout():
-        """
+        '''
         For non-bootstrap case, get stonith-watchdog-timeout value from cluster property
-        """
+        '''
         default = SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT
-        if not ServiceManager().service_is_active("pacemaker.service"):
+        if not ServiceManager().service_is_active(constants.PCMK_SERVICE):
             return default
         value = utils.get_property("stonith-watchdog-timeout")
         return int(value.strip('s')) if value else default
 
     def _load_configurations(self):
-        """
+        '''
         Load necessary configurations for both disk-based/disk-less sbd
-        """
+        '''
         self.two_node_without_qdevice = utils.is_2node_cluster_without_qdevice()
 
-        dev_list = SBDManager.get_sbd_device_from_config()
+        dev_list = SBDUtils.get_sbd_device_from_config()
         if dev_list:  # disk-based
             self.disk_based = True
             self.msgwait = SBDTimeout.get_sbd_msgwait(dev_list[0])
@@ -134,19 +261,19 @@ class SBDTimeout(object):
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
             self.stonith_watchdog_timeout = SBDTimeout.get_stonith_watchdog_timeout()
         self.sbd_delay_start_value_expected = self.get_sbd_delay_start_expected() if utils.detect_virt() else "no"
-        self.sbd_delay_start_value_from_config = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        self.sbd_delay_start_value_from_config = SBDUtils.get_sbd_value_from_config("SBD_DELAY_START")
 
         logger.debug("Inspect SBDTimeout: %s", vars(self))
 
     def get_stonith_timeout_expected(self):
-        """
+        '''
         Get stonith-timeout value for sbd cases, formulas are:
 
         value_from_sbd = 1.2 * (pcmk_delay_max + msgwait) # for disk-based sbd
         value_from_sbd = 1.2 * max (stonith_watchdog_timeout, 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
 
         stonith_timeout = max(value_from_sbd, constants.STONITH_TIMEOUT_DEFAULT) + token + consensus
-        """
+        '''
         if self.disk_based:
             value_from_sbd = int(1.2*(self.pcmk_delay_max + self.msgwait))
         else:
@@ -163,12 +290,12 @@ class SBDTimeout(object):
         return cls_inst.get_stonith_timeout_expected()
 
     def get_sbd_delay_start_expected(self):
-        """
+        '''
         Get the value for SBD_DELAY_START, formulas are:
 
         SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
         SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
-        """
+        '''
         token_and_consensus_timeout = corosync.token_and_consensus_timeout()
         if self.disk_based:
             value = token_and_consensus_timeout + self.pcmk_delay_max + self.msgwait
@@ -178,34 +305,38 @@ class SBDTimeout(object):
 
     @staticmethod
     def get_sbd_delay_start_sec_from_sysconfig():
-        """
+        '''
         Get suitable systemd start timeout for sbd.service
-        """
+        '''
         # TODO 5ms, 5us, 5s, 5m, 5h are also valid for sbd sysconfig
-        value = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        value = SBDUtils.get_sbd_value_from_config("SBD_DELAY_START")
         if utils.is_boolean_true(value):
             return 2*SBDTimeout.get_sbd_watchdog_timeout()
         return int(value)
 
     @staticmethod
     def is_sbd_delay_start():
-        """
+        '''
         Check if SBD_DELAY_START is not no or not set
-        """
-        res = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        '''
+        res = SBDUtils.get_sbd_value_from_config("SBD_DELAY_START")
         return res and res != "no"
 
+    @staticmethod
+    def get_sbd_systemd_start_timeout() -> int:
+        cmd = "systemctl show -p TimeoutStartUSec sbd --value"
+        out = sh.cluster_shell().get_stdout_or_raise_error(cmd)
+        return utils.get_systemd_timeout_start_in_sec(out)
+
     def adjust_systemd_start_timeout(self):
-        """
+        '''
         Adjust start timeout for sbd when set SBD_DELAY_START
-        """
-        sbd_delay_start_value = SBDManager.get_sbd_value_from_config("SBD_DELAY_START")
+        '''
+        sbd_delay_start_value = SBDUtils.get_sbd_value_from_config("SBD_DELAY_START")
         if sbd_delay_start_value == "no":
             return
 
-        cmd = "systemctl show -p TimeoutStartUSec sbd --value"
-        out = sh.cluster_shell().get_stdout_or_raise_error(cmd)
-        start_timeout = utils.get_systemd_timeout_start_in_sec(out)
+        start_timeout = SBDTimeout.get_sbd_systemd_start_timeout()
         if start_timeout > int(sbd_delay_start_value):
             return
 
@@ -216,15 +347,15 @@ class SBDTimeout(object):
         utils.cluster_run_cmd("systemctl daemon-reload")
 
     def adjust_stonith_timeout(self):
-        """
+        '''
         Adjust stonith-timeout property
-        """
+        '''
         utils.set_property("stonith-timeout", self.get_stonith_timeout_expected(), conditional=True)
 
     def adjust_sbd_delay_start(self):
-        """
+        '''
         Adjust SBD_DELAY_START in /etc/sysconfig/sbd
-        """
+        '''
         expected_value = str(self.sbd_delay_start_value_expected)
         config_value = self.sbd_delay_start_value_from_config
         if expected_value == config_value:
@@ -232,29 +363,23 @@ class SBDTimeout(object):
         if expected_value == "no" \
                 or (not re.search(r'\d+', config_value)) \
                 or (int(expected_value) > int(config_value)):
-            SBDManager.update_configuration({"SBD_DELAY_START": expected_value})
+            SBDManager.update_sbd_configuration({"SBD_DELAY_START": expected_value})
 
     @classmethod
     def adjust_sbd_timeout_related_cluster_configuration(cls):
-        """
+        '''
         Adjust sbd timeout related configurations
-        """
+        '''
         cls_inst = cls()
         cls_inst._load_configurations()
-
-        message = "Adjusting sbd related timeout values"
-        with logger_utils.status_long(message):
-            cls_inst.adjust_sbd_delay_start()
-            cls_inst.adjust_stonith_timeout()
-            cls_inst.adjust_systemd_start_timeout()
+        cls_inst.adjust_sbd_delay_start()
+        cls_inst.adjust_stonith_timeout()
+        cls_inst.adjust_systemd_start_timeout()
 
 
-class SBDManager(object):
-    """
-    Class to manage sbd configuration and services
-    """
+class SBDManager:
     SYSCONFIG_SBD_TEMPLATE = "/usr/share/fillup-templates/sysconfig.sbd"
-    SBD_STATUS_DESCRIPTION = """Configure SBD:
+    SBD_STATUS_DESCRIPTION = '''Configure SBD:
   If you have shared storage, for example a SAN or iSCSI target,
   you can use it avoid split-brain scenarios by configuring SBD.
   This requires a 1 MB partition, accessible to all nodes in the
@@ -262,91 +387,172 @@ class SBDManager(object):
   across all nodes in the cluster, so /dev/disk/by-id/* devices
   are a good choice.  Note that all data on the partition you
   specify here will be destroyed.
-"""
-    SBD_WARNING = "Not configuring SBD - STONITH will be disabled."
+'''
+    NO_SBD_WARNING = "Not configuring SBD - STONITH will be disabled."
+    DISKLESS_SBD_MIN_EXPECTED_VOTE = 3
     DISKLESS_SBD_WARNING = "Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice."
-    PARSE_RE = "[; ]"
-    DISKLESS_CRM_CMD = "crm configure property stonith-enabled=true stonith-watchdog-timeout={} stonith-timeout={}"
     SBD_RA = "stonith:fence_sbd"
     SBD_RA_ID = "stonith-sbd"
+    SBD_DEVICE_MAX = 3
 
-    def __init__(self, context):
-        """
-        Init function
+    def __init__(
+        self,
+        device_list_to_init: typing.List[str] | None = None,
+        timeout_dict: typing.Dict[str, int] | None = None,
+        update_dict: typing.Dict[str, str] | None = None,
+        no_overwrite_dev_map: typing.Dict[str, bool] | None = None,
+        new_config: bool = False,
+        diskless_sbd: bool = False,
+        bootstrap_context: bootstrap.Context | None = None
+    ):
+        '''
+        Init function which can be called from crm sbd subcommand or bootstrap
+        '''
+        self.package_installed = utils.package_is_installed("sbd")
+        if not self.package_installed:
+            return
 
-        sbd_devices is provided by '-s' option on init process
-        diskless_sbd is provided by '-S' option on init process
-        """
-        self.sbd_devices_input = context.sbd_devices
-        self.diskless_sbd = context.diskless_sbd
-        self._sbd_devices = None
-        self._watchdog_inst = None
-        self._context = context
-        self._delay_start = False
-        self.timeout_inst = None
-        self.no_overwrite_map = {}
-        self.no_update_config = False
+        self.device_list_to_init = device_list_to_init or []
+        self.timeout_dict = timeout_dict or {}
+        self.update_dict = update_dict or {}
+        self.diskless_sbd = diskless_sbd
+        self.cluster_is_running = ServiceManager().service_is_active(constants.PCMK_SERVICE)
+        self.bootstrap_context = bootstrap_context
+        self.no_overwrite_dev_map = no_overwrite_dev_map or {}
+        self.new_config = new_config
+
+        # From bootstrap init or join process, override the values
+        if self.bootstrap_context:
+            self.device_list_to_init = self.bootstrap_context.sbd_devices
+            self.diskless_sbd = self.bootstrap_context.diskless_sbd
+            self.cluster_is_running = self.bootstrap_context.cluster_is_running
+
+    def _load_attributes_from_bootstrap(self):
+        if not self.bootstrap_context:
+            return
+        timeout_inst = SBDTimeout(self.bootstrap_context)
+        timeout_inst.initialize_timeout()
+        self.timeout_dict["watchdog"] = timeout_inst.sbd_watchdog_timeout
+        if not self.diskless_sbd:
+            self.timeout_dict["msgwait"] = timeout_inst.sbd_msgwait
+        self.update_dict["SBD_WATCHDOG_TIMEOUT"] = str(timeout_inst.sbd_watchdog_timeout)
+        self.update_dict["SBD_WATCHDOG_DEV"] = watchdog.Watchdog.get_watchdog_device(self.bootstrap_context.watchdog)
 
     @staticmethod
-    def _get_device_uuid(dev, node=None):
-        """
-        Get UUID for specific device and node
-        """
-        out = sh.cluster_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev), node)
-        res = re.search(r"UUID\s*:\s*(.*)\n", out)
-        if not res:
-            raise ValueError("Cannot find sbd device UUID for {}".format(dev))
-        return res.group(1)
+    def convert_timeout_dict_to_opt_str(timeout_dict: typing.Dict[str, int]) -> str:
+        timeout_option_map = {
+            "watchdog": "-1",
+            "allocate": "-2",
+            "loop": "-3",
+            "msgwait": "-4"
+        }
+        return ' '.join([f"{timeout_option_map[k]} {v}" for k, v in timeout_dict.items()
+                         if k in timeout_option_map])
 
-    def _compare_device_uuid(self, dev, node_list):
-        """
-        Compare local sbd device UUID with other node's sbd device UUID
-        """
-        if not node_list:
+    def update_configuration(self) -> None:
+        '''
+        Update and sync sbd configuration
+        '''
+        if not self.update_dict:
             return
-        local_uuid = self._get_device_uuid(dev)
-        for node in node_list:
-            remote_uuid = self._get_device_uuid(dev, node)
-            if local_uuid != remote_uuid:
-                raise ValueError("Device {} doesn't have the same UUID with {}".format(dev, node))
+        if (self.bootstrap_context and self.bootstrap_context.type == "init") or self.new_config:
+            utils.copy_local_file(self.SYSCONFIG_SBD_TEMPLATE, SYSCONFIG_SBD)
 
-    def _verify_sbd_device(self, dev_list, compare_node_list=[]):
-        """
-        Verify sbd device
-        """
-        if len(dev_list) > 3:
-            raise ValueError("Maximum number of SBD device is 3")
-        for dev in dev_list:
-            if not utils.is_block_device(dev):
-                raise ValueError("{} doesn't look like a block device".format(dev))
-            self._compare_device_uuid(dev, compare_node_list)
+        for key, value in self.update_dict.items():
+            logger.info("Update %s in %s: %s", key, SYSCONFIG_SBD, value)
+        utils.sysconfig_set(SYSCONFIG_SBD, **self.update_dict)
+        bootstrap.sync_file(SYSCONFIG_SBD)
+        logger.info("Already synced %s to all nodes", SYSCONFIG_SBD)
 
-    def _no_overwrite_check(self, dev):
-        """
-        Check if device already initialized and if need to overwrite
-        """
-        return SBDManager.has_sbd_device_already_initialized(dev) and not bootstrap.confirm("SBD is already configured to use {} - overwrite?".format(dev))
+    @classmethod
+    def update_sbd_configuration(cls, update_dict: typing.Dict[str, str]) -> None:
+        inst = cls(update_dict=update_dict)
+        inst.update_configuration()
 
-    def _get_sbd_device_interactive(self):
-        """
+    def initialize_sbd(self):
+        if self.diskless_sbd:
+            logger.info("Configuring diskless SBD")
+            self._warn_diskless_sbd()
+            return
+        elif not all(self.no_overwrite_dev_map.values()):
+            logger.info("Configuring disk-based SBD")
+
+        opt_str = SBDManager.convert_timeout_dict_to_opt_str(self.timeout_dict)
+        shell = sh.cluster_shell()
+        for dev in self.device_list_to_init:
+            # skip if device already initialized and not overwrite
+            if dev in self.no_overwrite_dev_map and self.no_overwrite_dev_map[dev]:
+                continue
+            logger.info("Initializing SBD device %s", dev)
+            cmd = f"sbd {opt_str} -d {dev} create"
+            logger.debug("Running command: %s", cmd)
+            shell.get_stdout_or_raise_error(cmd)
+
+        SBDUtils.check_devices_metadata_consistent(self.device_list_to_init)
+
+    @staticmethod
+    def enable_sbd_service():
+        cluster_nodes = utils.list_cluster_nodes() or [utils.this_node()]
+        service_manager = ServiceManager()
+
+        for node in cluster_nodes:
+            if not service_manager.service_is_enabled(constants.SBD_SERVICE, node):
+                logger.info("Enable %s on node %s", constants.SBD_SERVICE, node)
+                service_manager.enable_service(constants.SBD_SERVICE, node)
+
+    @staticmethod
+    def restart_cluster_if_possible():
+        if not ServiceManager().service_is_active(constants.PCMK_SERVICE):
+            return
+        if xmlutil.CrmMonXmlParser().is_any_resource_running():
+            logger.warning("Resource is running, need to restart cluster service manually on each node")
+        else:
+            bootstrap.restart_cluster()
+
+    def configure_sbd(self):
+        '''
+        Configure fence_sbd resource and related properties
+        '''
+        if self.diskless_sbd:
+            utils.set_property("stonith-watchdog-timeout", SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT)
+        elif not xmlutil.CrmMonXmlParser().is_resource_configured(self.SBD_RA):
+            all_device_list = SBDUtils.get_sbd_device_from_config()
+            devices_param_str = f"params devices=\"{','.join(all_device_list)}\""
+            cmd = f"crm configure primitive {self.SBD_RA_ID} {self.SBD_RA} {devices_param_str}"
+            sh.cluster_shell().get_stdout_or_raise_error(cmd)
+        utils.set_property("stonith-enabled", "true")
+
+    def _warn_diskless_sbd(self, peer=None):
+        '''
+        Give warning when configuring diskless sbd
+        '''
+        # When in sbd stage or join process
+        if (self.diskless_sbd and self.cluster_is_running) or peer:
+            vote_dict = utils.get_quorum_votes_dict(peer)
+            expected_vote = int(vote_dict.get('Expected', 0))
+            if expected_vote < self.DISKLESS_SBD_MIN_EXPECTED_VOTE:
+                logger.warning(self.DISKLESS_SBD_WARNING)
+        # When in init process
+        elif self.diskless_sbd:
+            logger.warning(self.DISKLESS_SBD_WARNING)
+
+    def get_sbd_device_interactive(self):
+        '''
         Get sbd device on interactive mode
-        """
-        if self._context.yes_to_all:
-            logger.warning(self.SBD_WARNING)
+        '''
+        if self.bootstrap_context.yes_to_all:
+            logger.warning(self.NO_SBD_WARNING)
             return
-
         logger.info(self.SBD_STATUS_DESCRIPTION)
-
         if not bootstrap.confirm("Do you wish to use SBD?"):
-            logger.warning(self.SBD_WARNING)
+            logger.warning(self.NO_SBD_WARNING)
             return
 
-        configured_dev_list = self._get_sbd_device_from_config()
-        for dev in configured_dev_list:
-            self.no_overwrite_map[dev] = self._no_overwrite_check(dev)
-        if self.no_overwrite_map and all(self.no_overwrite_map.values()):
-            self.no_update_config = True
-            return configured_dev_list
+        configured_devices = SBDUtils.get_sbd_device_from_config()
+        for dev in configured_devices:
+            self.no_overwrite_dev_map[dev] = SBDUtils.no_overwrite_device_check(dev)
+        if self.no_overwrite_dev_map and all(self.no_overwrite_dev_map.values()):
+            return configured_devices
 
         dev_list = []
         dev_looks_sane = False
@@ -356,21 +562,20 @@ class SBDManager(object):
                 self.diskless_sbd = True
                 return
 
-            dev_list = utils.re_split_string(self.PARSE_RE, dev)
+            dev_list = utils.re_split_string("[; ]", dev)
             try:
-                self._verify_sbd_device(dev_list)
-            except ValueError as err_msg:
-                logger.error(str(err_msg))
+                SBDUtils.verify_sbd_device(dev_list)
+            except ValueError as e:
+                logger.error(e)
                 continue
-
             for dev in dev_list:
-                if dev not in self.no_overwrite_map:
-                    self.no_overwrite_map[dev] = self._no_overwrite_check(dev)
-                if self.no_overwrite_map[dev]:
+                if dev not in self.no_overwrite_dev_map:
+                    self.no_overwrite_dev_map[dev] = SBDUtils.no_overwrite_device_check(dev)
+                if self.no_overwrite_dev_map[dev]:
                     if dev == dev_list[-1]:
                         return dev_list
                     continue
-                logger.warning("All data on {} will be destroyed!".format(dev))
+                logger.warning("All data on %s will be destroyed", dev)
                 if bootstrap.confirm('Are you sure you wish to use this device?'):
                     dev_looks_sane = True
                 else:
@@ -379,248 +584,73 @@ class SBDManager(object):
 
         return dev_list
 
-    def _get_sbd_device(self):
-        """
-        Get sbd device from options or interactive mode
-        """
-        dev_list = []
-        if self.sbd_devices_input:
-            dev_list = self.sbd_devices_input
-            self._verify_sbd_device(dev_list)
-            for dev in dev_list:
-                self.no_overwrite_map[dev] = self._no_overwrite_check(dev)
-            if all(self.no_overwrite_map.values()) and dev_list == self._get_sbd_device_from_config():
-                self.no_update_config = True
+    def get_sbd_device_from_bootstrap(self):
+        '''
+        Handle sbd device input from 'crm cluster init' with -s or -S option
+        -s is for disk-based sbd
+        -S is for diskless sbd
+        '''
+        # specified sbd device with -s option
+        if self.device_list_to_init:
+            self.update_dict["SBD_DEVICE"] = ';'.join(self.device_list_to_init)
+        # no -s and no -S option
         elif not self.diskless_sbd:
-            dev_list = self._get_sbd_device_interactive()
-        self._sbd_devices = dev_list
+            self.device_list_to_init = self.get_sbd_device_interactive()
 
-    def _initialize_sbd(self):
-        """
-        Initialize SBD parameters according to profiles.yml, or the crmsh defined defaulst as the last resort.
-        This covers both disk-based-sbd, and diskless-sbd scenarios.
-        For diskless-sbd, set sbd_watchdog_timeout then return;
-        For disk-based-sbd, also calculate the msgwait value, then initialize the SBD device.
-        """
-        msg = ""
-        if self.diskless_sbd:
-            msg = "Configuring diskless SBD"
-        elif not all(self.no_overwrite_map.values()):
-            msg = "Initializing SBD"
-        if msg:
-            logger.info(msg)
-        self.timeout_inst = SBDTimeout(self._context)
-        self.timeout_inst.initialize_timeout()
-        if self.diskless_sbd:
+    def init_and_deploy_sbd(self):
+        '''
+        The process of deploying sbd includes:
+        1. Initialize sbd device
+        2. Write config file /etc/sysconfig/sbd
+        3. Enable sbd.service
+        4. Restart cluster service if possible
+        5. Configure stonith-sbd resource and related properties
+        '''
+        if not self.package_installed:
             return
 
-        opt = "-4 {} -1 {}".format(self.timeout_inst.sbd_msgwait, self.timeout_inst.sbd_watchdog_timeout)
+        if self.bootstrap_context:
+            self.get_sbd_device_from_bootstrap()
+            if not self.device_list_to_init and not self.diskless_sbd:
+                ServiceManager().disable_service(constants.SBD_SERVICE)
+                return
+            self._load_attributes_from_bootstrap()
 
-        for dev in self._sbd_devices:
-            if dev in self.no_overwrite_map and self.no_overwrite_map[dev]:
-                continue
-            rc, _, err = bootstrap.invoke("sbd {} -d {} create".format(opt, dev))
-            if not rc:
-                utils.fatal("Failed to initialize SBD device {}: {}".format(dev, err))
+        self.initialize_sbd()
+        self.update_configuration()
+        SBDManager.enable_sbd_service()
 
-    def _update_sbd_configuration(self):
-        """
-        Update /etc/sysconfig/sbd
-        """
-        if self.no_update_config:
-            bootstrap.sync_file(SYSCONFIG_SBD)
-            return
-
-        utils.copy_local_file(self.SYSCONFIG_SBD_TEMPLATE, SYSCONFIG_SBD)
-        sbd_config_dict = {
-                "SBD_WATCHDOG_DEV": self._watchdog_inst.watchdog_device_name,
-                "SBD_WATCHDOG_TIMEOUT": str(self.timeout_inst.sbd_watchdog_timeout)
-                }
-        if self._sbd_devices:
-            sbd_config_dict["SBD_DEVICE"] = ';'.join(self._sbd_devices)
-        utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
-        bootstrap.sync_file(SYSCONFIG_SBD)
-
-    def _get_sbd_device_from_config(self):
-        """
-        Gets currently configured SBD device, i.e. what's in /etc/sysconfig/sbd
-        """
-        res = SBDManager.get_sbd_value_from_config("SBD_DEVICE")
-        if res:
-            return utils.re_split_string(self.PARSE_RE, res)
-        else:
-            return []
-
-    def _restart_cluster_and_configure_sbd_ra(self):
-        """
-        Try to configure sbd resource, restart cluster on needed
-        """
-        if not xmlutil.CrmMonXmlParser().is_any_resource_running():
-            bootstrap.restart_cluster()
-            self.configure_sbd_resource_and_properties()
-        else:
-            logger.warning("To start sbd.service, need to restart cluster service manually on each node")
-            if self.diskless_sbd:
-                cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, SBDTimeout.get_stonith_timeout())
-                logger.warning("Then run \"{}\" on any node".format(cmd))
-            else:
-                self.configure_sbd_resource_and_properties()
-
-    def _enable_sbd_service(self):
-        """
-        Try to enable sbd service
-        """
-        if self._context.cluster_is_running:
-            # in sbd stage, enable sbd.service on cluster wide
-            utils.cluster_run_cmd("systemctl enable sbd.service")
-            self._restart_cluster_and_configure_sbd_ra()
-        else:
-            # in init process
-            bootstrap.invoke("systemctl enable sbd.service")
-
-    def _warn_diskless_sbd(self, peer=None):
-        """
-        Give warning when configuring diskless sbd
-        """
-        # When in sbd stage or join process
-        if (self.diskless_sbd and self._context.cluster_is_running) or peer:
-            vote_dict = utils.get_quorum_votes_dict(peer)
-            expected_vote = int(vote_dict['Expected'])
-            if (expected_vote < 2 and peer) or (expected_vote < 3 and not peer):
-                logger.warning(self.DISKLESS_SBD_WARNING)
-        # When in init process
-        elif self.diskless_sbd:
-            logger.warning(self.DISKLESS_SBD_WARNING)
-
-    def sbd_init(self):
-        """
-        Function sbd_init includes these steps:
-        1. Get sbd device from options or interactive mode
-        2. Initialize sbd device
-        3. Write config file /etc/sysconfig/sbd
-        """
-        from .watchdog import Watchdog
-
-        if not utils.package_is_installed("sbd"):
-            return
-        self._watchdog_inst = Watchdog(_input=self._context.watchdog)
-        self._watchdog_inst.init_watchdog()
-        self._get_sbd_device()
-        if not self._sbd_devices and not self.diskless_sbd:
-            bootstrap.invoke("systemctl disable sbd.service")
-            return
-        self._warn_diskless_sbd()
-        self._initialize_sbd()
-        self._update_sbd_configuration()
-        self._enable_sbd_service()
-
-    def configure_sbd_resource_and_properties(self):
-        """
-        Configure stonith-sbd resource and related properties
-        """
-        if not utils.package_is_installed("sbd") or \
-                not ServiceManager().service_is_enabled("sbd.service") or \
-                xmlutil.CrmMonXmlParser().is_resource_configured(self.SBD_RA):
-            return
-        shell = sh.cluster_shell()
-
-        # disk-based sbd
-        if self._get_sbd_device_from_config():
-            devices_param_str = f"params devices=\"{','.join(self._sbd_devices)}\""
-            cmd = f"crm configure primitive {self.SBD_RA_ID} {self.SBD_RA} {devices_param_str}"
-            shell.get_stdout_or_raise_error(cmd)
-            utils.set_property("stonith-enabled", "true")
-        # disk-less sbd
-        else:
-            if self.timeout_inst is None:
-                self.timeout_inst = SBDTimeout(self._context)
-                self.timeout_inst.initialize_timeout()
-            cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, constants.STONITH_TIMEOUT_DEFAULT)
-            shell.get_stdout_or_raise_error(cmd)
-
-        # in sbd stage
-        if self._context.cluster_is_running:
+        if self.cluster_is_running:
+            SBDManager.restart_cluster_if_possible()
+            self.configure_sbd()
             bootstrap.adjust_properties()
 
     def join_sbd(self, remote_user, peer_host):
-        """
+        '''
         Function join_sbd running on join process only
         On joining process, check whether peer node has enabled sbd.service
         If so, check prerequisites of SBD and verify sbd device on join node
-        """
-        from .watchdog import Watchdog
+        '''
+        if not self.package_installed:
+            return
 
-        if not utils.package_is_installed("sbd"):
+        service_manager = ServiceManager()
+        if not os.path.exists(SYSCONFIG_SBD) or not service_manager.service_is_enabled(constants.SBD_SERVICE, peer_host):
+            service_manager.disable_service(constants.SBD_SERVICE)
             return
-        if not os.path.exists(SYSCONFIG_SBD) or not ServiceManager().service_is_enabled("sbd.service", peer_host):
-            bootstrap.invoke("systemctl disable sbd.service")
-            return
+
+        from .watchdog import Watchdog
         self._watchdog_inst = Watchdog(remote_user=remote_user, peer_host=peer_host)
         self._watchdog_inst.join_watchdog()
-        dev_list = self._get_sbd_device_from_config()
+
+        dev_list = SBDUtils.get_sbd_device_from_config()
         if dev_list:
-            self._verify_sbd_device(dev_list, [peer_host])
+            SBDUtils.verify_sbd_device(dev_list, [peer_host])
         else:
             self._warn_diskless_sbd(peer_host)
+
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))
-        bootstrap.invoke("systemctl enable sbd.service")
-
-    @classmethod
-    def verify_sbd_device(cls):
-        """
-        This classmethod is for verifying sbd device on a running cluster
-        Raise ValueError for exceptions
-        """
-        inst = cls(bootstrap.Context())
-        dev_list = inst._get_sbd_device_from_config()
-        if not dev_list:
-            raise ValueError("No sbd device configured")
-        inst._verify_sbd_device(dev_list, utils.list_cluster_nodes_except_me())
-
-    @classmethod
-    def get_sbd_device_from_config(cls):
-        """
-        Get sbd device list from config
-        """
-        inst = cls(bootstrap.Context())
-        return inst._get_sbd_device_from_config()
-
-    @classmethod
-    def is_using_diskless_sbd(cls):
-        """
-        Check if using diskless SBD
-        """
-        inst = cls(bootstrap.Context())
-        dev_list = inst._get_sbd_device_from_config()
-        if not dev_list and ServiceManager().service_is_active("sbd.service"):
-            return True
-        return False
-
-    @staticmethod
-    def update_configuration(sbd_config_dict):
-        """
-        Update and sync sbd configuration
-        """
-        utils.sysconfig_set(SYSCONFIG_SBD, **sbd_config_dict)
-        bootstrap.sync_file(SYSCONFIG_SBD)
-
-    @staticmethod
-    def get_sbd_value_from_config(key):
-        """
-        Get value from /etc/sysconfig/sbd
-        """
-        conf = utils.parse_sysconfig(SYSCONFIG_SBD)
-        res = conf.get(key)
-        return res
-
-    @staticmethod
-    def has_sbd_device_already_initialized(dev):
-        """
-        Check if sbd device already initialized
-        """
-        cmd = "sbd -d {} dump".format(dev)
-        rc, _, _ = ShellUtils().get_stdout_stderr(cmd)
-        return rc == 0
+        service_manager.enable_service(constants.SBD_SERVICE)
 
 
 def clean_up_existing_sbd_resource():
@@ -628,5 +658,40 @@ def clean_up_existing_sbd_resource():
         sbd_id_list = xmlutil.CrmMonXmlParser().get_resource_id_list_via_type(SBDManager.SBD_RA)
         if xmlutil.CrmMonXmlParser().is_resource_started(SBDManager.SBD_RA):
             for sbd_id in sbd_id_list:
+                logger.info("Stop sbd resource '%s'(%s)", sbd_id, SBDManager.SBD_RA)
                 utils.ext_cmd("crm resource stop {}".format(sbd_id))
+        logger.info("Remove sbd resource '%s'", ';' .join(sbd_id_list))
         utils.ext_cmd("crm configure delete {}".format(' '.join(sbd_id_list)))
+
+
+def enable_sbd_on_cluster():
+    cluster_nodes = utils.list_cluster_nodes()
+    service_manager = ServiceManager()
+    for node in cluster_nodes:
+        if not service_manager.service_is_enabled(constants.SBD_SERVICE, node):
+            logger.info("Enable %s on node %s", constants.SBD_SERVICE, node)
+            service_manager.enable_service(constants.SBD_SERVICE, node)
+
+
+def disable_sbd_from_cluster():
+    '''
+    Disable SBD from cluster, the process includes:
+    - stop and remove sbd agent
+    - disable sbd.service
+    - adjust cluster attributes
+    - adjust related timeout values
+    '''
+    clean_up_existing_sbd_resource()
+
+    cluster_nodes = utils.list_cluster_nodes()
+    service_manager = ServiceManager()
+    for node in cluster_nodes:
+        if service_manager.service_is_enabled(constants.SBD_SERVICE, node):
+            logger.info("Disable %s on node %s", constants.SBD_SERVICE, node)
+            service_manager.disable_service(constants.SBD_SERVICE, node)
+
+    out = sh.cluster_shell().get_stdout_or_raise_error("stonith_admin -L")
+    res = re.search("([0-9]+) fence device[s]* found", out)
+    # after disable sbd.service, check if sbd is the last stonith device
+    if res and int(res.group(1)) <= 1:
+        utils.cleanup_stonith_related_properties()

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -472,9 +472,10 @@ class SBDManager:
             timeout_inst = SBDTimeout(self.bootstrap_context)
             timeout_inst.initialize_timeout()
             self.timeout_dict["watchdog"] = timeout_inst.sbd_watchdog_timeout
-            if not self.diskless_sbd:
+            if self.diskless_sbd:
+                self.update_dict["SBD_WATCHDOG_TIMEOUT"] = str(timeout_inst.sbd_watchdog_timeout)
+            else:
                 self.timeout_dict["msgwait"] = timeout_inst.sbd_msgwait
-            self.update_dict["SBD_WATCHDOG_TIMEOUT"] = str(timeout_inst.sbd_watchdog_timeout)
         self.update_dict["SBD_WATCHDOG_DEV"] = watchdog.Watchdog.get_watchdog_device(self.bootstrap_context.watchdog)
 
     @staticmethod

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -384,6 +384,14 @@ class ClusterShell:
         rc, stdout, stderr = self.get_rc_stdout_stderr_raw_without_input(host, cmd)
         return rc, Utils.decode_str(stdout).strip(), Utils.decode_str(stderr).strip()
 
+    def get_rc_output_without_input(self, host, cmd) -> typing.Tuple[int, str]:
+        result = self.subprocess_run_without_input(
+            host, None, cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT
+        )
+        return result.returncode, Utils.decode_str(result.stdout).strip()
+
     def get_stdout_or_raise_error(
             self,
             cmd: str,

--- a/crmsh/ui_root.py
+++ b/crmsh/ui_root.py
@@ -33,6 +33,7 @@ from . import ui_ra
 from . import ui_resource
 from . import ui_script
 from . import ui_site
+from . import ui_sbd
 
 
 class Root(command.UI):
@@ -148,6 +149,10 @@ level. Most commands are implemented using the crm_resource(8)
 program.
 ''')
     def do_resource(self):
+        pass
+
+    @command.level(ui_sbd.SBD)
+    def do_sbd(self):
         pass
 
     @command.level(ui_script.Script)

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -1,0 +1,481 @@
+import logging
+import typing
+import re
+import os
+
+from crmsh import sbd
+from crmsh import watchdog
+from crmsh import command
+from crmsh import utils
+from crmsh import bootstrap
+from crmsh import completers
+from crmsh import sh
+from crmsh import xmlutil
+from crmsh import constants
+from crmsh.service_manager import ServiceManager
+from crmsh.bootstrap import SYSCONFIG_SBD
+
+
+logger = logging.getLogger(__name__)
+
+
+def sbd_devices_completer(completed_list: typing.List[str]) -> typing.List[str]:
+    '''
+    completion for sbd devices
+    '''
+    if not ServiceManager().service_is_active(constants.SBD_SERVICE):
+        return []
+    dev_list = sbd.SBDUtils.get_sbd_device_from_config()
+    if dev_list:
+        return [dev for dev in dev_list if dev not in completed_list]
+    return []
+
+
+def sbd_configure_completer(completed_list: typing.List[str]) -> typing.List[str]:
+    '''
+    completion for sbd configure command
+    '''
+    if not ServiceManager().service_is_active(constants.PCMK_SERVICE):
+        return []
+    sbd_service_is_enabled = service_manager.service_is_enabled(constants.SBD_SERVICE)
+    dev_list = sbd.SBDUtils.get_sbd_device_from_config()
+    # Show disk-based sbd configure options
+    # if there are devices in config or sbd.service is not enabled
+    is_diskbased = bool(dev_list) or not sbd_service_is_enabled
+
+    parameters_pool = []
+    if completed_list[1] == '':
+        parameters_pool = ["show"]
+    elif completed_list[1] == "show":
+        if len(completed_list) == 3:
+            show_types = SBD.SHOW_TYPES if is_diskbased else SBD.DISKLESS_SHOW_TYPES
+            return [t for t in show_types if t not in completed_list]
+        else:
+            return []
+    if completed_list[-1] == "device=":
+        return []
+
+    timeout_types = SBD.TIMEOUT_TYPES if is_diskbased else SBD.DISKLESS_TIMEOUT_TYPES
+    parameters_pool.extend([f"{t}-timeout=" for t in timeout_types])
+    parameters_pool.append("watchdog-device=")
+    parameters_pool = [
+        p
+        for p in parameters_pool
+        if not any(c.startswith(p) for c in completed_list)
+    ]
+
+    if is_diskbased:
+        dev_count = sum(1 for c in completed_list if c.startswith("device="))
+        if dev_count < sbd.SBDManager.SBD_DEVICE_MAX:
+            parameters_pool.append("device=")
+
+    return parameters_pool
+
+
+class SBD(command.UI):
+    '''
+    Class for sbd sub-level
+
+    Includes commands:
+    - sbd configure
+    - sbd remove
+    - sbd status
+    '''
+    name = "sbd"
+    TIMEOUT_TYPES = ("watchdog", "allocate", "loop", "msgwait")
+    DISKLESS_TIMEOUT_TYPES = ("watchdog",)
+    SHOW_TYPES = ("disk_metadata", "sysconfig", "property")
+    DISKLESS_SHOW_TYPES = ("sysconfig", "property")
+    RESTART_INFO = "Requires to restart cluster service to take effect"
+    PCMK_ATTRS = (
+        "have-watchdog",
+        "stonith-timeout",
+        "stonith-watchdog-timeout",
+        "stonith-enabled",
+        "priority-fencing-delay",
+        "pcmk_delay_max"
+    )
+    PARSE_RE = re.compile(
+		# Match "device" key with any value, including empty
+        r'(device)=("[^"]*"|[\w/\d;]*)'
+		# Match other keys with non-empty values, capturing possible suffix
+        r'|(\w+)(?:-(\w+))?=("[^"]+"|[\w/\d;]+)'
+	    # Match standalone device path
+        r'|(/dev/[\w\d]+)'
+    )
+
+    class SyntaxError(Exception):
+        pass
+
+    def __init__(self):
+        self.device_list_from_config: list[str] = None
+        self.device_meta_dict_runtime: dict[str, int] = None
+        self.watchdog_timeout_from_config: int = None
+        self.watchdog_device_from_config: str = None
+        self.service_manager: ServiceManager = None
+        self.cluster_shell: sh.cluster_shell = None
+        self.cluster_nodes: list[str] = None
+        self.crm_mon_xml_parser: xmlutil.CrmMonXmlParser = None
+
+        command.UI.__init__(self)
+
+    def _load_attributes(self):
+        self.device_list_from_config = sbd.SBDUtils.get_sbd_device_from_config()
+        self.device_meta_dict_runtime = {}
+        if self.device_list_from_config:
+            self.device_meta_dict_runtime = sbd.SBDUtils.get_sbd_device_metadata(self.device_list_from_config[0], timeout_only=True)
+        try:
+            self.watchdog_timeout_from_config = sbd.SBDTimeout.get_sbd_watchdog_timeout()
+        except:
+            self.watchdog_timeout_from_config = None
+        self.watchdog_device_from_config = watchdog.Watchdog.get_watchdog_device_from_sbd_config()
+
+        self.service_manager = ServiceManager()
+        self.cluster_shell = sh.cluster_shell()
+        self.cluster_nodes = utils.list_cluster_nodes() or [utils.this_node()]
+        self.crm_mon_xml_parser = xmlutil.CrmMonXmlParser()
+
+    def requires(self) -> bool:
+        '''
+        Requirements check when entering sbd sub-level
+        '''
+        if not utils.package_is_installed("sbd"):
+            logger.error("sbd is not installed")
+            return False
+        return True
+
+    @property
+    def configure_usage(self) -> str:
+        '''
+        Build usage string for sbd configure command,
+        including disk-based and diskless sbd cases
+        '''
+        def build_timeout_usage_str(timeout_types: tuple[str]) -> str:
+            return " ".join([f"[{t}-timeout=<integer>]" for t in timeout_types])
+        timeout_usage_str = build_timeout_usage_str(self.TIMEOUT_TYPES)
+        timeout_usage_str_diskless = build_timeout_usage_str(self.DISKLESS_TIMEOUT_TYPES)
+        show_usage_str = f"[{'|'.join(self.SHOW_TYPES)}]"
+        show_usage_str_diskless = f"[{'|'.join(self.DISKLESS_SHOW_TYPES)}]"
+        return ("Usage for disk-based SBD:\n"
+                f"crm sbd configure show {show_usage_str}\n"
+                f"crm sbd configure [device=<dev>]... {timeout_usage_str} [watchdog-device=<dev>]\n\n"
+                "Usage for diskless SBD:\n"
+                f"crm sbd configure show {show_usage_str_diskless}\n"
+                f"crm sbd configure device=\"\" {timeout_usage_str_diskless} [watchdog-device=<dev>]\n")
+
+    @staticmethod
+    def _show_sysconfig() -> None:
+        '''
+        Show pure content of /etc/sysconfig/sbd
+        '''
+        with open(SYSCONFIG_SBD) as f:
+            content_list = [line.strip() for line in f.readlines()
+                            if not line.startswith("#")
+                            and line.strip()]
+        for line in content_list:
+            print(line)
+
+    def _show_disk_metadata(self) -> None:
+        '''
+        Show sbd disk metadata for each configured device
+        '''
+        for dev in self.device_list_from_config:
+            print(self.cluster_shell.get_stdout_or_raise_error(f"sbd -d {dev} dump"))
+            print()
+
+    def _show_property(self) -> None:
+        '''
+        Show sbd-related properties from cluster and systemd
+        '''
+        if self.service_manager.service_is_active(constants.PCMK_SERVICE):
+            cmd = "crm configure show"
+        else: # static case
+            cib_path = os.getenv("CIB_file", constants.CIB_RAW_FILE)
+            if not os.path.exists(cib_path):
+                return
+            cmd = f"CIB_file={cib_path} crm configure show"
+        out = self.cluster_shell.get_stdout_or_raise_error(cmd)
+
+        regex = f"({'|'.join(self.PCMK_ATTRS)})=([^\s]+)"
+        matches = re.findall(regex, out)
+        for match in matches:
+            print(f"{match[0]}={match[1]}")
+
+        systemd_start_timeout = sbd.SBDTimeout.get_sbd_systemd_start_timeout()
+        print(f"TimeoutStartUSec={systemd_start_timeout}")
+
+    def _configure_show(self, args) -> None:
+        if len(args) > 2:
+            raise self.SyntaxError("Invalid argument")
+        elif len(args) == 2:
+            match args[1]:
+                case "disk_metadata":
+                    self._show_disk_metadata()
+                case "sysconfig":
+                    SBD._show_sysconfig()
+                case "property":
+                    self._show_property()
+                case _:
+                    raise self.SyntaxError(f"Unknown argument: {args[1]}")
+        else:
+            self._show_disk_metadata()
+            if self.device_list_from_config:
+                print()
+            SBD._show_sysconfig()
+            print()
+            self._show_property()
+
+    def _parse_args(self, args: typing.List[str]) -> dict[str, int|str|list[str]]:
+        '''
+        Parse arguments and verify them
+
+        Possible arguments format like:
+        device="/dev/sdb5;/dev/sda6"
+        device="" watchdog-timeout=10
+        /dev/sda5 watchdog-timeout=10 watchdog-device=/dev/watchdog
+        device=/dev/sdb5 device=/dev/sda6 watchdog-timeout=10 msgwait-timeout=20
+        '''
+        parameter_dict = {"device-list": []}
+
+        for arg in args:
+            match = self.PARSE_RE.match(arg)
+            if not match:
+                raise self.SyntaxError(f"Invalid argument: {arg}")
+            device_key, device_value, key, suffix, value, device_path = match.groups()
+
+            # device=<device name> parameter
+            if device_key:
+                if device_value:
+                    parameter_dict.setdefault("device-list", []).extend(device_value.split(";"))
+                # explicitly set empty value, stands for diskless sbd
+                elif not parameter_dict.get("device-list"):
+                    parameter_dict.pop("device-list", None)
+            # standalone device parameter
+            elif device_path:
+                parameter_dict.setdefault("device-list", []).append(device_path)
+            # timeout related parameters
+            elif key in self.TIMEOUT_TYPES and suffix and suffix == "timeout":
+                if not value.isdigit():
+                    raise self.SyntaxError(f"Invalid timeout value: {value}")
+                parameter_dict[key] = int(value)
+            # watchdog device parameter
+            elif key == "watchdog" and suffix == "device":
+                parameter_dict["watchdog-device"] = value
+            else:
+                raise self.SyntaxError(f"Unknown argument: {arg}")
+
+        watchdog_device = parameter_dict.get("watchdog-device")
+        parameter_dict["watchdog-device"] = watchdog.Watchdog.get_watchdog_device(watchdog_device)
+
+        logger.debug("Parsed arguments: %s", parameter_dict)
+        return parameter_dict
+
+    @staticmethod
+    def _adjust_timeout_dict(timeout_dict: dict, diskless: bool = False) -> dict:
+        watchdog_timeout = timeout_dict.get("watchdog")
+        if not watchdog_timeout:
+            watchdog_timeout, _ = sbd.SBDTimeout.get_advised_sbd_timeout(diskless)
+            logger.info("No watchdog timeout specified, use advised value: %s", watchdog_timeout)
+            timeout_dict["watchdog"] = watchdog_timeout
+
+        if diskless:
+            return timeout_dict
+
+        msgwait_timeout = timeout_dict.get("msgwait")
+        if not msgwait_timeout:
+            msgwait_timeout = 2*watchdog_timeout
+            logger.info("No msgwait timeout specified, use 2*watchdog timeout: %s", msgwait_timeout)
+            timeout_dict["msgwait"] = msgwait_timeout
+
+        if msgwait_timeout < 2*watchdog_timeout:
+            logger.warning("It's recommended to set msgwait timeout >= 2*watchdog timeout")
+
+        return timeout_dict
+
+    def _configure_diskbase(self, parameter_dict: dict):
+        '''
+        Configure disk-based SBD based on input parameters and runtime config
+        '''
+        if not self.device_list_from_config:
+            self.watchdog_timeout_from_config = None
+            self.watchdog_device_from_config = None
+
+        update_dict = {}
+        device_list = parameter_dict.get("device-list", [])
+        if not device_list and not self.device_list_from_config:
+            raise self.SyntaxError("No device specified")
+        if len(device_list) > len(set(device_list)):
+            raise self.SyntaxError("Duplicate device")
+        watchdog_device = parameter_dict.get("watchdog-device")
+        if watchdog_device != self.watchdog_device_from_config:
+            update_dict["SBD_WATCHDOG_DEV"] = watchdog_device
+        timeout_dict = {k: v for k, v in parameter_dict.items() if k in self.TIMEOUT_TYPES}
+
+        all_device_list = list(
+            dict.fromkeys(self.device_list_from_config + device_list)
+        )
+        sbd.SBDUtils.verify_sbd_device(all_device_list)
+
+        new_device_list = list(
+            set(device_list) - set(self.device_list_from_config)
+        )
+        no_overwrite_dev_map : dict[str, bool] = {
+            dev: sbd.SBDUtils.no_overwrite_device_check(dev) for dev in new_device_list
+        }
+        if new_device_list:
+            update_dict["SBD_DEVICE"] = ";".join(all_device_list)
+
+        device_list_to_init = []
+        # initialize new devices only if no timeout parameter specified or timeout parameter is already in runtime config
+        if not timeout_dict or utils.is_subdict(timeout_dict, self.device_meta_dict_runtime):
+            device_list_to_init = new_device_list
+        # initialize all devices
+        else:
+            device_list_to_init = all_device_list
+
+        # merge runtime timeout dict with new timeout dict
+        timeout_dict = self.device_meta_dict_runtime | timeout_dict
+        # adjust watchdog and msgwait timeout
+        timeout_dict = self._adjust_timeout_dict(timeout_dict)
+        watchdog_timeout = timeout_dict.get("watchdog")
+        if watchdog_timeout != self.watchdog_timeout_from_config:
+            update_dict["SBD_WATCHDOG_TIMEOUT"] = str(watchdog_timeout)
+
+        sbd_manager = sbd.SBDManager(
+            device_list_to_init=device_list_to_init,
+            timeout_dict=timeout_dict,
+            update_dict=update_dict,
+            no_overwrite_dev_map=no_overwrite_dev_map,
+            new_config=False if self.device_list_from_config else True
+        )
+        sbd_manager.init_and_deploy_sbd()
+        
+    def _configure_diskless(self, parameter_dict: dict):
+        '''
+        Configure diskless SBD based on input parameters and runtime config
+        '''
+        if self.device_list_from_config:
+            self.watchdog_timeout_from_config = None
+            self.watchdog_device_from_config = None
+
+        update_dict = {}
+        parameter_dict = self._adjust_timeout_dict(parameter_dict, diskless=True)
+        watchdog_timeout = parameter_dict.get("watchdog")
+        if watchdog_timeout and watchdog_timeout != self.watchdog_timeout_from_config:
+            update_dict["SBD_WATCHDOG_TIMEOUT"] = str(watchdog_timeout)
+        watchdog_device = parameter_dict.get("watchdog-device")
+        if watchdog_device != self.watchdog_device_from_config:
+            update_dict["SBD_WATCHDOG_DEV"] = watchdog_device
+
+        sbd_manager = sbd.SBDManager(
+            update_dict=update_dict,
+            diskless_sbd=True,
+            new_config=True if self.device_list_from_config else False
+        )
+        sbd_manager.init_and_deploy_sbd()
+
+    @command.completers_repeating(sbd_configure_completer)
+    def do_configure(self, context, *args) -> bool:
+        '''
+        Implement sbd configure command
+        '''
+        self._load_attributes()
+
+        try:
+            if not args:
+                raise self.SyntaxError("No argument")
+
+            if args[0] == "show":
+                self._configure_show(args)
+                return True
+
+            if not self.service_manager.service_is_active(constants.PCMK_SERVICE):
+                logger.error("%s is not active", constants.PCMK_SERVICE)
+                return False
+
+            parameter_dict = self._parse_args(args)
+            # disk-based sbd case
+            if "device-list" in parameter_dict:
+                return self._configure_diskbase(parameter_dict)
+            # diskless sbd case
+            else:
+                return self._configure_diskless(parameter_dict)
+
+        except self.SyntaxError as e:
+            logger.error(str(e))
+            print(self.configure_usage)
+            return False
+
+    @command.completers_repeating(sbd_devices_completer)
+    def do_remove(self, context, *args) -> bool:
+        '''
+        Implement sbd remove command
+        '''
+        self._load_attributes()
+
+        if not self.service_manager.service_is_active(constants.SBD_SERVICE):
+            logger.error("%s is not active", constants.SBD_SERVICE)
+            return False
+
+        parameter_dict = self._parse_args(args)
+        dev_list = parameter_dict.get("device-list", [])
+        if dev_list:
+            if not self.device_list_from_config:
+                logger.error("No sbd device found in config")
+                return False
+            for dev in dev_list:
+                if dev not in self.device_list_from_config:
+                    logger.error("Device %s is not in config", dev)
+                    return False
+            changed_dev_list = set(self.device_list_from_config) - set(dev_list)
+            # remove part of devices from config
+            if changed_dev_list:
+                logger.info("Remove '%s' from %s", ";".join(dev_list), SYSCONFIG_SBD)
+                sbd.SBDManager.update_sbd_configuration({"SBD_DEVICE": ";".join(changed_dev_list)})
+            # remove all devices, equivalent to stop sbd.service
+            else:
+                sbd.disable_sbd_from_cluster()
+        else:
+            sbd.disable_sbd_from_cluster()
+
+        logger.info(self.RESTART_INFO)
+        return True
+
+    def do_status(self, context) -> bool:
+        '''
+        Implement sbd status command
+        '''
+        self._load_attributes()
+
+        print(f"{constants.SBD_SERVICE} status: (active|enabled|since)")
+        for node in self.cluster_nodes:
+            is_active = self.service_manager.service_is_active(constants.SBD_SERVICE, node)
+            is_active_str = "YES" if is_active else "NO"
+            is_enabled = self.service_manager.service_is_enabled(constants.SBD_SERVICE, node)
+            is_enabled_str = "YES" if is_enabled else "NO"
+            systemd_property = "ActiveEnterTimestamp" if is_active else "ActiveExitTimestamp"
+            since_str_prefix = "active since" if is_active else "disactive since"
+            systemctl_show_cmd = f"systemctl show {constants.SBD_SERVICE} --property={systemd_property} --value"
+            since = self.cluster_shell.get_stdout_or_raise_error(systemctl_show_cmd, node) or "N/A"
+            print(f"{node}: {is_active_str:<4}|{is_enabled_str:<4}|{since_str_prefix}: {since}")
+        print()
+
+        print("watchdog info: (device|driver|kernel timeout)")
+        watchdog_sbd_re = "\[[0-9]+\] (/dev/.*)\nIdentity: Busy: .*sbd.*\nDriver: (.*)"
+        for node in self.cluster_nodes:
+            out = self.cluster_shell.get_stdout_or_raise_error("sbd query-watchdog", node)
+            res = re.search(watchdog_sbd_re, out)
+            if res:
+                device, driver = res.groups()
+                kernel_timeout = self.cluster_shell.get_stdout_or_raise_error("cat /proc/sys/kernel/watchdog_thresh", node)
+                print(f"{node}: {device}|{driver}|{kernel_timeout}")
+            else:
+                logger.error("Failed to get watchdog info from %s", node)
+        print()
+
+        if self.crm_mon_xml_parser.is_resource_configured(sbd.SBDManager.SBD_RA):
+            print("fence_sbd status: ")
+            sbd_id_list = self.crm_mon_xml_parser.get_resource_id_list_via_type(sbd.SBDManager.SBD_RA)
+            for sbd_id in sbd_id_list:
+                out = self.cluster_shell.get_stdout_or_raise_error(f"crm resource status {sbd_id}")
+                print(out)

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -95,11 +95,11 @@ class SBD(command.UI):
     PCMK_ATTRS = (
         "have-watchdog",
         "stonith-timeout",
-        "stonith-watchdog-timeout",
         "stonith-enabled",
         "priority-fencing-delay",
         "pcmk_delay_max"
     )
+    PCMK_ATTRS_DISKLESS = ('stonith-watchdog-timeout',)
     PARSE_RE = re.compile(
 		# Match keys with non-empty values, capturing possible suffix
         r'(\w+)(?:-(\w+))?=("[^"]+"|[\w/\d;]+)'
@@ -208,7 +208,11 @@ class SBD(command.UI):
         out = self.cluster_shell.get_stdout_or_raise_error("crm configure show")
 
         logger.info("crm sbd configure show property")
-        regex = f"({'|'.join(self.PCMK_ATTRS)})=(\\S+)"
+        if self.device_list_from_config:
+            attrs = self.PCMK_ATTRS
+        else:
+            attrs = self.PCMK_ATTRS + self.PCMK_ATTRS_DISKLESS
+        regex = f"({'|'.join(attrs)})=(\\S+)"
         matches = re.findall(regex, out)
         for match in matches:
             print(f"{match[0]}={match[1]}")

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -359,6 +359,7 @@ class SBD(command.UI):
         if self.device_list_from_config:
             self.watchdog_timeout_from_config = None
             self.watchdog_device_from_config = None
+            sbd.clean_up_existing_sbd_resource()
 
         update_dict = {}
         parameter_dict = self._adjust_timeout_dict(parameter_dict, diskless=True)

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -191,14 +191,7 @@ class SBD(command.UI):
         '''
         Show sbd-related properties from cluster and systemd
         '''
-        if self.service_manager.service_is_active(constants.PCMK_SERVICE):
-            cmd = "crm configure show"
-        else: # static case
-            cib_path = os.getenv("CIB_file", constants.CIB_RAW_FILE)
-            if not os.path.exists(cib_path):
-                return
-            cmd = f"CIB_file={cib_path} crm configure show"
-        out = self.cluster_shell.get_stdout_or_raise_error(cmd)
+        out = self.cluster_shell.get_stdout_or_raise_error("crm configure show")
 
         logger.info("crm sbd configure show property")
         regex = f"({'|'.join(self.PCMK_ATTRS)})=([^\s]+)"

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -92,7 +92,6 @@ class SBD(command.UI):
     DISKLESS_TIMEOUT_TYPES = ("watchdog",)
     SHOW_TYPES = ("disk_metadata", "sysconfig", "property")
     DISKLESS_SHOW_TYPES = ("sysconfig", "property")
-    RESTART_INFO = "Requires to restart cluster service to take effect"
     PCMK_ATTRS = (
         "have-watchdog",
         "stonith-timeout",
@@ -357,7 +356,7 @@ class SBD(command.UI):
         logger.info("Remove devices: %s", ';'.join(devices_to_remove))
         update_dict = {"SBD_DEVICE": ";".join(left_device_list)}
         sbd.SBDManager.update_sbd_configuration(update_dict)
-        logger.info('%s', self.RESTART_INFO)
+        sbd.SBDManager.restart_cluster_if_possible()
 
     @command.completers_repeating(sbd_device_completer)
     def do_device(self, context, *args) -> bool:
@@ -440,7 +439,7 @@ class SBD(command.UI):
             logger.error("%s is not active", constants.SBD_SERVICE)
             return False
         sbd.disable_sbd_from_cluster()
-        logger.info('%s', self.RESTART_INFO)
+        sbd.SBDManager.restart_cluster_if_possible()
         return True
 
     def _print_sbd_type(self):

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -328,10 +328,15 @@ class SBD(command.UI):
         all_device_list = self.device_list_from_config + devices_to_add
         sbd.SBDUtils.verify_sbd_device(all_device_list)
 
+        devices_to_init, _ = sbd.SBDUtils.handle_input_sbd_devices(
+            devices_to_add,
+            self.device_list_from_config
+        )
+
         logger.info("Append devices: %s", ';'.join(devices_to_add))
         update_dict = {"SBD_DEVICE": ";".join(all_device_list)}
         sbd_manager = sbd.SBDManager(
-            device_list_to_init=devices_to_add,
+            device_list_to_init=devices_to_init,
             update_dict=update_dict,
             timeout_dict=self.device_meta_dict_runtime
         )

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -13,7 +13,6 @@ from crmsh import sh
 from crmsh import xmlutil
 from crmsh import constants
 from crmsh.service_manager import ServiceManager
-from crmsh.bootstrap import SYSCONFIG_SBD
 
 
 logger = logging.getLogger(__name__)
@@ -170,10 +169,12 @@ class SBD(command.UI):
         '''
         Show pure content of /etc/sysconfig/sbd
         '''
-        with open(SYSCONFIG_SBD) as f:
-            content_list = [line.strip() for line in f.readlines()
-                            if not line.startswith("#")
-                            and line.strip()]
+        with open(sbd.SBDManager.SYSCONFIG_SBD) as f:
+            content_list = [
+                line.strip()
+                for line in f.readlines()
+                if not line.startswith("#") and line.strip()
+            ]
         if content_list:
             logger.info("crm sbd configure show sysconfig")
         for line in content_list:
@@ -434,7 +435,7 @@ class SBD(command.UI):
             changed_dev_list = set(self.device_list_from_config) - set(dev_list)
             # remove part of devices from config
             if changed_dev_list:
-                logger.info("Remove '%s' from %s", ";".join(dev_list), SYSCONFIG_SBD)
+                logger.info("Remove '%s' from %s", ";".join(dev_list), sbd.SBDManager.SYSCONFIG_SBD)
                 sbd.SBDManager.update_sbd_configuration({"SBD_DEVICE": ";".join(changed_dev_list)})
             # remove all devices, equivalent to stop sbd.service
             else:

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -142,7 +142,7 @@ class SBD(command.UI):
         Requirements check when entering sbd sub-level
         '''
         if not utils.package_is_installed("sbd"):
-            logger.error("sbd is not installed")
+            logger.error('%s', sbd.SBDManager.SBD_NOT_INSTALLED_MSG)
             return False
         return True
 
@@ -442,7 +442,7 @@ class SBD(command.UI):
         else:
             sbd.disable_sbd_from_cluster()
 
-        logger.info(self.RESTART_INFO)
+        logger.info('%s', self.RESTART_INFO)
         return True
 
     def do_status(self, context) -> bool:

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -512,11 +512,9 @@ class SBD(command.UI):
             print("# Status of fence_sbd:")
             sbd_id_list = self.crm_mon_xml_parser.get_resource_id_list_via_type(sbd.SBDManager.SBD_RA)
             for sbd_id in sbd_id_list:
-                rc, out, err = self.cluster_shell.get_rc_stdout_stderr_without_input(None, f"crm resource status {sbd_id}")
-                if out:
-                    print(out)
-                if err:
-                    print(err)
+                rc, output = self.cluster_shell.get_rc_output_without_input(None, f"crm resource status {sbd_id}")
+                if output:
+                    print(output)
 
     def do_status(self, context) -> bool:
         '''

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -208,7 +208,7 @@ class SBD(command.UI):
             print(f"{match[0]}={match[1]}")
 
         print()
-        logger.info('%s', constants.SHOW_SBD_START_TIMEOUT_CMD)
+        logger.info('%s', sbd.SBDTimeout.SHOW_SBD_START_TIMEOUT_CMD)
         systemd_start_timeout = sbd.SBDTimeout.get_sbd_systemd_start_timeout()
         print(f"TimeoutStartUSec={systemd_start_timeout}")
 

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -95,13 +95,15 @@ class SBD(command.UI):
         "priority-fencing-delay",
         "pcmk_delay_max"
     )
+    # a commom character class for matching device path
+    dev_char_class = r'[\w/\d;\-:.]'
     PARSE_RE = re.compile(
 		# Match "device" key with any value, including empty
-        r'(device)=("[^"]*"|[\w/\d;]*)'
+        fr'(device)=("[^"]*"|{dev_char_class}*)'
 		# Match other keys with non-empty values, capturing possible suffix
         r'|(\w+)(?:-(\w+))?=("[^"]+"|[\w/\d;]+)'
 	    # Match standalone device path
-        r'|(/dev/[\w\d]+)'
+        fr'|(/dev/{dev_char_class}+)'
     )
 
     class SyntaxError(Exception):

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -172,6 +172,8 @@ class SBD(command.UI):
             content_list = [line.strip() for line in f.readlines()
                             if not line.startswith("#")
                             and line.strip()]
+        if content_list:
+            logger.info("crm sbd configure show sysconfig")
         for line in content_list:
             print(line)
 
@@ -179,6 +181,8 @@ class SBD(command.UI):
         '''
         Show sbd disk metadata for each configured device
         '''
+        if self.device_list_from_config:
+            logger.info("crm sbd configure show disk_metadata")
         for dev in self.device_list_from_config:
             print(self.cluster_shell.get_stdout_or_raise_error(f"sbd -d {dev} dump"))
             print()
@@ -196,11 +200,14 @@ class SBD(command.UI):
             cmd = f"CIB_file={cib_path} crm configure show"
         out = self.cluster_shell.get_stdout_or_raise_error(cmd)
 
+        logger.info("crm sbd configure show property")
         regex = f"({'|'.join(self.PCMK_ATTRS)})=([^\s]+)"
         matches = re.findall(regex, out)
         for match in matches:
             print(f"{match[0]}={match[1]}")
 
+        print()
+        logger.info("systemctl show -p TimeoutStartUSec sbd --value")
         systemd_start_timeout = sbd.SBDTimeout.get_sbd_systemd_start_timeout()
         print(f"TimeoutStartUSec={systemd_start_timeout}")
 

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -270,6 +270,12 @@ class SBD(command.UI):
         watchdog_device = parameter_dict.get("watchdog-device")
         parameter_dict["watchdog-device"] = watchdog.Watchdog.get_watchdog_device(watchdog_device)
 
+        # No need to specify device="" when trying to modify properties under diskless sbd
+        if sbd.SBDUtils.is_using_diskless_sbd() \
+                and "device-list" in parameter_dict \
+                and not parameter_dict["device-list"]:
+            parameter_dict.pop("device-list")
+
         logger.debug("Parsed arguments: %s", parameter_dict)
         return parameter_dict
 

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -477,5 +477,8 @@ class SBD(command.UI):
             print("fence_sbd status: ")
             sbd_id_list = self.crm_mon_xml_parser.get_resource_id_list_via_type(sbd.SBDManager.SBD_RA)
             for sbd_id in sbd_id_list:
-                out = self.cluster_shell.get_stdout_or_raise_error(f"crm resource status {sbd_id}")
-                print(out)
+                rc, out, err = self.cluster_shell.get_rc_stdout_stderr_without_input(None, f"crm resource status {sbd_id}")
+                if out:
+                    print(out)
+                if err:
+                    print(err)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3207,13 +3207,6 @@ def cleanup_stonith_related_properties():
         set_property("stonith-enabled", "false")
 
 
-def is_subdict(sub_dict, main_dict):
-    """
-    Check if sub_dict is a sub-dictionary of main_dict
-    """
-    return all(item in main_dict.items() for item in sub_dict.items())
-
-
 def strip_ansi_escape_sequences(text):
     """
     Remove ANSI escape sequences from text

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3213,4 +3213,11 @@ def strip_ansi_escape_sequences(text):
     """
     ansi_escape_pattern = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
     return ansi_escape_pattern.sub('', text)
+
+
+def is_subdict(sub_dict, main_dict):
+    """
+    Check if sub_dict is a sub-dictionary of main_dict
+    """
+    return all(main_dict.get(k) == v for k, v in sub_dict.items())
 # vim:ts=4:sw=4:et:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3212,4 +3212,12 @@ def is_subdict(sub_dict, main_dict):
     Check if sub_dict is a sub-dictionary of main_dict
     """
     return all(item in main_dict.items() for item in sub_dict.items())
+
+
+def strip_ansi_escape_sequences(text):
+    """
+    Remove ANSI escape sequences from text
+    """
+    ansi_escape_pattern = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+    return ansi_escape_pattern.sub('', text)
 # vim:ts=4:sw=4:et:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -28,6 +28,7 @@ import lzma
 import json
 import socket
 from pathlib import Path
+from collections import defaultdict
 from contextlib import contextmanager, closing
 from stat import S_ISBLK
 from lxml import etree
@@ -2497,6 +2498,19 @@ def is_block_device(dev):
     except OSError:
         return False
     return rc
+
+
+def detect_duplicate_device_path(device_list: typing.List[str]):
+    """
+    Resolve device path and check if there are duplicated device path
+    """
+    path_dict = defaultdict(list)
+    for dev in device_list:
+        resolved_path = Path(dev).resolve()
+        path_dict[resolved_path].append(dev)
+    for path, dev_list in path_dict.items():
+        if len(dev_list) > 1:
+            raise ValueError(f"Duplicated device path detected: {','.join(dev_list)}. They are all pointing to {path}")
 
 
 def has_stonith_running():

--- a/crmsh/watchdog.py
+++ b/crmsh/watchdog.py
@@ -27,7 +27,7 @@ class Watchdog(object):
         return self._watchdog_device_name
 
     @staticmethod
-    def _verify_watchdog_device(dev, ignore_error=False):
+    def verify_watchdog_device(dev, ignore_error=False):
         """
         Use wdctl to verify watchdog device
         """
@@ -48,7 +48,7 @@ class Watchdog(object):
         invoke("systemctl restart systemd-modules-load")
 
     @staticmethod
-    def _get_watchdog_device_from_sbd_config():
+    def get_watchdog_device_from_sbd_config():
         """
         Try to get watchdog device name from sbd config file
         """
@@ -81,7 +81,7 @@ class Watchdog(object):
         Get watchdog device name which has driver_name
         """
         for device, driver in self._watchdog_info_dict.items():
-            if driver == driver_name and self._verify_watchdog_device(device):
+            if driver == driver_name and self.verify_watchdog_device(device):
                 return device
         return None
 
@@ -108,7 +108,7 @@ class Watchdog(object):
         Get first unused watchdog device name
         """
         for dev in self._watchdog_info_dict:
-            if self._verify_watchdog_device(dev, ignore_error=True):
+            if self.verify_watchdog_device(dev, ignore_error=True):
                 return dev
         return None
 
@@ -120,8 +120,8 @@ class Watchdog(object):
           3. Set the self._input as softdog
         """
         if not self._input:
-            dev = self._get_watchdog_device_from_sbd_config()
-            if dev and self._verify_watchdog_device(dev, ignore_error=True):
+            dev = self.get_watchdog_device_from_sbd_config()
+            if dev and self.verify_watchdog_device(dev, ignore_error=True):
                 self._input = dev
                 return
             first_unused = self._get_first_unused_device()
@@ -131,7 +131,7 @@ class Watchdog(object):
         """
         Is an unused watchdog device
         """
-        if dev in self._watchdog_info_dict and self._verify_watchdog_device(dev):
+        if dev in self._watchdog_info_dict and self.verify_watchdog_device(dev):
             return True
         return False
 
@@ -142,7 +142,7 @@ class Watchdog(object):
         """
         self._set_watchdog_info()
 
-        res = self._get_watchdog_device_from_sbd_config()
+        res = self.get_watchdog_device_from_sbd_config()
         if not res:
             utils.fatal("Failed to get watchdog device from {}".format(SYSCONFIG_SBD))
         self._input = res
@@ -177,3 +177,9 @@ class Watchdog(object):
         if res:
             self._watchdog_device_name = res
             return
+
+    @classmethod
+    def get_watchdog_device(cls, dev_or_driver=None):
+        w = cls(_input=dev_or_driver)
+        w.init_watchdog()
+        return w.watchdog_device_name

--- a/data-manifest
+++ b/data-manifest
@@ -88,6 +88,7 @@ test/features/qdevice_usercase.feature
 test/features/qdevice_validate.feature
 test/features/resource_failcount.feature
 test/features/resource_set.feature
+test/features/sbd_ui.feature
 test/features/ssh_agent.feature
 test/features/steps/behave_agent.py
 test/features/steps/const.py

--- a/data-manifest
+++ b/data-manifest
@@ -213,6 +213,7 @@ test/unittests/test_sh.py
 test/unittests/test_time.py
 test/unittests/test_ui_cluster.py
 test/unittests/test_ui_corosync.py
+test/unittests/test_ui_sbd.py
 test/unittests/test_upgradeuitl.py
 test/unittests/test_utils.py
 test/unittests/test_watchdog.py

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2107,7 +2107,10 @@ utilization xen1 set memory 4096
 [[cmdhelp.sbd,SBD management]]
 === `sbd` - SBD management
 
-This level is for managing the SBD (STONITH Block Device) daemon.
+This level displays the real-time SBD status and the static SBD configuration.
+Additionally, it manages the configuration file for both disk-based and diskless SBD scenarios,
+as well as the on-disk metadata for the disk-based scenario.
+Currently, SBD management requires a running cluster.
 
 [[cmdhelp.sbd.configure,configure SBD]]
 ==== `configure`
@@ -2118,9 +2121,7 @@ Main functionailities include:
 - Show configured disk metadata
 - Show contents of /etc/sysconfig/sbd
 - Show SBD related cluster properties
-- Newly setup SBD configuration on a running cluster
-- Update the existing parameters
-- Add more devices to the existing disk-based SBD configuration
+- Update the SBD related configuration parameters
 
 For more details on SBD and related parameters, please see man sbd(8).
 
@@ -2128,11 +2129,11 @@ Usage:
 ...............
 # For disk-based SBD
 crm sbd configure show [disk_metadata|sysconfig|property]
-crm sbd configure [device=<dev>]... [watchdog-device=<dev>] [watchdog-timeout=<integer>] [allocate-timeout=<integer>] [loop-timeout=<integer>] [msgwait-timeout=<integer>]
+crm sbd configure [watchdog-timeout=<integer>] [allocate-timeout=<integer>] [loop-timeout=<integer>] [msgwait-timeout=<integer>] [watchdog-device=<device>]
 
 # For disk-less SBD
 crm sbd configure show [sysconfig|property]
-crm sbd configure device="" [watchdog-device=<dev>] [watchdog-timeout=<integer>]
+crm sbd configure [watchdog-timeout=<integer>] [watchdog-device=<device>]
 ...............
 
 example:
@@ -2141,32 +2142,43 @@ configure show
 configure show disk_metadata
 configure show sysconfig
 configure show property
-configure device="/dev/sdb1;/dev/sdb2"
-configure device=/dev/sdb1 device=/dev/sdb2
-configure device=/dev/sdb1 watchdog-timeout=30 msgwait-timeout=60
-configure device="" watchdog-timeout=30
+configure watchdog-timeout=30
 ...............
 
-[[cmdhelp.sbd.status,show SBD status]]
+[[cmdhelp.sbd.device,add or remove SBD device]]
+==== `device`
+
+Add or remove SBD device(s) from the existing SBD configuration.
+
+example:
+...............
+device add /dev/sdb5
+device add /dev/sdb5 /dev/sdb6
+device add "/dev/sda5;/dev/sda6"
+device remove /dev/sdb5
+...............
+
+[[cmdhelp.sbd.status,show SBD runtime status]]
 ==== `status`
 
-Show the status of the SBD daemon.
+Show the runtime status of the SBD daemon and
+the other information of those SBD related components,
+ie. watchdog, fence agent.
 
 Usage:
 ...............
 status
 ...............
 
-[[cmdhelp.sbd.remove,remove SBD configuration]]
-==== `remove`
+[[cmdhelp.sbd.purge,purge SBD from cluster]]
+==== `purge`
 
-Remove part of devices from the SBD configuration, or remove SBD
-service from the cluster.
+Disable the systemd sbd.service on all cluster nodes,
+move the sbd sysconfig to .bak and adjust SBD related cluster properties.
 
 Usage:
 ...............
-remove
-remove [<device> ...]
+purge
 ...............
 
 [[cmdhelp.node,Node management]]

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1,5 +1,5 @@
 :man source:   crm
-:man version:  4.6.0
+:man version:  5.0.0
 :man manual:   crmsh documentation
 
 crm(8)
@@ -2102,6 +2102,71 @@ utilization <rsc> show <attr>
 Example:
 ...............
 utilization xen1 set memory 4096
+...............
+
+[[cmdhelp.sbd,SBD management]]
+=== `sbd` - SBD management
+
+This level is for managing the SBD (STONITH Block Device) daemon.
+
+[[cmdhelp.sbd.configure,configure SBD]]
+==== `configure`
+
+Configure the SBD daemon for both disk-based and disk-less mode.
+
+Main functionailities include:
+- Show configured disk metadata
+- Show contents of /etc/sysconfig/sbd
+- Show SBD related cluster properties
+- Newly setup SBD configuration on a running cluster
+- Update the existing parameters
+- Add more devices to the existing disk-based SBD configuration
+
+For more details on SBD and related parameters, please see man sbd(8).
+
+Usage:
+...............
+# For disk-based SBD
+crm sbd configure show [disk_metadata|sysconfig|property]
+crm sbd configure [device=<dev>]... [watchdog-device=<dev>] [watchdog-timeout=<integer>] [allocate-timeout=<integer>] [loop-timeout=<integer>] [msgwait-timeout=<integer>]
+
+# For disk-less SBD
+crm sbd configure show [sysconfig|property]
+crm sbd configure device="" [watchdog-device=<dev>] [watchdog-timeout=<integer>]
+...............
+
+example:
+...............
+configure show
+configure show disk_metadata
+configure show sysconfig
+configure show property
+configure device="/dev/sdb1;/dev/sdb2"
+configure device=/dev/sdb1 device=/dev/sdb2
+configure device=/dev/sdb1 watchdog-timeout=30 msgwait-timeout=60
+configure device="" watchdog-timeout=30
+...............
+
+[[cmdhelp.sbd.status,show SBD status]]
+==== `status`
+
+Show the status of the SBD daemon.
+
+Usage:
+...............
+status
+...............
+
+[[cmdhelp.sbd.remove,remove SBD configuration]]
+==== `remove`
+
+Remove part of devices from the SBD configuration, or remove SBD
+service from the cluster.
+
+Usage:
+...............
+remove
+remove [<device> ...]
 ...............
 
 [[cmdhelp.node,Node management]]

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -18,8 +18,10 @@ Feature: configure sbd delay start correctly
     And     SBD option "SBD_DELAY_START" value is "no"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
-    # calculated and set by sbd RA
-    And     Cluster property "stonith-timeout" is "43"
+    # original value is 43, which is calculated by external/sbd RA
+    # now fence_sbd doesn't calculate it, so this value is the default one
+    # from pacemaker
+    And     Cluster property "stonith-timeout" is "60"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"
 
     Given   Has disk "/dev/sda1" on "hanode2"
@@ -112,8 +114,10 @@ Feature: configure sbd delay start correctly
     And     SBD option "SBD_DELAY_START" value is "no"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
-    # calculated and set by sbd RA
-    And     Cluster property "stonith-timeout" is "172"
+    # original value is 172, which is calculated by external/sbd RA
+    # now fence_sbd doesn't calculate it, so this value is the default one
+    # from pacemaker
+    And     Cluster property "stonith-timeout" is "60"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"
 
     Given   Has disk "/dev/sda1" on "hanode2"

--- a/test/features/bootstrap_sbd_normal.feature
+++ b/test/features/bootstrap_sbd_normal.feature
@@ -139,7 +139,7 @@ Feature: crmsh bootstrap sbd management
     And     Online nodes are "hanode1 hanode2"
     When    Run "crm configure primitive d Dummy op monitor interval=3s" on "hanode1"
     When    Run "crm cluster init sbd -s /dev/sda1 -y" on "hanode1"
-    Then    Expected "WARNING: To start sbd.service, need to restart cluster service manually on each node" in stderr
+    Then    Expected "WARNING: Resource is running, need to restart cluster service manually on each node" in stderr
     Then    Service "sbd" is "stopped" on "hanode1"
     And     Service "sbd" is "stopped" on "hanode2"
     When    Run "crm cluster restart" on "hanode1"
@@ -263,6 +263,8 @@ Feature: crmsh bootstrap sbd management
     And     Resource "stonith-sbd" type "fence_sbd" is "Started"
     And     Run "ps -ef|grep -v grep|grep 'watcher: /dev/sda1 '" OK
 
+    When    Try "crm cluster init sbd -s /dev/sda2 -y"
+    Then    Except "ERROR: cluster.init: Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy"
     When    Run "crm -F cluster init sbd -s /dev/sda2 -y" on "hanode1"
     Then    Service "sbd" is "started" on "hanode1"
     And     Service "sbd" is "started" on "hanode2"

--- a/test/features/sbd_ui.feature
+++ b/test/features/sbd_ui.feature
@@ -1,0 +1,100 @@
+@sbd
+Feature: crm sbd ui test cases
+
+  Tag @clean means need to stop cluster service if the service is available
+
+  @clean
+  Scenario: Syntax check for crm sbd
+    Given   Cluster service is "stopped" on "hanode1"
+    Given   Cluster service is "stopped" on "hanode2"
+    Given   Has disk "/dev/sda5" on "hanode1"
+    Given   Has disk "/dev/sda6" on "hanode1"
+    Given   Has disk "/dev/sda7" on "hanode1"
+    Given   Has disk "/dev/sda8" on "hanode1"
+    Given   Has disk "/dev/sda5" on "hanode2"
+    Given   Has disk "/dev/sda6" on "hanode2"
+    Given   Has disk "/dev/sda7" on "hanode2"
+    Given   Has disk "/dev/sda8" on "hanode2"
+    When    Try "crm sbd configure watchdog-timeout=30"
+    Then    Except "ERROR: pacemaker.service is not active"
+    When    Run "crm cluster init -y" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Try "crm sbd configure watchdog-timeout=30"
+    Then    Except "ERROR: sbd.service is not active"
+    When    Run "crm cluster init sbd -s /dev/sda5 -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "sbd" is "started" on "hanode1"
+    And     Resource "stonith-sbd" type "fence_sbd" is "Started"
+
+    When    Try "crm sbd configure show sysconfig xxx"
+    Then    Except "ERROR: Invalid argument"
+    When    Try "crm sbd configure show testing"
+    Then    Except "ERROR: Unknown argument: testing"
+    When    Try "crm sbd configure"
+    Then    Except "ERROR: No argument"
+    When    Try "crm sbd configure testing"
+    Then    Except "ERROR: Invalid argument: testing"
+    When    Try "crm sbd configure watchdog-timeout=f"
+    Then    Except "ERROR: Invalid timeout value: f"
+    When    Try "crm sbd configure name=testing"
+    Then    Except "ERROR: Unknown argument: name=testing"
+    When    Try "crm sbd device add /dev/sda6 /dev/sda6"
+    Then    Expected "Duplicated device path detected" in stderr
+    When    Try "crm sbd device add /dev/sda6 /dev/sda7 /dev/sda8"
+    Then    Expected "Maximum number of SBD device is 3" in stderr
+
+  Scenario: sbd configure for diskbased sbd
+    # Update disk metadata
+    When    Run "crm sbd configure watchdog-timeout=30 msgwait-timeout=60" on "hanode1"
+    Then    Run "crm sbd configure show disk_metadata|grep -E "watchdog.*30"" OK
+    Then    Run "crm sbd configure show disk_metadata|grep -E "msgwait.*60"" OK
+
+  Scenario: sbd device add and remove
+    # Add a sbd disk
+    Given   Run "crm sbd configure show sysconfig|grep "SBD_DEVICE=/dev/sda5"" OK
+    When    Run "crm -F sbd device add /dev/sda6" on "hanode1"
+    Then    Run "crm sbd configure show sysconfig|grep -E "SBD_DEVICE=\"/dev/sda5;/dev/sda6\""" OK
+    Then    Run "crm sbd configure show sysconfig|grep -E "SBD_DEVICE=\"/dev/sda5;/dev/sda6\""" OK on "hanode2"
+    And     Run "crm sbd configure show disk_metadata |grep -A 8 '/dev/sda6'|grep -E "watchdog.*30"" OK
+    And     Run "crm sbd configure show disk_metadata |grep -A 8 '/dev/sda6'|grep -E "msgwait.*60"" OK
+    When    Run "crm cluster restart --all" on "hanode1"
+    And     Wait for DC
+    # Remove a sbd disk
+    When    Run "crm sbd device remove /dev/sda5" on "hanode1"
+    Then    Run "crm sbd configure show sysconfig|grep "SBD_DEVICE=/dev/sda6"" OK
+    Then    Run "crm sbd configure show sysconfig|grep "SBD_DEVICE=/dev/sda6"" OK on "hanode2"
+    When    Run "crm cluster restart --all" on "hanode1"
+    And     Wait for DC
+    # Replace a sbd disk
+    When    Run "crm -F sbd device add /dev/sda7" on "hanode1"
+    Then    Run "crm sbd configure show sysconfig|grep -E "SBD_DEVICE=\"/dev/sda6;/dev/sda7\""" OK
+    Then    Run "crm sbd configure show sysconfig|grep -E "SBD_DEVICE=\"/dev/sda6;/dev/sda7\""" OK on "hanode2"
+    And     Run "crm sbd configure show disk_metadata |grep -A 8 '/dev/sda7'|grep -E "watchdog.*30"" OK
+    And     Run "crm sbd configure show disk_metadata |grep -A 8 '/dev/sda7'|grep -E "msgwait.*60"" OK
+    When    Run "crm cluster restart --all" on "hanode1"
+    And     Wait for DC
+    # Purge sbd from cluster
+    When    Run "crm sbd purge" on "hanode1"
+    And     Run "crm cluster restart --all" on "hanode1"
+    Then    Service "sbd.service" is "stopped" on "hanode1"
+    Then    Service "sbd.service" is "stopped" on "hanode2"
+
+  @clean
+  Scenario: sbd configure for diskless sbd
+    # Newly setup
+    When    Run "crm cluster init -S -y" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode1"
+    Then    Cluster service is "started" on "hanode2"
+    Then    Service "sbd" is "started" on "hanode1"
+    And     Service "sbd" is "started" on "hanode2"
+    And     Resource "stonith:fence_sbd" not configured
+    # Shoud not has any sbd device configured
+    When    Try "crm sbd configure show sysconfig|grep -E "SBD_DEVICE=.+""
+    Then    Expected return code is "1"
+    # Purge sbd from cluster
+    When    Run "crm sbd purge" on "hanode1"
+    And     Run "crm cluster restart --all" on "hanode1"
+    Then    Service "sbd.service" is "stopped" on "hanode1"
+    Then    Service "sbd.service" is "stopped" on "hanode2"

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -7,8 +7,9 @@ import yaml
 import behave
 from behave import given, when, then
 import behave_agent
-from crmsh import corosync, sbd, userdir, bootstrap
+from crmsh import corosync, userdir, bootstrap
 from crmsh import utils as crmutils
+from crmsh import sbd
 from crmsh.sh import ShellUtils
 from utils import check_cluster_state, check_service_state, online, run_command, me, \
                   run_command_local_or_remote, file_in_archive, \

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -439,7 +439,7 @@ def step_impl(context, res_id, node):
 
 @then('SBD option "{key}" value is "{value}"')
 def step_impl(context, key, value):
-    res = sbd.SBDManager.get_sbd_value_from_config(key)
+    res = sbd.SBDUtils.get_sbd_value_from_config(key)
     assert_eq(value, res)
 
 
@@ -453,27 +453,27 @@ def step_impl(context, key, dev, value):
 def step_impl(context, key, value):
     res = crmutils.get_property(key)
     assert res is not None
-    assert_eq(value, str(res))
+    assert_eq(value.strip('s'), str(res).strip('s'))
 
 
 @then('Property "{key}" in "{type}" is "{value}"')
 def step_impl(context, key, type, value):
     res = crmutils.get_property(key, type)
     assert res is not None
-    assert_eq(value, str(res))
+    assert_eq(value.strip('s'), str(res).strip('s'))
 
 
 @then('Parameter "{param_name}" not configured in "{res_id}"')
 def step_impl(context, param_name, res_id):
     _, out, _ = run_command(context, "crm configure show {}".format(res_id))
-    result = re.search("params {}=".format(param_name), out)
+    result = re.search("params .*{}=".format(param_name), out)
     assert result is None
 
 
 @then('Parameter "{param_name}" configured in "{res_id}"')
 def step_impl(context, param_name, res_id):
     _, out, _ = run_command(context, "crm configure show {}".format(res_id))
-    result = re.search("params {}=".format(param_name), out)
+    result = re.search("params .*{}=".format(param_name), out)
     assert result is not None
 
 

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -804,9 +804,9 @@ Membership information
 
     @mock.patch('crmsh.utils.set_property')
     @mock.patch('crmsh.sbd.SBDTimeout.get_stonith_timeout')
-    @mock.patch('crmsh.sbd.SBDManager.update_configuration')
-    @mock.patch('crmsh.sbd.SBDManager.get_sbd_value_from_config')
-    @mock.patch('crmsh.sbd.SBDManager.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
     def test_adjust_sbd_watchdog_timeout_with_qdevice(self, mock_check_reachable, mock_using_diskless_sbd, mock_get_sbd_value, mock_update_config, mock_get_timeout, mock_set_property):
         mock_using_diskless_sbd.return_value = True

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -187,7 +187,7 @@ PCMK_logfile=/var/log/pacemaker/pacemaker.log
         mock_open_write = mock.mock_open()
         file_handle = mock_open_write.return_value.__enter__.return_value
         mock_open_file.return_value = mock_open_write.return_value
-        mock_run.return_value = "data"
+        mock_run.side_effect = ["data", "data", "data"]
         mock_ctx_inst = mock.Mock(work_dir="/opt")
 
         collect.collect_sbd_info(mock_ctx_inst)
@@ -199,6 +199,12 @@ PCMK_logfile=/var/log/pacemaker/pacemaker.log
         file_handle.write.assert_has_calls([
             mock.call("\n\n#=====[ Command ] ==========================#\n"),
             mock.call("# . /etc/sysconfig/sbd;export SBD_DEVICE;sbd dump;sbd list\n"),
+            mock.call("data"),
+            mock.call("\n\n#=====[ Command ] ==========================#\n"),
+            mock.call("# crm sbd configure show\n"),
+            mock.call("data"),
+            mock.call("\n\n#=====[ Command ] ==========================#\n"),
+            mock.call("# crm sbd status\n"),
             mock.call("data")
             ])
         mock_debug.assert_called_once_with(f"Dump SBD config file into {constants.SBD_F}")

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -1,0 +1,580 @@
+import io
+import unittest
+from unittest import mock
+
+from crmsh import ui_sbd
+from crmsh import constants
+from crmsh import sbd
+
+
+class TestOutterFunctions(unittest.TestCase):
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_sbd_device_completer_return_no_diskbased_sbd(self, mock_is_using_disk_based_sbd):
+        mock_is_using_disk_based_sbd.return_value = False
+        self.assertEqual(ui_sbd.sbd_device_completer([]), [])
+        mock_is_using_disk_based_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_sbd_device_completer_return_options(self, mock_is_using_disk_based_sbd):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.assertEqual(ui_sbd.sbd_device_completer(["device", ""]), ["add", "remove"])
+        mock_is_using_disk_based_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_sbd_device_completer_return_no_options(self, mock_is_using_disk_based_sbd):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.assertEqual(ui_sbd.sbd_device_completer(["device", "add", "/dev/sda1"]), [])
+        mock_is_using_disk_based_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_sbd_device_completer_return_no_last_dev(self, mock_is_using_disk_based_sbd, mock_get_sbd_device_from_config):
+        mock_is_using_disk_based_sbd.return_value = True
+        mock_get_sbd_device_from_config.return_value = ["/dev/sda1", "/dev/sda2"]
+        self.assertEqual(ui_sbd.sbd_device_completer(["device", "remove", "/dev/sda1"]), [])
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_get_sbd_device_from_config.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_sbd_device_completer(self, mock_is_using_disk_based_sbd, mock_get_sbd_device_from_config):
+        mock_is_using_disk_based_sbd.return_value = True
+        mock_get_sbd_device_from_config.return_value = ["/dev/sda1", "/dev/sda2"]
+        self.assertEqual(ui_sbd.sbd_device_completer(["device", "remove", "/dev"]), mock_get_sbd_device_from_config.return_value)
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_get_sbd_device_from_config.assert_called_once()
+
+    @mock.patch('crmsh.ui_sbd.ServiceManager')
+    def test_sbd_configure_completer_return(self, mock_ServiceManager):
+        mock_ServiceManager.return_value.service_is_active.side_effect = [True, False]
+        self.assertEqual(ui_sbd.sbd_configure_completer([]), [])
+        mock_ServiceManager.return_value.service_is_active.assert_has_calls([
+            mock.call(constants.PCMK_SERVICE),
+            mock.call(constants.SBD_SERVICE)
+        ])
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    @mock.patch('crmsh.ui_sbd.ServiceManager')
+    def test_sbd_configure_completer_show_return(self, mock_ServiceManager, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_ServiceManager.return_value.service_is_active.side_effect = [True, True]
+        mock_is_using_disk_based_sbd.return_value = True
+        mock_is_using_diskless_sbd.return_value = False
+        self.assertEqual(ui_sbd.sbd_configure_completer(["configure", "show", ""]), list(ui_sbd.SBD.SHOW_TYPES))
+        mock_ServiceManager.return_value.service_is_active.assert_has_calls([
+            mock.call(constants.PCMK_SERVICE),
+            mock.call(constants.SBD_SERVICE)
+        ])
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    @mock.patch('crmsh.ui_sbd.ServiceManager')
+    def test_sbd_configure_completer_show_return_empty(self, mock_ServiceManager, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_ServiceManager.return_value.service_is_active.side_effect = [True, True]
+        mock_is_using_disk_based_sbd.return_value = True
+        mock_is_using_diskless_sbd.return_value = False
+        self.assertEqual(ui_sbd.sbd_configure_completer(["configure", "show", "xx", ""]), [])
+        mock_ServiceManager.return_value.service_is_active.assert_has_calls([
+            mock.call(constants.PCMK_SERVICE),
+            mock.call(constants.SBD_SERVICE)
+        ])
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    @mock.patch('crmsh.ui_sbd.ServiceManager')
+    def test_sbd_configure_completer_success(self, mock_ServiceManager, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_ServiceManager.return_value.service_is_active.side_effect = [True, True]
+        mock_is_using_disk_based_sbd.return_value = False
+        mock_is_using_diskless_sbd.return_value = True
+        self.assertEqual(ui_sbd.sbd_configure_completer(["configure", ""]), ["show", "watchdog-timeout=", "watchdog-device="])
+        mock_ServiceManager.return_value.service_is_active.assert_has_calls([
+            mock.call(constants.PCMK_SERVICE),
+            mock.call(constants.SBD_SERVICE)
+        ])
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_called_once()
+
+
+class TestSBD(unittest.TestCase):
+
+    @mock.patch('crmsh.utils.node_reachable_check')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
+    @mock.patch('crmsh.ui_sbd.sh.cluster_shell')
+    @mock.patch('crmsh.ui_sbd.ServiceManager')
+    @mock.patch('crmsh.watchdog.Watchdog.get_watchdog_device_from_sbd_config')
+    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata')
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
+    def setUp(self, mock_get_sbd_device_from_config, mock_get_sbd_device_metadata, mock_get_sbd_watchdog_timeout, mock_get_watchdog_device_from_sbd_config, mock_ServiceManager, mock_cluster_shell, mock_list_cluster_nodes, mock_node_reachable_check):
+
+        mock_list_cluster_nodes.return_value = ["node1", "node2"]
+        mock_get_sbd_device_from_config.return_value = ["/dev/sda1"]
+        mock_get_watchdog_device_from_sbd_config.return_value = "/dev/watchdog0"
+        mock_get_sbd_watchdog_timeout.return_value = 10
+        mock_get_sbd_device_metadata.return_value = {"watchdog": 10, "msgwait": 20}
+        self.sbd_instance_diskbased = ui_sbd.SBD()
+        self.sbd_instance_diskbased._load_attributes()
+
+        mock_get_sbd_device_from_config.return_value = []
+        self.sbd_instance_diskless = ui_sbd.SBD()
+        self.sbd_instance_diskless._load_attributes()
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch('crmsh.utils.package_is_installed')
+    def test_requires(self, mock_package_is_installed, mock_logger_error):
+        mock_package_is_installed.return_value = False
+        self.assertFalse(self.sbd_instance_diskbased.requires())
+        mock_package_is_installed.assert_called_with("sbd")
+        mock_package_is_installed.return_value = True
+        self.assertTrue(self.sbd_instance_diskbased.requires())
+        mock_package_is_installed.assert_called_with("sbd")
+
+    @mock.patch('logging.Logger.error')
+    def test_service_is_active_false(self, mock_logger_error):
+        self.sbd_instance_diskbased.service_manager.service_is_active = mock.Mock(return_value=False)
+        self.assertFalse(self.sbd_instance_diskbased.service_is_active(constants.PCMK_SERVICE))
+        mock_logger_error.assert_called_once_with("%s is not active", constants.PCMK_SERVICE)
+
+    @mock.patch('logging.Logger.error')
+    def test_service_is_active_true(self, mock_logger_error):
+        self.sbd_instance_diskbased.service_manager.service_is_active = mock.Mock(return_value=True)
+        self.assertTrue(self.sbd_instance_diskbased.service_is_active(constants.PCMK_SERVICE))
+        mock_logger_error.assert_not_called()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_configure_usage_none(self, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_is_using_disk_based_sbd.return_value = False
+        mock_is_using_diskless_sbd.return_value = False
+        self.assertEqual(self.sbd_instance_diskbased.configure_usage, "")
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_called_once()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_configure_usage_disk_diskbased(self, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_is_using_disk_based_sbd.return_value = True
+        timeout_usage_str = " ".join([f"[{t}-timeout=<integer>]" for t in ui_sbd.SBD.TIMEOUT_TYPES])
+        show_usage = f"crm sbd configure show [{'|'.join(ui_sbd.SBD.SHOW_TYPES)}]"
+        expected = f"Usage:\n{show_usage}\ncrm sbd configure {timeout_usage_str} [watchdog-device=<device>]\n"
+        self.assertEqual(self.sbd_instance_diskbased.configure_usage, expected)
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_not_called()
+
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_configure_usage_disk_diskless(self, mock_is_using_disk_based_sbd, mock_is_using_diskless_sbd):
+        mock_is_using_disk_based_sbd.return_value = False
+        mock_is_using_diskless_sbd.return_value = True
+        timeout_usage_str = " ".join([f"[{t}-timeout=<integer>]" for t in ui_sbd.SBD.DISKLESS_TIMEOUT_TYPES])
+        show_usage = f"crm sbd configure show [{'|'.join(ui_sbd.SBD.DISKLESS_SHOW_TYPES)}]"
+        expected = f"Usage:\n{show_usage}\ncrm sbd configure {timeout_usage_str} [watchdog-device=<device>]\n"
+        self.assertEqual(self.sbd_instance_diskless.configure_usage, expected)
+        mock_is_using_disk_based_sbd.assert_called_once()
+        mock_is_using_diskless_sbd.assert_called_once()
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('builtins.open', new_callable=mock.mock_open, read_data="# Comment line\nKEY1=value1\nKEY2=value2\n")
+    def test_show_sysconfig(self, mock_open, mock_logger_info):
+        with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            self.sbd_instance_diskbased._show_sysconfig()
+            self.assertTrue(mock_logger_info.called)
+            mock_logger_info.assert_called_with("crm sbd configure show sysconfig")
+            self.assertEqual(mock_stdout.getvalue(), "KEY1=value1\nKEY2=value2\n")
+
+    @mock.patch('logging.Logger.info')
+    def test_show_disk_metadata(self, mock_logger_info):
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.return_value = "disk metadata: data"
+        with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            self.sbd_instance_diskbased._show_disk_metadata()
+            self.assertTrue(mock_logger_info.called)
+            mock_logger_info.assert_called_with("crm sbd configure show disk_metadata")
+            self.assertEqual(mock_stdout.getvalue(), "disk metadata: data\n\n")
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.assert_called_with("sbd -d /dev/sda1 dump")
+
+    def test_do_configure_no_service(self):
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=False)
+        res = self.sbd_instance_diskbased.do_configure(mock.Mock())
+        self.assertFalse(res)
+
+    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_systemd_start_timeout')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('builtins.print')
+    def test_show_property(self, mock_print, mock_logger_info, mock_get_sbd_systemd_start_timeout):
+        data = """property cib-bootstrap-options: \
+        have-watchdog=true \
+        dc-version="2.1.7+20240711.239cba384-1.1-2.1.7+20240711.239cba384" \
+        cluster-infrastructure=corosync \
+        cluster-name=hacluster \
+        stonith-enabled=true \
+        stonith-timeout=83 \
+        priority-fencing-delay=60
+        """
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error = mock.Mock(return_value=data)
+        mock_get_sbd_systemd_start_timeout.return_value = 10
+        self.sbd_instance_diskbased._show_property()
+        mock_logger_info.assert_has_calls([
+            mock.call("crm sbd configure show property"),
+            mock.call("%s", sbd.SBDTimeout.SHOW_SBD_START_TIMEOUT_CMD)
+        ])
+        mock_print.assert_has_calls([
+            mock.call("have-watchdog=true"),
+            mock.call("stonith-enabled=true"),
+            mock.call("stonith-timeout=83"),
+            mock.call("priority-fencing-delay=60"),
+            mock.call(),
+            mock.call(f"TimeoutStartUSec=10")
+        ])
+
+    def test_configure_show_invalid_arg(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            res = self.sbd_instance_diskbased._configure_show(["arg1", "arg2", "arg3"])
+        self.assertEqual(str(e.exception), "Invalid argument")
+
+    def test_configure_show_unknown_arg(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            res = self.sbd_instance_diskbased._configure_show(["xxx1", "xxx2"])
+        self.assertEqual(str(e.exception), f"Unknown argument: xxx2")
+
+    def test_configure_show_disk_metadata(self):
+        self.sbd_instance_diskbased._show_disk_metadata = mock.Mock()
+        self.sbd_instance_diskbased._configure_show(["show", "disk_metadata"])
+        self.sbd_instance_diskbased._show_disk_metadata.assert_called_once()
+
+    @mock.patch('crmsh.ui_sbd.SBD._show_sysconfig')
+    def test_configure_show_sysconfig(self, mock_show_sysconfig):
+        self.sbd_instance_diskbased._configure_show(["show", "sysconfig"])
+        mock_show_sysconfig.assert_called_once()
+
+    def test_configure_show_property(self):
+        self.sbd_instance_diskbased._show_property = mock.Mock()
+        self.sbd_instance_diskbased._configure_show(["show", "property"])
+        self.sbd_instance_diskbased._show_property.assert_called_once()
+
+    @mock.patch('crmsh.ui_sbd.SBD._show_sysconfig')
+    @mock.patch('builtins.print')
+    def test_configure_show(self, mock_print, mock_show_sysconfig):
+        self.sbd_instance_diskbased._show_disk_metadata = mock.Mock()
+        self.sbd_instance_diskbased._show_property = mock.Mock()
+        self.sbd_instance_diskbased._configure_show(["show"])
+        mock_print.assert_has_calls([mock.call(), mock.call()])
+
+    def test_parse_args_invalid_args(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            self.sbd_instance_diskbased._parse_args(["arg1"])
+        self.assertEqual(str(e.exception), "Invalid argument: arg1")
+
+    def test_parse_args_invalid_timeout_value(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            self.sbd_instance_diskbased._parse_args(["watchdog-timeout=xxx"])
+        self.assertEqual(str(e.exception), "Invalid timeout value: xxx")
+
+    def test_parse_args_unknown_arg(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            self.sbd_instance_diskbased._parse_args(["name=xin"])
+        self.assertEqual(str(e.exception), "Unknown argument: name=xin")
+
+    @mock.patch('logging.Logger.debug')
+    @mock.patch('crmsh.watchdog.Watchdog.get_watchdog_device')
+    def test_parse_args(self, mock_get_watchdog_device, mock_logger_debug):
+        mock_get_watchdog_device.return_value = "/dev/watchdog0"
+        args = self.sbd_instance_diskbased._parse_args(["watchdog-timeout=10", "watchdog-device=/dev/watchdog0"])
+        self.assertEqual(args, {"watchdog": 10, "watchdog-device": "/dev/watchdog0"})
+
+    @mock.patch('logging.Logger.warning')
+    @mock.patch('logging.Logger.info')
+    def test_adjust_timeout_dict(self, mock_logger_info, mock_logger_warning):
+        timeout_dict = {"watchdog": 10, "msgwait": 10}
+        res = ui_sbd.SBD._adjust_timeout_dict(timeout_dict)
+        self.assertEqual(res, timeout_dict)
+        mock_logger_warning.assert_called_once_with("It's recommended to set msgwait timeout >= 2*watchdog timeout")
+        timeout_dict = {"watchdog": 10}
+        res = ui_sbd.SBD._adjust_timeout_dict(timeout_dict)
+        self.assertEqual(res, {"watchdog": 10, "msgwait": 20})
+        timeout_dict = {"msgwait": 10}
+        res = ui_sbd.SBD._adjust_timeout_dict(timeout_dict)
+        self.assertEqual(res, {"watchdog": 5, "msgwait": 10})
+
+    @mock.patch("crmsh.ui_sbd.SBD.configure_usage", new_callable=mock.PropertyMock)
+    @mock.patch('builtins.print')
+    @mock.patch('logging.Logger.error')
+    def test_do_configure_no_args(self, mock_logger_error, mock_print, mock_configure_usage):
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(side_effect=[True, True])
+        mock_configure_usage.return_value = "usage data"
+        res = self.sbd_instance_diskbased.do_configure(mock.Mock())
+        self.assertFalse(res)
+        mock_logger_error.assert_called_once_with('%s', "No argument")
+        mock_print.assert_called_once_with("usage data")
+
+    @mock.patch('crmsh.sbd.SBDManager')
+    def test_configure_diskbase(self, mock_SBDManager):
+        parameter_dict = {"watchdog": 12, "watchdog-device": "/dev/watchdog100"}
+        self.sbd_instance_diskbased._adjust_timeout_dict = mock.Mock(return_value=parameter_dict)
+        mock_SBDManager.return_value.init_and_deploy_sbd = mock.Mock()
+        self.sbd_instance_diskbased._configure_diskbase(parameter_dict)
+        mock_SBDManager.assert_called_once_with(
+            device_list_to_init=self.sbd_instance_diskbased.device_list_from_config,
+            timeout_dict={"watchdog": 12, "msgwait": 20, "watchdog-device": "/dev/watchdog100"},
+            update_dict={
+                "SBD_WATCHDOG_DEV": "/dev/watchdog100"
+            }
+        )
+        mock_SBDManager.return_value.init_and_deploy_sbd.assert_called_once()
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.utils.is_subdict')
+    @mock.patch('crmsh.sbd.SBDManager')
+    def test_configure_diskbase_no_change(self, mock_SBDManager, mock_is_subdict, mock_logger_info):
+        parameter_dict = {"watchdog": 10, "watchdog-device": "/dev/watchdog0"}
+        mock_is_subdict.return_value = True
+        self.sbd_instance_diskbased._configure_diskbase(parameter_dict)
+        mock_logger_info.assert_called_once_with("No change in SBD configuration")
+
+    @mock.patch('crmsh.sbd.SBDManager')
+    def test_configure_diskless(self, mock_SBDManager):
+        parameter_dict = {"watchdog": 12, "watchdog-device": "/dev/watchdog100"}
+        self.sbd_instance_diskless._adjust_timeout_dict = mock.Mock(return_value=parameter_dict)
+        mock_SBDManager.return_value.init_and_deploy_sbd = mock.Mock()
+        self.sbd_instance_diskless._configure_diskless(parameter_dict)
+        mock_SBDManager.assert_called_once_with(
+            update_dict={
+                "SBD_WATCHDOG_DEV": "/dev/watchdog100",
+                "SBD_WATCHDOG_TIMEOUT": "12"
+            },
+            diskless_sbd=True
+        )
+        mock_SBDManager.return_value.init_and_deploy_sbd.assert_called_once()
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDManager')
+    def test_configure_diskless_no_change(self, mock_SBDManager, mock_logger_info):
+        parameter_dict = {"watchdog": 10, "watchdog-device": "/dev/watchdog0"}
+        self.sbd_instance_diskless._configure_diskless(parameter_dict)
+        mock_logger_info.assert_called_once_with("No change in SBD configuration")
+
+    @mock.patch('crmsh.sbd.SBDManager')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.handle_input_sbd_devices')
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    def test_device_add(self, mock_verify_sbd_device, mock_handle_input_sbd_devices, mock_logger_info, mock_SBDManager):
+        mock_handle_input_sbd_devices.return_value = [["/dev/sda2"], ["/dev/sda1"]]
+        mock_SBDManager.return_value.init_and_deploy_sbd = mock.Mock()
+        self.sbd_instance_diskbased._device_add(["/dev/sda2"])
+        mock_verify_sbd_device.assert_called_once_with(["/dev/sda1", "/dev/sda2"])
+        mock_handle_input_sbd_devices.assert_called_once_with(["/dev/sda2"], ["/dev/sda1"])
+        mock_SBDManager.assert_called_once_with(
+            device_list_to_init=["/dev/sda2"],
+            update_dict={"SBD_DEVICE": "/dev/sda1;/dev/sda2"},
+            timeout_dict=self.sbd_instance_diskbased.device_meta_dict_runtime
+        )
+        mock_logger_info.assert_called_once_with("Append devices: %s", "/dev/sda2")
+
+    def test_device_remove_dev_not_in_config(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            self.sbd_instance_diskbased._device_remove(["/dev/sda2"])
+        self.assertEqual(str(e.exception), "Device /dev/sda2 is not in config")
+
+    def test_device_remove_last_dev(self):
+        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+            self.sbd_instance_diskbased._device_remove(["/dev/sda1"])
+        self.assertEqual(str(e.exception), "Not allowed to remove all devices")
+
+    @mock.patch('crmsh.sbd.SBDManager.restart_cluster_if_possible')
+    @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    @mock.patch('logging.Logger.info')
+    def test_device_remove(self, mock_logger_info, mock_update_sbd_configuration, mock_restart_cluster_if_possible):
+        self.sbd_instance_diskbased.device_list_from_config = ["/dev/sda1", "/dev/sda2"]
+        self.sbd_instance_diskbased._device_remove(["/dev/sda1"])
+        mock_update_sbd_configuration.assert_called_once_with({"SBD_DEVICE": "/dev/sda2"})
+        mock_restart_cluster_if_possible.assert_called_once()
+        mock_logger_info.assert_called_once_with("Remove devices: %s", "/dev/sda1")
+
+    def test_do_device_no_service(self):
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=False)
+        res = self.sbd_instance_diskbased.do_device(mock.Mock())
+        self.assertFalse(res)
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('logging.Logger.error')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_no_diskbase(self, mock_is_using_disk_based_sbd, mock_logger_error, mock_logger_info):
+        mock_is_using_disk_based_sbd.return_value = False
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        res = self.sbd_instance_diskbased.do_device(mock.Mock())
+        self.assertFalse(res)
+        mock_logger_error.assert_called_once_with("Only works for disk-based SBD")
+        mock_logger_info.assert_called_once_with("Please use 'crm cluster init sbd -s <dev1> [-s <dev2> [-s <dev3>]]' to configure the disk-based SBD first")
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_no_args(self, mock_is_using_disk_based_sbd, mock_logger_info, mock_logger_error):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        res = self.sbd_instance_diskbased.do_device(mock.Mock())
+        self.assertFalse(res)
+        mock_logger_error.assert_called_once_with('%s', "No argument")
+        mock_logger_info.assert_called_once_with("Usage: crm sbd device <add|remove> <device>...")
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_invalid_args(self, mock_is_using_disk_based_sbd, mock_logger_info, mock_logger_error):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        res = self.sbd_instance_diskbased.do_device(mock.Mock(), "arg1")
+        self.assertFalse(res)
+        mock_logger_error.assert_called_once_with('%s', "Invalid argument: arg1")
+        mock_logger_info.assert_called_once_with("Usage: crm sbd device <add|remove> <device>...")
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_no_device(self, mock_is_using_disk_based_sbd, mock_logger_info, mock_logger_error):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        res = self.sbd_instance_diskbased.do_device(mock.Mock(), "add")
+        self.assertFalse(res)
+        mock_logger_error.assert_called_once_with('%s', "No device specified")
+        mock_logger_info.assert_called_once_with("Usage: crm sbd device <add|remove> <device>...")
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_add(self, mock_is_using_disk_based_sbd, mock_logger_info):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        self.sbd_instance_diskbased._device_add = mock.Mock()
+        res = self.sbd_instance_diskbased.do_device(mock.Mock(), "add", "/dev/sda2;/dev/sda3")
+        self.assertTrue(res)
+        self.sbd_instance_diskbased._device_add.assert_called_once_with(["/dev/sda2", "/dev/sda3"])
+        mock_logger_info.assert_called_once_with("Configured sbd devices: %s", "/dev/sda1")
+
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
+    def test_do_device_remove(self, mock_is_using_disk_based_sbd, mock_logger_info):
+        mock_is_using_disk_based_sbd.return_value = True
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        self.sbd_instance_diskbased._device_remove = mock.Mock()
+        res = self.sbd_instance_diskbased.do_device(mock.Mock(), "remove", "/dev/sda1")
+        self.assertTrue(res)
+        self.sbd_instance_diskbased._device_remove.assert_called_once_with(["/dev/sda1"])
+        mock_logger_info.assert_called_once_with("Configured sbd devices: %s", "/dev/sda1")
+
+    @mock.patch('crmsh.sbd.purge_sbd_from_cluster')
+    def test_do_purge_no_service(self, mock_purge_sbd_from_cluster):
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=False)
+        res = self.sbd_instance_diskbased.do_purge(mock.Mock())
+        self.assertFalse(res)
+        mock_purge_sbd_from_cluster.assert_not_called()
+
+    @mock.patch('crmsh.sbd.SBDManager.restart_cluster_if_possible')
+    @mock.patch('crmsh.sbd.purge_sbd_from_cluster')
+    def test_do_purge(self, mock_purge_sbd_from_cluster, mock_restart_cluster_if_possible):
+        self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
+        res = self.sbd_instance_diskbased.do_purge(mock.Mock())
+        self.assertTrue(res)
+        mock_purge_sbd_from_cluster.assert_called_once()
+        mock_restart_cluster_if_possible.assert_called_once()
+
+    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    def test_print_sbd_agent_status(self, mock_CrmMonXmlParser):
+        mock_CrmMonXmlParser.return_value.is_resource_configured.return_value = True
+        mock_CrmMonXmlParser.return_value.get_resource_id_list_via_type.return_value = ["sbd"]
+        self.sbd_instance_diskbased.cluster_shell.get_rc_output_without_input.return_value = (0, "active")
+        with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            self.sbd_instance_diskbased._print_sbd_agent_status()
+            self.assertEqual(mock_stdout.getvalue(), "# Status of fence_sbd:\nactive\n")
+
+    @mock.patch('builtins.print')
+    def test_print_sbd_type_no_sbd(self, mock_print):
+        self.sbd_instance_diskbased.service_manager.service_is_active = mock.Mock(return_value=False)
+        self.sbd_instance_diskbased._print_sbd_type()
+        mock_print.assert_not_called()
+
+    @mock.patch('builtins.print')
+    def test_print_sbd_type(self, mock_print):
+        self.sbd_instance_diskbased.service_manager.service_is_active = mock.Mock(return_value=True)
+        self.sbd_instance_diskbased._print_sbd_type()
+        mock_print.assert_has_calls([
+            mock.call('# Type of SBD:'),
+            mock.call('Disk-based SBD configured'),
+            mock.call()
+        ])
+
+    @mock.patch('builtins.print')
+    def test_print_sbd_type_diskless(self, mock_print):
+        self.sbd_instance_diskless.service_manager.service_is_active = mock.Mock(return_value=True)
+        self.sbd_instance_diskless._print_sbd_type()
+        mock_print.assert_has_calls([
+            mock.call('# Type of SBD:'),
+            mock.call('Diskless SBD configured'),
+            mock.call()
+        ])
+
+    @mock.patch('builtins.print')
+    def test_print_sbd_status(self, mock_print):
+        self.sbd_instance_diskbased.service_manager.service_is_active = mock.Mock(side_effect=[True, False])
+        self.sbd_instance_diskbased.service_manager.service_is_enabled = mock.Mock(side_effect=[True, False])
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error = mock.Mock(side_effect=["10min", "10sec"])
+        self.sbd_instance_diskbased._print_sbd_status()
+        mock_print.assert_has_calls([
+            mock.call('# Status of sbd.service:'),
+            mock.call('Node   |Active  |Enabled |Since'),
+            mock.call('node1  |YES     |YES     |active since: 10min'),
+            mock.call('node2  |NO      |NO      |disactive since: 10sec'),
+            mock.call()
+        ])
+
+    @mock.patch('builtins.print')
+    def test_print_watchdog_info_no_cluster_nodes(self, mock_print):
+        data_node1 = """Discovered 1 watchdog devices:
+
+        [1] /dev/watchdog0
+        Identity: iTCO_wdt
+        Driver: iTCO_wdt
+        """
+        data_node2 = """Discovered 1 watchdog devices:
+
+        [1] /dev/watchdog0
+        Identity: iTCO_wdt
+        Driver: iTCO_wdt
+        """
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.side_effect = [data_node1, data_node2]
+        self.sbd_instance_diskbased._print_watchdog_info()
+        mock_print.assert_has_calls([
+            mock.call("# Watchdog info:"),
+            mock.call('Node   |Device  |Driver  |Kernel Timeout'),
+            mock.call('node1  |N/A     |N/A     |N/A'),
+            mock.call('node2  |N/A     |N/A     |N/A'),
+            mock.call()
+        ])
+
+    @mock.patch('builtins.print')
+    def test_print_watchdog_info(self, mock_print):
+        data_node1 = """Discovered 1 watchdog devices:
+
+[1] /dev/watchdog0
+Identity: Busy: PID 3120 (sbd)
+Driver: iTCO_wdt
+        """
+        data_node2 = """Discovered 1 watchdog devices:
+
+[1] /dev/watchdog0
+Identity: Busy: PID 3120 (sbd)
+Driver: iTCO_wdt
+        """
+        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.side_effect = [data_node1, "10", data_node2, "10"]
+        self.sbd_instance_diskbased._print_watchdog_info()
+
+    def test_do_status(self):
+        self.sbd_instance_diskbased._print_sbd_type = mock.Mock()
+        self.sbd_instance_diskbased._print_sbd_status = mock.Mock()
+        self.sbd_instance_diskbased._print_watchdog_info = mock.Mock()
+        self.sbd_instance_diskbased._print_sbd_agent_status = mock.Mock()
+        self.sbd_instance_diskbased._print_sbd_cgroup_status = mock.Mock()
+        mock_context = mock.Mock()
+        self.sbd_instance_diskbased.do_status(mock_context)

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -934,7 +934,7 @@ def test_has_disk_mounted(mock_run):
     mock_run.assert_called_once_with("mount")
 
 
-@mock.patch('crmsh.sbd.SBDManager.is_using_diskless_sbd')
+@mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
 @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
 def test_has_stonith_running(mock_run, mock_diskless):
     mock_run.return_value = """
@@ -1348,3 +1348,9 @@ def test_check_user_access_cluster(mock_user, mock_in, mock_sudo, mock_error):
     with pytest.raises(utils.TerminateSubCommand) as err:
         utils.check_user_access('cluster')
     mock_error.assert_called_once_with('Operation is denied. The current user lacks the necessary privilege.')
+
+
+def test_is_subdict():
+    d1 = {"a": 1, "b": 2}
+    d2 = {"a": 1}
+    assert utils.is_subdict(d2, d1) is True


### PR DESCRIPTION
## Motivation
The main configurations for sbd use cases are scattered among sysconfig,
on-disk meta data, CIB, and even could be related to other OS components
eg. coredump, SCSI, multipath. 

It's desirable to reduce the management complexity among them and to
streamline the workflow for the main use case scenarios. 

## Changed include
#### Disk-based SBD scenarios

1. Show usage when syntax error
2. Completion
3. Display SBD related configuration (UC4 in PED-8256)
4. Change the on-disk meta data of the existing sbd disks (UC2.1 in PED-8256)
5. Add a sbd disk with the existing sbd configuration (UC2.2 in PED-8256)
6. Remove a sbd disk (UC2.3 in PED-8256)
7. Remove sbd from cluster
8. Replace the storage for a sbd disk (UC2.4 in PED-8256)]
9. display status (focusing on the runtime information only) (UC5 in PED-8256)

#### Disk-less SBD scenarios

1. Show usage when syntax error (diskless)
2. completion (diskless)
3. Display SBD related configuration (UC4 in PED-8256, diskless)
4. Manipulate the basic diskless sbd configuration (UC3.1 in PED-8256)