### PR TITLE
[crmsh-4.6] Fix: hawk2 cannot call `crm script` as user hacluster (bsc#1228271)

### DIFF
--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -70,8 +70,8 @@ def primitives(args):
 
 
 nodes = call(xmlutil.listnodes)
-online_nodes = call(xmlutil.CrmMonXmlParser().get_node_list, "online")
-standby_nodes = call(xmlutil.CrmMonXmlParser().get_node_list, "standby")
+online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "online")
+standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "standby")
 
 shadows = call(xmlutil.listshadows)
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3021,9 +3021,7 @@ def check_user_access(level_name):
     Check current user's privilege and give hints to user
     """
     current_user = userdir.getuser()
-    if current_user == "root":
-        return
-    if level_name != "cluster" and in_haclient():
+    if current_user == "root" or in_haclient():
         return
 
     if not has_sudo_access():

--- a/test/features/user_access.feature
+++ b/test/features/user_access.feature
@@ -5,25 +5,12 @@ Feature: Functional test for user access
 
   Scenario: User in haclient group
     Given   Cluster service is "stopped" on "hanode1"
-    When    Run "useradd -m -s /bin/bash -N -g 90 xin1" on "hanode1"
+    When    Run "useradd -m -s /bin/bash -N -g haclient xin1" on "hanode1"
     When    Run "echo 'export PATH=$PATH:/usr/sbin/' >> ~xin1/.bashrc" on "hanode1"
-    When    Try "su - xin1 -c 'crm cluster init -y'"
-    Then    Except multiple lines
-      """
-      ERROR: Please run this command starting with "sudo".
-      Currently, this command needs to use sudo to escalate itself as root.
-      Please consider to add "xin1" as sudoer. For example:
-        sudo bash -c 'echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1'
-      """
     When    Run "echo "xin1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/xin1" on "hanode1"
-    When    Try "su - xin1 -c 'crm cluster init -y'"
-    Then    Except multiple lines
-      """
-      ERROR: Please run this command starting with "sudo"
-      """
     When    Run "su - xin1 -c 'sudo crm cluster init -y'" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-
+    And     Run "su - hacluster -c 'crm script run health'" OK on "hanode1"
     When    Run "su - xin1 -c 'crm node standby hanode1'" on "hanode1"
     Then    Node "hanode1" is standby
 


### PR DESCRIPTION
After the non-root feature is introduced, most of the subprocess calling rountines, including local ones and remote ones, try to switch to root before calling the specified command. This is good for command line usages. However, hawk2 also calls `crm script`, and as a webservice with less privileges, runs as user hacluster and should not escalate to root.

This pull request uses the interceptor interface provided by `prun` module to modify its behaviors. When `crm script` runs as hacluster, subprocesses will also be created as hacluster.

Also fixes a minor problem which stops script `hahealth` from parsing outputs correctly. The problem is caused by module `completers`, which try to call `crm_mon` before setting up the `PATH` environment variable.