### PR TITLE
 Dev: ui_cluster: Skip stopping cluster if dlm_controld is running in maintenance mode

### DIFF
--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -275,14 +275,17 @@ class Cluster(command.UI):
         for node in node_list:
             logger.info("The cluster stack stopped on {}".format(node))
 
+        return True
+
     @command.skill_level('administrator')
     def do_restart(self, context, *args):
         '''
         Restarts the cluster stack on all nodes or specific node(s)
         '''
-        parse_option_for_nodes(context, *args)
-        self.do_stop(context, *args)
-        self.do_start(context, *args)
+        stop_rc = self.do_stop(context, *args)
+        if stop_rc is False:
+            return False
+        return self.do_start(context, *args)
 
     @command.skill_level('administrator')
     def do_enable(self, context, *args):

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -254,6 +254,11 @@ class Cluster(command.UI):
             return
         logger.debug(f"stop node list: {node_list}")
 
+        if utils.is_cluster_in_maintenance_mode() and utils.is_dlm_running():
+            logger.info("The cluster is in maintenance mode")
+            logger.error("Stopping pacemaker/corosync will trigger unexpected node fencing when 'dlm_controld' is running in maintenance mode.")
+            return False
+
         utils.wait_for_dc(node_list[0])
 
         self._set_dlm(node_list[0])

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2816,6 +2816,11 @@ def delete_property(name, property_type="crm_config") -> bool:
     return False
 
 
+def is_cluster_in_maintenance_mode() -> bool:
+    maintenance_mode = get_property("maintenance-mode")
+    return maintenance_mode and is_boolean_true(maintenance_mode)
+
+
 @contextmanager
 def leverage_maintenance_mode() -> typing.Generator[bool, None, None]:
     """
@@ -2824,8 +2829,7 @@ def leverage_maintenance_mode() -> typing.Generator[bool, None, None]:
     Yield True if cluster is in maintenance mode or already in maintenance mode
     Yield False if not using -F/--force option or DC is not IDLE
     """
-    maintenance_mode = get_property("maintenance-mode")
-    if maintenance_mode and is_boolean_true(maintenance_mode):
+    if is_cluster_in_maintenance_mode():
         logger.info("Cluster is already in maintenance mode")
         yield True
         return

--- a/test/features/ocfs2.feature
+++ b/test/features/ocfs2.feature
@@ -59,3 +59,8 @@ Scenario: Add cluster lvm2 + ocfs2 on a running cluster
   And     Resource "ocfs2-lvmlockd" type "heartbeat:lvmlockd" is "Started"
   And     Resource "ocfs2-lvmactivate" type "heartbeat:LVM-activate" is "Started"
   And     Resource "ocfs2-clusterfs" type "heartbeat:Filesystem" is "Started"
+  # When cluster in maintenance mode and dlm is running, cannot do stop
+  When    Run "crm maintenance on" on "hanode1"
+  And     Try "crm cluster stop" on "hanode1"
+  Then    Expected return code is "1"
+  Then    Expected "Stopping pacemaker/corosync will trigger unexpected node fencing" in stderr


### PR DESCRIPTION
- Dev: ui_cluster: Skip stop cluster if cluster is in maintenance mode and dlm is running
```
# crm cluster restart
INFO: The cluster is in maintenance mode
ERROR: Stopping pacemaker/corosync will trigger unexpected node fencing when 'dlm_controld' is running in maintenance mode.
# crm cluster stop
INFO: The cluster is in maintenance mode
ERROR: Stopping pacemaker/corosync will trigger unexpected node fencing when 'dlm_controld' is running in maintenance mode.
```
Dev: ui_cluster: Refactor the `do_restart` function
    
    - Ensure the function returns `False` immediately if `do_stop` returns
      `False`, avoiding the execution of `do_start`.
    - Update the function to return the result of `do_start`, as it may
      return `False`.