### PR TITLE
[crmsh-4.6] Dev: workflows: Update CI image on github action

### DIFF
--- a/.github/workflows/crmsh-cd.yml
+++ b/.github/workflows/crmsh-cd.yml
@@ -22,7 +22,7 @@ jobs:
 
   delivery:
     needs: integration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
 
   submit:
     needs: delivery
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: ${{ false }}
     steps:

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   general_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: check data-manifest
@@ -29,7 +29,7 @@ jobs:
         }
 
   unit_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.6', '3.8', '3.10']
@@ -54,7 +54,7 @@ jobs:
         flags: unit
 
   functional_test_crm_report_bugs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
         flags: integration
 
   functional_test_crm_report_normal:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_bugs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_bugs_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_common:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -134,7 +134,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_common_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -150,7 +150,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_options:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -166,7 +166,7 @@ jobs:
         flags: integration
 
   functional_test_bootstrap_options_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_setup_remove:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_setup_remove_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -214,7 +214,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_options:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -230,7 +230,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_validate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -246,7 +246,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_validate_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -262,7 +262,7 @@ jobs:
         flags: integration
 
   functional_test_qdevice_user_case:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -278,7 +278,7 @@ jobs:
         flags: integration
 
   functional_test_resource_failcount:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -294,7 +294,7 @@ jobs:
         flags: integration
 
   functional_test_resource_set:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -310,7 +310,7 @@ jobs:
         flags: integration
 
   functional_test_resource_set_non_root:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -326,7 +326,7 @@ jobs:
         flags: integration
 
   functional_test_configure_sublevel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -342,7 +342,7 @@ jobs:
         flags: integration
 
   functional_test_constraints_bugs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -358,7 +358,7 @@ jobs:
         flags: integration
 
   functional_test_geo_cluster:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -390,7 +390,7 @@ jobs:
         flags: integration
 
   functional_test_cluster_api:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -405,7 +405,7 @@ jobs:
         flags: integration
 
   functional_test_user_access:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -420,7 +420,7 @@ jobs:
         flags: integration
 
   functional_test_ssh_agent:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -450,7 +450,7 @@ jobs:
         flags: integration
 
   original_regression_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -37,17 +37,14 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Run unit tests in Python container
       run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Test with pytest in tox
-      run: |
+        docker run --rm -v ${{ github.workspace }}:/app -w /app python:${{ matrix.python-version }} bash -c "
+        python -m pip install --upgrade pip &&
+        pip install tox &&
         tox -v -e${{ matrix.python-version }}
+        "
+
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Dev: workflows: Update CI image on github action
   As ubuntu-20.04 is not provided by github action anymore, we need to update the CI image to ubuntu-24.04.
- Dev: workflows: Run unit test with python container