### PR TITLE
Revert "Dev: ui_configure: Deprecate configure erase sub-command" (bsc#1228713)

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -885,9 +885,6 @@ class CibConfig(command.UI):
     @command.completers(compl.choice(['nodes']))
     def do_erase(self, context, nodes=None):
         "usage: erase [nodes]"
-        if not options.regression_tests:
-            logger.warning("`crm configure erase` is deprecated. The replacement could be `crm cluster remove [node]`")
-            return True
         cib_factory.ensure_cib_updated()
         if nodes is None:
             return cib_factory.erase()

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2875,12 +2875,6 @@ renamed. Please use the `rename` command instead.
 [[cmdhelp_configure_erase,erase the CIB]]
 ==== `erase`
 
-.Deprecation note
-****************************
-`crm configure erase` is deprecated.
-The replacement could be `crm cluster remove [node]`
-****************************
-
 The `erase` clears all configuration. Apart from nodes. To remove
 nodes, you have to specify an additional keyword `nodes`.
 


### PR DESCRIPTION
Revert #1107, since `configure erase` is still used by the user, it shouldn't be deprecated