### PR TITLE
[crmsh-4.6] Fix: Don't add time units to values for existing CIB (bsc#1228817)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -855,7 +855,8 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    advised_op_values = False
+    # Flag to auto add adviced operation values and time units
+    auto_add = False
     default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
@@ -865,12 +866,12 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
-            advised_op_values = False
+            auto_add = False
             default_promotable_meta = False
         else:
-            advised_op_values = config.core.add_advised_op_values
+            auto_add = config.core.add_advised_op_values
             default_promotable_meta = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, add_advised_op_values=advised_op_values)
+        node = parse.parse(cli, comments=comments, ignore_empty=False, auto_add=auto_add)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,13 +170,13 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, add_advised_op_values):
+    def do_parse(self, cmd, ignore_empty, auto_add):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
         self.ignore_empty = ignore_empty
-        self.add_advised_op_values = add_advised_op_values
+        self.auto_add = auto_add
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -661,7 +661,7 @@ class BaseParser(object):
         """
         Add default operation actions advised values
         """
-        if not self.add_advised_op_values or out.tag != "primitive":
+        if not self.auto_add or out.tag != "primitive":
             return
         ra_inst = ra.RAInfo(out.get('class'), out.get('type'), out.get('provider'))
         ra_actions_dict = ra_inst.actions()
@@ -753,7 +753,7 @@ class BaseParser(object):
                     inst_attrs = xmlutil.child(container_node, name)
                     # set meaningful id for port-mapping and storage-mapping
                     # when the bundle is newly created
-                    if self.add_advised_op_values:
+                    if self.auto_add:
                         id_str = f"{bundle_id}_{name.replace('-', '_')}_{index}"
                         inst_attrs.set('id', id_str)
                     child_flag = True
@@ -794,7 +794,7 @@ class BaseParser(object):
                 if inst_attrs is not None:
                     self.err(f"Attribute order error: {name} must appear before any instance attribute")
                 value = nvp.get('value')
-                if name in ('interval', 'timeout'):
+                if name in ('interval', 'timeout') and self.auto_add:
                     value = add_time_unit_if_needed(value)
                 node.set(name, value)
             else:
@@ -1795,7 +1795,7 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None, ignore_empty=True, add_advised_op_values=False):
+def parse(s, comments=None, ignore_empty=True, auto_add=False):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1841,7 +1841,7 @@ def parse(s, comments=None, ignore_empty=True, add_advised_op_values=False):
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, add_advised_op_values)
+        ret = parser.do_parse(s, ignore_empty, auto_add)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/test/features/resource_set.feature
+++ b/test/features/resource_set.feature
@@ -177,3 +177,11 @@ Feature: Use "crm configure set" to update attributes and operations
     When    Run "crm configure rsc_template dummy_template ocf:pacemaker:Dummy op monitor interval=12s" on "hanode1"
     And     Try "crm configure primitive d8 @dummy_template params passwd=123" on "hanode1"
     Then    Expected "got no meta-data, does this RA exist" not in stderr
+
+  @clean
+  Scenario: Don't add time units to values for existing CIB (bsc#1228817)
+    When    Run "crm configure show xml d > /tmp/d.xml" on "hanode1"
+    And     Run "sed -i '/<op name="monitor"/s/timeout="20s"/timeout="20"/' /tmp/d.xml" on "hanode1"
+    And     Run "crm configure load xml update /tmp/d.xml" on "hanode1"
+    And     Try "crm configure show|grep -E "^xml <primitive""
+    Then    Expected return code is "1"


### PR DESCRIPTION
## Problem
Commit 7b2cfb23 automatically appends 's' as the default time unit for timeout and interval. This causes inconsistency in the existing CIB.

## How to reproduce
1. Run `crm configure primitive vip IPaddr2 params ip=10.10.10.123 op monitor interval=10`
2. Run `crm configure show vip`, we can see `interval=10s`
    ```
    primitive vip IPaddr2 \
        params ip=10.10.10.123 \
        op monitor interval=10s timeout=20s \
        op start timeout=20s interval=0s \
        op stop timeout=20s interval=0s
    ```
3. Run `crm configure edit xml vip`, change `interval=10s` as `interval=10`, then run `crm configure show vip`
    ```
    xml <primitive id="vip" class="ocf" provider="heartbeat" type="IPaddr2"> \
        <instance_attributes id="vip-instance_attributes"> \
          <nvpair name="ip" value="10.10.10.123" id="vip-instance_attributes-ip"/> \
        </instance_attributes> \
        <operations> \
          <op name="monitor" interval="10" timeout="20s" id="vip-monitor-10s"/> \
          <op name="start" timeout="20s" interval="0s" id="vip-start-0s"/> \
          <op name="stop" timeout="20s" interval="0s" id="vip-stop-0s"/> \
        </operations> \
    </primitive>
    ````
    The above means for those old existing CIB which time value didn't have time unit, crmsh still tries to add the time unit on it, which causes CIB inconsistency
## Root cause
crmsh will compare parsed cib(auto add time unit 's') with original cib(without time unit 's'), if not equal, it will show the XML directly
## Fix
This commit renames the variable to reflect that it handles both adding advised operation values and time units, but only when the input is from a new(see above reproduce step 1) CLI command. Don't add time units to values for existing CIB.
```
# crm configure show vip
primitive vip IPaddr2 \
        params ip=10.10.10.123 \
        op monitor interval=10 timeout=20s \
        op start timeout=20s interval=0s \
        op stop timeout=20s interval=0s
```