### PR TITLE
Fix: behave: systemd bpf-restrict-fs fails in opensuse tumbleweed

### DIFF
--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -181,8 +181,12 @@ deploy_ha_node() {
         # CAP_AUDIT_CONTROL for sshd
         # CAP_NET_ADMIN for firewall and virtual ip
         podman_capabilties="--cap-add CAP_SYS_ADMIN --cap-add CAP_SYS_NICE --cap-add CAP_AUDIT_CONTROL --cap-add CAP_NET_ADMIN"
-        if [ -d /sys/kernel/security/apparmor ] && [ -f /etc/apparmor.d/podman ]; then
-            podman_security="--security-opt=apparmor=podman"
+        if [ -d /sys/kernel/security/apparmor ]; then
+            if [ -f /etc/apparmor.d/podman ]; then
+                podman_security="--security-opt=apparmor=podman"
+            else
+                podman_security="--security-opt=apparmor=unconfined"
+            fi
         else
             podman_security=""
         fi


### PR DESCRIPTION
Use apparmor=unconfined when the distribution does not provide a proper profile.