### PR TITLE
[crmsh-4.6] Fix: utils: Stop providing the detailed and precise sudoer rules to "hack" the privilege (bsc#1229093)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3024,18 +3024,7 @@ def check_user_access(level_name):
         return
 
     if not has_sudo_access():
-        if level_name == "cluster":
-            hints = f"""Please run this command starting with "sudo".
-Currently, this command needs to use sudo to escalate itself as root.
-Please consider to add "{current_user}" as sudoer. For example:
-  sudo bash -c 'echo "{current_user} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/{current_user}'"""
-        else:
-            hints = f"""This command needs higher privilege.
-Option 1) Please consider to add "{current_user}" as sudoer. For example:
-  sudo bash -c 'echo "{current_user} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/{current_user}'
-Option 2) Add "{current_user}" to the haclient group. For example:
-  sudo usermod -g haclient {current_user}"""
-        logger.error(hints)
+        logger.error("Operation is denied. The current user lacks the necessary privilege.")
     else:
         logger.error("Please run this command starting with \"sudo\"")
     raise TerminateSubCommand

--- a/test/features/user_access.feature
+++ b/test/features/user_access.feature
@@ -47,10 +47,7 @@ Feature: Functional test for user access
     Then    Except multiple lines
       """
       WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
-      ERROR: Please run this command starting with "sudo".
-      Currently, this command needs to use sudo to escalate itself as root.
-      Please consider to add "user1" as sudoer. For example:
-        sudo bash -c 'echo "user1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user1'
+      ERROR: Operation is denied. The current user lacks the necessary privilege.
       """
     When    Run "echo "user1 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user1" on "hanode1"
     When    Try "su - user1 -c 'crm cluster init -y'"
@@ -68,11 +65,7 @@ Feature: Functional test for user access
     Then    Except multiple lines
       """
       WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
-      ERROR: This command needs higher privilege.
-      Option 1) Please consider to add "user2" as sudoer. For example:
-        sudo bash -c 'echo "user2 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user2'
-      Option 2) Add "user2" to the haclient group. For example:
-        sudo usermod -g haclient user2
+      ERROR: Operation is denied. The current user lacks the necessary privilege.
       """
     When    Run "usermod -g haclient user2" on "hanode1"
     When    Run "su - user2 -c 'crm node standby hanode1'" on "hanode1"
@@ -84,11 +77,7 @@ Feature: Functional test for user access
     Then    Except multiple lines
       """
       WARNING: Failed to open log file: [Errno 13] Permission denied: '/var/log/crmsh/crmsh.log'
-      ERROR: This command needs higher privilege.
-      Option 1) Please consider to add "user3" as sudoer. For example:
-        sudo bash -c 'echo "user3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user3'
-      Option 2) Add "user3" to the haclient group. For example:
-        sudo usermod -g haclient user3
+      ERROR: Operation is denied. The current user lacks the necessary privilege.
       """
     When    Run "echo "user3 ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user3" on "hanode1"
     When    Try "su - user3 -c 'crm node online hanode1'"

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1451,7 +1451,7 @@ def test_check_user_access_acl(mock_user, mock_in, mock_sudo, mock_error):
     mock_sudo.return_value = False
     with pytest.raises(utils.TerminateSubCommand) as err:
         utils.check_user_access('ra')
-    mock_error.assert_called_once_with('This command needs higher privilege.\nOption 1) Please consider to add "user" as sudoer. For example:\n  sudo bash -c \'echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user\'\nOption 2) Add "user" to the haclient group. For example:\n  sudo usermod -g haclient user')
+    mock_error.assert_called_once_with('Operation is denied. The current user lacks the necessary privilege.')
 
 
 @mock.patch('logging.Logger.error')
@@ -1464,4 +1464,4 @@ def test_check_user_access_cluster(mock_user, mock_in, mock_sudo, mock_error):
     mock_sudo.return_value = False
     with pytest.raises(utils.TerminateSubCommand) as err:
         utils.check_user_access('cluster')
-    mock_error.assert_called_once_with('Please run this command starting with "sudo".\nCurrently, this command needs to use sudo to escalate itself as root.\nPlease consider to add "user" as sudoer. For example:\n  sudo bash -c \'echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user\'')
+    mock_error.assert_called_once_with('Operation is denied. The current user lacks the necessary privilege.')


### PR DESCRIPTION
backport from #1536 