### PR TITLE
[crmsh-4.6] Drop deprecated codes

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -242,11 +242,11 @@ date_ops = ('lt', 'gt', 'in_range', 'date_spec')
 date_spec_names = '''hours monthdays weekdays yearsdays months \
 weeks years weekyears moon'''.split()
 in_range_attrs = ('start', 'end')
-node_default_type = "normal"
+node_default_type = "member"
 node_attributes_keyw = ("attributes", "utilization")
 shadow_envvar = "CIB_shadow"
 attr_defaults = {
-    "node": {"type": "normal"},
+    "node": {"type": "member"},
     "resource_set": {"sequential": "true", "require-all": "true"},
     "rule": {"boolean-op": "and"},
 }

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -41,7 +41,7 @@ _UNARYOP_RE = re.compile(r'(%s)$' % ('|'.join(constants.unary_ops)), re.IGNORECA
 _ACL_RIGHT_RE = re.compile(r'(%s)$' % ('|'.join(constants.acl_rule_names)), re.IGNORECASE)
 _ROLE_REF_RE = re.compile(r'role:(.+)$', re.IGNORECASE)
 _PERM_RE = re.compile(r"([^:]+)(?::(.+))?$", re.I)
-_UNAME_RE = re.compile(r'([^:]+)(:(normal|member|ping|remote))?$', re.IGNORECASE)
+_UNAME_RE = re.compile(r'([^:]+)(:(member|ping|remote))?$', re.IGNORECASE)
 _TEMPLATE_RE = re.compile(r'@(.+)$')
 _RA_TYPE_RE = re.compile(r'[a-z0-9_:-]+$', re.IGNORECASE)
 _TAG_RE = re.compile(r"([a-zA-Z_][^\s:]*):?$")
@@ -866,7 +866,7 @@ def parse_node(self, cmd):
       [attributes <param>=<value> [<param>=<value>...]]
       [utilization <param>=<value> [<param>=<value>...]]
 
-    type :: normal | member | ping | remote
+    type :: member | ping | remote
     """
     self.begin(cmd, min_args=1)
     self.match('node')

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -496,14 +496,8 @@ class RAInfo(object):
         def unreq_param(p):
             '''
             Allow for some exceptions.
-
-            - the rhcs stonith agents sometimes require "action" (in
-              the meta-data) and "port", but they're automatically
-              supplied by stonithd
             '''
-            if self.ra_class == "stonith" and \
-                (self.ra_type.startswith("rhcs/") or
-                 self.ra_type.startswith("fence_")):
+            if self.ra_class == "stonith" and self.ra_type.startswith("fence_"):
                 if p in ("action", "port"):
                     return True
             return False

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -363,9 +363,9 @@ class RAStonith(RADriver):
         """
         Run test for stonith resource
         """
-        for prefix in ['rhcs/', 'fence_']:
+        for prefix in ['fence_', ]:
             if self.ra_type.startswith(prefix):
-                self.err("Cannot test RHCS STONITH resources!")
+                self.err("Cannot test STONITH resources!")
                 return False
         return RADriver.test_resource(self, node)
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1248,7 +1248,7 @@ class CibConfig(command.UI):
                     rsc_l += el.node.findall("primitive")
                 else:
                     rsc_l.append(el.node)
-            elif xmlutil.is_normal_node(el.node):
+            elif xmlutil.is_member_node(el.node):
                 current = "n"
                 node_l.append(el.node.get("uname"))
             else:

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -322,8 +322,8 @@ def resources_xml():
     return cibdump2elem("resources")
 
 
-def is_normal_node(n):
-    return n.tag == "node" and (n.get("type") in (None, "normal", "member", ""))
+def is_member_node(n):
+    return n.tag == "node" and (n.get("type") in (None, "member", ""))
 
 
 def unique_ra(typ, klass, provider):

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3335,7 +3335,7 @@ node [$id=<id>] <uname>[:<type>]
   [utilization [$id=<id>] [<score>:] [rule...]
     <param>=<value> [<param>=<value>...]] | $id-ref=<ref>
 
-type :: normal | member | ping | remote
+type :: member | ping | remote
 ...............
 Example:
 ...............


### PR DESCRIPTION
- Dev: Drop node type normal
   It's been deprecated for a long time, and it's time to remove it.
- Dev: Remove codes that include rhcs term