### PR TITLE
Dev: utils: Load CIB_file env before some readonly commands

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -572,6 +572,7 @@ class CibConfig(command.UI):
     def do_show(self, context, *args):
         "usage: show [xml] [<id>...]"
         from .utils import obscure
+        utils.load_cib_file_env()
         osargs = [arg[8:] for arg in args if arg.startswith('obscure:')]
         if not osargs and config.core.obscure_pattern:
             # obscure_pattern could be
@@ -591,6 +592,7 @@ class CibConfig(command.UI):
     @command.completers_repeating(compl.call(ra.get_properties_list))
     def do_get_property(self, context, *args):
         "usage: get-property [-t|--true [<name>...]"
+        utils.load_cib_file_env()
         properties = [a for a in args if a not in ('-t', '--true')]
         truth = any(a for a in args if a in ('-t', '--true'))
 
@@ -749,6 +751,7 @@ class CibConfig(command.UI):
     @command.skill_level('administrator')
     def do_verify(self, context):
         "usage: verify"
+        utils.load_cib_file_env()
         cib_factory.ensure_cib_updated()
         set_obj_all = mkset_obj("xml")
         return self._verify(set_obj_all, set_obj_all)

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -317,6 +317,7 @@ class NodeMgmt(command.UI):
     @command.completers(compl.nodes)
     def do_show(self, context, node=None):
         'usage: show [<node>]'
+        utils.load_cib_file_env()
         cib = xmlutil.cibdump2elem()
         if cib is None:
             return False
@@ -615,6 +616,7 @@ class NodeMgmt(command.UI):
         server -- print server hostname / address for each node
         server <node> ... -- print server hostname / address for node
         """
+        utils.load_cib_file_env()
         cib = xmlutil.cibdump2elem()
         if cib is None:
             return False

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3171,4 +3171,15 @@ def ssh_command():
     if config.core.no_ssh:
         raise NoSSHError(constants.NO_SSH_ERROR_MSG)
     return "ssh"
+
+
+def load_cib_file_env():
+    if options.regression_tests or ServiceManager().service_is_active("pacemaker.service"):
+        return
+    cib_file = os.environ.setdefault('CIB_file', constants.CIB_RAW_FILE)
+    logger.warning("Cluster is not running, loading the CIB file from %s", cib_file)
+    if not os.path.exists(cib_file):
+        raise ValueError(f"Cannot find cib file: {cib_file}")
+
+
 # vim:ts=4:sw=4:et:

--- a/test/features/configure_bugs.feature
+++ b/test/features/configure_bugs.feature
@@ -5,6 +5,22 @@ Feature: Functional test for configure sub level
   Need nodes: hanode1 hanode2
 
   @clean
+  Scenario: Load CIB_file env before read-only commands
+    Given   Cluster service is "stopped" on "hanode1"
+    # Should put this scenario at the beginning of the test suite
+    And     File "/var/lib/pacemaker/cib/cib.xml" not exist on "hanode1"
+    When    Try "crm configure show" on "hanode1"
+    Then    Except "Cannot find cib file: /var/lib/pacemaker/cib/cib.xml" in stderr
+    And     Expected return code is "1"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster stop" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode1"
+    When    Try "crm configure show" on "hanode1"
+    Then    Except "Cluster is not running, loading the CIB file from /var/lib/pacemaker/cib/cib.xml" in stderr
+    And     Expected return code is "0"
+
+  @clean
   Scenario: Replace sensitive data by default(bsc#1163581)
     Given   Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -500,6 +500,13 @@ def step_impl(context, path, node):
     assert rc == 0
 
 
+@given('File "{path}" not exist on "{node}"')
+def step_impl(context, path, node):
+    cmd = '[ ! -f {} ]'.format(path)
+    rc, _, stderr = behave_agent.call(node, 1122, cmd, user='root')
+    assert rc == 0
+
+
 @then('File "{path}" not exist on "{node}"')
 def step_impl(context, path, node):
     cmd = '[ ! -f {} ]'.format(path)


### PR DESCRIPTION
When cluster is not running, load CIB_file environment variable before some readonly commands to avoid the error message. (issue #1499 )

Current affected commands:
- crm configure show
- crm configure get_property
- crm configure verify
- crm node show
- crm node server