### PR TITLE
Drop deprecated codes

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -164,11 +164,11 @@ date_ops = ('lt', 'gt', 'in_range', 'date_spec')
 date_spec_names = '''hours monthdays weekdays yearsdays months \
 weeks years weekyears'''.split()
 in_range_attrs = ('start', 'end')
-node_default_type = "normal"
+node_default_type = "member"
 node_attributes_keyw = ("attributes", "utilization")
 shadow_envvar = "CIB_shadow"
 attr_defaults = {
-    "node": {"type": "normal"},
+    "node": {"type": "member"},
     "resource_set": {"sequential": "true", "require-all": "true"},
     "rule": {"boolean-op": "and"},
 }

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -41,7 +41,7 @@ _UNARYOP_RE = re.compile(r'(%s)$' % ('|'.join(constants.unary_ops)), re.IGNORECA
 _ACL_RIGHT_RE = re.compile(r'(%s)$' % ('|'.join(constants.acl_rule_names)), re.IGNORECASE)
 _ROLE_REF_RE = re.compile(r'role:(.+)$', re.IGNORECASE)
 _PERM_RE = re.compile(r"([^:]+)(?::(.+))?$", re.I)
-_UNAME_RE = re.compile(r'([^:]+)(:(normal|member|ping|remote))?$', re.IGNORECASE)
+_UNAME_RE = re.compile(r'([^:]+)(:(member|remote))?$', re.IGNORECASE)
 _TEMPLATE_RE = re.compile(r'@(.+)$')
 _RA_TYPE_RE = re.compile(r'[a-z0-9_:-]+$', re.IGNORECASE)
 _TAG_RE = re.compile(r"([a-zA-Z_][^\s:]*):?$")
@@ -865,7 +865,7 @@ def parse_node(self, cmd):
       [attributes <param>=<value> [<param>=<value>...]]
       [utilization <param>=<value> [<param>=<value>...]]
 
-    type :: normal | member | ping | remote
+    type :: member | remote
     """
     self.begin(cmd, min_args=1)
     self.match('node')

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -464,14 +464,8 @@ class RAInfo(object):
         def unreq_param(p):
             '''
             Allow for some exceptions.
-
-            - the rhcs stonith agents sometimes require "action" (in
-              the meta-data) and "port", but they're automatically
-              supplied by stonithd
             '''
-            if self.ra_class == "stonith" and \
-                (self.ra_type.startswith("rhcs/") or
-                 self.ra_type.startswith("fence_")):
+            if self.ra_class == "stonith" and self.ra_type.startswith("fence_"):
                 if p in ("action", "port"):
                     return True
             return False

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -15,7 +15,6 @@ from . import userdir
 from . import utils
 from .sh import ShellUtils
 from .utils import stdout2list, is_program, to_ascii
-from .utils import os_types_list
 from .utils import crm_msec, crm_time_cmp
 from . import log
 
@@ -36,23 +35,14 @@ def crm_resource(opts):
     return l
 
 
-@utils.memoize
-def can_use_crm_resource():
-    _rc, s = ShellUtils().get_stdout("crm_resource --list-ocf-providers", stderr_on=False)
-    return s != ""
-
-
 def ra_classes():
     '''
     List of RA classes.
     '''
     if cache.is_cached("ra_classes"):
         return cache.retrieve("ra_classes")
-    if can_use_crm_resource():
-        l = crm_resource("--list-standards")
-        l = [x for x in l if x not in ("lsb", "service")]
-    else:
-        l = ["ocf", "stonith", "systemd"]
+    l = crm_resource("--list-standards")
+    l = [x for x in l if x not in ("lsb", "service")]
     l.sort()
     return cache.store("ra_classes", l)
 
@@ -62,18 +52,10 @@ def ra_providers(ra_type, ra_class="ocf"):
     ident = "ra_providers-%s-%s" % (ra_class, ra_type)
     if cache.is_cached(ident):
         return cache.retrieve(ident)
-    if can_use_crm_resource():
-        if ra_class != "ocf":
-            logger.error("no providers for class %s", ra_class)
-            return []
-        l = crm_resource("--list-ocf-alternatives %s" % ra_type)
-    else:
-        l = []
-        if ra_class == "ocf":
-            for s in glob.glob("%s/resource.d/*/%s" % (os.environ["OCF_ROOT"], ra_type)):
-                a = s.split("/")
-                if len(a) == 7:
-                    l.append(a[5])
+    if ra_class != "ocf":
+        logger.error("no providers for class %s", ra_class)
+        return []
+    l = crm_resource("--list-ocf-alternatives %s" % ra_type)
     l.sort()
     return cache.store(ident, l)
 
@@ -94,45 +76,6 @@ def ra_providers_all(ra_class="ocf"):
     return []
 
 
-def os_types(ra_class):
-    'List of types for a class.'
-    def stonith_types():
-        rc, l = stdout2list("stonith -L")
-        if rc != 0:
-            # stonith(8) may not be installed
-            logger.debug("stonith exited with code %d", rc)
-            l = []
-        for ra in os_types_list("/usr/sbin/fence_*"):
-            if ra not in ("fence_ack_manual", "fence_pcmk", "fence_legacy"):
-                l.append(ra)
-        return l
-
-    def systemd_types():
-        l = []
-        rc, lines = stdout2list("systemctl list-unit-files --full")
-        if rc != 0:
-            return l
-        t = re.compile(r'^(.+)\.service')
-        for line in lines:
-            m = t.search(line)
-            if m:
-                l.append(m.group(1))
-        return l
-
-    l = []
-    if ra_class == "ocf":
-        l = os_types_list("%s/resource.d/*/*" % (os.environ["OCF_ROOT"]))
-    elif ra_class == "lsb":
-        l = os_types_list("/etc/init.d/*")
-    elif ra_class == "stonith":
-        l = stonith_types()
-    elif ra_class == "systemd":
-        l = systemd_types()
-    l = list(set(l))
-    l.sort()
-    return l
-
-
 def ra_types(ra_class="ocf", ra_provider=""):
     '''
     List of RA type for a class.
@@ -142,11 +85,7 @@ def ra_types(ra_class="ocf", ra_provider=""):
         """
         Actually go out and ask for the types of a class.
         """
-        if can_use_crm_resource():
-            l = crm_resource("--list-agents %s" % ra_class)
-        else:
-            l = os_types(ra_class)
-        return l
+        return crm_resource("--list-agents %s" % ra_class)
 
     if not ra_class:
         ra_class = "ocf"
@@ -168,21 +107,9 @@ def ra_meta(ra_class, ra_type, ra_provider):
     """
     Return metadata for the given class/type/provider
     """
-    if can_use_crm_resource():
-        if ra_provider:
-            return crm_resource("--show-metadata %s:%s:%s" % (ra_class, ra_provider, ra_type))
-        return crm_resource("--show-metadata %s:%s" % (ra_class, ra_type))
-    else:
-        l = []
-        if ra_class == "ocf":
-            _rc, l = stdout2list("%s/resource.d/%s/%s meta-data" %
-                                 (os.environ["OCF_ROOT"], ra_provider, ra_type))
-        elif ra_class == "stonith":
-            if ra_type.startswith("fence_") and os.path.exists("/usr/sbin/%s" % ra_type):
-                _rc, l = stdout2list("/usr/sbin/%s -o metadata" % ra_type)
-            else:
-                _rc, l = stdout2list("stonith -m -t %s" % ra_type)
-        return l
+    if ra_provider:
+        return crm_resource("--show-metadata %s:%s:%s" % (ra_class, ra_provider, ra_type))
+    return crm_resource("--show-metadata %s:%s" % (ra_class, ra_type))
 
 
 @utils.memoize

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -363,9 +363,9 @@ class RAStonith(RADriver):
         """
         Run test for stonith resource
         """
-        for prefix in ['rhcs/', 'fence_']:
+        for prefix in ['fence_', ]:
             if self.ra_type.startswith(prefix):
-                self.err("Cannot test RHCS STONITH resources!")
+                self.err("Cannot test STONITH resources!")
                 return False
         return RADriver.test_resource(self, node)
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1240,7 +1240,7 @@ class CibConfig(command.UI):
                     rsc_l += el.node.findall("primitive")
                 else:
                     rsc_l.append(el.node)
-            elif xmlutil.is_normal_node(el.node):
+            elif xmlutil.is_member_node(el.node):
                 current = "n"
                 node_l.append(el.node.get("uname"))
             else:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -440,15 +440,6 @@ class olist(list):
         super(olist, self).append(key.lower())
 
 
-def os_types_list(path):
-    l = []
-    for f in glob.glob(path):
-        if os.access(f, os.X_OK) and os.path.isfile(f):
-            a = f.split("/")
-            l.append(a[-1])
-    return l
-
-
 def listtemplates():
     l = []
     templates_dir = os.path.join(config.path.sharedir, 'templates')

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -324,8 +324,8 @@ def resources_xml():
     return cibdump2elem("resources")
 
 
-def is_normal_node(n):
-    return n.tag == "node" and (n.get("type") in (None, "normal", "member", ""))
+def is_member_node(n):
+    return n.tag == "node" and (n.get("type") in (None, "member", ""))
 
 
 def unique_ra(typ, klass, provider):

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3427,7 +3427,7 @@ node [$id=<id>] <uname>[:<type>]
   [utilization [$id=<id>] [<score>:] [rule...]
     <param>=<value> [<param>=<value>...]] | $id-ref=<ref>
 
-type :: normal | member | ping | remote
+type :: member | remote
 ...............
 Example:
 ...............

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -132,10 +132,10 @@ class TestCliParser(unittest.TestCase):
         self.assertEqual(out.get('id'), 'testid')
         self.assertEqual(out.get('uname'), 'node-1')
 
-        out = self._parse('node $id=testid node-1:ping')
+        out = self._parse('node $id=testid node-1:remote')
         self.assertEqual(out.get('id'), 'testid')
         self.assertEqual(out.get('uname'), 'node-1')
-        self.assertEqual(out.get('type'), 'ping')
+        self.assertEqual(out.get('type'), 'remote')
 
         out = self._parse('node node-1:unknown')
         self.assertFalse(out)


### PR DESCRIPTION
- Dev: Drop node type normal and ping
  According to the nodes-4.0.rng schema, only supports node type "member" and "remote"
- Dev: Remove codes that include rhcs term
- Dev: ra: Drop legacy codes to fetch ra informations