### PR TITLE
[crmsh-4.6] Dev: utils: Avoid hardcoding the ssh key type as RSA

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1037,10 +1037,8 @@ def change_user_shell(user, remote=None):
 
 def configure_ssh_key(user):
     """
-    Configure ssh rsa key on local or remote
-
-    If <home_dir>/.ssh/id_rsa not exist, generate a new one
-    Add <home_dir>/.ssh/id_rsa.pub to <home_dir>/.ssh/authorized_keys anyway, make sure itself authorized
+    Configure ssh key for user, generate a new key pair if needed,
+    and add the public key to authorized_keys
     """
     change_user_shell(user)
     shell = sh.LocalShell()

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1103,7 +1103,7 @@ def export_ssh_key_non_interactive(local_user_to_export, remote_user_to_swap, re
     """Copy ssh key from local to remote's authorized_keys. Require a configured non-interactive ssh authentication."""
     # ssh-copy-id will prompt for the password of the destination user
     # this is unwanted, so we write to the authorised_keys file ourselve
-    public_key = ssh_key.fetch_public_key_list(None, local_user_to_export, with_content=True)[0]
+    public_key = ssh_key.fetch_public_key_content_list(None, local_user_to_export)[0]
     # FIXME: prevent duplicated entries in authorized_keys
     cmd = '''mkdir -p ~{user}/.ssh && chown {user} ~{user}/.ssh && chmod 0700 ~{user}/.ssh && cat >> ~{user}/.ssh/authorized_keys << "EOF"
 {key}
@@ -1124,7 +1124,7 @@ EOF
 
 def import_ssh_key(local_user, remote_user, local_sudoer, remote_node, remote_sudoer):
     "Copy ssh key from remote to local authorized_keys"
-    remote_key_content = ssh_key.fetch_public_key_list(remote_node, remote_user, with_content=True)[0]
+    remote_key_content = ssh_key.fetch_public_key_content_list(remote_node, remote_user)[0]
     in_memory_key = ssh_key.InMemoryPublicKey(remote_key_content)
     shell = sh.SSHShell(sh.LocalShell(), local_user)
     ssh_key.AuthorizedKeyManager(shell).add(None, local_user, in_memory_key)
@@ -1226,7 +1226,7 @@ def init_qnetd_remote():
     Triggered by join_cluster, this function adds the joining node's key to the qnetd's authorized_keys
     """
     local_user, remote_user, join_node = _select_user_pair_for_ssh_for_secondary_components(_context.cluster_node)
-    join_node_key_content = ssh_key.fetch_public_key_list(join_node, remote_user, with_content=True)[0]
+    join_node_key_content = ssh_key.fetch_public_key_content_list(join_node, remote_user)[0]
     qnetd_host = corosync.get_value("quorum.device.net.host")
     _, qnetd_user, qnetd_host = _select_user_pair_for_ssh_for_secondary_components(qnetd_host)
     authorized_key_manager = ssh_key.AuthorizedKeyManager(sh.cluster_shell())
@@ -1654,7 +1654,7 @@ def _setup_passwordless_ssh_for_qnetd(cluster_node_list: typing.List[str]):
             if node == utils.this_node():
                 continue
             local_user, remote_user, node = _select_user_pair_for_ssh_for_secondary_components(node)
-            remote_key_content = ssh_key.fetch_public_key_list(node, remote_user, with_content=True)[0]
+            remote_key_content = ssh_key.fetch_public_key_content_list(node, remote_user)[0]
             in_memory_key = ssh_key.InMemoryPublicKey(remote_key_content)
             ssh_key.AuthorizedKeyManager(cluster_shell).add(qnetd_addr, qnetd_user, in_memory_key)
 

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1047,25 +1047,50 @@ def generate_ssh_key_pair_on_remote(
     shell = sh.LocalShell()
     # pass cmd through stdin rather than as arguments. It seems sudo has its own argument parsing mechanics,
     # which breaks shell expansion used in cmd
-    cmd = '''
-[ -f ~/.ssh/id_rsa ] || ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -C "Cluster internal on $(hostname)" -N ''
-[ -f ~/.ssh/id_rsa.pub ] || ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+    generate_key_script = f'''
+key_types=({ ' '.join(ssh_key.KeyFileManager.KNOWN_KEY_TYPES) })
+for key_type in "${{key_types[@]}}"; do
+    priv_key_file=~/.ssh/id_${{key_type}}
+    if [ -f "$priv_key_file" ]; then
+        pub_key_file=$priv_key_file.pub
+        break
+    fi
+done
+
+if [ -z "$pub_key_file" ]; then
+    key_type={ssh_key.KeyFileManager.DEFAULT_KEY_TYPE}
+    priv_key_file=~/.ssh/id_${{key_type}}
+    ssh-keygen -q -t $key_type -f $priv_key_file -C "Cluster internal on $(hostname)" -N ''
+    pub_key_file=$priv_key_file.pub
+fi
+
+[ -f "$pub_key_file" ] || ssh-keygen -y -f $priv_key_file > $pub_key_file
 '''
     result = shell.su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_host, remote_user),
-        input=cmd.encode('utf-8'),
+        input=generate_key_script.encode('utf-8'),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
     if result.returncode != 0:
         raise ValueError(codecs.decode(result.stdout, 'utf-8', 'replace'))
 
-    cmd = 'cat ~/.ssh/id_rsa.pub'
+    fetch_key_script = f'''
+key_types=({ ' '.join(ssh_key.KeyFileManager.KNOWN_KEY_TYPES) })
+for key_type in "${{key_types[@]}}"; do
+    priv_key_file=~/.ssh/id_${{key_type}}
+    if [ -f "$priv_key_file" ]; then
+        pub_key_file=$priv_key_file.pub
+        cat $pub_key_file
+        break
+    fi
+done
+'''
     result = shell.su_subprocess_run(
         local_sudoer,
         'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_host, remote_user),
-        input=cmd.encode('utf-8'),
+        input=fetch_key_script.encode('utf-8'),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -989,18 +989,6 @@ def _fetch_core_hosts(shell: sh.ClusterShell, remote_host) -> typing.Tuple[typin
     return user_list, host_list
 
 
-def key_files(user):
-    """
-    Find home directory for user and return key files with abspath
-    """
-    keyfile_dict = {}
-    home_dir = userdir.gethomedir(user)
-    keyfile_dict['private'] = "{}/.ssh/id_rsa".format(home_dir)
-    keyfile_dict['public'] = "{}/.ssh/id_rsa.pub".format(home_dir)
-    keyfile_dict['authorized'] = "{}/.ssh/authorized_keys".format(home_dir)
-    return keyfile_dict
-
-
 def is_nologin(user, remote=None):
     """
     Check if user's shell is nologin
@@ -1112,12 +1100,9 @@ EOF
 def import_ssh_key(local_user, remote_user, local_sudoer, remote_node, remote_sudoer):
     "Copy ssh key from remote to local authorized_keys"
     remote_key_content = ssh_key.fetch_public_key_list(remote_node, remote_user, with_content=True)[0]
-    _, _, local_authorized_file = key_files(local_user).values()
-    if not utils.check_text_included(remote_key_content, local_authorized_file, remote=None):
-        sh.LocalShell().get_stdout_or_raise_error(
-            local_user,
-            "sed -i '$a {}' '{}'".format(remote_key_content, local_authorized_file),
-        )
+    in_memory_key = ssh_key.InMemoryPublicKey(remote_key_content)
+    shell = sh.SSHShell(sh.LocalShell(), local_user)
+    ssh_key.AuthorizedKeyManager(shell).add(None, local_user, in_memory_key)
 
 
 def init_csync2():

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1092,9 +1092,7 @@ def export_ssh_key_non_interactive(local_user_to_export, remote_user_to_swap, re
     """Copy ssh key from local to remote's authorized_keys. Require a configured non-interactive ssh authentication."""
     # ssh-copy-id will prompt for the password of the destination user
     # this is unwanted, so we write to the authorised_keys file ourselve
-    # cmd = "ssh-copy-id -i ~{}/.ssh/id_rsa.pub {}@{}".format(local_user, remote_user_to_access, remote_node)
-    with open(os.path.expanduser('~{}/.ssh/id_rsa.pub'.format(local_user_to_export)), 'r', encoding='utf-8') as f:
-        public_key = f.read()
+    public_key = ssh_key.fetch_public_key_list(None, local_user_to_export, with_content=True)[0]
     # FIXME: prevent duplicated entries in authorized_keys
     cmd = '''mkdir -p ~{user}/.ssh && chown {user} ~{user}/.ssh && chmod 0700 ~{user}/.ssh && cat >> ~{user}/.ssh/authorized_keys << "EOF"
 {key}
@@ -1115,7 +1113,7 @@ EOF
 
 def import_ssh_key(local_user, remote_user, local_sudoer, remote_node, remote_sudoer):
     "Copy ssh key from remote to local authorized_keys"
-    remote_key_content = remote_public_key_from(remote_user, local_sudoer, remote_node, remote_sudoer)
+    remote_key_content = ssh_key.fetch_public_key_list(remote_node, remote_user, with_content=True)[0]
     _, _, local_authorized_file = key_files(local_user).values()
     if not utils.check_text_included(remote_key_content, local_authorized_file, remote=None):
         sh.LocalShell().get_stdout_or_raise_error(
@@ -1220,7 +1218,7 @@ def init_qnetd_remote():
     Triggered by join_cluster, this function adds the joining node's key to the qnetd's authorized_keys
     """
     local_user, remote_user, join_node = _select_user_pair_for_ssh_for_secondary_components(_context.cluster_node)
-    join_node_key_content = remote_public_key_from(remote_user, local_user, join_node, remote_user)
+    join_node_key_content = ssh_key.fetch_public_key_list(join_node, remote_user, with_content=True)[0]
     qnetd_host = corosync.get_value("quorum.device.net.host")
     _, qnetd_user, qnetd_host = _select_user_pair_for_ssh_for_secondary_components(qnetd_host)
     authorized_key_manager = ssh_key.AuthorizedKeyManager(sh.cluster_shell())
@@ -1648,7 +1646,7 @@ def _setup_passwordless_ssh_for_qnetd(cluster_node_list: typing.List[str]):
             if node == utils.this_node():
                 continue
             local_user, remote_user, node = _select_user_pair_for_ssh_for_secondary_components(node)
-            remote_key_content = remote_public_key_from(remote_user, local_user, node, remote_user)
+            remote_key_content = ssh_key.fetch_public_key_list(node, remote_user, with_content=True)[0]
             in_memory_key = ssh_key.InMemoryPublicKey(remote_key_content)
             ssh_key.AuthorizedKeyManager(cluster_shell).add(qnetd_addr, qnetd_user, in_memory_key)
 
@@ -1808,24 +1806,6 @@ def swap_public_ssh_key(
             import_ssh_key(local_user_to_swap, remote_user_to_swap, local_sudoer, remote_node, remote_sudoer)
         except ValueError as e:
             logger.warning(e)
-
-
-def remote_public_key_from(remote_user, local_sudoer, remote_node, remote_sudoer):
-    "Get the id_rsa.pub from the remote node"
-    cmd = 'cat ~/.ssh/id_rsa.pub'
-    result = sh.LocalShell().su_subprocess_run(
-        local_sudoer,
-        'ssh {} {}@{} sudo -H -u {} /bin/sh'.format(constants.SSH_OPTION, remote_sudoer, remote_node, remote_user),
-        input=cmd.encode('utf-8'),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        )
-    if result.returncode != 0:
-        utils.fatal("Can't get the remote id_rsa.pub from {}: {}".format(
-            remote_node,
-            codecs.decode(result.stderr, 'utf-8', 'replace'),
-        ))
-    return result.stdout.decode('utf-8')
 
 
 def join_csync2(seed_host, remote_user):

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -183,6 +183,7 @@ class AgentClient:
 
 
 class KeyFileManager:
+    DEFAULT_KEY_TYPE = 'rsa'
     KNOWN_KEY_TYPES = ['rsa', 'ed25519', 'ecdsa']   # dsa is not listed here as it is not so secure
     KNOWN_PUBLIC_KEY_FILENAME_PATTERN = re.compile('/id_(?:{})\\.pub$'.format('|'.join(KNOWN_KEY_TYPES)))
 
@@ -232,7 +233,7 @@ class KeyFileManager:
         * list_of_public_keys: all public keys of known types, including the newly generated one
         """
         script = '''if [ ! \\( {condition} \\) ]; then
-    ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -C "Cluster internal on $(hostname)" -N '' <> /dev/null
+    ssh-keygen -t {key_type} -f ~/.ssh/id_{key_type} -q -C "Cluster internal on $(hostname)" -N '' <> /dev/null
     echo 'GENERATED=1'
 fi
 for file in ~/.ssh/id_{{{pattern}}}; do
@@ -245,6 +246,7 @@ for file in ~/.ssh/id_{{{pattern}}}; do
 done
 '''.format(
             condition=' -o '.join([f'-f ~/.ssh/id_{t}' for t in self.KNOWN_KEY_TYPES]),
+            key_type=self.DEFAULT_KEY_TYPE,
             pattern=','.join(self.KNOWN_KEY_TYPES),
         )
         result = self.cluster_shell.subprocess_run_without_input(

--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -269,34 +269,55 @@ done
         return generated, keys
 
 
-def fetch_public_key_list(
+def fetch_public_key_file_list(
         host: typing.Optional[str],
         user: str,
-        generate_key_pair: bool = False,
-        with_content: bool = False
+        generate_key_pair: bool = False
 ) -> typing.List[str]:
     """
-    Fetch the public key list for the specified user on the specified host.
+    Fetch the public key file list for the specified user on the specified host.
 
     :param host: the host where the user is located. If None, the local host is assumed.
     :param user: the user name
     :param generate_key_pair: whether to generate a new key pair if no key pair is found,
      default is False
-    :param with_content: whether to return the content of the public key files,
-     default is False
 
-    :return: a list of public key files if with_content is False, otherwise a list of public key strings
+    :return: a list of public key file paths
 
     :raise Error: if no public key file is found for the user
     """
     key_file_manager = KeyFileManager(sh.cluster_shell())
     if generate_key_pair:
         key_file_manager.ensure_key_pair_exists_for_user(host, user)
-    if with_content:
-        keys_in_memory = key_file_manager.load_public_keys_for_user(host, user)
-        public_keys = [key.public_key() for key in keys_in_memory]
-    else:
-        public_keys = key_file_manager.list_public_key_for_user(host, user)
+    public_keys = key_file_manager.list_public_key_for_user(host, user)
+    if not public_keys:
+        host_str = f'@{host}' if host else ' locally'
+        raise Error(f'No public key file found for {user}{host_str}')
+    return public_keys
+
+
+def fetch_public_key_content_list(
+        host: typing.Optional[str],
+        user: str,
+        generate_key_pair: bool = False
+) -> typing.List[str]:
+    """
+    Fetch the public key content list for the specified user on the specified host.
+
+    :param host: the host where the user is located. If None, the local host is assumed.
+    :param user: the user name
+    :param generate_key_pair: whether to generate a new key pair if no key pair is found,
+     default is False
+
+    :return: a list of public key strings
+
+    :raise Error: if no public key file is found for the user
+    """
+    key_file_manager = KeyFileManager(sh.cluster_shell())
+    if generate_key_pair:
+        key_file_manager.ensure_key_pair_exists_for_user(host, user)
+    keys_in_memory = key_file_manager.load_public_keys_for_user(host, user)
+    public_keys = [key.public_key() for key in keys_in_memory]
     if not public_keys:
         host_str = f'@{host}' if host else ' locally'
         raise Error(f'No public key file found for {user}{host_str}')

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2470,16 +2470,6 @@ class InterfacesInfo(object):
         return _ip_list
 
 
-def check_text_included(text, target_file, remote=None):
-    "Check whether target_file includes the text"
-    if not detect_file(target_file, remote=remote):
-        return False
-
-    cmd = "cat {}".format(target_file)
-    target_data = sh.cluster_shell().get_stdout_or_raise_error(cmd, remote)
-    return text in target_data
-
-
 def package_is_installed(pkg, remote_addr=None):
     """
     Check if package is installed
@@ -2958,21 +2948,6 @@ def diff_and_patch(orig_cib_str, current_cib_str):
         logger.error("Failed to patch")
         return False
     return True
-
-
-def detect_file(_file, remote=None):
-    """
-    Detect if file exists, support both local and remote
-    """
-    rc = False
-    if not remote:
-        cmd = "test -f {}".format(_file)
-    else:
-        # FIXME
-        cmd = "ssh {} {}@{} 'test -f {}'".format(SSH_OPTION, user_of(remote), remote, _file)
-    code, _, _ = ShellUtils().get_stdout_stderr(cmd)
-    rc = code == 0
-    return rc
 
 
 def check_function_with_timeout(check_function, wait_timeout=30, interval=1, *args, **kwargs):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -133,7 +133,7 @@ def ssh_copy_id_no_raise(local_user, remote_user, remote_node, shell: sh.LocalSh
     if shell is None:
         shell = sh.LocalShell()
     if check_ssh_passwd_need(local_user, remote_user, remote_node, shell):
-        local_public_key = ssh_key.fetch_public_key_list(None, local_user)[0]
+        local_public_key = ssh_key.fetch_public_key_file_list(None, local_user)[0]
         logger.info("Configuring SSH passwordless with {}@{}".format(remote_user, remote_node))
         cmd = f"ssh-copy-id -i {local_public_key} '{remote_user}@{remote_node}' &> /dev/null"
         result = shell.su_subprocess_run(local_user, cmd, tty=True)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -40,6 +40,7 @@ from . import constants
 from . import options
 from . import term
 from distutils.version import LooseVersion
+from . import ssh_key
 from .constants import SSH_OPTION
 from . import log
 from .prun import prun
@@ -132,8 +133,9 @@ def ssh_copy_id_no_raise(local_user, remote_user, remote_node, shell: sh.LocalSh
     if shell is None:
         shell = sh.LocalShell()
     if check_ssh_passwd_need(local_user, remote_user, remote_node, shell):
+        local_public_key = ssh_key.fetch_public_key_list(None, local_user)[0]
         logger.info("Configuring SSH passwordless with {}@{}".format(remote_user, remote_node))
-        cmd = "ssh-copy-id -i ~/.ssh/id_rsa.pub '{}@{}' &> /dev/null".format(remote_user, remote_node)
+        cmd = f"ssh-copy-id -i {local_public_key} '{remote_user}@{remote_node}' &> /dev/null"
         result = shell.su_subprocess_run(local_user, cmd, tty=True)
         return result.returncode
     else:

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -675,33 +675,6 @@ done
         mock_swap.assert_not_called()
         mock_invoke.assert_not_called()
 
-
-    @mock.patch('crmsh.bootstrap.import_ssh_key')
-    @mock.patch('crmsh.bootstrap.export_ssh_key_non_interactive')
-    @mock.patch('logging.Logger.warning')
-    @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    def test_swap_public_ssh_key_exception(self, mock_check_passwd, mock_warn, mock_export_ssh_key, mock_import_ssh):
-        mock_check_passwd.return_value = False
-        mock_import_ssh.side_effect = ValueError("Can't get the remote id_rsa.pub from {}: {}")
-
-        bootstrap.swap_public_ssh_key("node1", "bob", "bob", "alice", "alice")
-
-        mock_check_passwd.assert_called_once_with("bob", "bob", "node1")
-        mock_import_ssh.assert_called_once_with("bob", "bob", "alice", "node1", "alice")
-        mock_warn.assert_called_once_with(mock_import_ssh.side_effect)
-
-    @mock.patch('crmsh.bootstrap.import_ssh_key')
-    @mock.patch('crmsh.bootstrap.export_ssh_key_non_interactive')
-    @mock.patch('crmsh.utils.check_ssh_passwd_need')
-    def test_swap_public_ssh_key(self, mock_check_passwd, mock_export_ssh, mock_import_ssh):
-        mock_check_passwd.return_value = True
-
-        bootstrap.swap_public_ssh_key("node1", "bob", "bob", "alice", "alice")
-
-        mock_check_passwd.assert_called_once_with("bob", "bob", "node1")
-        mock_export_ssh.assert_called_once_with("bob", "bob", "node1", "alice", "alice")
-        mock_import_ssh.assert_called_once_with("bob", "bob", "alice", "node1", "alice")
-
     @mock.patch('crmsh.utils.this_node')
     def test_bootstrap_add_return(self, mock_this_node):
         ctx = mock.Mock(user_at_node_list=[], use_ssh_agent=False)
@@ -806,7 +779,7 @@ done
         ])
         mock_swap.assert_has_calls([
             mock.call('node2', "carol", "bob", "carol", "bob"),
-            mock.call('node2', 'hacluster', 'hacluster', 'carol', 'bob', generate_key_on_remote=True)
+            mock.call('node2', 'hacluster', 'hacluster', 'carol', 'bob')
             ])
 
     @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -456,13 +456,6 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_change_user_shell.assert_called_once_with("hacluster")
 
-    @mock.patch('crmsh.userdir.gethomedir')
-    def test_key_files(self, mock_gethome):
-        mock_gethome.return_value = "/root"
-        expected_res = {"private": "/root/.ssh/id_rsa", "public": "/root/.ssh/id_rsa.pub", "authorized": "/root/.ssh/authorized_keys"}
-        self.assertEqual(bootstrap.key_files("root"), expected_res)
-        mock_gethome.assert_called_once_with("root")
-
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.is_nologin')
@@ -495,9 +488,24 @@ class TestBootstrap(unittest.TestCase):
             mock.call(
                 'local_sudoer',
                 'ssh -o StrictHostKeyChecking=no remote_sudoer@remote_host sudo -H -u remote_user /bin/sh',
-                input='''
-[ -f ~/.ssh/id_rsa ] || ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -C "Cluster internal on $(hostname)" -N ''
-[ -f ~/.ssh/id_rsa.pub ] || ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+                input=f'''
+key_types=({ ' '.join(crmsh.ssh_key.KeyFileManager.KNOWN_KEY_TYPES) })
+for key_type in "${{key_types[@]}}"; do
+    priv_key_file=~/.ssh/id_${{key_type}}
+    if [ -f "$priv_key_file" ]; then
+        pub_key_file=$priv_key_file.pub
+        break
+    fi
+done
+
+if [ -z "$pub_key_file" ]; then
+    key_type={crmsh.ssh_key.KeyFileManager.DEFAULT_KEY_TYPE}
+    priv_key_file=~/.ssh/id_${{key_type}}
+    ssh-keygen -q -t $key_type -f $priv_key_file -C "Cluster internal on $(hostname)" -N ''
+    pub_key_file=$priv_key_file.pub
+fi
+
+[ -f "$pub_key_file" ] || ssh-keygen -y -f $priv_key_file > $pub_key_file
 '''.encode('utf-8'),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
@@ -505,7 +513,17 @@ class TestBootstrap(unittest.TestCase):
             mock.call(
                 'local_sudoer',
                 'ssh -o StrictHostKeyChecking=no remote_sudoer@remote_host sudo -H -u remote_user /bin/sh',
-                input='cat ~/.ssh/id_rsa.pub'.encode('utf-8'),
+                input=f'''
+key_types=({ ' '.join(crmsh.ssh_key.KeyFileManager.KNOWN_KEY_TYPES) })
+for key_type in "${{key_types[@]}}"; do
+    priv_key_file=~/.ssh/id_${{key_type}}
+    if [ -f "$priv_key_file" ]; then
+        pub_key_file=$priv_key_file.pub
+        cat $pub_key_file
+        break
+    fi
+done
+'''.encode('utf-8'),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ),
@@ -590,7 +608,7 @@ class TestBootstrap(unittest.TestCase):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        mock_swap.assert_called_once_with("node1", "bob", "alice", "bob", "alice", add=True)
+        mock_swap.assert_called_once_with("node1", "bob", "alice", "bob", "alice")
         mock_swap_2.assert_called_once()
         args, kwargs = mock_swap_2.call_args
         self.assertEqual(3, len(args))
@@ -788,7 +806,7 @@ class TestBootstrap(unittest.TestCase):
         ])
         mock_swap.assert_has_calls([
             mock.call('node2', "carol", "bob", "carol", "bob"),
-            mock.call('node2', 'hacluster', 'hacluster', 'carol', 'bob', add=True)
+            mock.call('node2', 'hacluster', 'hacluster', 'carol', 'bob', generate_key_on_remote=True)
             ])
 
     @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
@@ -937,7 +955,7 @@ class TestBootstrap(unittest.TestCase):
     @mock.patch('crmsh.ssh_key.AuthorizedKeyManager')
     @mock.patch('crmsh.sh.cluster_shell')
     @mock.patch('crmsh.ssh_key.InMemoryPublicKey')
-    @mock.patch('crmsh.bootstrap.remote_public_key_from')
+    @mock.patch('crmsh.ssh_key.fetch_public_key_content_list')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.utils.ssh_copy_id_no_raise')
     @mock.patch('crmsh.utils.check_ssh_passwd_need')
@@ -952,7 +970,7 @@ class TestBootstrap(unittest.TestCase):
         mock_check_passwd.return_value = True
         mock_ssh_copy_id.return_value = 0
         mock_this_node.return_value = "node1"
-        mock_remote_public_key_from.return_value = "public_key"
+        mock_remote_public_key_from.return_value = ["public_key"]
         mock_in_memory_public_key.return_value = "public_key"
         mock_authorized_key_manager_instance = mock.Mock()
         mock_authorized_key_manager.return_value = mock_authorized_key_manager_instance


### PR DESCRIPTION
backport #1600 