### PR TITLE
Dev: ui_sbd: Configure crashdump watchdog timeout

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2725,12 +2725,12 @@ def adjust_pcmk_delay_max(is_2node_wo_qdevice):
         for res in cib_factory.fence_id_list_without_pcmk_delay():
             cmd = "crm resource param {} set pcmk_delay_max {}s".format(res, PCMK_DELAY_MAX)
             shell.get_stdout_or_raise_error(cmd)
-            logger.debug("Add parameter 'pcmk_delay_max={}s' for resource '{}'".format(PCMK_DELAY_MAX, res))
+            logger.info("Add parameter 'pcmk_delay_max={}s' for resource '{}'".format(PCMK_DELAY_MAX, res))
     else:
         for res in cib_factory.fence_id_list_with_pcmk_delay():
             cmd = "crm resource param {} delete pcmk_delay_max".format(res)
             shell.get_stdout_or_raise_error(cmd)
-            logger.debug("Delete parameter 'pcmk_delay_max' for resource '{}'".format(res))
+            logger.info("Delete parameter 'pcmk_delay_max' for resource '{}'".format(res))
 
 
 def adjust_stonith_timeout():

--- a/crmsh/cibquery.py
+++ b/crmsh/cibquery.py
@@ -33,6 +33,26 @@ def has_primitive_filesystem_with_fstype(cib: lxml.etree.Element, fstype: str) -
         f'/instance_attributes/nvpair[@name="fstype" and @value="{fstype}"]'
     ))
 
+
+def get_primitives_with_ra(cib: lxml.etree.Element, ra: ResourceAgent) -> list[str]:
+    """
+    Given cib and ResourceAgent instance, return id list of primitives that matched
+    consider provider as optional
+    """
+    provider_condition = f' and @provider="{ra.m_provider}"' if ra.m_provider else ""
+    return cib.xpath(
+        f'/cib/configuration/resources//primitive[@class="{ra.m_class}"{provider_condition} and @type="{ra.m_type}"]/@id'
+    )
+
+
+def get_parameter_value(cib: lxml.etree.Element, res_id: str, param_name: str) -> typing.Optional[str]:
+    result = cib.xpath(
+        f'/cib/configuration/resources//primitive[@id="{res_id}"]'
+        f'/instance_attributes/nvpair[@name="{param_name}"]/@value'
+    )
+    return result[0] if result else None
+
+
 def get_cluster_nodes(cib: lxml.etree.Element) -> list[ClusterNode]:
     """Return a list of cluster nodes, excluding pacemaker-remote nodes"""
     result = list()

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -559,7 +559,8 @@ class SBDManager:
         Configure fence_sbd resource and related properties
         '''
         if self.diskless_sbd:
-            utils.set_property("stonith-watchdog-timeout", SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT)
+            swt_value = self.timeout_dict.get("stonith-watchdog", SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT)
+            utils.set_property("stonith-watchdog-timeout", swt_value)
         else:
             if utils.get_property("stonith-watchdog-timeout", get_default=False):
                 utils.delete_property("stonith-watchdog-timeout")

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -81,6 +81,14 @@ class SBDUtils:
         return utils.parse_sysconfig(SBDManager.SYSCONFIG_SBD).get(key)
 
     @staticmethod
+    def get_crashdump_watchdog_timeout() -> typing.Optional[int]:
+        res = SBDUtils.get_sbd_value_from_config("SBD_OPTS")
+        if not res:
+            return None
+        matched = re.search(r"-C\s+(\d+)", res)
+        return int(matched.group(1)) if matched else None
+
+    @staticmethod
     def get_sbd_device_from_config():
         '''
         Get sbd device list from config

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -96,9 +96,7 @@ class SBD(command.UI):
     PCMK_ATTRS = (
         "have-watchdog",
         "stonith-timeout",
-        "stonith-enabled",
-        "priority-fencing-delay",
-        "pcmk_delay_max"
+        "stonith-enabled"
     )
     PCMK_ATTRS_DISKLESS = ('stonith-watchdog-timeout',)
     PARSE_RE = re.compile(
@@ -227,6 +225,13 @@ class SBD(command.UI):
         matches = re.findall(regex, out)
         for match in matches:
             print(f"{match[0]}={match[1]}")
+
+        cmd = "crm configure show related:fence_sbd"
+        out = self.cluster_shell.get_stdout_or_raise_error(cmd)
+        if out:
+            print()
+            logger.info('%s', cmd)
+            print(out)
 
         print()
         logger.info('%s', sbd.SBDTimeout.SHOW_SBD_START_TIMEOUT_CMD)
@@ -540,15 +545,14 @@ class SBD(command.UI):
         '''
         try:
             self._load_attributes()
-            for service in (constants.PCMK_SERVICE, constants.SBD_SERVICE):
-                if not self.service_is_active(service):
-                    return False
             if not args:
                 raise self.SyntaxError("No argument")
-
             if args[0] == "show":
                 self._configure_show(args)
                 return True
+            for service in (constants.PCMK_SERVICE, constants.SBD_SERVICE):
+                if not self.service_is_active(service):
+                    return False
 
             parameter_dict = self._parse_args(args)
             if sbd.SBDUtils.is_using_disk_based_sbd():

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -102,8 +102,11 @@ class SBD(command.UI):
     )
     PCMK_ATTRS_DISKLESS = ('stonith-watchdog-timeout',)
     PARSE_RE = re.compile(
-		# Match keys with non-empty values, capturing possible suffix
-        r'([\w-]+)-([\w-]+)=([\w/\d]+)'
+        # To extract key, suffix and value from these possible arguments:
+        # watchdog-timeout=30
+        # crashdump-watchdog-timeout=120
+        # watchdog-device=/dev/watchdog
+        r'([\w-]+)-([\w]+)=([\w/]+)'
     )
 
     class SyntaxError(Exception):

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -314,9 +314,13 @@ class SBD(command.UI):
         logger.info("Set crashdump option for fence_sbd resource")
 
     def _check_kdump_service(self):
+        no_kdump = False
         for node in self.cluster_nodes:
             if not self.service_manager.service_is_active("kdump.service", node):
                 logger.warning("Kdump service is not active on %s", node)
+                no_kdump = True
+        if no_kdump:
+            logger.warning("Kdump service is required for crashdump")
 
     def _configure_diskbase(self, parameter_dict: dict):
         '''

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3202,11 +3202,4 @@ def strip_ansi_escape_sequences(text):
     """
     ansi_escape_pattern = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
     return ansi_escape_pattern.sub('', text)
-
-
-def is_subdict(sub_dict, main_dict):
-    """
-    Check if sub_dict is a sub-dictionary of main_dict
-    """
-    return all(main_dict.get(k) == v for k, v in sub_dict.items())
 # vim:ts=4:sw=4:et:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2136,6 +2136,7 @@ Main functionailities include:
 - Show contents of /etc/sysconfig/sbd
 - Show SBD related cluster properties
 - Update the SBD related configuration parameters
+- NOTE: sbd crashdump is used for debugging. Understand the risks and run `crm sbd purge crashdump` afterward
 
 For more details on SBD and related parameters, please see man sbd(8).
 
@@ -2143,11 +2144,11 @@ Usage:
 ...............
 # For disk-based SBD
 crm sbd configure show [disk_metadata|sysconfig|property]
-crm sbd configure [watchdog-timeout=<integer>] [allocate-timeout=<integer>] [loop-timeout=<integer>] [msgwait-timeout=<integer>] [watchdog-device=<device>]
+crm sbd configure [watchdog-timeout=<integer>] [allocate-timeout=<integer>] [loop-timeout=<integer>] [msgwait-timeout=<integer>] [crashdump-watchdog-timeout=<integer>] [watchdog-device=<device>]
 
 # For disk-less SBD
 crm sbd configure show [sysconfig|property]
-crm sbd configure [watchdog-timeout=<integer>] [watchdog-device=<device>]
+crm sbd configure [watchdog-timeout=<integer>] [crashdump-watchdog-timeout=<integer>] [watchdog-device=<device>]
 ...............
 
 example:
@@ -2189,10 +2190,13 @@ status
 
 Disable the systemd sbd.service on all cluster nodes,
 move the sbd sysconfig to .bak and adjust SBD related cluster properties.
+If `crashdump` is specified, the crashdump related configurations will be
+removed.
 
 Usage:
 ...............
 purge
+purge crashdump
 ...............
 
 [[cmdhelp.node,Node management]]

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -97,6 +97,18 @@ class TestSBDUtils(unittest.TestCase):
         result = SBDUtils.get_sbd_device_from_config()
         self.assertEqual(result, ['/dev/sbd_device', '/dev/another_sbd_device'])
 
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_get_crashdump_watchdog_timeout_none(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = None
+        result = SBDUtils.get_crashdump_watchdog_timeout()
+        self.assertIsNone(result)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_get_crashdump_watchdog_timeout(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = "-C 60 -Z"
+        result = SBDUtils.get_crashdump_watchdog_timeout()
+        self.assertEqual(result, 60)
+
     @patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
     @patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_is_using_diskless_sbd(self, mock_service_is_active, mock_get_sbd_device_from_config):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1340,9 +1340,3 @@ def test_check_user_access_cluster(mock_user, mock_in, mock_sudo, mock_error):
     with pytest.raises(utils.TerminateSubCommand) as err:
         utils.check_user_access('cluster')
     mock_error.assert_called_once_with('Operation is denied. The current user lacks the necessary privilege.')
-
-
-def test_is_subdict():
-    d1 = {"a": 1, "b": 2}
-    d2 = {"a": 1}
-    assert utils.is_subdict(d2, d1) is True


### PR DESCRIPTION
This PR supports configuring the crashdump watchdog timeout
by using `crm sbd configure crashdump-watchdog-timeout=<timeout>`,
for both disk-based and diskless SBD.

- disk-based SBD case
```
# crm sbd configure crashdump-watchdog-timeout=60
WARNING: Kdump service is not active on alp-1
WARNING: Kdump service is not active on alp-2
INFO: Set crashdump option for fence_sbd resource
INFO: Set msgwait-timeout to 2*watchdog-timeout + crashdump-watchdog-timeout: 90
INFO: Configuring disk-based SBD
INFO: Initializing SBD device /dev/sda8
INFO: Update SBD_TIMEOUT_ACTION in /etc/sysconfig/sbd: flush,crashdump
INFO: Update SBD_OPTS in /etc/sysconfig/sbd: -C 60
INFO: Already synced /etc/sysconfig/sbd to all nodes
WARNING: Resource is running, need to restart cluster service manually on each node
INFO: Update SBD_DELAY_START in /etc/sysconfig/sbd: 131
INFO: Already synced /etc/sysconfig/sbd to all nodes
WARNING: "stonith-timeout" in crm_config is set to 155, it was 83
```
- diskless SBD case
```
# crm sbd configure crashdump-watchdog-timeout=60
WARNING: Kdump service is not active on alp-1
WARNING: Kdump service is not active on alp-2
INFO: Set stonith-watchdog-timeout to SBD_WATCHDOG_TIMEOUT + crashdump-watchdog-timeout: 75
INFO: Configuring diskless SBD
WARNING: Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice.
INFO: Update SBD_TIMEOUT_ACTION in /etc/sysconfig/sbd: flush,crashdump
INFO: Update SBD_OPTS in /etc/sysconfig/sbd: -C 60 -Z
INFO: Already synced /etc/sysconfig/sbd to all nodes
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
...........                                                                                                                                                                                        
INFO: END Waiting for cluster
WARNING: "stonith-watchdog-timeout" in crm_config is set to 75, it was -1
WARNING: "stonith-timeout" in crm_config is set to 101, it was 71
```
- To cleanup crashdump related option and configurations
```
# crm sbd purge crashdump 
INFO: Delete crashdump option for fence_sbd resource
INFO: Delete SBD_TIMEOUT_ACTION: flush,crashdump and restore original value
INFO: Update SBD_OPTS in /etc/sysconfig/sbd: 
INFO: Already synced /etc/sysconfig/sbd to all nodes
WARNING: Resource is running, need to restart cluster service manually on each node
```