### PR TITLE
[crmsh-4.6] Fix: ui_cluster: Stop renaming cluster name when using qdevice

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -497,7 +497,7 @@ def is_online():
         return False
 
     # if peer_node is None, this is in the init process
-    if _context.cluster_node is None:
+    if not _context or _context.cluster_node is None:
         return True
     # In join process
     # If the joining node is already online but can't find the init node
@@ -2654,9 +2654,7 @@ def remove_qdevice():
     if qdevice_reload_policy == qdevice.QdevicePolicy.QDEVICE_RELOAD:
         invoke("crm cluster run 'crm corosync reload'")
     elif qdevice_reload_policy == qdevice.QdevicePolicy.QDEVICE_RESTART:
-        logger.info("Restarting cluster service")
-        utils.cluster_run_cmd("crm cluster restart")
-        wait_for_cluster()
+        restart_cluster()
     else:
         logger.warning("To remove qdevice service, need to restart cluster service manually on each node")
 
@@ -3077,4 +3075,10 @@ def sync_file(path):
         utils.cluster_copy_file(path, nodes=_context.node_list_in_cluster, output=False)
     else:
         csync2_update(path)
+
+
+def restart_cluster():
+    logger.info("Restarting cluster service")
+    utils.cluster_run_cmd("crm cluster restart")
+    wait_for_cluster()
 # EOF

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -597,9 +597,7 @@ class QDevice(object):
             logger.info("Starting corosync-qdevice.service in cluster")
             utils.cluster_run_cmd("systemctl restart corosync-qdevice")
         elif self.qdevice_reload_policy == QdevicePolicy.QDEVICE_RESTART:
-            logger.info("Restarting cluster service")
-            utils.cluster_run_cmd("crm cluster restart")
-            bootstrap.wait_for_cluster()
+            bootstrap.restart_cluster()
         else:
             logger.warning("To use qdevice service, need to restart cluster service manually on each node")
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -457,9 +457,7 @@ class SBDManager(object):
         Try to configure sbd resource, restart cluster on needed
         """
         if not xmlutil.CrmMonXmlParser().is_any_resource_running():
-            logger.info("Restarting cluster service")
-            utils.cluster_run_cmd("crm cluster restart")
-            bootstrap.wait_for_cluster()
+            bootstrap.restart_cluster()
             self.configure_sbd_resource_and_properties()
         else:
             logger.warning("To start sbd.service, need to restart cluster service manually on each node")


### PR DESCRIPTION
backport from #1573 