### PR TITLE
Dev: bootstrap: Add a log info when starting pacemaker.service

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -786,6 +786,7 @@ def start_pacemaker(node_list=[], enable_flag=False):
             except ValueError as err:
                 node_list.remove(node)
                 logger.error(err)
+    logger.info("Starting %s on %s", constants.PCMK_SERVICE, ', '.join(node_list) or utils.this_node())
     return service_manager.start_service("pacemaker.service", enable=enable_flag, node_list=node_list)
 
 


### PR DESCRIPTION
Add a log message to indicate the start of pacemaker.service. This helps users understand that the system is not hanging but is actually starting pacemaker, especially when SBD_DELAY_START is set and it takes longer to start pacemaker.

Port from #1590 