### PR TITLE
[crmsh-4.5] Fix: cibconfig: Disable auto add advise values for operations (bsc#1231386)

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -793,7 +793,7 @@ def id_for_node(node, id_hint=None):
     return obj_id
 
 
-def postprocess_cli(node, oldnode=None, id_hint=None, complete_advised=False):
+def postprocess_cli(node, oldnode=None, id_hint=None, promotable_default_meta=False):
     """
     input: unprocessed but parsed XML
     output: XML, obj_type, obj_id
@@ -816,14 +816,14 @@ def postprocess_cli(node, oldnode=None, id_hint=None, complete_advised=False):
     resolve_references(node)
     if oldnode is not None:
         remove_id_used_attributes(oldnode)
-    if complete_advised:
-        complete_advised_meta(node)
+    if promotable_default_meta:
+        add_promotable_default_meta_attr(node)
     return node, obj_type, obj_id
 
 
-def complete_advised_meta(node):
+def add_promotable_default_meta_attr(node):
     """
-    Complete advised meta attributes
+    Add promotable default advised meta attributes
     """
     if node.tag != "clone":
         return
@@ -856,6 +856,7 @@ def parse_cli_to_xml(cli, oldnode=None):
     """
     node = None
     complete = False
+    default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
         utils.auto_convert_role = False
@@ -864,12 +865,13 @@ def parse_cli_to_xml(cli, oldnode=None):
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
         complete = True
+        default_promotable_meta = True
         node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete)
     if node is False:
         return None, None, None
     elif node is None:
         return None, None, None
-    return postprocess_cli(node, oldnode, complete_advised=complete)
+    return postprocess_cli(node, oldnode, promotable_default_meta=default_promotable_meta)
 
 #
 # cib element classes (CibObject the parent class)

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -855,7 +855,7 @@ def parse_cli_to_xml(cli, oldnode=None):
     output: XML, obj_type, obj_id
     """
     node = None
-    complete = False
+    has_ra_advised_op = False
     default_promotable_meta = False
     comments = []
     if isinstance(cli, str):
@@ -864,9 +864,9 @@ def parse_cli_to_xml(cli, oldnode=None):
             node = parse.parse(s, comments=comments)
     else:  # should be a pre-tokenized list
         utils.auto_convert_role = True
-        complete = True
+        has_ra_advised_op = config.core.has_ra_advised_op
         default_promotable_meta = True
-        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=complete)
+        node = parse.parse(cli, comments=comments, ignore_empty=False, complete_advised=has_ra_advised_op)
     if node is False:
         return None, None, None
     elif node is None:

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -256,6 +256,7 @@ DEFAULTS = {
         'lock_timeout': opt_string('120'),
         'no_ssh': opt_boolean('no'),
         'OCF_1_1_SUPPORT': opt_boolean('no'),
+        'has_ra_advised_op': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },
     'path': {

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -21,6 +21,7 @@
 ; report_tool_options =
 ; lock_timeout = 120
 ; no_ssh = no
+; has_ra_advised_op = no
 
 ; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.
 ; OCF_1_1_SUPPORT = yes

--- a/test/features/cluster_api.feature
+++ b/test/features/cluster_api.feature
@@ -103,17 +103,6 @@ Feature: Functional test to cover SAP clusterAPI
     And     Show cluster status on "hanode1"
     When    Run "su - hacluster -c 'crm configure show'" on "hanode1"
     Then    Expected return code is "0"
-    And     Expected multiple lines in output
-      """
-      primitive d2 Dummy \
-      	params fake=test \
-      	meta resource-stickiness=5000 \
-      	op monitor interval=10s timeout=20s on-fail=restart \
-      	op start timeout=20s interval=0s \
-      	op stop timeout=20s interval=0s
-      group g d2 \
-      	meta resource-stickiness=3000
-      """
 
   @clean
   Scenario: pacemaker ACL related operations by hacluster

--- a/test/features/crm_report_bugs.feature
+++ b/test/features/crm_report_bugs.feature
@@ -126,8 +126,8 @@ Feature: crm report functional test for verifying bugs
 
   @clean
   Scenario: crm report collect trace ra log
-    When    Run "crm configure primitive d Dummy" on "hanode1"
-    And     Run "crm configure primitive d2 Dummy" on "hanode1"
+    When    Run "crm configure primitive d Dummy op monitor interval=10s" on "hanode1"
+    And     Run "crm configure primitive d2 Dummy op monitor interval=10s" on "hanode1"
     Then    Resource "d" is started on "hanode1"
     And     Resource "d2" is started on "hanode2"
     When    Run "crm resource trace d monitor" on "hanode1"

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -424,6 +424,7 @@ adjust_test_case() {
 run_origin_regression_test() {
 	CONFIG_COROSYNC_FLAG=0
 	setup_cluster "hanode1"
+        docker_exec "hanode1" "echo -e '[core]\nhas_ra_advised_op = yes' > /etc/crm/crm.conf"
 	docker_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
 	return $?
 }


### PR DESCRIPTION
 - Dev: Add option core.has_ra_advised_op;
 - Since this auto-add feature might surprise users, we should disable it by setting the option 'has_ra_advised_op' value to 'no'.