### PR TITLE
Collect ~/.config/crm/crm.conf in crm report result

### DIFF
--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -298,8 +298,13 @@ DEFAULTS = {
         'compress': opt_boolean('yes'),
         'compress_prog': opt_string('gzip'),
         'speed_up': opt_boolean('no'),
-        'collect_extra_logs': opt_string('/var/log/messages \
-                /var/log/crmsh/crmsh.log /etc/crm/profiles.yml /etc/crm/crm.conf'),
+        'collect_extra_logs': opt_list([
+            '/var/log/messages',
+            '/var/log/crmsh/crmsh.log',
+            '/etc/crm/profiles.yml',
+            '/etc/crm/crm.conf',
+            '~/.config/crm/crm.conf'
+        ]),
         'remove_exist_dest': opt_boolean('no'),
         'single_node': opt_boolean('no'),
         'sanitize_rule': opt_string('passw.*'),

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -96,28 +96,6 @@ def collect_journal_logs(context: core.Context) -> None:
         logger.debug(f"Dump jounal log for {item} into {utils.real_path(_file)}")
 
 
-def dump_D_process() -> str:
-    """
-    Dump D-state process stack
-    """
-    out_string = ""
-
-    sh_utils_inst = ShellUtils()
-    _, out, _ = sh_utils_inst.get_stdout_stderr("ps aux|awk '$8 ~ /^D/{print $2}'")
-    len_D_process = len(out.split('\n')) if out else 0
-    out_string += f"Dump D-state process stack: {len_D_process}\n"
-    if len_D_process == 0:
-        return out_string
-
-    for pid in out.split('\n'):
-        _, cmd_out, _ = sh_utils_inst.get_stdout_stderr(f"cat /proc/{pid}/comm")
-        out_string += f"pid: {pid}     comm: {cmd_out}\n"
-        _, stack_out, _ = sh_utils_inst.get_stdout_stderr(f"cat /proc/{pid}/stack")
-        out_string += stack_out + "\n\n"
-
-    return out_string
-
-
 def collect_ratraces(context: core.Context) -> None:
     """
     Collect ra trace file from default /var/lib/heartbeat/trace_ra and custom one

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -65,9 +65,11 @@ def collect_ha_logs(context: core.Context) -> None:
     Collect pacemaker, corosync and extra logs
     """
     log_list = [get_pcmk_log(), get_corosync_log()] + context.extra_log_list
-    for log in log_list:
+    log_list = [os.path.expanduser(log) for log in log_list]
+    log_list_marked_same_basename = utils.mark_duplicate_basenames(log_list)
+    for log, same_basename in log_list_marked_same_basename:
         if log and os.path.isfile(log):
-            utils.dump_logset(context, log)
+            utils.dump_logset(context, log, create_dir=same_basename)
 
 
 def collect_journal_logs(context: core.Context) -> None:

--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -40,7 +40,7 @@ class Context:
         self.to_time: float = utils.now()
         self.no_compress: bool = not config.report.compress
         self.speed_up: bool = config.report.speed_up
-        self.extra_log_list: List[str] = config.report.collect_extra_logs.split()
+        self.extra_log_list: List[str] = config.report.collect_extra_logs
         self.rm_exist_dest: bool = config.report.remove_exist_dest
         self.single: bool= config.report.single_node
         self.sensitive_regex_list: List[str] = []

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -10,6 +10,7 @@ import sys
 import traceback
 from dateutil import tz
 from enum import Enum
+from collections import Counter
 from typing import Optional, List, Tuple
 
 from crmsh import utils as crmutils
@@ -228,7 +229,7 @@ def get_distro_info() -> str:
     return res.group(1) if res else "Unknown"
 
 
-def dump_logset(context: core.Context, logf: str) -> None:
+def dump_logset(context: core.Context, logf: str, create_dir: bool = False) -> None:
     """
     Dump the log set into the specified output file
     """
@@ -255,7 +256,17 @@ def dump_logset(context: core.Context, logf: str) -> None:
             out_string += print_logseg(newest, 0, context.to_time)
 
     if out_string:
-        outf = os.path.join(context.work_dir, os.path.basename(logf))
+        if create_dir:
+            basename, dirname = os.path.basename(logf), os.path.dirname(logf)
+            dest_dir = os.path.join(
+                context.work_dir,
+                f'{basename}.d',
+                dirname.lstrip('/')
+            )
+            crmutils.mkdirp(dest_dir)
+            outf = os.path.join(dest_dir, basename)
+        else:
+            outf = os.path.join(context.work_dir, os.path.basename(logf))
         crmutils.str2file(out_string.strip('\n'), outf)
         logger.debug(f"Dump {logf} into {real_path(outf)}")
 
@@ -775,4 +786,14 @@ def print_traceback():
 
 def real_path(target_file: str) -> str:
     return '/'.join(target_file.split('/')[3:])
+
+
+def mark_duplicate_basenames(file_path_list: list[str]) -> list[tuple[str, bool]]:
+    """
+    Mark the paths with the same basename
+    Return a list of tuples, each tuple contains the path and a boolean value
+    indicating whether the path has the same basename with others
+    """
+    counter = Counter([os.path.basename(path) for path in file_path_list])
+    return [(path, counter[os.path.basename(path)] > 1) for path in file_path_list]
 # vim:ts=4:sw=4:et:

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -82,7 +82,7 @@ ocf_root = @OCF_ROOT_DIR@
 ; compress = yes
 ; compress_prog = gzip
 ; speed_up = no
-; collect_extra_logs = /var/log/messages /var/log/pacemaker.log
+; collect_extra_logs = /var/log/messages, /var/log/crmsh/crmsh.log, /etc/crm/profiles.yml, /etc/crm/crm.conf, ~/.config/crm/crm.conf
 ; remove_exist_dest = no
 ; single_node = no
 ;

--- a/test/unittests/test_report_core.py
+++ b/test/unittests/test_report_core.py
@@ -39,7 +39,7 @@ class TestContext(unittest.TestCase):
         mock_config.report = mock.Mock(
             from_time="20230101",
             compress=False,
-            collect_extra_logs="file1 file2",
+            collect_extra_logs=["file1", "file2"],
             remove_exist_dest=False,
             single_node=False
         )


### PR DESCRIPTION
Changes include:
1. The file `~/.config/crm/crm.conf` is now collected in crm report result

2. To manage files that have the same basename (e.g., `crm.conf`), the PR implements a new directory. When multiple files share the same basename, a directory named `{basename}.d` is created in the report result. All files with the same basename are then placed inside this directory. For instance, the files `/etc/crm/crm.conf` and `/root/.config/crm/crm.conf` will be placed inside a directory named `crm.conf.d`