### PR TITLE
[crmsh-4.6] Dev: bootstrap: Skip ssh-agent warning when cluster is running

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -608,7 +608,7 @@ def check_prereqs():
         logger.warning("{} is not configured to start at system boot.".format(timekeeper))
         warned = True
 
-    if _context.use_ssh_agent == False and 'SSH_AUTH_SOCK' in os.environ:
+    if not _context.cluster_is_running and _context.use_ssh_agent == False and 'SSH_AUTH_SOCK' in os.environ:
         msg = "$SSH_AUTH_SOCK is detected. As a tip, using the --use-ssh-agent option could avoid generate local root ssh keys on cluster nodes."
         logger.warning(msg)
         warned = True


### PR DESCRIPTION
backport #1630 