### PR TITLE
Dev: sbd: Leverage maintenance mode when need to restart cluster

### DIFF
--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -296,12 +296,12 @@ class SBD(command.UI):
             return timeout_dict
         if watchdog_timeout and not msgwait_timeout:
             timeout_dict["msgwait"] = 2*watchdog_timeout
-            logger.info("No msgwait timeout specified, use 2*watchdog timeout: %s", 2*watchdog_timeout)
+            logger.info("No 'msgwait-timeout=' specified in the command, use 2*watchdog timeout: %s", 2*watchdog_timeout)
             return timeout_dict
         if msgwait_timeout and not watchdog_timeout:
             watchdog_timeout = msgwait_timeout//2
             timeout_dict["watchdog"] = watchdog_timeout
-            logger.info("No watchdog timeout specified, use msgwait timeout/2: %s", watchdog_timeout)
+            logger.info("No 'watchdog-timeout=' specified in the command, use msgwait timeout/2: %s", watchdog_timeout)
             return timeout_dict
         return timeout_dict
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2126,6 +2126,11 @@ Additionally, it manages the configuration file for both disk-based and diskless
 as well as the on-disk metadata for the disk-based scenario.
 Currently, SBD management requires a running cluster.
 
+When run with `crm -F` or `--force` option, the `sbd` subcommand will leverage maintenance mode
+for any changes that require restarting sbd.service.
+WARNING: Understand risks that running RA has no cluster protection while the cluster is
+in maintenance mode and restarting
+
 [[cmdhelp.sbd.configure,configure SBD]]
 ==== `configure`
 

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -413,7 +413,11 @@ class TestSBDManager(unittest.TestCase):
         mock_CrmMonXmlParser.return_value.is_any_resource_running.return_value = True
         SBDManager.restart_cluster_if_possible()
         mock_ServiceManager.return_value.service_is_active.assert_called_once_with(constants.PCMK_SERVICE)
-        mock_logger_warning.assert_called_once_with("Resource is running, need to restart cluster service manually on each node")
+        mock_logger_warning.assert_has_calls([
+            call("Resource is running, need to restart cluster service manually on each node"),
+            call("Or, run with `crm -F` or `--force` option, the `sbd` subcommand will leverage maintenance mode for any changes that require restarting sbd.service"),
+            call("Understand risks that running RA has no cluster protection while the cluster is in maintenance mode and restarting")
+        ])
 
     @patch('crmsh.bootstrap.restart_cluster')
     @patch('logging.Logger.warning')


### PR DESCRIPTION
Changing the SBD configuration requires restarting the cluster.
This PR enables the use of the crm -F/--force option to leverage maintenance mode when a cluster restart is necessary.
```
# crm -F sbd configure crashdump-watchdog-timeout=60
...
INFO: Set cluster to maintenance mode
WARNING: "maintenance-mode" in crm_config is set to true, it was false
INFO: Configuring disk-based SBD
...
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
............                                                                                                                                                                                       
INFO: END Waiting for cluster
INFO: Set cluster from maintenance mode to normal
INFO: Delete cluster property "maintenance-mode" in crm_config
```

