### PR TITLE
Dev: ui_resource: Refactor do_trace function

### DIFF
--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2037,7 +2037,9 @@ stop <rsc> [<rsc> ...]
 ==== `trace`
 
 Start tracing RA for the given operation. When `[<log-dir>]`
-is not specified the trace files are stored in `$HA_VARLIB/trace_ra`.
+is not specified, the trace files are stored in `<heartbeat_dir>/trace_ra`.
+If `<heartbeat_dir>` option in `/etc/crm/crm.conf` is not defined,
+it defaults to `/var/lib/heartbeat`.
 If the operation to be traced is monitor, note that the number
 of trace files can grow very quickly.
 

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -416,6 +416,7 @@ INFO: Trace set, restart p0 to trace non-monitor operations
           <op name="monitor" interval="0" id="p0-monitor-0">
             <instance_attributes id="p0-monitor-0-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-monitor-0-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-monitor-0-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
         </operations>
@@ -446,11 +447,13 @@ INFO: Trace set, restart p0 to trace the start operation
           <op name="monitor" interval="0" id="p0-monitor-0">
             <instance_attributes id="p0-monitor-0-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-monitor-0-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-monitor-0-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
           <op name="start" timeout="20s" interval="0s" id="p0-start-0s">
             <instance_attributes id="p0-start-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-start-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-start-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
         </operations>
@@ -480,16 +483,19 @@ INFO: Trace set, restart p0 to trace the stop operation
           <op name="monitor" interval="0" id="p0-monitor-0">
             <instance_attributes id="p0-monitor-0-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-monitor-0-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-monitor-0-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
           <op name="start" timeout="20s" interval="0s" id="p0-start-0s">
             <instance_attributes id="p0-start-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-start-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-start-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
           <op name="stop" timeout="20s" interval="0s" id="p0-stop-0s">
             <instance_attributes id="p0-stop-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-stop-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-stop-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
         </operations>
@@ -518,11 +524,13 @@ INFO: Stop tracing p0 for operation monitor
           <op name="start" timeout="20s" interval="0s" id="p0-start-0s">
             <instance_attributes id="p0-start-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-start-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-start-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
           <op name="stop" timeout="20s" interval="0s" id="p0-stop-0s">
             <instance_attributes id="p0-stop-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-stop-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-stop-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
         </operations>
@@ -551,6 +559,7 @@ INFO: Stop tracing p0 for operation start
           <op name="stop" timeout="20s" interval="0s" id="p0-stop-0s">
             <instance_attributes id="p0-stop-0s-instance_attributes">
               <nvpair name="trace_ra" value="1" id="p0-stop-0s-instance_attributes-trace_ra"/>
+	      <nvpair name="trace_dir" value="/var/lib/heartbeat/trace_ra" id="p0-stop-0s-instance_attributes-trace_dir"/>
             </instance_attributes>
           </op>
           <op name="start" timeout="20s" interval="0s" id="p0-start-0s"/>


### PR DESCRIPTION
Ensure the trace directory is specified either through the argument or by using the value of the heartbeat_dir option. Eliminate any inconsistencies that might arise from heartbeat_dir (from etc/crm/crm.conf) or from HA_VARLIB (from /usr/lib/ocf/heartbeat/ocf-directories).