### PR TITLE
Dev: bootstrap: Option -N should require option -y

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -238,6 +238,8 @@ class Context(object):
         """
         Validate -N/--nodes option
         """
+        if self.user_at_node_list and not self.yes_to_all:
+            utils.fatal("Can't use -N/--nodes option without -y/--yes option")
         if self.user_at_node_list and self.stage:
             utils.fatal("Can't use -N/--nodes option and stage({}) together".format(self.stage))
         me = utils.this_node()

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -34,6 +34,8 @@ Feature: crmsh bootstrap process - options
       """
     When    Try "crm cluster init sbd -x -y" on "hanode1"
     Then    Expected "-x option or SKIP_CSYNC2_SYNC can't be used with any stage" in stderr
+    When    Try "crm cluster init -N hanode2" on "hanode1"
+    Then    Expected "Can't use -N/--nodes option without -y/--yes option" in stderr
     When    Try "crm cluster init sbd -N hanode1 -N hanode2 -y" on "hanode1"
     Then    Expected "Can't use -N/--nodes option and stage(sbd) together" in stderr
     When    Try "crm corosync link help add" on "hanode1"


### PR DESCRIPTION
To avoid potential misconfiguration between nodes on interactive mode.

e.g. Specify multiple interfaces on local node, but the peer node don't know the configuration.