### PR TITLE
Dev: bootstrap: Improve node removal handling and messaging

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2498,7 +2498,13 @@ def bootstrap_remove(context):
         utils.fatal("No existing IP/hostname specified (use -c option)")
 
     remote_user, cluster_node = _parse_user_at_host(_context.cluster_node, _context.current_user)
-    cluster_node = get_node_canonical_hostname(cluster_node)
+
+    if service_manager.service_is_active("pacemaker.service", cluster_node):
+        cluster_node = get_node_canonical_hostname(cluster_node)
+    else:
+        configured_nodes = utils.list_cluster_nodes()
+        if cluster_node not in configured_nodes:
+            utils.fatal(f"Node {cluster_node} is not configured in cluster! (valid nodes: {', '.join(configured_nodes)})")
 
     if not force_flag and not confirm("Removing node \"{}\" from the cluster: Are you sure?".format(cluster_node)):
         return

--- a/test/features/bootstrap_init_join_remove.feature
+++ b/test/features/bootstrap_init_join_remove.feature
@@ -74,6 +74,23 @@ Feature: crmsh bootstrap process - init, join and remove
     Then    Directory "/var/lib/pacemaker/pengine/" is empty on "hanode2"
     Then    Directory "/var/lib/corosync/" is empty on "hanode2"
 
+  Scenario: Remove peer node when cluster is not running
+    Then    File "/etc/corosync/authkey" exists on "hanode2"
+    Then    File "/etc/corosync/corosync.conf" exists on "hanode2"
+    Then    File "/etc/pacemaker/authkey" exists on "hanode2"
+    Then    Directory "/var/lib/pacemaker/cib/" not empty on "hanode2"
+    Then    Directory "/var/lib/corosync/" not empty on "hanode2"
+    When    Run "crm cluster stop" on "hanode2"
+    When    Try "crm cluster remove @hanode2.ip.0 -y" on "hanode1"
+    Then    Expected "Node @hanode2.ip.0 is not configured in cluster! (valid nodes: hanode1, hanode2)" in stderr
+    When    Run "crm cluster remove hanode2 -y" on "hanode1"
+    Then    File "/etc/corosync/authkey" not exist on "hanode2"
+    Then    File "/etc/corosync/corosync.conf" not exist on "hanode2"
+    Then    File "/etc/pacemaker/authkey" not exist on "hanode2"
+    Then    Directory "/var/lib/pacemaker/cib/" is empty on "hanode2"
+    Then    Directory "/var/lib/pacemaker/pengine/" is empty on "hanode2"
+    Then    Directory "/var/lib/corosync/" is empty on "hanode2"
+
   Scenario: Remove local node "hanode1"
     When    Run "crm configure primitive d1 Dummy" on "hanode1"
     When    Run "crm configure primitive d2 Dummy" on "hanode1"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1839,7 +1839,7 @@ class TestValidation(unittest.TestCase):
             mock_list, mock_remove, mock_fetch, mock_run):
         mock_context_inst = mock.Mock(cluster_node="node2", qdevice_rm_flag=None, force=True)
         mock_context.return_value = mock_context_inst
-        mock_active.side_effect = [True, False]
+        mock_active.side_effect = [True, False, True]
         mock_hostname.return_value = "node2"
         mock_this_node.return_value = "node1"
         mock_list.return_value = ["node1", "node2"]
@@ -1850,7 +1850,8 @@ class TestValidation(unittest.TestCase):
         mock_init.assert_called_once_with()
         mock_active.assert_has_calls([
             mock.call("corosync.service"),
-            mock.call("csync2.socket")
+            mock.call("csync2.socket"),
+            mock.call("pacemaker.service", "node2")
             ])
         mock_qdevice.assert_not_called()
         mock_hostname.assert_called_once_with('node2')


### PR DESCRIPTION
When removing a peer node from the cluster, if the cluster service is not running on that node, get_node_canonical_hostname fails because `crm_node --name` does not return a hostname.
```
# crm cluster remove alp-2
INFO: Removing node alp-2 from cluster
ERROR: cluster.remove:

# crm -d cluster remove alp-2
DEBUG: 2025/06/06 21:44:00
DEBUG: crm(live/alp-1)# cluster remove alp-2
DEBUG: ================================================================
DEBUG: /sbin/crm -d cluster remove alp-2
DEBUG: ----------------------------------------------------------------
INFO: Removing node alp-2 from cluster
DEBUG: su_subprocess_run: ['/bin/sh', '-c', 'ssh -A -o StrictHostKeyChecking=no -o BatchMode=yes root@alp-2 sudo -H -u root --preserve-env=SSH_AUTH_SOCK /bin/sh'], env={'SSH_AUTH_SOCK': ''}, {'input': b'crm_node --name', 'start_new_session': True, 'stdout': -1, 'stderr': -1}
ERROR: cluster.remove: 
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/crmsh/ui_context.py", line 93, in run
    rv = self.execute_command() is not False
         ~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/crmsh/ui_context.py", line 276, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib/python3.13/site-packages/crmsh/ui_cluster.py", line 590, in do_remove
    bootstrap.bootstrap_remove(rm_context)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/crmsh/bootstrap.py", line 2491, in bootstrap_remove
    cluster_node = get_node_canonical_hostname(cluster_node)
  File "/usr/lib/python3.13/site-packages/crmsh/bootstrap.py", line 510, in get_node_canonical_hostname
    utils.fatal(err)
    ~~~~~~~~~~~^^^^^
  File "/usr/lib/python3.13/site-packages/crmsh/utils.py", line 2677, in fatal
    raise ValueError(error_msg)
ValueError
```
In this case, ensure that the node being removed is present in the cluster node list.