### PR TITLE
[crmsh-4.6] Fix: report.utils: Fix the performance issue (bsc#1232821)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -66,7 +66,7 @@ def collect_ha_logs(context: core.Context) -> None:
     """
     log_list = [get_pcmk_log(), get_corosync_log()] + context.extra_log_list
     for log in log_list:
-        if os.path.isfile(log):
+        if log and os.path.isfile(log):
             utils.dump_logset(context, log)
 
 

--- a/crmsh/report/constants.py
+++ b/crmsh/report/constants.py
@@ -3,7 +3,7 @@
 BIN_CRM = "/usr/sbin/crm"
 BIN_COLLECTOR = f"{BIN_CRM} report __collector"
 COMPRESS_DATA_FLAG = "COMPRESS CRM_REPORT DATA:::"
-LOG_PATTERNS = "CRIT: ERROR: error: warning: crit:"
+LOG_PATTERNS = ["CRIT:", "ERROR:", "WARNING:", "crit:", "error:", "warning:"]
 PTEST = "crm_simulate"
 SSH_OPTS = "-o StrictHostKeyChecking=no -o EscapeChar=none -o ConnectTimeout=15"
 CHECK_LOG_LINES = 10

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -153,15 +153,15 @@ def extract_critical_log(context: core.Context) -> List[str]:
     Extract warnings and errors from collected log files
     """
     result_list = []
-    log_pattern_list = [f".*{p}.*" for p in constants.LOG_PATTERNS.split()]
-    log_pattern_str = '|'.join(log_pattern_list)
+    grep_e_option_str = f"-e {' -e '.join(constants.LOG_PATTERNS)}"
+    shell = sh.ShellUtils()
 
     for f in glob.glob(f"{context.work_dir}/*/*.log"):
-        _list = re.findall(log_pattern_str, crmutils.read_from_file(f))
-        if _list:
-            result_list.append(f"\nWARNINGS or ERRORS in {'/'.join(f.split('/')[3:])}:")
-            result_list.extend(_list)
-
+        grep_cmd = f"grep -F {grep_e_option_str} {f}"
+        _, out, _ = shell.get_stdout_stderr(grep_cmd)
+        if out:
+            result_list.append(f"\nWARNINGS or ERRORS in {real_path(f)}:")
+            result_list.append(out)
     return result_list
 
 

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -54,6 +54,9 @@ def arch_logs(context: core.Context, logf: str) -> Tuple[List[str], LogType]:
     file_list = [logf] + glob.glob(logf+"*[0-9z]")
     # like ls -t, newest first
     for f in sorted(file_list, key=os.path.getmtime, reverse=True):
+        modify_time = os.path.getmtime(f)
+        if context.from_time > modify_time:
+            break # no need to check the rest
         tmp = is_our_log(context, f)
         logger.debug2("File %s is %s", f, convert_logtype_to_str(tmp))
         if tmp not in (LogType.GOOD, LogType.IRREGULAR):

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -29,6 +29,17 @@ class LogType(Enum):
     AFTER_TIMESPAN = 4   # log after timespan; exclude
 
 
+def convert_logtype_to_str(log_type: LogType) -> str:
+    log_type_str = {
+        LogType.GOOD: "in timespan",
+        LogType.IRREGULAR: "irregular",
+        LogType.EMPTY: "empty",
+        LogType.BEFORE_TIMESPAN: "before timespan",
+        LogType.AFTER_TIMESPAN: "after timespan"
+    }
+    return log_type_str[log_type]
+
+
 class ReportGenericError(Exception):
     pass
 
@@ -44,13 +55,18 @@ def arch_logs(context: core.Context, logf: str) -> Tuple[List[str], LogType]:
     # like ls -t, newest first
     for f in sorted(file_list, key=os.path.getmtime, reverse=True):
         tmp = is_our_log(context, f)
+        logger.debug2("File %s is %s", f, convert_logtype_to_str(tmp))
         if tmp not in (LogType.GOOD, LogType.IRREGULAR):
             continue
         log_type = tmp
         return_list.append(f)
 
     if return_list:
-        logger.debug2(f"Found logs {return_list} in {get_timespan_str(context)}")
+        logger.debug2(
+            "Found %s logs: %s",
+            convert_logtype_to_str(log_type),
+            ', '.join(return_list)
+        )
     return return_list, log_type
 
 


### PR DESCRIPTION
The function `extract_critical_log` can be very slow when processing large log files. The main issue is the inefficiency of the regular expression, which combines multiple wildcards (.*) with alternation (|), leading to excessive backtracking. Additionally, the function reads the entire file into memory, which is not optimal for large files.

To improve performance, it is better to use `grep` with the -F option to search for fixed strings.

And for a sequence of archived log files, check the modify time. No need to check the rest of the files if the from time is greater than the modify time of the file.

