### PR TITLE
Dev: Add error log when cluster services fail to start

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -777,7 +777,8 @@ def init_cluster_local():
     if pass_msg:
         logger.warning("You should change the hacluster password to something more secure!")
 
-    start_pacemaker(enable_flag=True)
+    if not start_pacemaker(enable_flag=True):
+        utils.fatal("Failed to start cluster services")
     wait_for_cluster()
 
 

--- a/crmsh/service_manager.py
+++ b/crmsh/service_manager.py
@@ -2,6 +2,7 @@ import typing
 
 import crmsh.parallax
 import crmsh.sh
+from crmsh import utils
 
 
 class ServiceManager(object):
@@ -52,7 +53,7 @@ class ServiceManager(object):
         else:
             rc = self._run_on_single_host(cmd, remote_addr)
             if rc == 0:
-                return [remote_addr]
+                return [remote_addr or utils.this_node()]
             else:
                 return list()
 


### PR DESCRIPTION
## Problem 1
crmsh will show success logs when success to start:
```
# crm cluster start --all
INFO: Starting pacemaker.service on alp-1, alp-2
INFO: The cluster stack started on alp-1
INFO: The cluster stack started on alp-2
```
But will show nothing when fail to start:
```
# crm cluster start --all
INFO: Starting pacemaker.service on alp-1, alp-2
```
## Solution
```
# crm cluster start --all
INFO: Starting pacemaker.service on alp-1, alp-2
ERROR: The cluster stack failed to start on alp-1
INFO: The cluster stack started on alp-2
```

## Promblem 2
When the fatal error leads to start pacemaker failing, the bootstrap process will wait for a long time:
```
# crm cluster init -y
...
INFO: Starting pacemaker.service on alp-1
INFO: BEGIN Waiting for cluster
.............................................................                                                                                                                                      
ERROR: FAIL Waiting for cluster
ERROR: cluster.init: Time out waiting for cluster.
```
## Solution
check the return code and quit quickly
```
# crm cluster init -y
...
INFO: Starting pacemaker.service on alp-1
ERROR: cluster.init: Failed to start cluster services
```