### PR TITLE
Revert "Fix: ui_context: Don't complete for unknown argument"

### DIFF
--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -143,12 +143,7 @@ class Context(object):
                         # use the completer for the command
                         ret = self.command_info.complete(self, tokens)
                         if tokens:
-                            last_token = tokens[-1]
-                            if last_token:
-                                ret = [t for t in ret if t.startswith(last_token)]
-                            elif len(tokens) > 1:
-                                # don't complete for the unknown token
-                                ret = [t for t in ret if t in tokens[:-1]]
+                            ret = [t for t in ret if t.startswith(tokens[-1])]
 
                         if not ret or self.command_info.aliases:
                             if not token in self.current_level().get_completions():


### PR DESCRIPTION
This reverts commit 9c308b2c3ae85b7d004f114a07ab65b5ffa58dcd.

To fix regression #1681 
Since it's hard to tell if this 'unknown argument' is an `id` or not