### PR TITLE
Dev: ui_configure: Show the changes with diff like format

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2784,6 +2784,8 @@ class CibFactory(object):
         for obj in self.cib_objects:
             self._update_links(obj)
 
+        self.cib_objects_orig = copy.deepcopy(self.cib_objects)
+
     def cli_use_validate_all(self):
         for obj in self.cib_objects:
             if not obj.cli_use_validate():
@@ -2817,6 +2819,7 @@ class CibFactory(object):
         self.cib_orig = None     # the CIB which we loaded
         self.cib_attrs = {}      # cib version dictionary
         self.cib_objects = []    # a list of cib objects
+        self.cib_objects_orig = []  # a list of cib objects (original)
         self.remove_queue = []   # a list of cib objects to be removed
         self.id_refs = {}        # dict of id-refs
         self.new_schema = False  # schema changed
@@ -3285,6 +3288,8 @@ class CibFactory(object):
         """
         if not filters:
             return True, copy.copy(self.cib_objects)
+        if filters[0] == 'orig':
+            return True, copy.copy(self.cib_objects_orig)
         if filters[0] == 'NOOBJ':
             return True, orderedset.oset([])
         obj_set = orderedset.oset([])

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -5,6 +5,7 @@
 import os
 import re
 import time
+import difflib
 from packaging import version
 from . import command
 from . import completers as compl
@@ -582,6 +583,20 @@ class CibConfig(command.UI):
     def do_assist(self):
         pass
 
+    def _show_diff(self):
+        obj_orig = mkset_obj("orig")
+        obj_orig_str = obj_orig.repr()
+        obj_changed = mkset_obj()
+        obj_changed_str = obj_changed.repr()
+
+        diff = difflib.unified_diff(obj_orig_str.splitlines(), obj_changed_str.splitlines())
+        diff = [
+                line for line in diff
+                if not line.startswith('+++ ') and not line.startswith('--- ')
+        ]
+
+        utils.page_string('\n'.join(diff))
+
     @command.skill_level('administrator')
     @command.completers_repeating(_id_show_list)
     def do_show(self, context, *args):
@@ -598,6 +613,9 @@ class CibConfig(command.UI):
         args = [arg for arg in args if not arg.startswith('obscure:')]
         cib_factory.ensure_cib_updated()
         with obscure(osargs):
+            if args and args[0] == "changed":
+                self._show_diff()
+                return True
             set_obj = mkset_obj(*args)
             return set_obj.show()
 
@@ -1265,7 +1283,9 @@ class CibConfig(command.UI):
             if no_questions_asked or not options.interactive:
                 ok = self._commit()
             else:
-                confirm_msg = "There are changes pending. Do you want to commit them, or cancel the operation?"
+                print("There are changes pending:")
+                self._show_diff()
+                confirm_msg = "Do you want to commit them, or cancel the operation?"
                 rc = utils.ask(confirm_msg, cancel_option=True)
                 if rc:
                     ok = self._commit()


### PR DESCRIPTION
- `show changed` interface, to show what has been removed and added, using a diff-like format
```
crm(live/alp-1)configure# delete d
crm(live/alp-1)configure# primitive vip IPaddr2 params ip=10.10.10.123
crm(live/alp-1)configure# property cluster-delay=3
crm(live/alp-1)configure# show changed
 node 1: alp-1
 node 2: alp-2
-primitive d Dummy \
-       meta target-role=Stopped
 primitive stonith-sbd stonith:fence_sbd \
        params pcmk_delay_max=30s
+primitive vip IPaddr2 \
+       params ip=10.10.10.123
 property cib-bootstrap-options: \
        have-watchdog=true \
        dc-version="3.0.0+20250310.476dc59612-2.1-3.0.0+20250310.476dc59612" \
        cluster-name=hacluster \
        stonith-enabled=true \
        stonith-timeout=83 \
-       priority-fencing-delay=60
+       priority-fencing-delay=60 \
+       cluster-delay=3
 rsc_defaults build-resource-defaults: \
        resource-stickiness=1 \
        migration-threshold=3 \
```
- Show the difference when leaving the configure level without commit
```
crm(live/alp-1)configure# delete d
crm(live/alp-1)configure# up
There are changes pending:
 node 1: alp-1
 node 2: alp-2
-primitive d Dummy \
-       meta target-role=Stopped
 primitive stonith-sbd stonith:fence_sbd \
        params pcmk_delay_max=30s
 property cib-bootstrap-options: \
Do you want to commit them, or cancel the operation  (y/n/c)?
```