### PR TITLE
[crmsh-4.6] Dev: cibverify: Print output of crm_verify directly

### DIFF
--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -22,11 +22,6 @@ def _prettify(line, indent=0):
 def verify(cib):
     rc, _, stderr = ShellUtils().get_stdout_stderr(cib_verify, cib.encode('utf-8'))
     for i, line in enumerate(line for line in stderr.split('\n') if line):
-        if i == 0:
-            if "warning:" in line:
-                logger.warning(_prettify(line, 0))
-            else:
-                logger.error(_prettify(line, 0))
-        else:
-            logger.error(_prettify(line, 7))
+        indent = 0 if i == 0 else 7
+        print(_prettify(line, indent))
     return rc

--- a/test/testcases/common.excl
+++ b/test/testcases/common.excl
@@ -23,4 +23,4 @@ Error performing operation: Not connected
 ^\.EXT sed ["][^"]+
 ^\.EXT [a-zA-Z]+ validate-all
 ^[ ]+File ["][^"]+
-^.*\: ([0-9]+\: )?\(cluster\_status\) 	warning\: Fencing and resource management disabled due to lack of quorum
+\(cluster\_status\) 	warning\: Fencing and resource management disabled due to lack of quorum


### PR DESCRIPTION
To avoid the log level difference between pacemaker and crmsh
backport from #1673 