### PR TITLE
[crmsh-4.6] Fix: report: Check if mounted.ocfs2 command exists before using it (bsc#1236220)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -199,7 +199,8 @@ def collect_cluster_fs_info(context: core.Context) -> None:
         crmutils.str2file(out_string, target_f)
 
     # Collect OCFS2 information
-    collect_info("mounted.ocfs2 -d", "OCFS2", constants.OCFS2_F)
+    if shutil.which("mounted.ocfs2"):
+        collect_info("mounted.ocfs2 -d", "OCFS2", constants.OCFS2_F)
 
     # Collect GFS2 information
     collect_info('mount|grep "type gfs2"', "GFS2", constants.GFS2_F)

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -569,7 +569,9 @@ id            0x19041a12
     @mock.patch("crmsh.report.collect.lsof_cluster_fs_device")
     @mock.patch("crmsh.report.collect.dump_D_process")
     @mock.patch("crmsh.report.collect.ShellUtils")
-    def test_collect_cluster_fs_info(self, mock_run, mock_dump, mock_lsof, mock_cluster, mock_debug, mock_real_path, mock_str2file, mock_error):
+    @mock.patch("shutil.which")
+    def test_collect_cluster_fs_info(self, mock_which, mock_run, mock_dump, mock_lsof, mock_cluster, mock_debug, mock_real_path, mock_str2file, mock_error):
+        mock_which.return_value = True
         mock_run_inst = mock.Mock()
         mock_run.return_value = mock_run_inst
         mock_run_inst.get_stdout_stderr.side_effect = [


### PR DESCRIPTION
backport #1669 