### PR TITLE
Dev: ui_configure: Improve 'configure upgrade' command

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2507,7 +2507,9 @@ class CibFactory(object):
         else:
             logger.warning("bad parameter for regtest: %s", param)
 
-    def get_schema(self):
+    def get_schema(self, refresh=False):
+        if refresh:
+            self.refresh()
         return self.cib_attrs["validate-with"]
 
     def change_schema(self, schema_st):
@@ -2569,7 +2571,7 @@ class CibFactory(object):
         if not self.is_cib_sane():
             return False
         validator = self.cib_elem.get("validate-with")
-        if force or not validator or re.match("0[.]6", validator):
+        if force or not validator:
             return ext_cmd("cibadmin --upgrade --force") == 0
 
     def _import_cib(self, cib_elem):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -968,11 +968,14 @@ class CibConfig(command.UI):
     @command.skill_level('administrator')
     @command.completers(compl.choice(['force']))
     def do_upgrade(self, context, force=None):
-        "usage: upgrade [force]"
-        if force and force != "force":
-            context.fatal_error("Expected 'force' or no argument")
+        "usage: upgrade <force>"
+        if not force or force != "force":
+            context.fatal_error("'force' option is required")
         cib_factory.ensure_cib_updated()
-        return cib_factory.upgrade_validate_with(force=config.core.force or force)
+        if cib_factory.upgrade_validate_with(force):
+            logger.info("Current schema version is %s", cib_factory.get_schema(refresh=True))
+            return True
+        return False
 
     @command.skill_level('administrator')
     @command.completers(schema_completer)

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -4070,13 +4070,11 @@ version. Commonly, this is required if the error
 `CIB not supported` occurs. It typically means that the
 active CIB version is coming from an older release.
 
-As a safety precaution, the force argument is required if the
-+validation-with+ attribute is set to anything other than
-+0.6+. Thus in most cases, it is required.
+As a safety precaution, the 'force' argument is required.
 
 Usage:
 ...............
-upgrade [force]
+upgrade <force>
 ...............
 
 Example:


### PR DESCRIPTION
## Problems
```
crm(live/alp-1)configure# schema
pacemaker-3.9
crm(live/alp-1)configure# upgrade               # Don't know this not works
crm(live/alp-1)configure# schema
pacemaker-3.9
crm(live/alp-1)configure# upgrade force
crm(live/alp-1)configure# schema                # Still show the old schema version
pacemaker-3.9
```
## Changes
- Make the 'force' option mandatory for the 'upgrade' command
```
crm(live/alp-1)configure# upgrade
ERROR: configure.upgrade: 'force' option is required
```
- Show current schema version after successfully upgraded
```
crm(live/alp-1)configure# upgrade force
INFO: Current schema version is pacemaker-4.0
```
- Refresh before reading the schema version