### PR TITLE
Add an option 'add_advised_op_values' to disable adding advised op values

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -854,7 +854,7 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    default_op_values = False
+    advised_op_values = False
     default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
@@ -864,12 +864,12 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
-            default_op_values = False
+            advised_op_values = False
             default_promotable_meta = False
         else:
-            default_op_values = True
+            advised_op_values = True
             default_promotable_meta = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, add_default_op_values=default_op_values)
+        node = parse.parse(cli, comments=comments, ignore_empty=False, add_advised_op_values=advised_op_values)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -867,7 +867,7 @@ def parse_cli_to_xml(cli, oldnode=None):
             advised_op_values = False
             default_promotable_meta = False
         else:
-            advised_op_values = True
+            advised_op_values = config.core.add_advised_op_values
             default_promotable_meta = True
         node = parse.parse(cli, comments=comments, ignore_empty=False, add_advised_op_values=advised_op_values)
     if node is False:

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -256,6 +256,7 @@ DEFAULTS = {
         'ignore_missing_metadata': opt_boolean('no'),
         'report_tool_options': opt_string(''),
         'lock_timeout': opt_string('120'),
+        'add_advised_op_values': opt_boolean('yes'),
         'OCF_1_1_SUPPORT': opt_boolean('yes'),
         'obscure_pattern': opt_string('passw*')
     },

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,13 +170,13 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, add_default_op_values):
+    def do_parse(self, cmd, ignore_empty, add_advised_op_values):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
         self.ignore_empty = ignore_empty
-        self.add_default_op_values = add_default_op_values
+        self.add_advised_op_values = add_advised_op_values
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -661,7 +661,7 @@ class BaseParser(object):
         """
         Add default operation actions advised values
         """
-        if not self.add_default_op_values or out.tag != "primitive":
+        if not self.add_advised_op_values or out.tag != "primitive":
             return
         ra_inst = ra.RAInfo(out.get('class'), out.get('type'), out.get('provider'))
         ra_actions_dict = ra_inst.actions()
@@ -753,7 +753,7 @@ class BaseParser(object):
                     inst_attrs = xmlutil.child(container_node, name)
                     # set meaningful id for port-mapping and storage-mapping
                     # when the bundle is newly created
-                    if self.add_default_op_values:
+                    if self.add_advised_op_values:
                         id_str = f"{bundle_id}_{name.replace('-', '_')}_{index}"
                         inst_attrs.set('id', id_str)
                     child_flag = True
@@ -1794,7 +1794,7 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None, ignore_empty=True, add_default_op_values=False):
+def parse(s, comments=None, ignore_empty=True, add_advised_op_values=False):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1840,7 +1840,7 @@ def parse(s, comments=None, ignore_empty=True, add_default_op_values=False):
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, add_default_op_values)
+        ret = parser.do_parse(s, ignore_empty, add_advised_op_values)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -20,6 +20,7 @@
 ; ignore_missing_metadata = no
 ; report_tool_options =
 ; lock_timeout = 120
+; add_advised_op_values = yes
 
 ; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.
 ; OCF_1_1_SUPPORT = yes


### PR DESCRIPTION
This PR is for issue #1442 

The default value for `add_advised_op_values` is 'yes'.
When set to 'no', the advised operation values will not be added automatically if the user has not specified them