### PR TITLE
Dev: bash_completion.sh: Add nosort option to disable sorting

### DIFF
--- a/contrib/bash_completion.sh
+++ b/contrib/bash_completion.sh
@@ -253,4 +253,4 @@ _crm() {
 
 	__crm_compgen
 } &&
-complete -o bashdefault -o default -o nospace -F _crm crm || complete -o default -o nospace -F _crm crm
+complete -o bashdefault -o default -o nospace -o nosort -F _crm crm || complete -o default -o nospace -o nosort -F _crm crm

--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -540,6 +540,7 @@ class ChildInfo(object):
                 ret = self.completer([self.name] + args, context)
             else:
                 ret = self.completer([self.name] + args)
+            ret = ret if already_used_custom_sort_order() else sorted(ret)
         return ret
 
     def __repr__(self):
@@ -567,8 +568,12 @@ def enable_custom_sort_order():
         sort_completion_inst.value = 0
 
 
+def already_used_custom_sort_order():
+    return sort_completion_inst is not None and sort_completion_inst.value == 0
+
+
 def disable_custom_sort_order():
-    if sort_completion_inst is not None and sort_completion_inst.value == 0:
+    if already_used_custom_sort_order():
         # Restore the original value of rl_sort_completion_matches
         # before calling the completer again
         sort_completion_inst.value = orig_sort_completion_value


### PR DESCRIPTION
## Problem
In interactive mode, some completers display in a custom order, whereas in non-interactive mode, these custom completers are displayed in alphabetical order.
```
# interactive, required parameters first
crm(live/alp-2)configure# primitive vip IPaddr2 params 
ip=
...

# non-interactive, in alphabetical order
crm configure primitive vip IPaddr2 params 
arp_bg=                                    
...
```
## Solution
This PR:
- On the `bash_completion.sh` side, add the `nosort` option to disable sorting. This ensures that completion results are displayed in the same order as returned by the command's completer.
- On the `crmsh` side, if a custom order completer is used, return the results as is; otherwise, sort the results before returning them.

Fix #1684 