### PR TITLE
Dev: behave: update test container to latest tumbleweed and use knet-1.29

### DIFF
--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -9,7 +9,7 @@ on:
   - workflow_call
 
 env:
-  DOCKER_SCRIPT: ./test/run-functional-tests
+  DOCKER_SCRIPT: sudo ./test/run-functional-tests
   GET_INDEX_OF: ./test/run-functional-tests _get_index_of
 
 jobs:
@@ -60,8 +60,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for crm_report bugs
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF crm_report_bugs`
         $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -9,7 +9,7 @@ on:
   - workflow_call
 
 env:
-  DOCKER_SCRIPT: sudo ./test/run-functional-tests
+  CONTAINER_SCRIPT: sudo ./test/run-functional-tests
   GET_INDEX_OF: ./test/run-functional-tests _get_index_of
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
     - name: functional test for crm_report bugs
       run:  |
         index=`$GET_INDEX_OF crm_report_bugs`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -74,10 +74,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for crm_report normal
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF crm_report_normal`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -90,10 +88,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap bugs
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -106,10 +102,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap bugs, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_bugs`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -122,10 +116,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap common
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -138,10 +130,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap common, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_init_join_remove`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -154,10 +144,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap options
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -170,10 +158,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for crm corosync subcommand
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF corosync_ui`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -186,10 +172,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for bootstrap options, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF bootstrap_options`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -202,10 +186,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice setup and remove
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -218,10 +200,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice setup and remove, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_setup_remove`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -234,10 +214,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice options
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_options`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -250,10 +228,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice validate
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -266,10 +242,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice validate, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_validate`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -282,10 +256,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for qdevice user case
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF qdevice_usercase`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -298,10 +270,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for resource failcount
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_failcount`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -314,10 +284,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for resource set
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
-        $DOCKER_SCRIPT $index
+        $CONTAINER_SCRIPT $index
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -330,10 +298,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for resource set, under non root user
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF resource_set`
-        $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -346,10 +312,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for configure sublevel bugs
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF configure_bugs`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -362,10 +326,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for constraints bugs
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF constraints_bugs`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -378,10 +340,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for geo cluster
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF geo_setup`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -394,10 +354,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for healthcheck
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
         index=`$GET_INDEX_OF healthcheck`
-        $DOCKER_SCRIPT $index && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT $index -u
+        $CONTAINER_SCRIPT $index && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT $index -u
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -410,9 +368,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for cluster api
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        $DOCKER_SCRIPT `$GET_INDEX_OF cluster_api`
+        $CONTAINER_SCRIPT `$GET_INDEX_OF cluster_api`
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -425,9 +381,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for user access
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        $DOCKER_SCRIPT `$GET_INDEX_OF user_access`
+        $CONTAINER_SCRIPT `$GET_INDEX_OF user_access`
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -440,9 +394,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for ssh agent
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        $DOCKER_SCRIPT `$GET_INDEX_OF ssh_agent` && $DOCKER_SCRIPT -d && $DOCKER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
+        $CONTAINER_SCRIPT `$GET_INDEX_OF ssh_agent` && $CONTAINER_SCRIPT -d && $CONTAINER_SCRIPT -u `$GET_INDEX_OF ssh_agent`
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -455,9 +407,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: functional test for blocking ssh
       run:  |
-        echo '{ "exec-opts": ["native.cgroupdriver=systemd"] }' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        $DOCKER_SCRIPT `$GET_INDEX_OF cluster_blocking_ssh`
+        $CONTAINER_SCRIPT `$GET_INDEX_OF cluster_blocking_ssh`
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -470,4 +420,4 @@ jobs:
     - uses: actions/checkout@v4
     - name: original regression test
       run:  |
-        $DOCKER_SCRIPT `$GET_INDEX_OF "regression test"`
+        $CONTAINER_SCRIPT `$GET_INDEX_OF "regression test"`

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -81,7 +81,7 @@ Feature: Regression test for bootstrap bugs
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     When    Run "crm corosync get nodelist.node.ring0_addr" on "hanode1"
-    Then    Expected "@hanode2.ip.0" in stdout
+    Then    Expected "@hanode2.ip.1" in stdout
     #And     Service "hawk.service" is "started" on "hanode2"
     When    Run "crm cluster remove hanode2 -y" on "hanode1"
     Then    Online nodes are "hanode1"
@@ -89,7 +89,7 @@ Feature: Regression test for bootstrap bugs
     # verify bsc#1175708
     #And     Service "hawk.service" is "stopped" on "hanode2"
     When    Run "crm corosync get nodelist.node.ring0_addr" on "hanode1"
-    Then    Expected "@hanode2.ip.0" not in stdout
+    Then    Expected "@hanode2.ip.1" not in stdout
 
   @clean
   Scenario: Multi nodes join in parallel(bsc#1175976)

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -83,11 +83,11 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Using multiple network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
-    And     IP "@hanode1.ip.default" is belong to "eth0"
+    And     IP "@hanode1.ip.0" is belong to "eth0"
     And     IP "@hanode1.ip.0" is belong to "eth1"
     When    Run "crm cluster init -i eth0 -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip.default" is used by corosync on "hanode1"
+    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
     And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
     And     Show corosync ring status
 
@@ -97,11 +97,11 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -i eth0 -i @hanode1.ip.0 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip.default" is used by corosync on "hanode1"
+    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
     And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
     When    Run "crm cluster join -c hanode1 -i eth0 -i @hanode2.ip.0 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
-    And     IP "@hanode2.ip.default" is used by corosync on "hanode2"
+    And     IP "@hanode2.ip.0" is used by corosync on "hanode2"
     And     IP "@hanode2.ip.0" is used by corosync on "hanode2"
 
     When    Try "crm cluster join cluster -c hanode1 -y" on "hanode2"
@@ -147,10 +147,10 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -I -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip6.default" is used by corosync on "hanode1"
+    And     IP "@hanode1.ip6.0" is used by corosync on "hanode1"
     When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
-    And     IP "@hanode2.ip6.default" is used by corosync on "hanode2"
+    And     IP "@hanode2.ip6.0" is used by corosync on "hanode2"
 
   @clean
   Scenario: Init cluster with -N option (bsc#1175863)

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -64,10 +64,10 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Bind specific network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
-    And     IP "@hanode1.ip.0" is belong to "eth1"
+    And     IP "@hanode1.ip.1" is belong to "eth1"
     When    Run "crm cluster init -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
-    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
+    And     IP "@hanode1.ip.1" is used by corosync on "hanode1"
     And     Show corosync ring status
  
   @clean
@@ -84,25 +84,25 @@ Feature: crmsh bootstrap process - options
   Scenario: Using multiple network interface using "-i" option
     Given   Cluster service is "stopped" on "hanode1"
     And     IP "@hanode1.ip.0" is belong to "eth0"
-    And     IP "@hanode1.ip.0" is belong to "eth1"
+    And     IP "@hanode1.ip.1" is belong to "eth1"
     When    Run "crm cluster init -i eth0 -i eth1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
-    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
+    And     IP "@hanode1.ip.1" is used by corosync on "hanode1"
     And     Show corosync ring status
 
   @clean
   Scenario: Using "-i" option, mixing with IP and NIC name
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -i eth0 -i @hanode1.ip.0 -y" on "hanode1"
+    When    Run "crm cluster init -i eth0 -i @hanode1.ip.1 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
-    And     IP "@hanode1.ip.0" is used by corosync on "hanode1"
-    When    Run "crm cluster join -c hanode1 -i eth0 -i @hanode2.ip.0 -y" on "hanode2"
+    And     IP "@hanode1.ip.1" is used by corosync on "hanode1"
+    When    Run "crm cluster join -c hanode1 -i eth0 -i @hanode2.ip.1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     IP "@hanode2.ip.0" is used by corosync on "hanode2"
-    And     IP "@hanode2.ip.0" is used by corosync on "hanode2"
+    And     IP "@hanode2.ip.1" is used by corosync on "hanode2"
 
     When    Try "crm cluster join cluster -c hanode1 -y" on "hanode2"
     Then    Expected "Cluster is active, can't run 'cluster' stage" in stderr
@@ -136,19 +136,19 @@ Feature: crmsh bootstrap process - options
   @clean
   Scenario: Detect multi IP in the same NIC
     Given   Cluster service is "stopped" on "hanode1"
-    When    Try "crm cluster init -i eth1 -i @hanode1.ip.0 -y"
+    When    Try "crm cluster init -i eth0 -i @hanode1.ip.0 -y"
     Then    Except "ERROR: cluster.init: Invalid input '@hanode1.ip.0': the IP in the same NIC already used"
-    When    Try "crm cluster init -i @hanode1.ip.0 -i eth1 -y"
-    Then    Except "ERROR: cluster.init: Invalid input 'eth1': The same NIC already used"
+    When    Try "crm cluster init -i @hanode1.ip.0 -i eth0 -y"
+    Then    Except "ERROR: cluster.init: Invalid input 'eth0': The same NIC already used"
 
   @clean
   Scenario: Init cluster service with ipv6 using "-I" option
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
-    When    Run "crm cluster init -I -i eth1 -y" on "hanode1"
+    When    Run "crm cluster init -I -i eth0 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     IP "@hanode1.ip6.0" is used by corosync on "hanode1"
-    When    Run "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
+    When    Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     IP "@hanode2.ip6.0" is used by corosync on "hanode2"
 

--- a/test/features/cluster_blocking_ssh.feature
+++ b/test/features/cluster_blocking_ssh.feature
@@ -35,13 +35,13 @@ Feature: cluster testing with ssh blocked
 
       nodelist {
         node {
-                ring0_addr: @hanode1.ip.default
+                ring0_addr: @hanode1.ip.0
                 name: hanode1
                 nodeid: 1
         }
 
         node {
-                ring0_addr: @hanode2.ip.default
+                ring0_addr: @hanode2.ip.0
                 name: hanode2
                 nodeid: 2
         }

--- a/test/features/qdevice_usercase.feature
+++ b/test/features/qdevice_usercase.feature
@@ -73,8 +73,8 @@ Feature: Verify usercase master survive when split-brain
     When    Run "corosync-quorumtool -s" on "hanode1"
     Then    Expected "Quorate:          Yes" in stdout
     # Use iptables command to simulate split-brain
-    When    Run "iptables -I INPUT -s @hanode2.ip.default -j DROP; sudo iptables -I OUTPUT -d @hanode2.ip.default -j DROP" on "hanode1"
-    And     Run "iptables -I INPUT -s @hanode1.ip.default -j DROP; sudo iptables -I OUTPUT -d @hanode1.ip.default -j DROP" on "hanode2"
+    When    Run "iptables -I INPUT -s @hanode2.ip.0 -j DROP; sudo iptables -I OUTPUT -d @hanode2.ip.0 -j DROP" on "hanode1"
+    And     Run "iptables -I INPUT -s @hanode1.ip.0 -j DROP; sudo iptables -I OUTPUT -d @hanode1.ip.0 -j DROP" on "hanode2"
     # Check whether hanode1 has quorum, while hanode2 doesn't
     And     Run "sleep 20" on "hanode1"
     When    Run "crm corosync status quorum" on "hanode1"

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,8 +1,7 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:knet-1.29"}
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-"docker.io/nyang23/haleap:knet-1.29"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
-DOCKER_SERVICE="docker.service"
 COROSYNC_CONF="/etc/corosync/corosync.conf"
 COROSYNC_AUTH="/etc/corosync/authkey"
 HA_NETWORK_FIRST="ha_network_first"
@@ -82,34 +81,6 @@ is_number() {
 }
 
 
-check_docker_env() {
-	# check if docker available
-	systemctl list-unit-files $DOCKER_SERVICE &> /dev/null
-	if [ "$?" -ne 0 ];then
-		fatal "$DOCKER_SERVICE is not available"
-	fi
-	# check if docker.service started
-	systemctl is-active $DOCKER_SERVICE &> /dev/null
-	if [ "$?" -ne 0 ];then
-		fatal "$DOCKER_SERVICE is not active"
-	fi
-	# check if docker cgroup driver is systemd
-	docker info 2> /dev/null|grep -q "Cgroup Driver: systemd"
-	if [ "$?" -ne 0 ];then
-		warning "docker cgroup driver suggest to be \"systemd\""
-	fi
-
-	[ "$1" == "cleanup" ] && return
-	# check if ha network already exists
-	for network in ${HA_NETWORK_ARRAY[@]};do
-		docker network ls|grep -q "$network"
-		if [ "$?" -eq 0 ];then
-			fatal "HA specific network \"$network\" already exists"
-		fi
-	done
-}
-
-
 get_test_case_array() {
 	test -d $BEHAVE_CASE_DIR || fatal "Cannot find '$BEHAVE_CASE_DIR'"
 	ls $BEHAVE_CASE_DIR|grep "\.feature"|grep -Ev "$BEHAVE_CASE_EXCLUDE"
@@ -170,27 +141,27 @@ END
 }
 
 
-docker_exec() {
+podman_exec() {
 	name=$1
 	cmd=$2
-	docker exec -t $name /bin/sh -c "$cmd"
+	podman exec -t $name /bin/sh -c "$cmd"
 }
 
 set_sshd_config_like_in_azure() {
 	node_name=$1
-	docker_exec $node_name "echo \"$SSHD_CONFIG_AZURE\" > /etc/ssh/sshd_config"
-	docker_exec $node_name "systemctl restart sshd.service"
+	podman_exec $node_name "echo \"$SSHD_CONFIG_AZURE\" > /etc/ssh/sshd_config"
+	podman_exec $node_name "systemctl restart sshd.service"
 }
 
 create_custom_user() {
 	user_name=$1
 	user_id=$2
-	docker_exec $node_name "useradd -m -s /bin/bash ${user_name} 2>/dev/null"
-	docker_exec $node_name "echo \"${user_name} ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/${user_name}"
-	docker_exec $node_name "chmod 0440 /etc/sudoers.d/${user_name}"
-	docker_exec $node_name "echo 'export PATH=\$PATH:/usr/sbin/' >> ~${user_name}/.bashrc"
-	docker_exec $node_name "echo -e \"linux\\nlinux\" | passwd ${user_name} 2>/dev/null"
-	docker_exec $node_name "cp -r /root/.ssh ~${user_name}/ && chown ${user_name}:haclient -R ~${user_name}/.ssh"
+	podman_exec $node_name "useradd -m -s /bin/bash ${user_name} 2>/dev/null"
+	podman_exec $node_name "echo \"${user_name} ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/${user_name}"
+	podman_exec $node_name "chmod 0440 /etc/sudoers.d/${user_name}"
+	podman_exec $node_name "echo 'export PATH=\$PATH:/usr/sbin/' >> ~${user_name}/.bashrc"
+	podman_exec $node_name "echo -e \"linux\\nlinux\" | passwd ${user_name} 2>/dev/null"
+	podman_exec $node_name "cp -r /root/.ssh ~${user_name}/ && chown ${user_name}:haclient -R ~${user_name}/.ssh"
 	info "Create user '$user_name' on $node_name"
 }
 
@@ -205,40 +176,43 @@ create_alice_bob_carol() {
 
 deploy_ha_node() {
 	node_name=$1
-	docker_options="-d --name $node_name -h $node_name --privileged --shm-size 1g"
+	podman_options="--name $node_name -h $node_name --systemd always --shm-size 1g"
+        # CAP_SYS_NICE for corosync to set realtime priority
+        # CAP_AUDIT_CONTROL for sshd
+        podman_capabilties="--cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL"
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."
-	docker run --restart always $docker_options $DOCKER_IMAGE &> /dev/null
+	podman run -d $podman_options $podman_capabilties $CONTAINER_IMAGE &> /dev/null
 	for network in ${HA_NETWORK_ARRAY[@]};do
-		docker network connect $network $node_name
+		podman network connect $network $node_name
 	done
 
 	if [ "$node_name" != "qnetd-node" ];then
 		rm_qnetd_cmd="rpm -q corosync-qnetd && rpm -e corosync-qnetd"
-		docker_exec $node_name "$rm_qnetd_cmd" &> /dev/null
+		podman_exec $node_name "$rm_qnetd_cmd" &> /dev/null
 	fi
-	docker_exec $node_name "rm -rf /run/nologin"
-	docker_exec $node_name "echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config"
-	docker_exec $node_name "systemctl start sshd.service"
+	podman_exec $node_name "rm -rf /run/nologin"
+	podman_exec $node_name "echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config"
+	podman_exec $node_name "systemctl start sshd.service"
 
 	if [ "$node_name" != "qnetd-node" ];then
-	  docker cp $PROJECT_PATH $node_name:/opt/crmsh
+	  podman cp $PROJECT_PATH $node_name:/opt/crmsh
 	  info "Building crmsh on \"$node_name\"..."
-	  docker_exec $node_name "$make_cmd" 1> /dev/null || \
+	  podman_exec $node_name "$make_cmd" 1> /dev/null || \
 		fatal "Building failed on $node_name!"
-	  docker_exec $node_name "chown hacluster:haclient -R /var/log/crmsh"
-	  docker_exec $node_name "chmod g+w -R /var/log/crmsh"
+	  podman_exec $node_name "chown hacluster:haclient -R /var/log/crmsh"
+	  podman_exec $node_name "chmod g+w -R /var/log/crmsh"
 	  create_alice_bob_carol
 	  if [ "$NORMAL_USER_FLAG" -eq 1 ];then
 		set_sshd_config_like_in_azure $node_name
           fi
-	  docker_exec $node_name "sed -i 's/; \[report\]/[report]/' /etc/crm/crm.conf"
-	  docker_exec $node_name "sed -i 's/; compress_prog = .*$/compress_prog = bzip2/g' /etc/crm/crm.conf"
+	  podman_exec $node_name "sed -i 's/; \[report\]/[report]/' /etc/crm/crm.conf"
+	  podman_exec $node_name "sed -i 's/; compress_prog = .*$/compress_prog = bzip2/g' /etc/crm/crm.conf"
 	else
-	  docker_exec $node_name "useradd -m -s /bin/bash alice 2>/dev/null"
-	  docker_exec $node_name "echo \"alice ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/alice"
-	  docker_exec $node_name "cp -r /root/.ssh ~alice/ && chown alice:users -R ~alice/.ssh"
+	  podman_exec $node_name "useradd -m -s /bin/bash alice 2>/dev/null"
+	  podman_exec $node_name "echo \"alice ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/alice"
+	  podman_exec $node_name "cp -r /root/.ssh ~alice/ && chown alice:users -R ~alice/.ssh"
 	  info "Create user 'alice' on $node_name"
 	  [ "$NORMAL_USER_FLAG" -eq 1 ] && set_sshd_config_like_in_azure $node_name
 	fi
@@ -246,13 +220,14 @@ deploy_ha_node() {
 
 
 create_node() {
-	info "Loading docker image $DOCKER_IMAGE..."
-        docker pull $DOCKER_IMAGE &> /dev/null
+	info "Loading container image $CONTAINER_IMAGE..."
 
+        echo 16777216 > /proc/sys/net/core/rmem_max
+        echo 16777216 > /proc/sys/net/core/wmem_max
 	for index in ${!HA_NETWORK_ARRAY[@]};do
 		network=${HA_NETWORK_ARRAY[$index]}
-		info "Create ha specific docker network \"$network\"..."
-		docker network create --ipv6 --subnet ${HA_NETWORK_V6_ARRAY[$index]} $network &> /dev/null
+		info "Create ha specific container network \"$network\"..."
+		podman network create --ipv6 --subnet ${HA_NETWORK_V6_ARRAY[$index]} $network
 	done
 
 	for node in $*;do
@@ -265,7 +240,7 @@ create_node() {
 config_cluster() {
 	node_num=$#
 	insert_str=""
-	container_ip_array=(`docker network inspect $HA_NETWORK_ARRAY -f '{{range .Containers}}{{printf "%s " .IPv4Address}}{{end}}'`)
+	container_ip_array=(`podman network inspect $HA_NETWORK_ARRAY -f '{{range .Containers}}{{printf "%s " .IPv4Address}}{{end}}'`)
 
 	for i in $(seq $node_num -1 1);do
 		ip=`echo ${container_ip_array[$((i-1))]}|awk -F/ '{print $1}'`
@@ -279,15 +254,15 @@ config_cluster() {
 	info "Copy corosync.conf to $*"
 	for node in $*;do
 		if [ $node == $1 ];then
-			docker_exec $1 "echo \"$corosync_conf_str\" >> $COROSYNC_CONF"
-			docker_exec $1 "corosync-keygen -l -k $COROSYNC_AUTH &> /dev/null"
+			podman_exec $1 "echo \"$corosync_conf_str\" >> $COROSYNC_CONF"
+			podman_exec $1 "corosync-keygen -l -k $COROSYNC_AUTH &> /dev/null"
 		else
 			while :
 			do
-				docker_exec $1 "ssh -T -o Batchmode=yes $node true &> /dev/null" && break
+				podman_exec $1 "ssh -T -o Batchmode=yes $node true &> /dev/null" && break
 				sleep 1
 			done
-			docker_exec $1 "scp -p $COROSYNC_CONF $COROSYNC_AUTH $node:/etc/corosync &> /dev/null"
+			podman_exec $1 "scp -p $COROSYNC_CONF $COROSYNC_AUTH $node:/etc/corosync &> /dev/null"
 		fi
 	done
 }
@@ -295,7 +270,7 @@ config_cluster() {
 
 start_cluster() {
 	for node in $*;do
-		docker_exec $node "crm cluster enable && crm cluster start" 1> /dev/null
+		podman_exec $node "crm cluster enable && crm cluster start" 1> /dev/null
 		if [ "$?" -eq 0 ];then
 			info "Cluster service started on \"$node\""
 		else
@@ -306,7 +281,7 @@ start_cluster() {
 
 
 container_already_exists() {
-	docker ps -a|grep -q "$1"
+	podman ps -a|grep -q "$1"
 	if [ "$?" -eq 0 ];then
 		fatal "Container \"$1\" already running"
 	fi
@@ -333,44 +308,44 @@ setup_cluster() {
 	[ "$CONFIG_COROSYNC_FLAG" -eq 0 ] && return
 	config_cluster ${hanodes_arry[@]}
 	start_cluster ${hanodes_arry[@]}
-	docker_exec "hanode1" "crm configure property stonith-enabled=false"
+	podman_exec "hanode1" "crm configure property stonith-enabled=false"
 }
 
 
 cleanup_container() {
 	node=$1
 	info "Cleanup container \"$node\"..."
-	docker container stop $node &> /dev/null
-	docker container rm $node &> /dev/null
+	podman stop $node
+	podman rm $node
 }
 
 
 cleanup_cluster() {
 	exist_network_array=()
 	for network in ${HA_NETWORK_ARRAY[@]};do
-		docker network ls|grep -q $network && exist_network_array+=($network)
+		podman network ls|grep -q $network && exist_network_array+=($network)
 	done
 	if [ ${#exist_network_array[@]} -eq 0 ];then
 		info "Already cleaned up"
 		return 0
 	fi
 
-	container_array=(`docker network inspect $exist_network_array -f '{{range .Containers}}{{printf "%s " .Name}}{{end}}'`)
+	container_array=(`podman network inspect $exist_network_array -f '{{range .Containers}}{{printf "%s " .Name}}{{end}}'`)
 	for node in ${container_array[@]};do
 		cleanup_container $node &
 	done
 	wait
 
 	for network in ${exist_network_array[@]};do
-		info "Cleanup ha specific docker network \"$network\"..."
-		docker network rm $network &> /dev/null
+		info "Cleanup ha specific container network \"$network\"..."
+		podman network rm $network
 	done
 }
 
 
 adjust_test_case() {
 	node_name=$1
-	replace_arry=(`docker_exec $node_name "grep -o -E '@(hanode[0-9]+|qnetd-node)\.ip[6]?\.(default|[0-9])' $2|sort -u|dos2unix"`)
+	replace_arry=(`podman_exec $node_name "grep -o -E '@(hanode[0-9]+|qnetd-node)\.ip[6]?\.(default|[0-9])' $2|sort -u|dos2unix"`)
 	for item in ${replace_arry[@]};do
 		item_str=${item##@}
 		node=`echo $item_str|cut -d "." -f 1`
@@ -381,22 +356,22 @@ adjust_test_case() {
 		fi
 		index=`echo $item_str|cut -d "." -f 3|tr -d "\r"`
 		if [ "$index" == "default" ];then
-			ip=`docker container inspect $node -f "{{range .NetworkSettings.Networks}}{{printf \"%s \" .$ip_search_str}}{{end}}"|awk '{print $1}'|tr -d "\r"`
+			ip=`podman container inspect $node -f "{{range .NetworkSettings.Networks}}{{printf \"%s \" .$ip_search_str}}{{end}}"|awk '{print $1}'|tr -d "\r"`
 		else
-			ip=`docker container inspect $node -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[$index]}.$ip_search_str}}"|tr -d "\r"`
+			ip=`podman container inspect $node -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[$index]}.$ip_search_str}}"|tr -d "\r"`
 		fi
 		item=`echo $item|tr -d "\r"`
-		docker_exec $node_name "sed -i s/$item/$ip/g $2"
+		podman_exec $node_name "sed -i s/$item/$ip/g $2"
 	done
 
-	vip_replace_array=(`docker_exec $node_name "grep -o -E '@vip\.[0-9]' $2|sort -u|dos2unix"`)
+	vip_replace_array=(`podman_exec $node_name "grep -o -E '@vip\.[0-9]' $2|sort -u|dos2unix"`)
 	for item in ${vip_replace_array[@]};do
 		index=`echo $item|cut -d "." -f 2|tr -d "\r"`
 		suffix=$((123+index))
-		ip=`docker container inspect $node_name -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[0]}.IPAddress}}"|tr -d "\r"`
+		ip=`podman container inspect $node_name -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[0]}.IPAddress}}"|tr -d "\r"`
 		vip=`echo $ip|sed "s/\.[0-9][0-9]*$/\.$suffix/g"|tr -d "\r"`
 		item=`echo $item|tr -d "\r"`
-		docker_exec $node_name "sed -i s/$item/$vip/g $2"
+		podman_exec $node_name "sed -i s/$item/$vip/g $2"
 	done
 }
 
@@ -404,15 +379,15 @@ adjust_test_case() {
 run_origin_regression_test() {
 	CONFIG_COROSYNC_FLAG=0
 	setup_cluster "hanode1"
-	docker_exec "hanode1" "echo -e '[core]\nhas_ra_advised_op = yes\nhas_fa_advised_op = yes' > /etc/crm/crm.conf"
-	docker_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
+	podman_exec "hanode1" "echo -e '[core]\nhas_ra_advised_op = yes\nhas_fa_advised_op = yes' > /etc/crm/crm.conf"
+	podman_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
 	return $?
 }
 
 
 prepare_coverage_env() {
 	for node in $*; do
-            docker cp "$PROJECT_PATH"/test/features/coverage/sitecustomize.py "$node":/usr/lib/python3.11/site-packages/sitecustomize.py
+            podman cp "$PROJECT_PATH"/test/features/coverage/sitecustomize.py "$node":/usr/lib/python3.11/site-packages/sitecustomize.py
 	done
 }
 
@@ -420,9 +395,9 @@ prepare_coverage_env() {
 fetch_coverage_report() {
 	local unique_id=$(dd if=/dev/urandom count=1 bs=6 | base64 | tr '+/' '-_')
 	for node in $*; do
-		docker_exec "$node" "coverage combine; coverage xml -o /opt/coverage.xml"
+		podman_exec "$node" "coverage combine; coverage xml -o /opt/coverage.xml"
 		# see https://github.com/codecov/codecov-cli/blob/master/codecov_cli/services/upload/coverage_file_finder.py
-		docker cp "$node":/opt/coverage.xml coverage."$unique_id"."$node".xml
+		podman cp "$node":/opt/coverage.xml coverage."$unique_id"."$node".xml
 	done
 }
 
@@ -441,7 +416,6 @@ case $1 in
 	exit 0
 	;;
 -d)
-	check_docker_env cleanup
 	cleanup_cluster
 	exit $?
 	;;
@@ -458,7 +432,6 @@ case $1 in
 	shift
 	;;
 -n)
-	check_docker_env
 	shift
 	is_number $1 || fatal "-n option need a number larger than 0"
 	SETUP_N_NODES_CLUSTER=$1
@@ -502,11 +475,9 @@ done
 
 for case_num in $*;do
 	if [ "$case_num" -ne $1 ];then
-		check_docker_env cleanup
 		cleanup_cluster
 		echo
 	fi
-	check_docker_env
 	test_case_array=(`get_test_case_array`)
 	if [ $case_num -gt ${#test_case_array[*]} ];then
 		run_origin_regression_test || exit 1
@@ -522,10 +493,10 @@ for case_num in $*;do
         prepare_coverage_env "${node_arry[@]}"
 	if [ "$NORMAL_USER_FLAG" -eq 0 ];then
 		info "Running \"$case_file_in_container\" under 'root'..."
-		docker_exec ${node_arry[0]} "behave --no-logcapture $case_file_in_container || exit 1" || exit 1
+		podman_exec ${node_arry[0]} "behave --no-logcapture $case_file_in_container || exit 1" || exit 1
 	else
 		info "Running \"$case_file_in_container\" under normal user 'alice'..."
-                docker_exec ${node_arry[0]} "su - alice -c 'sudo behave --no-logcapture $case_file_in_container || exit 1'" || exit 1
+                podman_exec ${node_arry[0]} "su - alice -c 'sudo behave --no-logcapture $case_file_in_container || exit 1'" || exit 1
 	fi
 	fetch_coverage_report "${node_arry[@]}"
 	echo

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -179,7 +179,8 @@ deploy_ha_node() {
 	podman_options="--name $node_name -h $node_name --systemd always --shm-size 1g"
         # CAP_SYS_NICE for corosync to set realtime priority
         # CAP_AUDIT_CONTROL for sshd
-        podman_capabilties="--cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL"
+        # CAP_NET_ADMIN for firewall and virtual ip
+        podman_capabilties="--cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL --cap-add CAP_NET_ADMIN"
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -176,7 +176,7 @@ create_alice_bob_carol() {
 
 deploy_ha_node() {
 	node_name=$1
-	podman_options="--name $node_name -h $node_name --systemd always --shm-size 1g"
+	podman_options="--name $node_name -h $node_name --network ha_network_first --systemd always --shm-size 1g"
         # CAP_SYS_NICE for corosync to set realtime priority
         # CAP_AUDIT_CONTROL for sshd
         # CAP_NET_ADMIN for firewall and virtual ip
@@ -184,10 +184,8 @@ deploy_ha_node() {
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."
-	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE &> /dev/null
-	for network in ${HA_NETWORK_ARRAY[@]};do
-		podman network connect $network $node_name
-	done
+	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE
+        podman network connect ha_network_second $node_name
 
 	if [ "$node_name" != "qnetd-node" ];then
 		rm_qnetd_cmd="rpm -q corosync-qnetd && rpm -e corosync-qnetd"
@@ -328,7 +326,7 @@ cleanup_cluster() {
 
 adjust_test_case() {
 	node_name=$1
-	replace_arry=(`podman_exec $node_name "grep -o -E '@(hanode[0-9]+|qnetd-node)\.ip[6]?\.(default|[0-9])' $2|sort -u|dos2unix"`)
+	replace_arry=(`podman_exec $node_name "grep -o -E '@(hanode[0-9]+|qnetd-node)\.ip6?\.[0-9]' $2|sort -u"`)
 	for item in ${replace_arry[@]};do
 		item_str=${item##@}
 		node=`echo $item_str|cut -d "." -f 1`
@@ -338,11 +336,7 @@ adjust_test_case() {
 			ip_search_str="GlobalIPv6Address"
 		fi
 		index=`echo $item_str|cut -d "." -f 3|tr -d "\r"`
-		if [ "$index" == "default" ];then
-			ip=`podman container inspect $node -f "{{range .NetworkSettings.Networks}}{{printf \"%s \" .$ip_search_str}}{{end}}"|awk '{print $1}'|tr -d "\r"`
-		else
-			ip=`podman container inspect $node -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[$index]}.$ip_search_str}}"|tr -d "\r"`
-		fi
+                ip=`podman container inspect $node -f "{{.NetworkSettings.Networks.${HA_NETWORK_ARRAY[$index]}.$ip_search_str}}"|tr -d "\r"`
 		item=`echo $item|tr -d "\r"`
 		podman_exec $node_name "sed -i s/$item/$ip/g $2"
 	done

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -183,7 +183,7 @@ deploy_ha_node() {
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."
-	podman run -d $podman_options $podman_capabilties $CONTAINER_IMAGE &> /dev/null
+	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE &> /dev/null
 	for network in ${HA_NETWORK_ARRAY[@]};do
 		podman network connect $network $node_name
 	done
@@ -312,30 +312,12 @@ setup_cluster() {
 }
 
 
-cleanup_container() {
-	node=$1
-	info "Cleanup container \"$node\"..."
-	podman stop $node
-	podman rm $node
-}
-
-
 cleanup_cluster() {
+        podman ps --format json | jq -r '.[].Names[]' | grep -E 'hanode.*|qnetd-node' | xargs podman stop
 	exist_network_array=()
 	for network in ${HA_NETWORK_ARRAY[@]};do
 		podman network ls|grep -q $network && exist_network_array+=($network)
 	done
-	if [ ${#exist_network_array[@]} -eq 0 ];then
-		info "Already cleaned up"
-		return 0
-	fi
-
-	container_array=(`podman network inspect $exist_network_array | jq -r '.[].containers[].name' | sort | uniq`)
-	for node in ${container_array[@]};do
-		cleanup_container $node &
-	done
-	wait
-
 	for network in ${exist_network_array[@]};do
 		info "Cleanup ha specific container network \"$network\"..."
 		podman network rm $network

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -1,5 +1,5 @@
 #!/bin/bash
-DOCKER_IMAGE=${DOCKER_IMAGE:-"liangxin1300/alpha"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"nyang23/haleap:knet-1.29"}
 PROJECT_PATH=$(dirname $(dirname `realpath $0`))
 PROJECT_INSIDE="/opt/crmsh"
 DOCKER_SERVICE="docker.service"

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -330,7 +330,7 @@ cleanup_cluster() {
 		return 0
 	fi
 
-	container_array=(`podman network inspect $exist_network_array -f '{{range .Containers}}{{printf "%s " .Name}}{{end}}'`)
+	container_array=(`podman network inspect $exist_network_array | jq -r '.[].containers[].name' | sort | uniq`)
 	for node in ${container_array[@]};do
 		cleanup_container $node &
 	done

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -181,10 +181,15 @@ deploy_ha_node() {
         # CAP_AUDIT_CONTROL for sshd
         # CAP_NET_ADMIN for firewall and virtual ip
         podman_capabilties="--cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL --cap-add CAP_NET_ADMIN"
+        if [ -d /sys/kernel/security/apparmor ]; then
+            podman_security="--security-opt=apparmor=podman"
+        else
+            podman_security=""
+        fi
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."
-	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE > /dev/null
+	podman run --rm -d $podman_options $podman_capabilties $podman_security $CONTAINER_IMAGE > /dev/null
         podman network connect ha_network_second $node_name
 
 	if [ "$node_name" != "qnetd-node" ];then

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -184,7 +184,7 @@ deploy_ha_node() {
 	make_cmd="cd $PROJECT_INSIDE;./autogen.sh && ./configure --prefix /usr && make install && make install-crmconfDATA prefix= && cp /usr/bin/crm /usr/sbin"
 
 	info "Deploying \"$node_name\"..."
-	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE
+	podman run --rm -d $podman_options $podman_capabilties $CONTAINER_IMAGE > /dev/null
         podman network connect ha_network_second $node_name
 
 	if [ "$node_name" != "qnetd-node" ];then
@@ -223,9 +223,9 @@ create_node() {
 
         echo 16777216 > /proc/sys/net/core/rmem_max
         echo 16777216 > /proc/sys/net/core/wmem_max
+        info "Create ha specific container networks..."
 	for index in ${!HA_NETWORK_ARRAY[@]};do
 		network=${HA_NETWORK_ARRAY[$index]}
-		info "Create ha specific container network \"$network\"..."
 		podman network create --ipv6 --subnet ${HA_NETWORK_V6_ARRAY[$index]} $network
 	done
 
@@ -312,13 +312,14 @@ setup_cluster() {
 
 
 cleanup_cluster() {
+        info "Cleanup ha specific containers..."
         podman ps --format json | jq -r '.[].Names[]' | grep -E 'hanode.*|qnetd-node' | xargs podman stop
+        info "Cleanup ha specific container networks..."
 	exist_network_array=()
 	for network in ${HA_NETWORK_ARRAY[@]};do
 		podman network ls|grep -q $network && exist_network_array+=($network)
 	done
 	for network in ${exist_network_array[@]};do
-		info "Cleanup ha specific container network \"$network\"..."
 		podman network rm $network
 	done
 }

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1147,36 +1147,44 @@ INFO: "rm" is accepted as "delete"
 .EXT crm_simulate -sUL
 2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
-Node node1: UNCLEAN (offline)
+Current cluster status:
+  * Node List:
+    * Node node1: UNCLEAN (offline)
 
- st	(stonith:null):	Stopped 
-     Stopped: [ node1 ]
-     Stopped: [ node1 ]
-p3	(ocf:heartbeat:Dummy):	 Stopped (disabled) 
-     Stopped: [ node1 ]
+  * Full List of Resources:
+    * st	(stonith:null):	 Stopped
+    * Clone Set: c1 [p1] (unmanaged):
+      * Stopped: [ node1 ]
+    * Clone Set: m1 [p2] (promotable):
+      * Stopped: [ node1 ]
+    * p3	(ocf:heartbeat:Dummy):	 Stopped (disabled)
+    * Clone Set: msg [g] (promotable):
+      * Stopped: [ node1 ]
 
-Original: node1 capacity:
-pcmk__primitive_assign: st allocation score on node1: 0
-pcmk__clone_assign: c1 allocation score on node1: 0
-pcmk__clone_assign: p1:0 allocation score on node1: 0
-pcmk__primitive_assign: p1:0 allocation score on node1: -INFINITY
-pcmk__clone_assign: m1 allocation score on node1: 0
-pcmk__clone_assign: p2:0 allocation score on node1: 0
-pcmk__primitive_assign: p2:0 allocation score on node1: -INFINITY
-p2:0 promotion score on none: 0
-pcmk__primitive_assign: p3 allocation score on node1: -INFINITY
-pcmk__clone_assign: msg allocation score on node1: 0
-pcmk__clone_assign: g:0 allocation score on node1: 0
-pcmk__clone_assign: p0:0 allocation score on node1: 0
-pcmk__clone_assign: p4:0 allocation score on node1: 0
-pcmk__group_assign: g:0 allocation score on node1: -INFINITY
-pcmk__group_assign: p0:0 allocation score on node1: -INFINITY
-pcmk__group_assign: p4:0 allocation score on node1: -INFINITY
-pcmk__primitive_assign: p0:0 allocation score on node1: -INFINITY
-pcmk__primitive_assign: p4:0 allocation score on node1: -INFINITY
-g:0 promotion score on none: 0
-Remaining: node1 capacity:
+Assignment Scores and Utilization Information:
+  * Original: node1 capacity:
+  * pcmk__primitive_assign: st allocation score on node1: 0
+  * pcmk__clone_assign: c1 allocation score on node1: 0
+  * pcmk__clone_assign: p1:0 allocation score on node1: 0
+  * pcmk__primitive_assign: p1:0 allocation score on node1: -INFINITY
+  * pcmk__clone_assign: m1 allocation score on node1: 0
+  * pcmk__clone_assign: p2:0 allocation score on node1: 0
+  * pcmk__primitive_assign: p2:0 allocation score on node1: -INFINITY
+  * p2:0 promotion score (inactive): -INFINITY
+  * pcmk__primitive_assign: p3 allocation score on node1: -INFINITY
+  * pcmk__clone_assign: msg allocation score on node1: 0
+  * pcmk__clone_assign: g:0 allocation score on node1: 0
+  * pcmk__clone_assign: p0:0 allocation score on node1: 0
+  * pcmk__clone_assign: p4:0 allocation score on node1: 0
+  * pcmk__group_assign: g:0 allocation score on node1: -INFINITY
+  * pcmk__group_assign: p0:0 allocation score on node1: -INFINITY
+  * pcmk__group_assign: p4:0 allocation score on node1: -INFINITY
+  * pcmk__primitive_assign: p0:0 allocation score on node1: -INFINITY
+  * pcmk__primitive_assign: p4:0 allocation score on node1: -INFINITY
+  * g:0 promotion score (inactive): -INFINITY
+  * Remaining: node1 capacity:
 
+Transition Summary:
 .SETENV showobj=
 .TRY configure primitive p5 Dummy
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/tumbleweed
+FROM docker.io/opensuse/tumbleweed
 MAINTAINER Xin Liang <XLiang@suse.com>
 
 CMD ["/usr/lib/systemd/systemd", "--system"]

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER Xin Liang <XLiang@suse.com>
 CMD ["/usr/lib/systemd/systemd", "--system"]
 
 RUN zypper ar -fG https://download.opensuse.org/repositories/home:/nicholasyang/openSUSE_Tumbleweed/home:nicholasyang.repo
-RUN zypper refresh && \
-    zypper -n install systemd \
-        make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables cpio gawk \
+RUN zypper -n install systemd openssh \
+        firewalld iptables iptables-backend-nft \
+        make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 tar file glibc-locale-base libopenssl1_1 dos2unix cpio gawk \
         python3 python3-pip python3-lxml python3-python-dateutil python3-setuptools python3-PyYAML python3-curses python3-behave python3-coverage python3-packaging \
-        csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd libknet1-*
+        csync2 libglue-devel corosync corosync-qdevice pacemaker booth corosync-qnetd
 
 RUN ssh-keygen -t rsa -f /root/.ssh/id_rsa -N '' && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \

--- a/test_container/Dockerfile
+++ b/test_container/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Xin Liang <XLiang@suse.com>
 
 CMD ["/usr/lib/systemd/systemd", "--system"]
 
+RUN zypper ar -fG https://download.opensuse.org/repositories/home:/nicholasyang/openSUSE_Tumbleweed/home:nicholasyang.repo
 RUN zypper refresh && \
     zypper -n install systemd \
         make autoconf automake vim which libxslt-tools mailx iproute2 iputils bzip2 openssh tar file glibc-locale-base firewalld libopenssl1_1 dos2unix iptables cpio gawk \


### PR DESCRIPTION
* use knet-1.29 and rebuild the test container with latest tumbleweed
* replace privileged docker containers with unprivileged podman containers
    * latest systemd in tumbleweed does no longer like to run in a privileged container. Instead it need the container runtime to setup a environment according to CONTAINER_INTERFACE[^1].
* replace legacy iptables with iptables-nft
    * legacy iptables does not work in unprivileged containers
* stop using the default bridge container network
    * ha_netowork_first and ha_network_second are enough for functional tests
    * the default bridge network makes network interface names inside the containers unstable

close #1572.

[^1]: https://systemd.io/CONTAINER_INTERFACE/