### PR TITLE
Dev: utils: Change `get_dc` function as the behavior of `crmadmin -D` changed

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -985,9 +985,7 @@ def append_file(dest, src):
 def get_dc(peer=None):
     cmd = "crmadmin -D -t 1"
     _, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(peer, cmd)
-    if not out:
-        return None
-    if not out.startswith("Designated"):
+    if not out or not out.startswith("Designated") or "not yet elected" in out:
         return None
     return out.split()[-1]
 


### PR DESCRIPTION
The behavior of `crmadmin -D` changed when no DC elected
original:
```
# crmadmin -D -t 1
error: Timed out after 1000ms waiting for reply from controller API on DC
error: Command failed: Resource temporarily unavailable
```
now:
```
# crmadmin -D -t 1
Designated Controller is: not yet elected
```