### PR TITLE
Dev: help: Support '--help' option for cluster properties

### DIFF
--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -386,7 +386,8 @@ Examples:
         levels = levels[1:]     # drop the 1st element "root"
         levels.extend(args)
         h = help_module.help_contextual(levels)
-        h.paginate()
+        if h:
+            h.paginate()
         context.command_name = ""
 
     def get_completions(self):

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -37,6 +37,7 @@ from .utils import page_string
 from . import config
 from . import clidisplay
 from . import log
+from . import ra
 
 
 logger = log.setup_logger(__name__)
@@ -313,6 +314,10 @@ def _is_level(levels: typing.Sequence[str]):
     return node is not None and node.children
 
 
+def _is_property(levels: typing.Sequence[str]):
+    return len(levels) == 3 and levels[0] == 'configure' and levels[1] == 'property'
+
+
 def help_contextual(levels: typing.Sequence[str]):
     """
     Returns contextual help
@@ -324,6 +329,16 @@ def help_contextual(levels: typing.Sequence[str]):
         return help_topic(levels[0])
     elif _is_command(levels) or _is_level(levels):
         return help_command(levels[0:])
+    elif _is_property(levels):
+        agent = ra.get_properties_meta()
+        if agent:
+            all_properties = agent.params()
+            property_name = levels[-1]
+            if property_name in all_properties:
+                print(agent.meta_parameter(property_name))
+            else:
+                raise ValueError(f"Unknown property '{property_name}'")
+        return None
     else:
         topic = levels[0].lower()
         t = fuzzy_get(_TOPICS, topic)

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1131,6 +1131,9 @@ class CibConfig(command.UI):
     def do_property(self, context, *args):
         "usage: property [$id=<set_id>] <option>=<value>"
         self.__override_lower_level_attrs(*args)
+        if not args:
+            utils.multicolumn(ra.get_properties_list())
+            return
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('administrator')

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3612,6 +3612,12 @@ When setting the +maintenance-mode+ property, it will
 inform the user if there are nodes or resources that
 have the +maintenance+ property.
 
+If no property name is passed to the command, the list of known
+cluster properties is printed.
+
+To print one property's help, use the +--help+ option; Or use <Tab>
+to complete the help text for the property on interactive mode.
+
 For more information on rule expressions, see
 <<topics.Syntax.RuleExpressions,Syntax: Rule expressions>>.
 
@@ -3621,6 +3627,7 @@ property [<set_id>:] [rule ...] <option>=<value> [<option>=<value> ...]
 ...............
 Example:
 ...............
+property stonith-enabled --help
 property stonith-enabled=true
 property rule date spec years=2014 stonith-enabled=false
 ...............


### PR DESCRIPTION
By using `crm configure property <property_name> --help`, print the help of property on non-interactive mode.

Also, for `crm configure property` command, print all properties if no property is specified