### PR TITLE
Dev: utils: Catch PermissionError when reading files

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3102,6 +3102,9 @@ def read_from_file(infile: str) -> str:
     try:
         with _open(infile, 'rt', encoding='utf-8', errors='replace') as f:
             data = f.read()
+    except PermissionError as err:
+        logger.warning("When reading file \"%s\": %s", infile, str(err))
+        return ""
     except Exception as err:
         logger.error("When reading file \"%s\": %s", infile, str(err))
         return ""


### PR DESCRIPTION
Log a warning message instead of an error during the crm report process under hacluster, as logging an error may be considered too severe