### PR TITLE
README.md: use crmsh-cd as build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crmsh
 
-[![Build Status](https://github.com/ClusterLabs/crmsh/actions/workflows/crmsh-ci.yml/badge.svg)](https://github.com/ClusterLabs/crmsh/actions/workflows/crmsh-ci.yml)[![codecov](https://codecov.io/gh/ClusterLabs/crmsh/graph/badge.svg?token=16HW9ntzmz)](https://codecov.io/gh/ClusterLabs/crmsh)
+[![Build Status](https://github.com/ClusterLabs/crmsh/actions/workflows/crmsh-cd.yml/badge.svg)](https://github.com/ClusterLabs/crmsh/actions/workflows/crmsh-cd.yml)[![codecov](https://codecov.io/gh/ClusterLabs/crmsh/graph/badge.svg?token=16HW9ntzmz)](https://codecov.io/gh/ClusterLabs/crmsh)
 
 
 ## Introduction


### PR DESCRIPTION
as crmsh-ci no longer runs for master branch