### PR TITLE
Dev: sbd: Remove pcmk_delay_max while cacaulating stonith timeout value

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -305,7 +305,6 @@ class SBDTimeout(object):
         if dev_list:  # disk-based
             self.disk_based = True
             self.msgwait = SBDTimeout.get_sbd_msgwait(dev_list[0])
-            self.pcmk_delay_max = utils.get_pcmk_delay_max(self.two_node_without_qdevice)
         else:  # disk-less
             self.disk_based = False
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
@@ -319,13 +318,13 @@ class SBDTimeout(object):
         '''
         Get stonith-timeout value for sbd cases, formulas are:
 
-        value_from_sbd = 1.2 * (pcmk_delay_max + msgwait) # for disk-based sbd
+        value_from_sbd = 1.2 * msgwait # for disk-based sbd
         value_from_sbd = 1.2 * max (stonith_watchdog_timeout, 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
 
         stonith_timeout = max(value_from_sbd, constants.STONITH_TIMEOUT_DEFAULT) + token + consensus
         '''
         if self.disk_based:
-            value_from_sbd = int(1.2*(self.pcmk_delay_max + self.msgwait))
+            value_from_sbd = int(1.2*self.msgwait)
         else:
             value_from_sbd = int(1.2*max(self.stonith_watchdog_timeout, 2*self.sbd_watchdog_timeout))
 
@@ -343,12 +342,12 @@ class SBDTimeout(object):
         '''
         Get the value for SBD_DELAY_START, formulas are:
 
-        SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+        SBD_DELAY_START = (token + consensus + msgwait)  # for disk-based sbd
         SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
         '''
         token_and_consensus_timeout = corosync.token_and_consensus_timeout()
         if self.disk_based:
-            value = token_and_consensus_timeout + self.pcmk_delay_max + self.msgwait
+            value = token_and_consensus_timeout + self.msgwait
         else:
             value = token_and_consensus_timeout + 2*self.sbd_watchdog_timeout
         return value

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2758,15 +2758,6 @@ def is_2node_cluster_without_qdevice():
     return (current_num + qdevice_num) == 2
 
 
-def get_pcmk_delay_max(two_node_without_qdevice=False):
-    """
-    Get value of pcmk_delay_max
-    """
-    if ServiceManager().service_is_active("pacemaker.service") and two_node_without_qdevice:
-        return constants.PCMK_DELAY_MAX
-    return 0
-
-
 def get_property(name, property_type="crm_config", peer=None, get_default=True):
     """
     Get cluster properties

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -333,10 +333,9 @@ class TestSBDTimeout(unittest.TestCase):
     def test_get_sbd_delay_start_expected_diskbased(self, mock_token_and_consensus_timeout):
         inst = sbd.SBDTimeout()
         inst.disk_based = True
-        inst.pcmk_delay_max = 10
         inst.msgwait = 5
         mock_token_and_consensus_timeout.return_value = 10
-        self.assertEqual(inst.get_sbd_delay_start_expected(), 25)
+        self.assertEqual(inst.get_sbd_delay_start_expected(), 15)
 
     @patch('crmsh.corosync.token_and_consensus_timeout')
     def test_get_sbd_delay_start_expected_diskless(self, mock_token_and_consensus_timeout):
@@ -360,7 +359,6 @@ class TestSBDTimeout(unittest.TestCase):
     def test_get_stonith_timeout_expected_diskbased(self, mock_token_and_consensus_timeout, mock_logger_debug):
         inst = sbd.SBDTimeout()
         inst.disk_based = True
-        inst.pcmk_delay_max = 10
         inst.msgwait = 5
         mock_token_and_consensus_timeout.return_value = 10
         result = inst.get_stonith_timeout_expected()


### PR DESCRIPTION
fix #1739
- Remove pcmk_delay_max from the formula to calculate stonith-timeout
- Remove pcmk_delay_max from the formula to calculate SBD_DELAY_START