### PR TITLE
Dev: ui_configure: Remove 'ms' sub-command (jsc#PED-8231)

### DIFF
--- a/crmsh/cmd_status.py
+++ b/crmsh/cmd_status.py
@@ -20,8 +20,7 @@ _WARNS = ['pending',
           'Stopped',
           'standby',
           'WITHOUT quorum']
-_OKS = ['Masters', 'Slaves', 'Started', 'Master', 'Slave', 'Online', 'online', 'ok', 'master',
-        'with quorum']
+_OKS = ['Started', 'Online', 'online', 'ok', 'with quorum', 'Promoted', 'Unpromoted']
 _ERRORS = ['not running',
            'unknown error',
            'invalid parameter',
@@ -30,13 +29,13 @@ _ERRORS = ['not running',
            'not installed',
            'not configured',
            'not running',
-           r'master \(failed\)',
+           'promoted (failed)',
            'OCF_SIGNAL',
            'OCF_NOT_SUPPORTED',
            'OCF_TIMEOUT',
            'OCF_OTHER_ERROR',
            'OCF_DEGRADED',
-           'OCF_DEGRADED_MASTER',
+           'OCF_DEGRADED_PROMOTED',
            'unknown',
            'Unknown',
            'OFFLINE',
@@ -67,7 +66,7 @@ class CrmMonFilter(object):
     _RESOURCES = re.compile(r'(\d+ Resources configured)')
 
     _RESOURCE = re.compile(r'(\S+)(\s+)\((\S+:\S+)\):')
-    _GROUP = re.compile(r'((?:Resource Group)|(?:Clone Set)|(?:Master/Slave Set)): (\S+)')
+    _GROUP = re.compile(r'((?:Resource Group)|(?:Clone Set)): (\S+)')
 
     def _filter(self, line):
         line = self._RESOURCE.sub("%s%s(%s):" % (clidisplay.help_header(r'\1'),

--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -395,8 +395,7 @@ Examples:
         return tab completions
         '''
         return [x for x in self._children.keys() if
-                x not in self._aliases and
-                x not in constants.HIDDEN_COMMANDS]
+                x not in self._aliases]
 
     def get_child(self, child):
         '''

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -442,9 +442,6 @@ CSYNC2_PORT = 30865
 HAWK_PORT = 7630
 DLM_PORT = 21064
 
-# Commands that are deprecated and hidden from UI
-HIDDEN_COMMANDS = {'ms'}
-
 NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mode."
 
 PCMK_SERVICE = "pacemaker.service"

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -114,8 +114,8 @@ lrm_exit_codes = {
     "installed": "5",
     "configured": "6",
     "not_running": "7",
-    "master": "8",
-    "failed_master": "9",
+    "promoted": "8",
+    "failed_promoted": "9",
 }
 lrm_status_codes = {
     "pending": "-1",

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -45,7 +45,7 @@ class RADriver(object):
         self.ec_l = {}
         self.ec_ok = self.unused
         self.ec_stopped = self.unused
-        self.ec_master = self.unused
+        self.ec_promoted = self.unused
         self.last_op = None
         self.last_rec = {}
         self.timeout = 20000
@@ -123,9 +123,9 @@ class RADriver(object):
         'Was last op successful?'
         return self.op_status(host) == self.ec_ok
 
-    def is_master(self, host):
+    def is_promoted(self, host):
         'Only if last op was probe/monitor.'
-        return self.op_status(host) == self.ec_master
+        return self.op_status(host) == self.ec_promoted
 
     def is_stopped(self, host):
         'Only if last op was probe/monitor.'
@@ -230,8 +230,8 @@ class RADriver(object):
         if not stopped:
             if self.is_ok(node):
                 self.warn("resource running at %s" % (node))
-            elif self.is_ms_or_promotable_clone() and self.is_master(node):
-                self.warn("resource is master at %s" % (node))
+            elif self.is_ms_or_promotable_clone() and self.is_promoted(node):
+                self.warn("resource is promoted at %s" % (node))
             else:
                 self.warn("resource not clean at %s" % (node))
                 self.show_log(node)
@@ -251,14 +251,14 @@ class RAOCF(RADriver):
     OCF_ERR_INSTALLED = 5
     OCF_ERR_CONFIGURED = 6
     OCF_NOT_RUNNING = 7
-    OCF_RUNNING_MASTER = 8
-    OCF_FAILED_MASTER = 9
+    OCF_RUNNING_PROMOTED = 8
+    OCF_FAILED_PROMOTED = 9
 
     def __init__(self, *args):
         RADriver.__init__(self, *args)
         self.ec_ok = self.OCF_SUCCESS
         self.ec_stopped = self.OCF_NOT_RUNNING
-        self.ec_master = self.OCF_RUNNING_MASTER
+        self.ec_promoted = self.OCF_RUNNING_PROMOTED
 
     def set_rscenv(self, op):
         RADriver.set_rscenv(self, op)
@@ -295,7 +295,7 @@ class RALSB(RADriver):
         RADriver.__init__(self, *args)
         self.ec_ok = self.LSB_OK
         self.ec_stopped = self.LSB_STATUS_NOT_RUNNING
-        self.ec_master = self.unused
+        self.ec_promoted = self.unused
 
     def set_rscenv(self, op):
         RADriver.set_rscenv(self, op)
@@ -323,7 +323,7 @@ class RASystemd(RADriver):
         RADriver.__init__(self, *args)
         self.ec_ok = self.SYSD_OK
         self.ec_stopped = self.SYSD_NOT_RUNNING
-        self.ec_master = self.unused
+        self.ec_promoted = self.unused
 
     def set_rscenv(self, op):
         RADriver.set_rscenv(self, op)

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -88,7 +88,7 @@ def _group_completer(args):
 
 def _advanced_completer(args):
     '''
-    meta completers for group/ms/clone resource type 
+    meta completers for group/clone resource type
     '''
     key_words = ["meta", "params"]
     completing = args[-1]
@@ -103,8 +103,6 @@ def _advanced_completer(args):
             return_list = utils.filter_keys(constants.group_meta_attributes, args)
         if resource_type == "clone":
             return_list = utils.filter_keys(constants.clone_meta_attributes, args)
-        if resource_type in ["ms", "master"]:
-            return_list = utils.filter_keys(constants.ms_meta_attributes, args)
     return return_list + key_words
 
 
@@ -1075,18 +1073,6 @@ class CibConfig(command.UI):
         """usage: clone <name> <rsc>
         [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
-        return self.__conf_object(context.get_command_name(), *args)
-
-    @command.alias('master')
-    @command.skill_level('administrator')
-    @command.completers_repeating(compl.attr_id, _f_children_id_list, _advanced_completer)
-    def do_ms(self, context, *args):
-        """usage: ms <name> <rsc>
-        [params <param>=<value> [<param>=<value>...]]
-        [meta <attribute>=<value> [<attribute>=<value>...]]"""
-        format_str = " " if "meta" in args else " meta "
-        new_cmd_str = ' '.join(args) + "{}promotable=true".format(format_str)
-        logger.warning('"ms" is deprecated. Please use "clone {}"'.format(new_cmd_str))
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('administrator')

--- a/scripts/db2-hadr/main.yml
+++ b/scripts/db2-hadr/main.yml
@@ -37,7 +37,7 @@ actions:
   - include: virtual-ip
   - include: db2
   - cib: |
-      ms ms-{{db2:id}} {{db2:id}}
-        meta target-role=Stopped notify=true
+      clone promotable-{{db2:id}} {{db2:id}}
+        meta target-role=Stopped notify=true promotable=true
       colocation {{virtual-ip:id}}-with-master inf: {{virtual-ip:id}}:Started ms-{{db2:id}}:Master
       order {{virtual-ip:id}}-after-master Mandatory: ms-{{db2:id}}:promote {{virtual-ip:id}}:start

--- a/scripts/drbd/main.yml
+++ b/scripts/drbd/main.yml
@@ -37,5 +37,5 @@ actions:
           drbdconf="{{drbdconf}}"
         op monitor interval="29s" role="Master"
         op monitor interval="31s" role="Slave"
-      ms ms-{{id}} {{id}}
-        meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true
+      clone promotable-{{id}} {{id}}
+        meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true promotable=true

--- a/test/unittests/test_bugs.py
+++ b/test/unittests/test_bugs.py
@@ -573,7 +573,6 @@ primitive p2 ocf:heartbeat:Delay \
     params startdelay=2 mondelay=2 stopdelay=2
 primitive p3 ocf:pacemaker:Dummy
 clone c1 p1
-ms m1 p2
 op_defaults timeout=60s
 """)
     assert ok


### PR DESCRIPTION
As pacemaker 3.0 already dropped support for deprecated master resources [1][2]
    
[1]
https://github.com/ClusterLabs/pacemaker/blob/main/xml/resources-4.0.rng#L19-L30
[2]
https://github.com/ClusterLabs/pacemaker/releases/tag/Pacemaker-3.0.0