### PR TITLE
[crmsh-4.6] Fix: idmgmt: Replace hashtag('#') with point('.') in id (bsc#1239782)

### DIFF
--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -65,7 +65,9 @@ def new(node, pfx):
             node_id = pfx
     if is_used(node_id):
         node_id = _gen_free_id(node_id)
-    node_id = re.sub(r'#', '.', node_id)
+    # The ID type in XML allows only `^[_a-zA-Z][\w\-.]*$`
+    # `crm_attribute` command replaces `#` with `.` in this case
+    node_id = node_id.replace('#', '.')
     save(node_id)
     return node_id
 

--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -65,6 +65,7 @@ def new(node, pfx):
             node_id = pfx
     if is_used(node_id):
         node_id = _gen_free_id(node_id)
+    node_id = re.sub(r'#', '.', node_id)
     save(node_id)
     return node_id
 

--- a/test/features/configure_bugs.feature
+++ b/test/features/configure_bugs.feature
@@ -73,3 +73,11 @@ Feature: Functional test for configure sub level
     Given   Get the latest schema version
     When    Use crm configure upgrade to upgrade the schema
     Then    The schema version is the latest
+
+  @clean
+  Scenario: Edit attributes starts with a hashtag (bsc#1239782)
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm node attribute hanode1 set cpu 2" on "hanode1"
+    Then    Run "crm -F configure filter "sed 's/cpu=/#cpu='/g"" OK on "hanode1"


### PR DESCRIPTION
backport #1718 