### PR TITLE
[crmsh-4.6] Fix: Add a new option 'has_fa_advised_op' (bsc#1228858)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -857,6 +857,8 @@ def parse_cli_to_xml(cli, oldnode=None):
     node = None
     # Flag to auto add adviced operation values and time units
     auto_add = False
+    # Flag to auto add adviced operation values for fence agents
+    fa_advised_op_values = False
     default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
@@ -867,11 +869,18 @@ def parse_cli_to_xml(cli, oldnode=None):
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
             auto_add = False
+            fa_advised_op_values = False
             default_promotable_meta = False
         else:
             auto_add = config.core.add_advised_op_values
+            fa_advised_op_values = config.core.fa_advised_op_values
             default_promotable_meta = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, auto_add=auto_add)
+        node = parse.parse(
+                cli,
+                comments=comments,
+                ignore_empty=False,
+                auto_add=auto_add,
+                fa_advised_op_values=fa_advised_op_values)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -856,9 +856,9 @@ def parse_cli_to_xml(cli, oldnode=None):
     """
     node = None
     # Flag to auto add advised operation values for resource agents
-    ra_advised_op_values = False
+    has_ra_advised_op = False
     # Flag to auto add adviced operation values for fence agents
-    fa_advised_op_values = False
+    has_fa_advised_op = False
     # Flag to auto add time units for operations
     auto_add_time_units = False
     default_promotable_meta = False
@@ -870,21 +870,21 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
-            ra_advised_op_values = False
-            fa_advised_op_values = False
+            has_ra_advised_op = False
+            has_fa_advised_op = False
             auto_add_time_units = False
             default_promotable_meta = False
         else:
-            ra_advised_op_values = config.core.ra_advised_op_values
-            fa_advised_op_values = config.core.fa_advised_op_values
+            has_ra_advised_op = config.core.has_ra_advised_op
+            has_fa_advised_op = config.core.has_fa_advised_op
             auto_add_time_units = True
             default_promotable_meta = True
         node = parse.parse(
                 cli,
                 comments=comments,
                 ignore_empty=False,
-                ra_advised_op_values=ra_advised_op_values,
-                fa_advised_op_values=fa_advised_op_values,
+                has_ra_advised_op=has_ra_advised_op,
+                has_fa_advised_op=has_fa_advised_op,
                 auto_add_time_units=auto_add_time_units)
     if node is False:
         return None, None, None

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -855,8 +855,8 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    # Flag to auto add adviced operation values and time units
-    auto_add = False
+    # Flag to auto add advised operation values for resource agents
+    ra_advised_op_values = False
     # Flag to auto add adviced operation values for fence agents
     fa_advised_op_values = False
     # Flag to auto add time units for operations
@@ -870,12 +870,12 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
-            auto_add = False
+            ra_advised_op_values = False
             fa_advised_op_values = False
             auto_add_time_units = False
             default_promotable_meta = False
         else:
-            auto_add = config.core.add_advised_op_values
+            ra_advised_op_values = config.core.ra_advised_op_values
             fa_advised_op_values = config.core.fa_advised_op_values
             auto_add_time_units = True
             default_promotable_meta = True
@@ -883,7 +883,7 @@ def parse_cli_to_xml(cli, oldnode=None):
                 cli,
                 comments=comments,
                 ignore_empty=False,
-                auto_add=auto_add,
+                ra_advised_op_values=ra_advised_op_values,
                 fa_advised_op_values=fa_advised_op_values,
                 auto_add_time_units=auto_add_time_units)
     if node is False:

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -859,6 +859,8 @@ def parse_cli_to_xml(cli, oldnode=None):
     auto_add = False
     # Flag to auto add adviced operation values for fence agents
     fa_advised_op_values = False
+    # Flag to auto add time units for operations
+    auto_add_time_units = False
     default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
@@ -870,17 +872,20 @@ def parse_cli_to_xml(cli, oldnode=None):
         if len(cli) >= 3 and cli[0] == "primitive" and cli[2].startswith("@"):
             auto_add = False
             fa_advised_op_values = False
+            auto_add_time_units = False
             default_promotable_meta = False
         else:
             auto_add = config.core.add_advised_op_values
             fa_advised_op_values = config.core.fa_advised_op_values
+            auto_add_time_units = True
             default_promotable_meta = True
         node = parse.parse(
                 cli,
                 comments=comments,
                 ignore_empty=False,
                 auto_add=auto_add,
-                fa_advised_op_values=fa_advised_op_values)
+                fa_advised_op_values=fa_advised_op_values,
+                auto_add_time_units=auto_add_time_units)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -257,7 +257,7 @@ DEFAULTS = {
         'lock_timeout': opt_string('120'),
         'no_ssh': opt_boolean('no'),
         'OCF_1_1_SUPPORT': opt_boolean('no'),
-        'add_advised_op_values': opt_boolean('yes'),
+        'ra_advised_op_values': opt_boolean('yes'),
         'fa_advised_op_values': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -257,8 +257,8 @@ DEFAULTS = {
         'lock_timeout': opt_string('120'),
         'no_ssh': opt_boolean('no'),
         'OCF_1_1_SUPPORT': opt_boolean('no'),
-        'ra_advised_op_values': opt_boolean('yes'),
-        'fa_advised_op_values': opt_boolean('no'),
+        'has_ra_advised_op': opt_boolean('yes'),
+        'has_fa_advised_op': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },
     'path': {

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -258,6 +258,7 @@ DEFAULTS = {
         'no_ssh': opt_boolean('no'),
         'OCF_1_1_SUPPORT': opt_boolean('no'),
         'add_advised_op_values': opt_boolean('yes'),
+        'fa_advised_op_values': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },
     'path': {

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,7 +170,7 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, auto_add, fa_advised_op_values):
+    def do_parse(self, cmd, ignore_empty, auto_add, fa_advised_op_values, auto_add_time_unit):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
@@ -178,6 +178,7 @@ class BaseParser(object):
         self.ignore_empty = ignore_empty
         self.auto_add = auto_add
         self.fa_advised_op_values = fa_advised_op_values
+        self.auto_add_time_unit = auto_add_time_unit
         out = self.parse(cmd)
         if self.has_tokens():
             self.err("Unknown arguments: " + ' '.join(self._cmd[self._currtok:]))
@@ -798,7 +799,7 @@ class BaseParser(object):
                 if inst_attrs is not None:
                     self.err(f"Attribute order error: {name} must appear before any instance attribute")
                 value = nvp.get('value')
-                if name in ('interval', 'timeout') and self.auto_add:
+                if name in ('interval', 'timeout') and self.auto_add_time_unit:
                     value = add_time_unit_if_needed(value)
                 node.set(name, value)
             else:
@@ -1799,7 +1800,12 @@ class ResourceSet(object):
         return ret
 
 
-def parse(s, comments=None, ignore_empty=True, auto_add=False, fa_advised_op_values=False):
+def parse(s,
+        comments=None,
+        ignore_empty=True,
+        auto_add=False,
+        fa_advised_op_values=False,
+        auto_add_time_units=False):
     '''
     Input: a list of tokens (or a CLI format string).
     Return: a cibobject
@@ -1845,7 +1851,7 @@ def parse(s, comments=None, ignore_empty=True, auto_add=False, fa_advised_op_val
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, auto_add, fa_advised_op_values)
+        ret = parser.do_parse(s, ignore_empty, auto_add, fa_advised_op_values, auto_add_time_units)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -170,13 +170,13 @@ class BaseParser(object):
         self.begin(cmd, min_args=min_args)
         return self.match_dispatch(errmsg="Unknown command")
 
-    def do_parse(self, cmd, ignore_empty, auto_add, fa_advised_op_values, auto_add_time_unit):
+    def do_parse(self, cmd, ignore_empty, ra_advised_op_values, fa_advised_op_values, auto_add_time_unit):
         """
         Called by CliParser. Calls parse()
         Parsers should pass their return value through this method.
         """
         self.ignore_empty = ignore_empty
-        self.auto_add = auto_add
+        self.ra_advised_op_values = ra_advised_op_values
         self.fa_advised_op_values = fa_advised_op_values
         self.auto_add_time_unit = auto_add_time_unit
         out = self.parse(cmd)
@@ -663,7 +663,7 @@ class BaseParser(object):
         """
         Add default operation actions advised values
         """
-        if not self.auto_add or out.tag != "primitive":
+        if not self.ra_advised_op_values or out.tag != "primitive":
             return
         ra_class = out.get('class')
         if ra_class == "stonith" and not self.fa_advised_op_values:
@@ -758,7 +758,7 @@ class BaseParser(object):
                     inst_attrs = xmlutil.child(container_node, name)
                     # set meaningful id for port-mapping and storage-mapping
                     # when the bundle is newly created
-                    if self.auto_add:
+                    if self.ra_advised_op_values:
                         id_str = f"{bundle_id}_{name.replace('-', '_')}_{index}"
                         inst_attrs.set('id', id_str)
                     child_flag = True
@@ -1803,7 +1803,7 @@ class ResourceSet(object):
 def parse(s,
         comments=None,
         ignore_empty=True,
-        auto_add=False,
+        ra_advised_op_values=False,
         fa_advised_op_values=False,
         auto_add_time_units=False):
     '''
@@ -1851,7 +1851,7 @@ def parse(s,
         return False
 
     try:
-        ret = parser.do_parse(s, ignore_empty, auto_add, fa_advised_op_values, auto_add_time_units)
+        ret = parser.do_parse(s, ignore_empty, ra_advised_op_values, fa_advised_op_values, auto_add_time_units)
         if ret is not None and len(comments) > 0:
             if ret.tag in constants.defaults_tags:
                 xmlutil.stuff_comments(ret[0], comments)

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -23,6 +23,9 @@
 ; add_advised_op_values = yes
 ; no_ssh = no
 
+; For fence agent, automatically add the advised values, default is no.
+; fa_advised_op_values = no
+
 ; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.
 ; OCF_1_1_SUPPORT = yes
 

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -20,8 +20,10 @@
 ; ignore_missing_metadata = no
 ; report_tool_options =
 ; lock_timeout = 120
-; add_advised_op_values = yes
 ; no_ssh = no
+
+; For resource agent, automatically add the advised values, default is yes.
+; ra_advised_op_values = yes
 
 ; For fence agent, automatically add the advised values, default is no.
 ; fa_advised_op_values = no

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -23,10 +23,10 @@
 ; no_ssh = no
 
 ; For resource agent, automatically add the advised values, default is yes.
-; ra_advised_op_values = yes
+; has_ra_advised_op = yes
 
 ; For fence agent, automatically add the advised values, default is no.
-; fa_advised_op_values = no
+; has_fa_advised_op = no
 
 ; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.
 ; OCF_1_1_SUPPORT = yes

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -424,6 +424,7 @@ adjust_test_case() {
 run_origin_regression_test() {
 	CONFIG_COROSYNC_FLAG=0
 	setup_cluster "hanode1"
+	docker_exec "hanode1" "echo -e '[core]\nfa_advised_op_values = yes' > /etc/crm/crm.conf"
 	docker_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
 	return $?
 }

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -424,7 +424,7 @@ adjust_test_case() {
 run_origin_regression_test() {
 	CONFIG_COROSYNC_FLAG=0
 	setup_cluster "hanode1"
-	docker_exec "hanode1" "echo -e '[core]\nfa_advised_op_values = yes' > /etc/crm/crm.conf"
+	docker_exec "hanode1" "echo -e '[core]\nhas_fa_advised_op = yes' > /etc/crm/crm.conf"
 	docker_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
 	return $?
 }


### PR DESCRIPTION
This option is used to automatically add the advised operation values
for fencing agents. Default value is 'no', which means doesn't add the
advised operation values for fencing agents.

Other changes:
- Dev: Add a new internal flag to control auto add time units on operation
- Dev: Rename the option 'add_advised_op_values' to 'has_ra_advised_op'