### PR TITLE
[crmsh-4.6] Dev: ssh_key: more robust error handling in KeyFileManager (bsc#1239084)

### DIFF
--- a/crmsh/ssh_key.py
+++ b/crmsh/ssh_key.py
@@ -231,7 +231,8 @@ class KeyFileManager:
         * is_generated: whether a new keypair is generated
         * list_of_public_keys: all public keys of known types, including the newly generated one
         """
-        script = '''if [ ! \\( {condition} \\) ]; then
+        script = '''set -e
+if [ ! \\( {condition} \\) ]; then
     ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -C "Cluster internal on $(hostname)" -N '' <> /dev/null
     echo 'GENERATED=1'
 fi


### PR DESCRIPTION
add `set -e` to the shell script so that it exits and reports on errors.

(cherry picked from commit af9f40cea180079875d1e094e65a224aa3cd9b4a)