### PR TITLE
Change default DLM RA name

### DIFF
--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -58,7 +58,7 @@ class ClusterFSManager(object):
             # Consider such issue might not be fixed in the local pacemaker version
             # https://github.com/ClusterLabs/pacemaker/pull/3766
             # DLM RA's id shouldn avoid using 'gfs' as prefix
-            self.DLM_RA_ID = "dlm"
+            self.DLM_RA_ID = "dlm-controld-ra"
             self.FS_RA_ID = f"{prefix}-clusterfs"
             self.LVMLOCKD_RA_ID = f"{prefix}-lvmlockd"
             self.LVMACTIVATE_RA_ID = f"{prefix}-lvmactivate"

--- a/test/features/gfs2.feature
+++ b/test/features/gfs2.feature
@@ -25,7 +25,7 @@ Scenario: Configure gfs2 along with init process
   Then    Cluster service is "started" on "hanode1"
   And     Service "sbd" is "started" on "hanode1"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
-  And     Resource "dlm" type "pacemaker:controld" is "Started"
+  And     Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "gfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
 
 @clean
@@ -37,7 +37,7 @@ Scenario: Configure cluster lvm2 + gfs2 with init process
   Then    Cluster service is "started" on "hanode1"
   And     Service "sbd" is "started" on "hanode1"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
-  And     Resource "dlm" type "pacemaker:controld" is "Started"
+  And     Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "gfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
   And     Resource "gfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
   And     Resource "gfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
@@ -55,7 +55,7 @@ Scenario: Add gfs2 alone on a running cluster
   And     Service "sbd" is "started" on "hanode2"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
   When    Run "crm cluster init gfs2 -g /dev/sda2 -y" on "hanode1"
-  Then    Resource "dlm" type "pacemaker:controld" is "Started"
+  Then    Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "gfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
 
 @clean
@@ -71,7 +71,7 @@ Scenario: Add cluster lvm2 + gfs2 on a running cluster
   And     Service "sbd" is "started" on "hanode2"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
   When    Run "crm cluster init gfs2 -g /dev/sda2 -C -y" on "hanode1"
-  Then    Resource "dlm" type "pacemaker:controld" is "Started"
+  Then    Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "gfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
   And     Resource "gfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
   And     Resource "gfs2-clusterfs" type "heartbeat:Filesystem" is "Started"

--- a/test/features/ocfs2.feature
+++ b/test/features/ocfs2.feature
@@ -9,7 +9,7 @@ Scenario: Configure ocfs2 along with init process
   Then    Cluster service is "started" on "hanode1"
   And     Service "sbd" is "started" on "hanode1"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
-  And     Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
 
 @clean
@@ -21,7 +21,7 @@ Scenario: Configure cluster lvm2 + ocfs2 with init process
   Then    Cluster service is "started" on "hanode1"
   And     Service "sbd" is "started" on "hanode1"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
-  And     Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  And     Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "ocfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
   And     Resource "ocfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
   And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
@@ -39,7 +39,7 @@ Scenario: Add ocfs2 alone on a running cluster
   And     Service "sbd" is "started" on "hanode2"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
   When    Run "crm cluster init ocfs2 -o /dev/sda2 -y" on "hanode1"
-  Then    Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  Then    Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
 
 @clean
@@ -55,7 +55,7 @@ Scenario: Add cluster lvm2 + ocfs2 on a running cluster
   And     Service "sbd" is "started" on "hanode2"
   And     Resource "stonith-sbd" type "fence_sbd" is "Started"
   When    Run "crm cluster init ocfs2 -o /dev/sda2 -C -y" on "hanode1"
-  Then    Resource "ocfs2-dlm" type "pacemaker:controld" is "Started"
+  Then    Resource "dlm-controld-ra" type "pacemaker:controld" is "Started"
   And     Resource "ocfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
   And     Resource "ocfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
   And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"


### PR DESCRIPTION
## Problem
- Commit c4d23d820 set a default DLM RA name when configuring gfs2/ocfs2, without syncing the name in related behave functional test cases
- The default DLM RA name is too simple and may conflict with

## Changed
- Dev: cluster_fs: Use 'dlm-controld-ra' as the default dlm ra name;
   Since the original name 'dlm' is simply too short and may conflict with
- Dev: behave: Sync dlm ra name in ocfs2 and gfs2 test cases