### PR TITLE
Fix: ui_cluster: Return when cluster service on all nodes are already startd (bsc#1241358)

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -180,7 +180,7 @@ class Cluster(command.UI):
             logger.info("Please try 'crm cluster start' on each node")
             return False
         if not node_list:
-            return False
+            return
 
         if start_qdevice:
             service_manager.start_service("corosync-qdevice", node_list=node_list)

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -249,7 +249,7 @@ class Cluster(command.UI):
         except utils.NoSSHError as msg:
             logger.error('%s', msg)
             logger.info("Please try 'crm cluster stop' on each node")
-            return
+            return False
         if not node_list:
             return
         logger.debug(f"stop node list: {node_list}")

--- a/test/features/cluster_api.feature
+++ b/test/features/cluster_api.feature
@@ -130,3 +130,13 @@ Feature: Functional test to cover SAP clusterAPI
     And     Directory "hanode2" in "/tmp/report.tar.bz2"
     And     File "pacemaker.log" in "/tmp/report.tar.bz2"
     And     File "corosync.conf" in "/tmp/report.tar.bz2"
+
+  @clean
+  Scenario: crm cluster start should return 0 for successful repeated execution (bsc#1241358)
+    When    Run "crm cluster start" on "hanode1"
+    Then    Expected return code is "0"
+    Then    Expected "The cluster stack already started on hanode1" in stdout
+    When    Run "crm cluster stop" on "hanode1"
+    And     Run "crm cluster stop" on "hanode1"
+    Then    Expected return code is "0"
+    Then    Expected "The cluster stack already stopped on hanode1" in stdout

--- a/test/features/cluster_blocking_ssh.feature
+++ b/test/features/cluster_blocking_ssh.feature
@@ -73,5 +73,5 @@ Feature: cluster testing with ssh blocked
     Then    Directory "/tmp/report/hanode2" not created
     Then    Expected "ERROR: ssh-related operations are disabled. crmsh works in local mode." in stderr
     Then    Run "crm status" OK on "hanode1"
-    When    Run "crm cluster stop --all" on "hanode1"
-    Then    Expected "ERROR: ssh-related operations are disabled. crmsh works in local mode." in stderr
+    When    Try "crm cluster stop --all"
+    Then    Except "ERROR: ssh-related operations are disabled. crmsh works in local mode." in stderr


### PR DESCRIPTION
When cluster is already started, the return value of `crm cluster start` is 1, which was expected as 0

```
# crm cluster start
INFO: The cluster stack already started on node1
# echo $?
1
```
This regression was introduced from #1692 