### PR TITLE
Fix: crash_test: Correctly retrieve fence event information (bsc#1243786)

### DIFF
--- a/crmsh/crash_test/config.py
+++ b/crmsh/crash_test/config.py
@@ -4,6 +4,5 @@ BLOCK_IP = '''iptables -{action} INPUT -s {peer_ip} -j DROP;
               iptables -{action} OUTPUT -d {peer_ip} -j DROP'''
 REMOVE_PORT = "firewall-cmd --zone=public --remove-port={port}/udp"
 ADD_PORT = "firewall-cmd --zone=public --add-port={port}/udp"
-FENCE_HISTORY = "stonith_admin -h {node}"
 SBD_CONF = "/etc/sysconfig/sbd"
 SBD_CHECK_CMD = "sbd -d {dev} dump"

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1574,4 +1574,19 @@ class CrmMonXmlParser(object):
         """
         xpath = f'//resource[@resource_agent="{ra_type}"]'
         return [elem.get('id') for elem in self.xml_elem.xpath(xpath)]
+
+    def get_last_fence_event_info(self) -> dict:
+        fence_event_info = {}
+        fence_events = self.xml_elem.xpath(r'//fence_history/fence_event')
+        if not fence_events:
+            return fence_event_info
+        last_event = fence_events[0]
+        fence_event_info = {
+            'origin': last_event.get('origin', ''),
+            'target': last_event.get('target', ''),
+            'action': last_event.get('action', ''),
+            'status': last_event.get('status', ''),
+            'completed': last_event.get('completed', '')
+        }
+        return fence_event_info
 # vim:ts=4:sw=4:et:


### PR DESCRIPTION
Previously, `crash_test --fence-node` obtained fence event information by parsing the string output from crm_mon and stonith_admin, which was unreliable. This update changes the approach to parse the XML output from crm_mon at the '//fence_history/fence_event' path, resulting in more accurate and robust retrieval of fence event details.