### PR TITLE
[crmsh-4.6] Fix: utils: group check failure when os.getgroups() returns empty (bsc#1229030)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -21,6 +21,7 @@ import ipaddress
 import argparse
 import random
 import string
+import pwd
 import grp
 import gzip
 import bz2
@@ -444,12 +445,10 @@ def chown(path, user, group):
     if isinstance(user, int):
         uid = user
     else:
-        import pwd
         uid = pwd.getpwnam(user).pw_uid
     if isinstance(group, int):
         gid = group
     else:
-        import grp
         gid = grp.getgrnam(group).gr_gid
     try:
         os.chown(path, uid, gid)
@@ -3013,7 +3012,7 @@ def in_haclient():
     """
     Check if current user is in haclient group
     """
-    return constants.HA_GROUP in [grp.getgrgid(g).gr_name for g in os.getgroups()]
+    return grp.getgrnam(constants.HA_GROUP).gr_gid in (os.getgroups() + [os.getegid()])
 
 
 def check_user_access(level_name):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1398,15 +1398,16 @@ def test_has_sudo_access(mock_run):
     mock_run.assert_called_once_with("sudo -S -k -n id -u")
 
 
-@mock.patch('grp.getgrgid')
+@mock.patch('grp.getgrnam')
+@mock.patch('os.getegid')
 @mock.patch('os.getgroups')
-def test_in_haclient(mock_group, mock_getgrgid):
-    mock_group.return_value = [90, 100]
-    mock_getgrgid_inst1 = mock.Mock(gr_name=constants.HA_GROUP)
-    mock_getgrgid_inst2 = mock.Mock(gr_name="other")
-    mock_getgrgid.side_effect = [mock_getgrgid_inst1, mock_getgrgid_inst2]
+def test_in_haclient(mock_getgroups, mock_getegid, mock_getgrnam):
+    mock_getgroups.return_value = [90]
+    mock_getegid.return_value = 90
+    mock_getgrnam_inst = mock.Mock(gr_gid=90)
+    mock_getgrnam.return_value = mock_getgrnam_inst
     assert utils.in_haclient() is True
-    mock_group.assert_called_once_with()
+    mock_getgrnam.assert_called_once_with(constants.HA_GROUP)
 
 
 @mock.patch('crmsh.utils.in_haclient')


### PR DESCRIPTION
port from #1513 