### PR TITLE
Fix: command: `do_help` does not work as a 3rd level subcommand

### DIFF
--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -382,11 +382,9 @@ Examples:
     @completer(_help_completer)
     def do_help(self, context, *args):
         """usage: help topic|level|command"""
-        if context.level_name() == 'root':
-            levels = args
-        else:
-            levels = [context.level_name()]
-            levels.extend(args)
+        levels = [ui.name for ui in context.stack]
+        levels = levels[1:]     # drop the 1st element "root"
+        levels.extend(args)
         h = help_module.help_contextual(levels)
         h.paginate()
         context.command_name = ""

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -36,6 +36,8 @@ Feature: crmsh bootstrap process - options
     Then    Expected "-x option or SKIP_CSYNC2_SYNC can't be used with any stage" in stderr
     When    Try "crm cluster init sbd -N hanode1 -N hanode2 -y" on "hanode1"
     Then    Expected "Can't use -N/--nodes option and stage(sbd) together" in stderr
+    When    Try "crm corosync link help add" on "hanode1"
+    Then    Expected return code is "0"
 
   @clean
   Scenario: Stage validation


### PR DESCRIPTION
should pass the name of all ancestor levels to `help_contextual`.