### PR TITLE
Fix: report.collect: Detect log existence before using it (bsc#1244515)

### DIFF
--- a/test/features/crm_report_bugs.feature
+++ b/test/features/crm_report_bugs.feature
@@ -171,3 +171,11 @@ Feature: crm report functional test for verifying bugs
     # found password
     Then    Expected return code is "0"
     When    Run "rm -rf report.tar.bz2 report" on "hanode1"
+
+  @clean
+  Scenario: When no logfile in corosync.conf (bsc#1244515, bsc#1232821)
+    When    Run "sed -i '/logfile:/d' /etc/corosync/corosync.conf" on "hanode1"
+    When    Run "sed -i '/logfile:/d' /etc/corosync/corosync.conf" on "hanode2"
+    When    Try "crm report report" on "hanode1"
+    # Should no exception here
+    Then    Expected "TypeError:" not in stderr

--- a/test/features/crm_report_normal.feature
+++ b/test/features/crm_report_normal.feature
@@ -87,6 +87,10 @@ Feature: crm report functional test for common cases
 
     When    Run "crm report -d /tmp/report" on "hanode1"
     Then    Directory "/tmp/report" created
+    Then    Directory "/tmp/report/hanode1/crm.conf.d/root/.config/crm" created
+    Then    Directory "/tmp/report/hanode1/crm.conf.d/etc/crm" created
+    Then    Directory "/tmp/report/hanode2/crm.conf.d/root/.config/crm" created
+    Then    Directory "/tmp/report/hanode2/crm.conf.d/etc/crm" created
     When    Try "crm report -d /tmp/report" on "hanode1"
     Then    Expected "Destination directory /tmp/report exists, please cleanup or use -Z option" in stderr
     When    Run "crm report -d -Z /tmp/report" on "hanode1"

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -13,7 +13,7 @@ class TestCollect(unittest.TestCase):
     def test_get_pcmk_log_no_config(self, mock_isfile, mock_warning):
         mock_isfile.side_effect = [False, False, False]
         res = collect.get_pcmk_log()
-        self.assertEqual(res, "")
+        self.assertIsNone(res)
         mock_isfile.assert_has_calls([
             mock.call(constants.PCMKCONF),
             mock.call("/var/log/pacemaker/pacemaker.log"),
@@ -74,7 +74,7 @@ PCMK_logfile=/var/log/pacemaker/pacemaker.log
     def test_get_corosync_log_not_exist(self, mock_conf, mock_exists, mock_warning):
         mock_conf.return_value = "/etc/corosync/corosync.conf"
         mock_exists.return_value = False
-        self.assertEqual(collect.get_corosync_log(), "")
+        self.assertIsNone(collect.get_corosync_log())
 
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('os.path.exists')


### PR DESCRIPTION
This is the same error as reported in https://github.com/ClusterLabs/crmsh/pull/1606, which can be reproduced by deleting the `logfile:` line from corosync.conf. Although this was previously fixed, the issue regressed in #1622.

To prevent future regressions, I have added functional test cases for both #1622 and this scenario.
