### PR TITLE
Dev: Prevent actions when offline nodes are unreachable

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -227,7 +227,7 @@ class Context(object):
 
         if self.stage == "sbd":
             if self.cluster_is_running:
-                utils.check_all_nodes_reachable()
+                utils.check_all_nodes_reachable("setup SBD")
                 for node in utils.list_cluster_nodes():
                     if not utils.package_is_installed("sbd", node):
                         utils.fatal(SBDManager.SBD_NOT_INSTALLED_MSG + f" on {node}")
@@ -1630,6 +1630,7 @@ def init_qdevice():
         return
 
     logger.info("""Configure Qdevice/Qnetd:""")
+    utils.check_all_nodes_reachable("setup Qdevice")
     cluster_node_list = utils.list_cluster_nodes()
     for node in cluster_node_list:
         if not ServiceManager().service_is_available("corosync-qdevice.service", node):
@@ -2398,6 +2399,7 @@ def bootstrap_join(context):
         try:
             with lock_inst.lock():
                 service_manager = ServiceManager()
+                utils.check_all_nodes_reachable("joining a node to the cluster", cluster_node)
                 _context.node_list_in_cluster = utils.fetch_cluster_node_list_from_node(cluster_node)
                 setup_passwordless_with_other_nodes(cluster_node)
                 _context.skip_csync2 = not service_manager.service_is_active(CSYNC2_SERVICE, cluster_node)
@@ -2439,7 +2441,7 @@ def remove_qdevice() -> None:
     if not confirm("Removing QDevice service and configuration from cluster: Are you sure?"):
         return
 
-    utils.check_all_nodes_reachable()
+    utils.check_all_nodes_reachable("removing QDevice from the cluster")
     qdevice_reload_policy = qdevice.evaluate_qdevice_quorum_effect(qdevice.QDEVICE_REMOVE)
 
     logger.info("Disable corosync-qdevice.service")
@@ -2502,6 +2504,8 @@ def bootstrap_remove(context):
 
     if not _context.cluster_node:
         utils.fatal("No existing IP/hostname specified (use -c option)")
+
+    utils.check_all_nodes_reachable("removing a node from the cluster")
 
     remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
 

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -70,7 +70,7 @@ def primitives(args):
 
 
 nodes = call(xmlutil.listnodes)
-online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "online")
-standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(x), "standby")
+online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), False)
+standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), True)
 
 shadows = call(xmlutil.listshadows)

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -630,7 +630,6 @@ class QDevice(object):
         """
         Adjust SBD_WATCHDOG_TIMEOUT when configuring qdevice and diskless SBD
         """
-        utils.check_all_nodes_reachable()
         self.using_diskless_sbd = SBDUtils.is_using_diskless_sbd()
         # add qdevice after diskless sbd started
         if self.using_diskless_sbd:

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -516,6 +516,8 @@ class SBD(command.UI):
             if len(args) < 2:
                 raise self.SyntaxError("No device specified")
 
+            utils.check_all_nodes_reachable("configuring SBD device")
+
             logger.info("Configured sbd devices: %s", ';'.join(self.device_list_from_config))
             if len(args) == 2 and ";" in args[1]:
                 device_list_from_args = args[1].split(";")
@@ -549,6 +551,8 @@ class SBD(command.UI):
                 if not self._service_is_active(service):
                     return False
 
+            utils.check_all_nodes_reachable("configuring SBD")
+
             parameter_dict = self._parse_args(args)
             if sbd.SBDUtils.is_using_disk_based_sbd():
                 self._configure_diskbase(parameter_dict)
@@ -571,6 +575,8 @@ class SBD(command.UI):
         self._load_attributes()
         if not self._service_is_active(constants.SBD_SERVICE):
             return False
+
+        utils.check_all_nodes_reachable("purging SBD")
 
         if args and args[0] == "crashdump":
             self._set_crashdump_option(delete=True)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -42,6 +42,7 @@ from . import constants
 from . import options
 from . import term
 from . import log
+from . import xmlutil
 from .prun import prun
 from .sh import ShellUtils
 from .service_manager import ServiceManager
@@ -1722,7 +1723,6 @@ def list_cluster_nodes(no_reg=False) -> list[str]:
     '''
     Returns a list of nodes in the cluster.
     '''
-    from . import xmlutil
     rc, out, err = ShellUtils().get_stdout_stderr(constants.CIB_QUERY, no_reg=no_reg)
     # When cluster service running
     if rc == 0:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2460,12 +2460,28 @@ def get_quorum_votes_dict(remote=None):
     return dict(re.findall(r"(Expected|Total) votes:\s+(\d+)", out))
 
 
-def check_all_nodes_reachable():
+def check_all_nodes_reachable(action_to_do :str, peer_node :str = None):
     """
     Check if all cluster nodes are reachable
     """
-    out = sh.cluster_shell().get_stdout_or_raise_error("crm_node -l")
-    for node in re.findall(r"\d+ (.*) \w+", out):
+    crm_mon_inst = xmlutil.CrmMonXmlParser(peer_node)
+    online_nodes = crm_mon_inst.get_node_list()
+    offline_nodes = crm_mon_inst.get_node_list(online=False)
+    dead_nodes = []
+    for node in offline_nodes:
+        try:
+            node_reachable_check(node)
+        except ValueError:
+            dead_nodes.append(node)
+    if dead_nodes:
+        # dead nodes bring risk to cluster, either bring them online or remove them
+        msg = f"""There are offline nodes also unreachable: {', '.join(dead_nodes)}.
+Please bring them online before {action_to_do}.
+Or use `crm cluster remove <offline_node> --force` to remove the offline node.
+        """
+        fatal(msg)
+
+    for node in online_nodes:
         node_reachable_check(node)
 
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2460,7 +2460,13 @@ def get_quorum_votes_dict(remote=None):
     return dict(re.findall(r"(Expected|Total) votes:\s+(\d+)", out))
 
 
-def check_all_nodes_reachable(action_to_do :str, peer_node :str = None):
+class DeadNodeError(ValueError):
+    def __init__(self, msg: str, dead_nodes=None):
+        super().__init__(msg)
+        self.dead_nodes = dead_nodes or []
+
+
+def check_all_nodes_reachable(action_to_do: str, peer_node: str = None):
     """
     Check if all cluster nodes are reachable
     """
@@ -2479,7 +2485,7 @@ def check_all_nodes_reachable(action_to_do :str, peer_node :str = None):
 Please bring them online before {action_to_do}.
 Or use `crm cluster remove <offline_node> --force` to remove the offline node.
         """
-        fatal(msg)
+        raise DeadNodeError(msg, dead_nodes)
 
     for node in online_nodes:
         node_reachable_check(node)

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1531,16 +1531,20 @@ class CrmMonXmlParser(object):
         xpath = f'//node[@name="{node}" and @online="true"]'
         return bool(self.xml_elem.xpath(xpath))
 
-    def get_node_list(self, attr=None):
+    def get_node_list(self, online=True, standby=False, exclude_remote=True) -> list[str]:
         """
         Get a list of nodes based on the given attribute
         """
-        attr_dict = {
-            'standby': '[@standby="true"]',
-            'online': '[@standby="false"]'
-        }
-        xpath_str = f'//node{attr_dict.get(attr, "")}'
-        return [e.get('name') for e in self.xml_elem.xpath(xpath_str)]
+        xpath_str = '//nodes/node'
+        conditions = []
+        online_value = "true" if online else "false"
+        conditions.append(f'@online="{online_value}"')
+        standby_value = "true" if standby else "false"
+        conditions.append(f'@standby="{standby_value}"')
+        if exclude_remote:
+            conditions.append('@type="member"')
+        xpath_str += '[' + ' and '.join(conditions) + ']'
+        return [elem.get('name') for elem in self.xml_elem.xpath(xpath_str)]
 
     def is_resource_configured(self, ra_type):
         """

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -205,3 +205,16 @@ Feature: crmsh bootstrap process - init, join and remove
     Then    Cluster service is "started" on "hanode3"
     And     Online nodes are "hanode1 hanode2 hanode3"
     And     Check passwordless for hacluster between "hanode1 hanode2 hanode3" "successfully"
+
+  @skip_non_root
+  Scenario: Remove offline and unreachable node
+    When    Run "init 0" on "hanode2"
+    Then    Online nodes are "hanode1"
+    When    Run "sleep 10" on "hanode1"
+    When    Try "crm cluster remove hanode2 -y" on "hanode1"
+    Then    Expected "There are offline nodes also unreachable: hanode2" in stderr
+    When    Try "crm status|grep "OFFLINE.*hanode2"" on "hanode1"
+    Then    Expected return code is "0"
+    When    Run "crm cluster remove hanode2 -y --force" on "hanode1"
+    When    Try "crm status|grep "OFFLINE.*hanode2"" on "hanode1"
+    Then    Expected return code is "1"

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -842,15 +842,13 @@ Membership information
     @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
     @mock.patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
     @mock.patch('crmsh.sbd.SBDUtils.is_using_diskless_sbd')
-    @mock.patch('crmsh.utils.check_all_nodes_reachable')
-    def test_adjust_sbd_watchdog_timeout_with_qdevice(self, mock_check_reachable, mock_using_diskless_sbd, mock_get_sbd_value, mock_update_config, mock_get_timeout, mock_set_property):
+    def test_adjust_sbd_watchdog_timeout_with_qdevice(self, mock_using_diskless_sbd, mock_get_sbd_value, mock_update_config, mock_get_timeout, mock_set_property):
         mock_using_diskless_sbd.return_value = True
         mock_get_sbd_value.return_value = ""
         mock_get_timeout.return_value = 100
 
         self.qdevice_with_stage_cluster_name.adjust_sbd_watchdog_timeout_with_qdevice()
 
-        mock_check_reachable.assert_called_once_with()
         mock_using_diskless_sbd.assert_called_once_with()
         mock_get_sbd_value.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
         mock_update_config.assert_called_once_with({"SBD_WATCHDOG_TIMEOUT": str(sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)})

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -535,9 +535,10 @@ class TestSBD(unittest.TestCase):
         mock_logger_error.assert_called_once_with('%s', "No device specified")
         mock_logger_info.assert_called_once_with("Usage: crm sbd device <add|remove> <device>...")
 
+    @mock.patch('crmsh.utils.check_all_nodes_reachable')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
-    def test_do_device_add(self, mock_is_using_disk_based_sbd, mock_logger_info):
+    def test_do_device_add(self, mock_is_using_disk_based_sbd, mock_logger_info, mock_check_all_nodes_reachable):
         mock_is_using_disk_based_sbd.return_value = True
         self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
         self.sbd_instance_diskbased._load_attributes = mock.Mock()
@@ -546,10 +547,12 @@ class TestSBD(unittest.TestCase):
         self.assertTrue(res)
         self.sbd_instance_diskbased._device_add.assert_called_once_with(["/dev/sda2", "/dev/sda3"])
         mock_logger_info.assert_called_once_with("Configured sbd devices: %s", "/dev/sda1")
+        mock_check_all_nodes_reachable.assert_called_once_with("configuring SBD device")
 
+    @mock.patch('crmsh.utils.check_all_nodes_reachable')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.sbd.SBDUtils.is_using_disk_based_sbd')
-    def test_do_device_remove(self, mock_is_using_disk_based_sbd, mock_logger_info):
+    def test_do_device_remove(self, mock_is_using_disk_based_sbd, mock_logger_info, mock_check_all_nodes_reachable):
         mock_is_using_disk_based_sbd.return_value = True
         self.sbd_instance_diskbased.service_is_active = mock.Mock(return_value=True)
         self.sbd_instance_diskbased._load_attributes = mock.Mock()
@@ -558,6 +561,7 @@ class TestSBD(unittest.TestCase):
         self.assertTrue(res)
         self.sbd_instance_diskbased._device_remove.assert_called_once_with(["/dev/sda1"])
         mock_logger_info.assert_called_once_with("Configured sbd devices: %s", "/dev/sda1")
+        mock_check_all_nodes_reachable.assert_called_once_with("configuring SBD device")
 
     @mock.patch('crmsh.sbd.purge_sbd_from_cluster')
     def test_do_purge_no_service(self, mock_purge_sbd_from_cluster):
@@ -567,8 +571,9 @@ class TestSBD(unittest.TestCase):
         self.assertFalse(res)
         mock_purge_sbd_from_cluster.assert_not_called()
 
+    @mock.patch('crmsh.utils.check_all_nodes_reachable')
     @mock.patch('crmsh.sbd.purge_sbd_from_cluster')
-    def test_do_purge(self, mock_purge_sbd_from_cluster):
+    def test_do_purge(self, mock_purge_sbd_from_cluster, mock_check_all_nodes_reachable):
         self.sbd_instance_diskbased._load_attributes = mock.Mock()
         self.sbd_instance_diskbased._service_is_active = mock.Mock(return_value=True)
         res = self.sbd_instance_diskbased.do_purge(mock.Mock())
@@ -577,6 +582,7 @@ class TestSBD(unittest.TestCase):
         self.sbd_instance_diskbased._load_attributes.assert_called_once()
         self.sbd_instance_diskbased._service_is_active.assert_called_once_with(constants.SBD_SERVICE)
         mock_purge_sbd_from_cluster.assert_called_once_with()
+        mock_check_all_nodes_reachable.assert_called_once_with("purging SBD")
 
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
     def test_print_sbd_agent_status(self, mock_CrmMonXmlParser):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -971,12 +971,26 @@ def test_is_block_device(mock_stat, mock_isblk):
 
 
 @mock.patch('crmsh.utils.node_reachable_check')
-@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
-def test_check_all_nodes_reachable(mock_run, mock_reachable):
-    mock_run.return_value = "1084783297 15sp2-1 member"
-    utils.check_all_nodes_reachable()
-    mock_run.assert_called_once_with("crm_node -l")
-    mock_reachable.assert_called_once_with("15sp2-1")
+@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+def test_check_all_nodes_reachable_dead_nodes(mock_xml, mock_reachable):
+    mock_xml_inst = mock.Mock()
+    mock_xml.return_value = mock_xml_inst
+    mock_xml_inst.get_node_list.side_effect = [["node1"], ["node2"]]
+    mock_reachable.side_effect = ValueError
+
+    with pytest.raises(utils.DeadNodeError) as err:
+        utils.check_all_nodes_reachable("testing")
+    assert err.value.dead_nodes == ["node2"]
+
+
+@mock.patch('crmsh.utils.node_reachable_check')
+@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+def test_check_all_nodes_reachable(mock_xml, mock_reachable):
+    mock_xml_inst = mock.Mock()
+    mock_xml.return_value = mock_xml_inst
+    mock_xml_inst.get_node_list.side_effect = [["node1"], []]
+    utils.check_all_nodes_reachable("testing")
+    mock_reachable.assert_called_once_with("node1")
 
 
 @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -41,8 +41,8 @@ class TestCrmMonXmlParser(unittest.TestCase):
         assert self.parser_inst.is_node_online("tbw-2") is False
 
     def test_get_node_list(self):
-        assert self.parser_inst.get_node_list("standby") == ['tbw-1']
-        assert self.parser_inst.get_node_list("online") == ['tbw-2']
+        assert self.parser_inst.get_node_list(standby=True) == ['tbw-1']
+        assert self.parser_inst.get_node_list(online=False) == ['tbw-2']
 
     def test_is_resource_configured(self):
         assert self.parser_inst.is_resource_configured("test") is False


### PR DESCRIPTION
Before performing operations that require all nodes to be online or at least SSH-reachable, such as:

- Joining a node to the cluster
- Removing a node from the cluster
- Configure SBD
- Setup SBD
- Setup QDevice
- Removing QDevice

Check for any offline nodes that are also unreachable.
    
If such nodes are found, the operation is blocked, and the user is 
prompted to either bring the nodes online or forcibly remove them from
the cluster.
    
This enhances cluster safety by ensuring potentially problematic nodes
are handled explicitly before critical actions are taken.
```
# crm sbd purge 
WARNING: host "alp-2" is unreachable
ERROR: sbd.purge: There are offline nodes also unreachable: alp-2.
Please bring them online before purging SBD.
Or use `crm cluster remove <offline_node> --force` to remove the offline node.
```

Also implement `crm cluster remove <offline_node> --force` to remove the offline node
```
# crm cluster remove alp-2 --force
INFO: Removing node alp-2 from cluster
INFO: Removing node alp-2 from CIB
INFO: Delete parameter 'pcmk_delay_max' for resource 'stonith-sbd'
WARNING: "priority" in rsc_defaults is set to 0, it was 1
WARNING: "priority-fencing-delay" in crm_config is set to 0, it was 60
INFO: Propagating configuration changes across the remaining nodes
INFO: Done (log saved to /var/log/crmsh/crmsh.log on alp-1)
```
