### PR TITLE
[crmsh-4.6] Fix: completers: Enhance node completers with dynamic online and standby node lists

### DIFF
--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -61,6 +61,22 @@ def resources(args=None):
     return rsc_id_list
 
 
+def online_nodes(completed_args):
+    xml_parser = xmlutil.CrmMonXmlParser()
+    online_nodes = xml_parser.get_node_list("online")
+    if completed_args:
+        online_nodes = [node for node in online_nodes if node not in completed_args]
+    return online_nodes
+
+
+def standby_nodes(completed_args):
+    xml_parser = xmlutil.CrmMonXmlParser()
+    standby_nodes = xml_parser.get_node_list("standby")
+    if completed_args:
+        standby_nodes = [node for node in standby_nodes if node not in completed_args]
+    return standby_nodes
+
+
 def primitives(args):
     cib_el = xmlutil.resources_xml()
     if cib_el is None:
@@ -70,9 +86,6 @@ def primitives(args):
 
 
 nodes = call(xmlutil.listnodes)
-online_nodes = call(xmlutil.CrmMonXmlParser().get_node_list, "online")
-standby_nodes = call(xmlutil.CrmMonXmlParser().get_node_list, "standby")
-
 shadows = call(xmlutil.listshadows)
 
 status_option = """full bynode inactive ops timing failcounts

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -349,7 +349,7 @@ class NodeMgmt(command.UI):
         return True
 
     @command.wait
-    @command.completers(compl.online_nodes)
+    @command.completers_repeating(compl.online_nodes)
     def do_standby(self, context, *args):
         """
         usage: standby [<node>] [<lifetime>]
@@ -426,7 +426,7 @@ class NodeMgmt(command.UI):
             logger.info("standby node %s", node)
 
     @command.wait
-    @command.completers(compl.standby_nodes)
+    @command.completers_repeating(compl.standby_nodes)
     def do_online(self, context, *args):
         """
         usage: online [<node>]


### PR DESCRIPTION
- Introduced `online_nodes` and `standby_nodes` functions in `completers.py` to dynamically generate lists of online and standby nodes. These functions also filter out nodes already completed in the command line.
- Removed static `online_nodes` and `standby_nodes` assignments in `completers.py`, which might cause can't find path of `crm_mon` issue under hacluster user (#1525 ).