### PR TITLE
Fix: behave: AppArmor profile "podman" specified but not loaded in opensuse tumbleweed

### DIFF
--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -181,7 +181,7 @@ deploy_ha_node() {
         # CAP_AUDIT_CONTROL for sshd
         # CAP_NET_ADMIN for firewall and virtual ip
         podman_capabilties="--cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL --cap-add CAP_NET_ADMIN"
-        if [ -d /sys/kernel/security/apparmor ]; then
+        if [ -d /sys/kernel/security/apparmor ] && [ -f /etc/apparmor.d/podman ]; then
             podman_security="--security-opt=apparmor=podman"
         else
             podman_security=""


### PR DESCRIPTION
Do not try to apply this profile if it is not defined.