### PR TITLE
Dev: Add cancel option when confirming to commit for the pending changes

### DIFF
--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1274,7 +1274,10 @@ class CibConfig(command.UI):
         if cib_factory.has_cib_changed():
             if no_questions_asked or not options.interactive:
                 ok = self._commit()
-            elif utils.ask("There are changes pending. Do you want to commit them?"):
-                ok = self._commit()
+            else:
+                confirm_msg = "There are changes pending. Do you want to commit them, or cancel the operation?"
+                rc = utils.ask(confirm_msg, cancel_option=True)
+                if rc:
+                    ok = self._commit()
         cib_factory.reset()
         return ok

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -347,7 +347,10 @@ class Context(object):
         '''
         Exit from the top level
         '''
-        ok = self.current_level().end_game()
+        try:
+            ok = self.current_level().end_game()
+        except utils.TerminateSubCommand:
+            return
         if options.interactive and not options.batch:
             if constants.need_reset:
                 utils.ext_cmd("reset")

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -289,7 +289,7 @@ def can_ask(background_wait=True):
     return can_ask
 
 
-def ask(msg, background_wait=True):
+def ask(msg, background_wait=True, cancel_option=False):
     """Ask for user confirmation.
 
     Parameters:
@@ -306,9 +306,10 @@ def ask(msg, background_wait=True):
     if not can_ask(background_wait):
         return False
 
+    option_str = "y/n" + "/c" if cancel_option else ""
     msg += ' '
     if msg.endswith('? '):
-        msg = msg[:-2] + ' (y/n)? '
+        msg = msg[:-2] + f'  ({option_str})? '
 
     while True:
         try:
@@ -317,6 +318,8 @@ def ask(msg, background_wait=True):
             ans = 'n'
         if ans:
             ans = ans[0].lower()
+            if ans == 'c':
+                raise TerminateSubCommand
             if ans in 'yn':
                 return ans == 'y'
 


### PR DESCRIPTION
This PR is an implementation for #1685 
When running `up` or `Ctrl-C` or `quit` while there are changes not been committed, there is an option `c` to cancel `up` or exit, and it will stay at `configure` level to do further check/modify
```
crm(live/alp-1)configure# primitive d Dummy

crm(live/alp-1)configure# up
There are changes pending. Do you want to commit them, or cancel the operation  (y/n/c)? c
crm(live/alp-1)configure# show d
primitive d Dummy

crm(live/alp-1)configure# Ctrl-C, leaving
There are changes pending. Do you want to commit them, or cancel the operation  (y/n/c)? c
crm(live/alp-1)configure# show d
primitive d Dummy

crm(live/alp-1)configure# quit
There are changes pending. Do you want to commit them, or cancel the operation  (y/n/c)? c
crm(live/alp-1)configure# show d
primitive d Dummy
``` 