### PR TITLE
[crmsh-4.5] Fix: log: fix a typo of a variable name

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -411,7 +411,7 @@ class LoggerUtils(object):
     def update_err(self, obj_id, cibadm_opt, xml, rc):
         CIB_PERMISSION_DENIED_CODE = 54
         task_table = {"-U": "update", "-D": "delete", "-P": "patch"}
-        task = task_table.get(cibadmin_opt, "replace")
+        task = task_table.get(cibadm_opt, "replace")
         self.logger.error("could not %s %s (rc=%d)", task, obj_id, int(rc))
         if int(rc) == CIB_PERMISSION_DENIED_CODE:
             self.logger.info("Permission denied.")


### PR DESCRIPTION
backport #1782