### PR TITLE
Dev: xmlutil: Improve for completer of pacemaker remote node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2489,7 +2489,7 @@ def bootstrap_remove(context):
         if not force_flag:
             utils.fatal("Removing self requires --force")
         remove_self(force_flag)
-    elif cluster_node in xmlutil.listnodes():
+    elif cluster_node in utils.list_cluster_nodes():
         remove_node_from_cluster(cluster_node)
     else:
         utils.fatal("Specified node {} is not configured in cluster! Unable to remove.".format(cluster_node))
@@ -2502,7 +2502,7 @@ def bootstrap_remove(context):
 def remove_self(force_flag=False):
     me = utils.this_node()
     yes_to_all = _context.yes_to_all
-    nodes = xmlutil.listnodes(include_remote_nodes=False)
+    nodes = utils.list_cluster_nodes()
     othernode = next((x for x in nodes if x != me), None)
     if othernode is not None:
         logger.info("Removing node %s from cluster on %s", me, othernode)

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -4,6 +4,7 @@
 # Helper completers
 
 from . import xmlutil
+from . import utils
 
 
 def choice(lst):
@@ -69,8 +70,9 @@ def primitives(args):
     return [x.get("id") for x in nodes if xmlutil.is_primitive(x)]
 
 
-nodes = call(xmlutil.listnodes)
-online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "online")
-standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "standby")
+nodes = call(utils.list_cluster_nodes)
+nodes_with_remote = call(xmlutil.CrmMonXmlParser().get_node_list, True)
+online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list_with_attr(x), "online")
+standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list_with_attr(x), "standby")
 
 shadows = call(xmlutil.listshadows)

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -435,7 +435,7 @@ class RscMgmt(command.UI):
     @command.alias('migrate')
     @command.skill_level('administrator')
     @command.wait
-    @command.completers_repeating(compl.resources, compl.nodes)
+    @command.completers_repeating(compl.resources, compl.nodes_with_remote)
     def do_move(self, context, rsc, *args):
         """usage: move <rsc> [<node>] [<lifetime>] [force]"""
         return self.move_or_ban(context, rsc, *args)
@@ -443,7 +443,7 @@ class RscMgmt(command.UI):
 
     @command.skill_level('administrator')
     @command.wait
-    @command.completers_repeating(compl.resources, compl.nodes)
+    @command.completers_repeating(compl.resources, compl.nodes_with_remote)
     def do_ban(self, context, rsc, *args):
         """usage: ban <rsc> [<node>] [<lifetime>] [force]"""
         return self.move_or_ban(context, rsc, *args)
@@ -486,7 +486,7 @@ class RscMgmt(command.UI):
         return utils.ext_cmd("crm_resource -a -r '%s'" % (resource))
 
     @command.wait
-    @command.completers(compl.resources, _attrcmds, compl.nodes)
+    @command.completers(compl.resources, _attrcmds, compl.nodes_with_remote)
     def do_failcount(self, context, rsc, cmd, node, value=None, operation=None, interval=None):
         """usage:
         failcount <rsc> set <node> <value> [operation] [interval]

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1789,7 +1789,7 @@ class TestValidation(unittest.TestCase):
         mock_self.assert_called_once_with(True)
         mock_run.assert_called_once_with('rm -rf /var/lib/crmsh', 'node1')
 
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -1825,7 +1825,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.utils.fetch_cluster_node_list_from_node')
     @mock.patch('crmsh.bootstrap.remove_node_from_cluster')
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -1861,7 +1861,7 @@ class TestValidation(unittest.TestCase):
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     def test_remove_self_other_nodes(self, mock_this_node, mock_list, mock_run, mock_error):
         mock_this_node.return_value = 'node1'
@@ -1873,7 +1873,7 @@ class TestValidation(unittest.TestCase):
             bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True)
             bootstrap.remove_self()
 
-        mock_list.assert_called_once_with(include_remote_nodes=False)
+        mock_list.assert_called_once_with()
         mock_run.assert_called_once_with("node2", "crm cluster remove -y -c node1")
         mock_error.assert_called_once_with("Failed to remove this node from node2: err")
 

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -40,9 +40,9 @@ class TestCrmMonXmlParser(unittest.TestCase):
         assert self.parser_inst.is_node_online("tbw-1") is True
         assert self.parser_inst.is_node_online("tbw-2") is False
 
-    def test_get_node_list(self):
-        assert self.parser_inst.get_node_list("standby") == ['tbw-1']
-        assert self.parser_inst.get_node_list("online") == ['tbw-2']
+    def test_get_node_list_with_attr(self):
+        assert self.parser_inst.get_node_list_with_attr("standby") == ['tbw-1']
+        assert self.parser_inst.get_node_list_with_attr("online") == ['tbw-2']
 
     def test_is_resource_configured(self):
         assert self.parser_inst.is_resource_configured("test") is False


### PR DESCRIPTION
## Problem
- Some commands don't need to complete pacemaker remote node, like:
```
crm node standby
crm cluster remove
```

- While some commands need to include pacemaker remote node, like:
```
crm resource failcount
crm resource move
```

  See #1727

- The way to get remote node's name
```
/cib/status/node_state[@remote_node="true"]/@uname
```
Might have problem:
```
>>> xmlutil.listnodes()
['rm', 'alp-2']
# if the pacemaker remote RA's name changed from `rm` to `rm_node`, then got two remote nodes
>>> xmlutil.listnodes()
['rm', 'rm_node', 'alp-2']
```
Instead, get pacemaker remote node from `crm_mon -1 --output-as=xml` looks more accurately
```
  <nodes>
    <node name="alp-2" id="2" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" health="green" feature_set="3.20.0" shutdown="false" expected_up="true" is_dc="true" resources_running="1" type="member"/>
    <node name="rm_node" id="rm_node" online="true" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" health="green" shutdown="false" expected_up="false" is_dc="false" resources_running="0" type="remote"/>
  </nodes>
```
## Solution
- Drop xmlutil.listnodes function, use utils.list_cluster_nodes instead
- Rename xmlutil.CrmMonXmlParser.get_node_list to xmlutil.CrmMonXmlParser.get_node_list_with_attr
- Add a new function xmlutil.CrmMonXmlParser.get_node_list to get node list including pacemaker remote node; Thus add a new completer completers.nodes_with_remote