### PR TITLE
Make minor changes based on Pacemaker-3.0's changelog (jsc#PED-8231)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1458,7 +1458,7 @@ def init_cluster():
     logger.info("Loading initial cluster configuration")
 
     crm_configure_load("update", """property cib-bootstrap-options: stonith-enabled=false
-op_defaults op-options: timeout=600 record-pending=true
+op_defaults op-options: timeout=600
 rsc_defaults rsc-options: resource-stickiness=1 migration-threshold=3
 """)
 

--- a/crmsh/cmd_status.py
+++ b/crmsh/cmd_status.py
@@ -41,6 +41,22 @@ _ERRORS = ['not running',
            'Unknown',
            'OFFLINE',
            'Failed actions']
+CRM_MON_OPTIONS_MAP = {
+        "bynode": "-n",
+        "inactive": "-r",
+        "ops": "-o",
+        "timing": "-t",
+        "failcounts": "-f",
+        "verbose": "-V",
+        "quiet": "-Q",
+        "html": "--output-as html",
+        "xml": "--output-as xml",
+        "tickets": "-c",
+        "noheaders": "-D",
+        "detail": "-R",
+        "brief": "-b",
+        "full": "-ncrft",
+}
 
 
 class CrmMonFilter(object):
@@ -96,24 +112,7 @@ def cmd_status(args):
     Displays the output, paging if necessary.
     Raises IOError if crm_mon fails.
     '''
-    opts = {
-        "bynode": "-n",
-        "inactive": "-r",
-        "ops": "-o",
-        "timing": "-t",
-        "failcounts": "-f",
-        "verbose": "-V",
-        "quiet": "-Q",
-        "html": "--output-as html",
-        "xml": "--output-as xml",
-        "simple": "-s",
-        "tickets": "-c",
-        "noheaders": "-D",
-        "detail": "-R",
-        "brief": "-b",
-        "full": "-ncrft",
-    }
-    extra = ' '.join(opts.get(arg, arg) for arg in args)
+    extra = ' '.join(CRM_MON_OPTIONS_MAP.get(arg, arg) for arg in args)
     if not args:
         extra = "-r"
     rc, s, err = crm_mon(extra)

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -74,7 +74,3 @@ online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "onlin
 standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "standby")
 
 shadows = call(xmlutil.listshadows)
-
-status_option = """full bynode inactive ops timing failcounts
-                   verbose quiet xml simple tickets noheaders
-                   detail brief""".split()

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -162,7 +162,7 @@ unary_ops = ('defined', 'not_defined')
 simple_date_ops = ('lt', 'gt')
 date_ops = ('lt', 'gt', 'in_range', 'date_spec')
 date_spec_names = '''hours monthdays weekdays yearsdays months \
-weeks years weekyears moon'''.split()
+weeks years weekyears'''.split()
 in_range_attrs = ('start', 'end')
 node_default_type = "normal"
 node_attributes_keyw = ("attributes", "utilization")

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -258,11 +258,7 @@ simulate_programs = {
 meta_progs_20 = ("pacemaker-controld", "pacemaker-schedulerd", "pacemaker-fenced", "pacemaker-based")
 
 # elide these properties from tab completion
-controld_metadata_do_not_complete = ("dc-version",
-                                 "cluster-infrastructure",
-                                 "crmd-integration-timeout",
-                                 "crmd-finalization-timeout",
-                                 "expected-quorum-votes")
+controld_metadata_do_not_complete = ("dc-version", "cluster-infrastructure")
 extra_cluster_properties = ("dc-version",
                             "cluster-infrastructure",
                             "last-lrm-refresh",

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -133,8 +133,8 @@ rsc_meta_attributes = (
     "allow-migrate", "maintenance", "is-managed", "interval-origin",
     "migration-threshold", "priority", "multiple-active",
     "failure-timeout", "resource-stickiness", "target-role",
-    "restart-type", "description", "remote-node", "requires",
-    "provides", "remote-port", "remote-addr", "remote-connect-timeout",
+    "description", "remote-node", "requires", "provides",
+    "remote-port", "remote-addr", "remote-connect-timeout",
     "critical", "allow-unhealthy-nodes", "container-attribute-target"
 )
 common_meta_attributes = ("priority", "target-role", "is-managed")

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from contextlib import contextmanager
 from crmsh import utils as crmshutils
 from . import config
+from crmsh import ra
 from crmsh import log
 from crmsh.sh import ShellUtils
 from crmsh import constants
@@ -118,8 +119,9 @@ class FenceInfo(object):
     @property
     def fence_action(self):
         action_result = crmshutils.get_property("stonith-action")
-        if action_result is None or action_result not in ["off", "poweroff", "reboot"]:
-            msg_error("Cluster property \"stonith-action\" should be reboot|off|poweroff")
+        supported_actions = ra.get_property_options("stonith-action")
+        if action_result is None or action_result not in supported_actions:
+            msg_error(f"Cluster property \"stonith-action\" should be {'|'.join(supported_actions)}")
             return None
         return action_result
 

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -511,7 +511,6 @@ class BaseParser(object):
                      | weeks=<value>
                      | years=<value>
                      | weekyears=<value>
-                     | moon=<value>
         """
         boolop = None
         exprs = [self._match_simple_exp()]

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -202,6 +202,11 @@ def get_properties_meta():
 
 
 @utils.memoize
+def get_property_options(property_name):
+    return get_properties_meta().param_options(property_name)
+
+
+@utils.memoize
 def get_properties_list():
     try:
         return list(get_properties_meta().params().keys())
@@ -363,6 +368,7 @@ class RAInfo(object):
                 "unique": unique,
                 "type": typ,
                 "default": default,
+                "options": self.get_selecte_value_list(c)
             }
         items = list(d.items())
         # Sort the dictionary by required and then alphabetically
@@ -402,6 +408,16 @@ class RAInfo(object):
                 actions_dict[name] = d
 
         return cache.store(ident, actions_dict)
+
+    def param_options(self, pname):
+        '''
+        Return parameter's option values if available
+        '''
+        d = self.params()
+        try:
+            return d[pname]["options"]
+        except:
+            return None
 
     def param_default(self, pname):
         '''

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -370,7 +370,7 @@ def dump_runtime_state(workdir: str) -> None:
 
     # Dump other runtime state files
     for cmd, f, desc in [
-        ("cibadmin -Ql", constants.CIB_F, "CIB contents"),
+        ("cibadmin -Q", constants.CIB_F, "CIB contents"),
         ("crm_node -p", constants.MEMBERSHIP_F, "members of this partition")
     ]:
         out = cluster_shell_inst.get_stdout_or_raise_error(cmd)

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -513,7 +513,7 @@ class RscMgmt(command.UI):
 
         if cmd == "set":
             # query the current failcount status
-            query_cmd = "cibadmin -Ql --xpath '/cib/status/node_state[@id='{}']'".format(nodeid)
+            query_cmd = "cibadmin -Q --xpath '/cib/status/node_state[@id='{}']'".format(nodeid)
             rc, out, err = ShellUtils().get_stdout_stderr(query_cmd)
             if rc != 0:
                 context.fatal_error(err)

--- a/crmsh/ui_root.py
+++ b/crmsh/ui_root.py
@@ -173,7 +173,7 @@ Geo-cluster related management.
     def do_site(self):
         pass
 
-    @command.completers(compl.choice(compl.status_option))
+    @command.completers(compl.choice(cmd_status.CRM_MON_OPTIONS_MAP))
     @command.help('''show cluster status
 Show cluster status. The status is displayed by `crm_mon`. Supply
 additional arguments for more information or different format.

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1034,12 +1034,11 @@ def wait_dc_stable(what="", show_progress=True):
     if not wait_for_dc():
         logger.warning("can't find DC")
         return False
-    cmd = "crm_attribute -Gq -t crm_config -n crmd-transition-delay 2> /dev/null"
-    delay = ShellUtils().get_stdout(add_sudo(cmd))[1]
+    delay = get_property("transition-delay")
     if delay:
         delaymsec = crm_msec(delay)
         if delaymsec > 0:
-            logger.info("The crmd-transition-delay is configured. Waiting %d msec before check DC status.", delaymsec)
+            logger.info("The transition-delay is configured. Waiting %d msec before check DC status.", delaymsec)
             time.sleep(delaymsec // 1000)
     cnt = 0
     output_started = 0

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -84,7 +84,7 @@ def compressed_file_to_cib(s):
     return cib_elem
 
 
-cib_dump = "cibadmin -Ql"
+cib_dump = "cibadmin -Q"
 
 
 def sudocall(cmd):

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -751,20 +751,6 @@ primitive dummy-1 params $dummy-state-on:state=1
 primitive dummy-2 params @dummy-state-on
 ............
 
-There is also the possibility that two resources both use the same
-attribute value but with different names. For example, a web server
-may have a parameter +server_ip+ for setting the IP address where it
-listens for incoming requests, and a virtual IP resource may have a
-parameter called +ip+ which sets the IP address it creates. To
-configure these two resources with an IP without repeating the value,
-the reference can be given a name using the syntax +@<id>:<name>+.
-
-Example:
-............
-primitive virtual-ip IPaddr2 params $vip:ip=192.168.1.100
-primitive webserver apache params @vip:server_ip
-............
-
 [[topics.Syntax.RuleExpressions,Syntax: Rule expressions]]
 === Syntax: Rule expressions
 

--- a/test/testcases/common.excl
+++ b/test/testcases/common.excl
@@ -13,7 +13,7 @@ Error performing operation: Not connected
 .EXT crm_resource --list-ocf-alternatives Delay
 .EXT crm_resource --list-ocf-alternatives Dummy
 ^\.EXT crmd version
-^\.EXT cibadmin \-Ql
+^\.EXT cibadmin \-Q
 ^\.EXT crm_verify \-VV \-p
 ^\.EXT cibadmin \-p \-P
 ^\.EXT crm_diff \-\-help

--- a/test/unittests/test_cliformat.py
+++ b/test/unittests/test_cliformat.py
@@ -114,7 +114,7 @@ def test_comment2():
 
 def test_nvpair_ref1():
     factory.create_from_cli("primitive dummy-0 Dummy params $fiz:buz=bin")
-    roundtrip('primitive dummy-1 Dummy params @fiz:boz')
+    roundtrip('primitive dummy-1 Dummy params @fiz')
 
 
 def test_idresolve():

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -77,16 +77,20 @@ class TestFenceInfo(TestCase):
         mock_get_property.assert_called_once_with("stonith-enabled")
 
     @mock.patch('crmsh.crash_test.utils.msg_error')
+    @mock.patch('crmsh.ra.get_property_options')
     @mock.patch('crmsh.crash_test.utils.crmshutils.get_property')
-    def test_fence_action_none(self, mock_get_property, mock_error):
+    def test_fence_action_none(self, mock_get_property, mock_get_property_options, mock_error):
+        mock_get_property_options.return_value = ["off", "reboot"]
         mock_get_property.return_value = None
         res = self.fence_info_inst.fence_action
         self.assertEqual(res, None)
         mock_get_property.assert_called_once_with("stonith-action")
-        mock_error.assert_called_once_with('Cluster property "stonith-action" should be reboot|off|poweroff')
+        mock_error.assert_called_once_with('Cluster property "stonith-action" should be off|reboot')
 
+    @mock.patch('crmsh.ra.get_property_options')
     @mock.patch('crmsh.crash_test.utils.crmshutils.get_property')
-    def test_fence_action(self, mock_get_property):
+    def test_fence_action(self, mock_get_property, mock_get_property_options):
+        mock_get_property_options.return_value = ["off", "reboot"]
         mock_get_property.return_value = "reboot"
         res = self.fence_info_inst.fence_action
         self.assertEqual(res, "reboot")

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -222,11 +222,10 @@ class TestCliParser(unittest.TestCase):
         self.assertEqual(out.get('class'), 'ocf')
         self.assertEqual(['foo'], out.xpath('.//nvpair/@id-ref'))
 
-        out = self._parse('primitive dummy-0 Dummy params @fiz:buz')
+        out = self._parse('primitive dummy-0 Dummy params @fiz')
         self.assertEqual(out.get('id'), 'dummy-0')
         self.assertEqual(out.get('class'), 'ocf')
         self.assertEqual(['fiz'], out.xpath('.//nvpair/@id-ref'))
-        self.assertEqual(['buz'], out.xpath('.//nvpair/@name'))
 
     @mock.patch('logging.Logger.error')
     def test_location(self, mock_error):


### PR DESCRIPTION
Changed:
- Dev: bootstrap: Drop 'record-pending' operation option
- Dev: utils: Make change since 'crmd-transition-delay' already renamed to 'transition-delay'
- Dev: constants: Drop deprecated "crmd-integration-timeout" and "crmd-finalization-timeout"
- Dev: crash_test: Drop deprecated 'poweroff' value of 'stonith-action' option
- Dev: Remove deprecated cibadmin --local option
- Dev: Drop unsupported 'moon' in date_spec
- Dev: constants: Drop deprecated 'restart-type' resource option
- Dev: Improve options of 'crm status' command
    
    - Reduce duplicated options definition
    - Drop deprecated '-s/--simple-status' option