### PR TITLE
Fix: sbd: Check if fence_sbd command exists before initializing device (bsc#1236184)

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1,6 +1,7 @@
 import os
 import re
 import typing
+import shutil
 from . import utils, sh
 from . import bootstrap
 from . import log
@@ -436,6 +437,7 @@ class SBDManager:
     DISKLESS_SBD_MIN_EXPECTED_VOTE = 3
     DISKLESS_SBD_WARNING = "Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice."
     SBD_NOT_INSTALLED_MSG = "Package sbd is not installed."
+    FENCE_SBD_NOT_EXISTED_MSG = "fence_sbd command does not exist."
     SBD_RA = "stonith:fence_sbd"
     SBD_RA_ID = "stonith-sbd"
     SBD_DEVICE_MAX = 3
@@ -521,6 +523,9 @@ class SBDManager:
             logger.info("Configuring disk-based SBD")
         else:
             return
+
+        if not shutil.which("fence_sbd"):
+            utils.fatal(self.FENCE_SBD_NOT_EXISTED_MSG)
 
         opt_str = SBDManager.convert_timeout_dict_to_opt_str(self.timeout_dict)
         shell = sh.cluster_shell()

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -697,8 +697,10 @@ class TestSBDManager(unittest.TestCase):
     @patch('logging.Logger.debug')
     @patch('crmsh.sbd.sh.cluster_shell')
     @patch('crmsh.sbd.SBDManager.convert_timeout_dict_to_opt_str')
+    @patch('shutil.which')
     @patch('logging.Logger.info')
-    def test_initialize_sbd_diskbased(self, mock_logger_info, mock_convert_timeout_dict_to_opt_str, mock_cluster_shell, mock_logger_debug, mock_ServiceManager):
+    def test_initialize_sbd_diskbased(self, mock_logger_info, mock_which, mock_convert_timeout_dict_to_opt_str, mock_cluster_shell, mock_logger_debug, mock_ServiceManager):
+        mock_which.return_value = "/sbin/fence_sbd"
         sbdmanager_instance = SBDManager(device_list_to_init=['/dev/sbd_device'], timeout_dict={'watchdog': 5, 'msgwait': 10})
         sbdmanager_instance.initialize_sbd()
         mock_logger_info.assert_has_calls([


### PR DESCRIPTION
This checking can be useful for both interactive and non-interactive cases