### PR TITLE
Dev: behave: Fix cross-network isolation issue

### DIFF
--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -66,11 +66,13 @@ Feature: Regression test for bootstrap bugs
     Given   Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -i eth0 -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
+    When    Run "iptables -A INPUT -i eth1 -s @hanode1.ip.0 -j DROP" on "hanode2"
     When    Try "crm cluster join -c hanode1 -i eth1 -y" on "hanode2"
     Then    Cluster service is "stopped" on "hanode2"
     And     Except "Cannot see peer node "hanode1", please check the communication IP" in stderr
     When    Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
+    When    Run "iptables -D INPUT -i eth1 -s @hanode1.ip.0 -j DROP" on "hanode2"
 
   @clean
   Scenario: Remove correspond nodelist in corosync.conf while remove(bsc#1165644)


### PR DESCRIPTION
After the GitHub Actions environment was updated, the network isolation between the two interfaces no longer functions as it did previously. As a result, the test case "Setup cluster with crossed network" does not fail as expected.

To address this, an iptables rule was added to simulate the isolated network environment required for the test case.