### PR TITLE
Dev: bootstrap: Improve configuration for admin IP

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -474,7 +474,7 @@ def crm_configure_load(action, configuration):
     sh.cluster_shell().get_stdout_or_raise_error(f"crm -F configure load {action} {configuration_tmpfile}")
 
 
-def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT):
+def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT, fatal_on_timeout=True):
     """
     Wait for resource started
     """
@@ -485,7 +485,12 @@ def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT):
                 break
             status_progress(progress_bar)
             if 0 < timeout_ms <= (int(time.clock_gettime(time.CLOCK_MONOTONIC) * 1000) - start_time):
-                utils.fatal('Time out waiting for resource.')
+                error_msg = f'Time out waiting for resource "{resource}" to start.'
+                if fatal_on_timeout:
+                    utils.fatal(error_msg)
+                else:
+                    logger.error(error_msg)
+                    break
             sleep(1)
 
 
@@ -1525,7 +1530,12 @@ def init_admin():
         adminaddr = prompt_for_string('Virtual IP', valid_func=Validation.valid_admin_ip)
 
     crm_configure_load("update", 'primitive admin-ip IPaddr2 ip=%s op monitor interval=10 timeout=20' % (utils.doublequote(adminaddr)))
-    wait_for_resource("Configuring virtual IP ({})".format(adminaddr), "admin-ip")
+    wait_for_resource(
+        f"Configuring virtual IP ({adminaddr})",
+        "admin-ip",
+        timeout_ms=5000,
+        fatal_on_timeout=False
+    )
 
 
 def configure_qdevice_interactive():

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -7,7 +7,7 @@ Feature: crmsh bootstrap process - options
       "-n":      Set the name of the configured cluster
       "-A":      Configure IP address as an administration virtual IP
   Tag @clean means need to stop cluster service if the service is available
-  Need nodes: hanode1 hanode2 hanode3
+  Need nodes: hanode1 hanode2 hanode3 qnetd-node
 
   @clean
   Scenario: Check help output
@@ -134,6 +134,13 @@ Feature: crmsh bootstrap process - options
     And     Cluster name is "hatest"
     And     Cluster virtual IP is "@vip.0"
     And     Show cluster status on "hanode1"
+
+  @clean
+  Scenario: Invalid virtual IP address wouldn't block cluster init
+    Given   Cluster service is "stopped" on "hanode1"
+    When    Run "crm cluster init -A 60.60.60.6 --qnetd-hostname qnetd-node -y" on "hanode1"
+    Then    Expected "Time out waiting for resource "admin-ip" to start" in stderr
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
  
   @clean
   Scenario: Detect multi IP in the same NIC


### PR DESCRIPTION
## Problem
- If an invalid admin IP is configured (for example, one on a different subnet), the process will wait for a long time
- When a timeout occurs, it will simply exit and will not proceed to configure the qdevice.
```
# crm cluster init -A 40.40.40.123 -y --qnetd-hostname server1
...
INFO: BEGIN Configuring virtual IP (40.40.40.123)
.........................................................    # here we wait for a long time, actually IPaddr2 RA failed quickly                                                                                                   ERROR: FAIL Configuring virtual IP (40.40.40.123)
ERROR: cluster.init: Time out waiting for resource.          # cannot configure qdevice here, just exit
```
## Changes
- Wait for shorter time for admin IP to be started
- Don't exit if admin IP start fails, just log an error