### PR TITLE
[crmsh-4.6] Dev: bootstrap: Option -N should require option -y

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -223,6 +223,8 @@ class Context(object):
         """
         Validate -N/--nodes option
         """
+        if self.user_at_node_list and not self.yes_to_all:
+            utils.fatal("Can't use -N/--nodes option without -y/--yes option")
         if self.user_at_node_list and self.stage:
             utils.fatal("Can't use -N/--nodes option and stage({}) together".format(self.stage))
         me = utils.this_node()

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -39,6 +39,8 @@ Feature: crmsh bootstrap process - options
     Then    Expected "-x option or SKIP_CSYNC2_SYNC can't be used with any stage" in stderr
     When    Try "crm cluster init -i eth0 -i eth1 -i eth2 -y" on "hanode1"
     Then    Expected "Maximum number of interface is 2" in stderr
+    When    Try "crm cluster init -N hanode2" on "hanode1"
+    Then    Expected "Can't use -N/--nodes option without -y/--yes option" in stderr
     When    Try "crm cluster init sbd -N hanode1 -N hanode2 -y" on "hanode1"
     Then    Expected "Can't use -N/--nodes option and stage(sbd) together" in stderr
 


### PR DESCRIPTION
backport #1656 