### PR TITLE
[crmsh-4.6] Dev: utils: Introduced `detect_duplicate_device_path` function in utils

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -321,6 +321,7 @@ class SBDManager(object):
             if not utils.is_block_device(dev):
                 raise ValueError("{} doesn't look like a block device".format(dev))
             self._compare_device_uuid(dev, compare_node_list)
+        utils.detect_duplicate_device_path(dev_list)
 
     def _no_overwrite_check(self, dev):
         """

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -27,6 +27,7 @@ import gzip
 import bz2
 import lzma
 from pathlib import Path
+from collections import defaultdict
 from contextlib import contextmanager, closing
 from stat import S_ISBLK
 from lxml import etree
@@ -2561,6 +2562,19 @@ def is_block_device(dev):
     except OSError:
         return False
     return rc
+
+
+def detect_duplicate_device_path(device_list: typing.List[str]):
+    """
+    Resolve device path and check if there are duplicated device path
+    """
+    path_dict = defaultdict(list)
+    for dev in device_list:
+        resolved_path = Path(dev).resolve()
+        path_dict[resolved_path].append(dev)
+    for path, dev_list in path_dict.items():
+        if len(dev_list) > 1:
+            raise ValueError(f"Duplicated device path detected: {','.join(dev_list)}. They are all pointing to {path}")
 
 
 def has_stonith_running():


### PR DESCRIPTION
- A new function `detect_duplicate_device_path` has been added to `utils.py`.
- This function checks for duplicated device paths in a given list of devices, raising a ValueError if duplicates are found.

To fix issue #1581 