### PR TITLE
[crmsh-4.6] Fix: bootstrap: ssh public key should be copied to qnetd node when ssh-agent feature is not enabled (bsc#1228950)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -885,14 +885,15 @@ def init_ssh_impl(local_user: str, ssh_public_keys: typing.List[ssh_key.Key], us
                 logger.info("Adding public keys to authorized_keys on %s@%s", user, node)
                 for key in ssh_public_keys:
                     authorized_key_manager.add(node, local_user, key)
-                if user != 'root' and 0 != shell.subprocess_run_without_input(
-                        node, user, 'sudo true',
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                ).returncode:
-                    raise ValueError(f'Failed to sudo on {user}@{node}')
         else:
             _init_ssh_on_remote_nodes(local_user, user_node_list)
+        for user, node in user_node_list:
+            if user != 'root' and 0 != shell.subprocess_run_without_input(
+                    node, user, 'sudo true',
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+            ).returncode:
+                raise ValueError(f'Failed to sudo on {user}@{node}')
         for user, node in user_node_list:
             user_by_host.add(user, node)
         user_by_host.add(local_user, utils.this_node())

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1727,6 +1727,13 @@ def join_ssh_impl(local_user, seed_host, seed_user, ssh_public_keys: typing.List
             raise ValueError(msg)
         # After this, login to remote_node is passwordless
         swap_public_ssh_key(seed_host, local_user, seed_user, local_user, seed_user, add=True)
+    ssh_shell = sh.SSHShell(local_shell, local_user)
+    if seed_user != 'root' and 0 != ssh_shell.subprocess_run_without_input(
+            seed_host, seed_user, 'sudo true',
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+    ).returncode:
+        raise ValueError(f'Failed to sudo on {seed_user}@{seed_host}')
 
     user_by_host = utils.HostUserConfig()
     user_by_host.clear()
@@ -1757,12 +1764,6 @@ def join_ssh_with_ssh_agent(
     if not shell.can_run_as(seed_host, seed_user):
         for key in ssh_public_keys:
             authorized_key_manager.add(seed_host, seed_user, key)
-    if seed_user != 'root' and 0 != shell.subprocess_run_without_input(
-            seed_host, seed_user, 'sudo true',
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-    ).returncode:
-        raise ValueError(f'Failed to sudo on {seed_user}@{seed_host}')
     for key in ssh_public_keys:
         authorized_key_manager.add(None, local_user, key)
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1625,19 +1625,21 @@ def _setup_passwordless_ssh_for_qnetd(cluster_node_list: typing.List[str]):
                 'root',
             )).add(qnetd_addr, qnetd_user, key)
     else:
-        if utils.check_ssh_passwd_need(local_user, qnetd_user, qnetd_addr):
-            if 0 != utils.ssh_copy_id_no_raise(local_user, qnetd_user, qnetd_addr):
-                msg = f"Failed to login to {qnetd_user}@{qnetd_addr}. Please check the credentials."
-                sudoer = userdir.get_sudoer()
-                if sudoer and qnetd_user != sudoer:
-                    args = ['sudo crm']
-                    args += [x for x in sys.argv[1:]]
-                    for i, arg in enumerate(args):
-                        if arg == '--qnetd-hostname' and i + 1 < len(args):
-                            if '@' not in args[i + 1]:
-                                args[i + 1] = f'{sudoer}@{qnetd_addr}'
-                                msg += '\nOr, run "{}".'.format(' '.join(args))
-                raise ValueError(msg)
+        if 0 != utils.ssh_copy_id_no_raise(
+                local_user, qnetd_user, qnetd_addr,
+                sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': ''}),
+        ):
+            msg = f"Failed to login to {qnetd_user}@{qnetd_addr}. Please check the credentials."
+            sudoer = userdir.get_sudoer()
+            if sudoer and qnetd_user != sudoer:
+                args = ['sudo crm']
+                args += [x for x in sys.argv[1:]]
+                for i, arg in enumerate(args):
+                    if arg == '--qnetd-hostname' and i + 1 < len(args):
+                        if '@' not in args[i + 1]:
+                            args[i + 1] = f'{sudoer}@{qnetd_addr}'
+                            msg += '\nOr, run "{}".'.format(' '.join(args))
+            raise ValueError(msg)
 
         cluster_shell = sh.cluster_shell()
         # Add other nodes' public keys to qnetd's authorized_keys
@@ -1711,9 +1713,9 @@ def join_ssh_impl(local_user, seed_host, seed_user, ssh_public_keys: typing.List
         local_shell = sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': os.environ.get('SSH_AUTH_SOCK')})
         join_ssh_with_ssh_agent(local_shell, local_user, seed_host, seed_user, ssh_public_keys)
     else:
-        local_shell = sh.LocalShell()
+        local_shell = sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': ''})
         configure_ssh_key(local_user)
-        if 0 != utils.ssh_copy_id_no_raise(local_user, seed_user, seed_host):
+        if 0 != utils.ssh_copy_id_no_raise(local_user, seed_user, seed_host, local_shell):
             msg = f"Failed to login to {seed_user}@{seed_host}. Please check the credentials."
             sudoer = userdir.get_sudoer()
             if sudoer and seed_user != sudoer:
@@ -2913,7 +2915,10 @@ def bootstrap_join_geo(context):
             join_ssh_with_ssh_agent(local_shell, local_user, node, remote_user, keys)
         else:
             configure_ssh_key(local_user)
-            if 0 != utils.ssh_copy_id_no_raise(local_user, remote_user, node):
+            if 0 != utils.ssh_copy_id_no_raise(
+                    local_user, remote_user, node,
+                    sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': ''}),
+            ):
                 raise ValueError(f"Failed to login to {remote_user}@{node}. Please check the credentials.")
             swap_public_ssh_key(node, local_user, remote_user, local_user, remote_user, add=True)
         user_by_host = utils.HostUserConfig()
@@ -2949,7 +2954,10 @@ def bootstrap_arbitrator(context):
             join_ssh_with_ssh_agent(local_shell, local_user, node, remote_user, keys)
         else:
             configure_ssh_key(local_user)
-            if 0 != utils.ssh_copy_id_no_raise(local_user, remote_user, node):
+            if 0 != utils.ssh_copy_id_no_raise(
+                    local_user, remote_user, node,
+                    sh.LocalShell(additional_environ={'SSH_AUTH_SOCK': ''}),
+            ):
                 raise ValueError(f"Failed to login to {remote_user}@{node}. Please check the credentials.")
             swap_public_ssh_key(node, local_user, remote_user, local_user, remote_user, add=True)
         user_by_host.add(local_user, utils.this_node())

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -126,11 +126,13 @@ def user_pair_for_ssh(host):
         raise ValueError('Can not create ssh session from {} to {}.'.format(this_node(), host))
 
 
-def ssh_copy_id_no_raise(local_user, remote_user, remote_node):
-    if check_ssh_passwd_need(local_user, remote_user, remote_node):
+def ssh_copy_id_no_raise(local_user, remote_user, remote_node, shell: sh.LocalShell = None):
+    if shell is None:
+        shell = sh.LocalShell()
+    if check_ssh_passwd_need(local_user, remote_user, remote_node, shell):
         logger.info("Configuring SSH passwordless with {}@{}".format(remote_user, remote_node))
         cmd = "ssh-copy-id -i ~/.ssh/id_rsa.pub '{}@{}' &> /dev/null".format(remote_user, remote_node)
-        result = sh.LocalShell().su_subprocess_run(local_user, cmd, tty=True)
+        result = shell.su_subprocess_run(local_user, cmd, tty=True)
         return result.returncode
     else:
         return 0
@@ -2138,21 +2140,16 @@ def debug_timestamp():
     return datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')
 
 
-def check_ssh_passwd_need(local_user, remote_user, host):
+def check_ssh_passwd_need(local_user, remote_user, host, shell: sh.LocalShell = None):
     """
     Check whether access to host need password
     """
     ssh_options = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
-    ssh_cmd = "{} ssh {} -T -o Batchmode=yes {}@{} true".format(get_ssh_agent_str(), ssh_options, remote_user, host)
-    rc, _ = sh.LocalShell().get_rc_and_error(local_user, ssh_cmd)
+    ssh_cmd = "ssh {} -T -o Batchmode=yes {}@{} true".format(ssh_options, remote_user, host)
+    if shell is None:
+        shell = sh.LocalShell()
+    rc, _ = shell.get_rc_and_error(local_user, ssh_cmd)
     return rc != 0
-
-
-def get_ssh_agent_str():
-    ssh_agent_str = ""
-    if crmsh.user_of_host.instance().use_ssh_agent():
-        ssh_agent_str = f"SSH_AUTH_SOCK={os.environ.get('SSH_AUTH_SOCK')}"
-    return ssh_agent_str
 
 
 def check_port_open(ip, port):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -79,7 +79,7 @@ def test_check_ssh_passwd_need(mock_run):
     assert res is True
     mock_run.assert_called_once_with(
         "bob",
-        " ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes alice@node1 true",
+        "ssh -o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15 -T -o Batchmode=yes alice@node1 true",
     )
 
 


### PR DESCRIPTION
# Problems

When running `crm cluster init qdevice --qnetd-hostame <qnetd-node>` with an environ `SSH_AUTH_SOCK`, even if `--enable-ssh-agent` is not specified, crmsh will use that ssh-agent for `check_ssh_passwd_need`. If the ssh-agent provides a key enabling passwordless ssh authentication to the `<qnetd-node>`, the ssh public key of the `<init-node>` will not be added to the `authorized_keys` of `<qnetd-node>`.

This makes the ssh authentication between `<init-node>` and `<qnetd-node>` to depend on ssh-agent. It is unexpected and causes problems. For example, when a new node joins without ssh-agent, the new node needs the help of `<init-node>` to copy its ssh public key to `<qnetd-node>` (by running `crm cluster init qnetd-remote <new-node>` on `<init-node>`). This will fail as the `<init-node>` cannot get ssh access to `<qnetd-node>` without ssh-agent.

# Fixes

When ssh-agent support is not enabled, drop environ `SSH_AUTH_SOCK` before checking whether passwordless ssh is available.