### PR TITLE
Fix: corosync: Don't set quorum.two_node to 1 if qdevice configured

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -81,7 +81,8 @@ def configure_two_node(removing: bool = False, qdevice_adding: bool = False) -> 
         expected_votes -= 1
     if qdevice_adding and expected_votes > 1:
         expected_votes += 1
-    set_value("quorum.two_node", 1 if expected_votes == 2 else 0)
+    need_two_node = expected_votes == 2 and not is_qdevice_configured()
+    set_value("quorum.two_node", 1 if need_two_node else 0)
 
 
 def conf():

--- a/test/features/qdevice_setup_remove.feature
+++ b/test/features/qdevice_setup_remove.feature
@@ -75,6 +75,29 @@ Feature: corosync qdevice/qnetd setup/remove process
     And     Show corosync qdevice configuration
 
   @clean
+  Scenario: Remove one node from a two-node+qdevice cluster
+    When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Online nodes are "hanode1 hanode2"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    And     two_node in corosync.conf is "0"
+
+    When    Run "crm cluster remove hanode2 -y" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode2"
+    And     Service "corosync-qdevice" is "stopped" on "hanode2"
+    And     two_node in corosync.conf is "0"
+    When    Run "crm cluster restart" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    And     Service "corosync-qdevice" is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    And     Service "corosync-qdevice" is "started" on "hanode2"
+    And     two_node in corosync.conf is "0"
+
+  @clean
   Scenario: Setup qdevice on multi nodes
     When    Run "crm cluster init --qnetd-hostname=qnetd-node -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"


### PR DESCRIPTION
Fix #1795 