### PR TITLE
Dev: Refactored node reachability handling in multiple modules

### DIFF
--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -352,14 +352,7 @@ def process_node_list(context: Context) -> None:
         if not context.node_list:
             raise utils.ReportGenericError("Could not figure out a list of nodes; is this a cluster node?")
 
-    for node in context.node_list[:]:
-        if node == context.me:
-            continue
-        try:
-            crmutils.node_reachable_check(node)
-        except Exception as err:
-            logger.error(str(err))
-            context.node_list.remove(node)
+    context.node_list = crmutils.get_reachable_node_list(context.node_list)
 
 
 def process_arguments(context: Context) -> None:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -254,13 +254,7 @@ keep the node in standby after reboot. The life time defaults to
             context.fatal_error(f"Node '{node}' is not a member of the cluster")
 
     node_list = member_list if options.all else args
-    for node in node_list:
-        try:
-            utils.node_reachable_check(node)
-        except ValueError as err:
-            logger.warning(str(err))
-            node_list.remove(node)
-    return node_list
+    return utils.get_reachable_node_list(node_list)
 
 
 class NodeMgmt(command.UI):

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -142,12 +142,7 @@ class SBD(command.UI):
         self.service_manager = ServiceManager()
         self.cluster_shell = sh.cluster_shell()
         self.cluster_nodes = utils.list_cluster_nodes() or [utils.this_node()]
-        for node in self.cluster_nodes[:]:
-            try:
-                utils.node_reachable_check(node)
-            except Exception as e:
-                logger.error(e)
-                self.cluster_nodes.remove(node)
+        self.cluster_nodes = utils.get_reachable_node_list(self.cluster_nodes)
 
     def requires(self) -> bool:
         '''

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2452,6 +2452,17 @@ def node_reachable_check(node, ping_count=1, port=22, timeout=3):
     raise ValueError(f"host \"{node}\" is unreachable")
 
 
+def get_reachable_node_list(node_list:list[str]) -> list[str]:
+    reachable_node_list = []
+    for node in node_list:
+        try:
+            if node_reachable_check(node):
+                reachable_node_list.append(node)
+        except ValueError as e:
+            logger.warning(str(e))
+    return reachable_node_list
+
+
 def calculate_quorate_status(expected_votes, actual_votes):
     """
     Given expected votes and actual votes, calculate if is quorated

--- a/test/unittests/test_report_core.py
+++ b/test/unittests/test_report_core.py
@@ -466,21 +466,22 @@ class TestRun(unittest.TestCase):
             core.process_node_list(mock_ctx_inst)
             self.assertEqual("Could not figure out a list of nodes; is this a cluster node?", str(err.exception))
 
+    @mock.patch('crmsh.utils.get_reachable_node_list')
     @mock.patch('crmsh.report.core.local_mode')
     @mock.patch('crmsh.utils.list_cluster_nodes')
-    def test_process_node_list_single(self, mock_list_nodes, mock_local_mode):
+    def test_process_node_list_single(self, mock_list_nodes, mock_local_mode, mock_reachable):
         mock_local_mode.return_value = True
         mock_ctx_inst = mock.Mock(node_list=["node1", "node2"], single=True, me="node1")
         core.process_node_list(mock_ctx_inst)
 
+    @mock.patch('crmsh.utils.get_reachable_node_list')
     @mock.patch('crmsh.report.core.local_mode')
     @mock.patch('logging.Logger.error')
-    @mock.patch('crmsh.utils.node_reachable_check')
     @mock.patch('crmsh.utils.list_cluster_nodes')
-    def test_process_node_list(self, mock_list_nodes, mock_reachable, mock_error, mock_local_mode):
+    def test_process_node_list(self, mock_list_nodes, mock_error, mock_local_mode, mock_reachable):
         mock_local_mode.return_value = False
         mock_ctx_inst = mock.Mock(node_list=["node1", "node2"], single=False, me="node1")
-        mock_reachable.side_effect = ValueError("error")
+        mock_reachable.return_value = ["node1"]
         core.process_node_list(mock_ctx_inst)
         self.assertEqual(mock_ctx_inst.node_list, ["node1"])
 

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1391,3 +1391,16 @@ def test_is_dc_idle(mock_dc, mock_shell):
     mock_shell.return_value = mock_shell_inst
     mock_shell_inst.get_stdout_stderr.return_value = (0, "in S_IDLE: ok", None)
     assert utils.is_dc_idle() is True
+
+
+@mock.patch('logging.Logger.warning')
+@mock.patch('crmsh.utils.node_reachable_check')
+def test_get_reachable_node_list(mock_reachable, mock_warn):
+    mock_reachable.side_effect = [False, True, ValueError("error for node3")]
+    assert utils.get_reachable_node_list(["node1", "node2", "node3"]) == ["node2"]
+    mock_warn.assert_called_once_with("error for node3")
+    mock_reachable.assert_has_calls([
+        mock.call("node1"),
+        mock.call("node2"),
+        mock.call("node3")
+    ])


### PR DESCRIPTION
- Added the function `get_reachable_node_list` to `crmsh/utils.py` for centralizing node reachability checks.
- Update node list handling in multiple modules to use `utils.get_reachable_node_list`. Avoid possible modification of node list which can lead to unexpected behavior [#1764 ].