### PR TITLE
Fix: cibconfig: Disable auto add advise values for operations (bsc#1231386)

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -258,7 +258,7 @@ DEFAULTS = {
         'lock_timeout': opt_string('120'),
         'OCF_1_1_SUPPORT': opt_boolean('yes'),
         'no_ssh': opt_boolean('no'),
-        'has_ra_advised_op': opt_boolean('yes'),
+        'has_ra_advised_op': opt_boolean('no'),
         'has_fa_advised_op': opt_boolean('no'),
         'obscure_pattern': opt_string('passw*')
     },

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -22,10 +22,10 @@
 ; lock_timeout = 120
 ; no_ssh = no
 
-; For resource agent, automatically add the advised values, default is yes.
-; has_ra_advised_op = yes
+; For resource agent, automatically add the advised values for operation, default is no.
+; has_ra_advised_op = no
 
-; For fence agent, automatically add the advised values, default is no.
+; For fence agent, automatically add the advised values for operation, default is no.
 ; has_fa_advised_op = no
 
 ; set OCF_1_1_SUPPORT to yes is to fully turn on OCF 1.1 feature once the corresponding CIB detected.

--- a/test/features/cluster_api.feature
+++ b/test/features/cluster_api.feature
@@ -103,17 +103,6 @@ Feature: Functional test to cover SAP clusterAPI
     And     Show cluster status on "hanode1"
     When    Run "su - hacluster -c 'crm configure show'" on "hanode1"
     Then    Expected return code is "0"
-    And     Expected multiple lines in output
-      """
-      primitive d2 Dummy \
-      	params fake=test \
-      	meta resource-stickiness=5000 \
-      	op monitor interval=10s timeout=20s on-fail=restart \
-      	op start timeout=20s interval=0s \
-      	op stop timeout=20s interval=0s
-      group g d2 \
-      	meta resource-stickiness=3000
-      """
 
   @clean
   Scenario: pacemaker ACL related operations by hacluster

--- a/test/features/crm_report_normal.feature
+++ b/test/features/crm_report_normal.feature
@@ -17,8 +17,8 @@ Feature: crm report functional test for common cases
 
   @clean
   Scenario: crm report collect trace ra log
-    When    Run "crm configure primitive d Dummy" on "hanode1"
-    And     Run "crm configure primitive d2 Dummy" on "hanode1"
+    When    Run "crm configure primitive d Dummy op monitor interval=10s" on "hanode1"
+    And     Run "crm configure primitive d2 Dummy op monitor interval=10s" on "hanode1"
     Then    Resource "d" is started on "hanode1"
     And     Resource "d2" is started on "hanode2"
     When    Run "crm resource trace d monitor" on "hanode1"

--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -404,7 +404,7 @@ adjust_test_case() {
 run_origin_regression_test() {
 	CONFIG_COROSYNC_FLAG=0
 	setup_cluster "hanode1"
-	docker_exec "hanode1" "echo -e '[core]\nhas_fa_advised_op = yes' > /etc/crm/crm.conf"
+	docker_exec "hanode1" "echo -e '[core]\nhas_ra_advised_op = yes\nhas_fa_advised_op = yes' > /etc/crm/crm.conf"
 	docker_exec "hanode1" "sh /usr/share/crmsh/tests/regression.sh"
 	return $?
 }


### PR DESCRIPTION
Since this auto-add feature might surprise users, we should disable it by setting the option 'has_ra_advised_op' value to 'no'.