### PR TITLE
[crmsh-4.6] Fix: report.collect: Detect log existence before using it (bsc#1244515)

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -11,7 +11,7 @@ import pwd
 import datetime
 import subprocess
 from subprocess import TimeoutExpired
-from typing import List
+from typing import List, Optional
 
 import crmsh.user_of_host
 from crmsh import log, sh, corosync
@@ -24,11 +24,11 @@ from crmsh.service_manager import ServiceManager
 logger = log.setup_report_logger(__name__)
 
 
-def get_corosync_log() -> str:
+def get_corosync_log() -> Optional[str]:
     """
     Get the path of the corosync log file
     """
-    corosync_log = ""
+    corosync_log = None
     corosync_conf_path = corosync.conf()
     if os.path.exists(corosync_conf_path):
         corosync_log = corosync.get_value("logging.logfile")
@@ -37,7 +37,7 @@ def get_corosync_log() -> str:
     return corosync_log
 
 
-def get_pcmk_log() -> str:
+def get_pcmk_log() -> Optional[str]:
     """
     Get the path of the pacemaker log file
     """
@@ -58,7 +58,7 @@ def get_pcmk_log() -> str:
             return log
 
     logger.warning("No valid pacemaker log file found")
-    return ""
+    return None
 
 
 def collect_ha_logs(context: core.Context) -> None:
@@ -66,10 +66,10 @@ def collect_ha_logs(context: core.Context) -> None:
     Collect pacemaker, corosync and extra logs
     """
     log_list = [get_pcmk_log(), get_corosync_log()] + context.extra_log_list
-    log_list = [os.path.expanduser(log) for log in log_list]
+    log_list = [os.path.expanduser(log) for log in log_list if log is not None]
     log_list_marked_same_basename = utils.mark_duplicate_basenames(log_list)
     for log, same_basename in log_list_marked_same_basename:
-        if log and os.path.isfile(log):
+        if os.path.isfile(log):
             utils.dump_logset(context, log, create_dir=same_basename)
 
 

--- a/test/features/crm_report_bugs.feature
+++ b/test/features/crm_report_bugs.feature
@@ -171,3 +171,11 @@ Feature: crm report functional test for verifying bugs
     # found password
     Then    Expected return code is "0"
     When    Run "rm -rf report.tar.bz2 report" on "hanode1"
+
+  @clean
+  Scenario: When no logfile in corosync.conf (bsc#1244515, bsc#1232821)
+    When    Run "sed -i '/logfile:/d' /etc/corosync/corosync.conf" on "hanode1"
+    When    Run "sed -i '/logfile:/d' /etc/corosync/corosync.conf" on "hanode2"
+    When    Try "crm report report" on "hanode1"
+    # Should no exception here
+    Then    Expected "TypeError:" not in stderr

--- a/test/features/crm_report_normal.feature
+++ b/test/features/crm_report_normal.feature
@@ -87,6 +87,10 @@ Feature: crm report functional test for common cases
 
     When    Run "crm report -d /tmp/report" on "hanode1"
     Then    Directory "/tmp/report" created
+    Then    Directory "/tmp/report/hanode1/crm.conf.d/root/.config/crm" created
+    Then    Directory "/tmp/report/hanode1/crm.conf.d/etc/crm" created
+    Then    Directory "/tmp/report/hanode2/crm.conf.d/root/.config/crm" created
+    Then    Directory "/tmp/report/hanode2/crm.conf.d/etc/crm" created
     When    Try "crm report -d /tmp/report" on "hanode1"
     Then    Expected "Destination directory /tmp/report exists, please cleanup or use -Z option" in stderr
     When    Run "crm report -d -Z /tmp/report" on "hanode1"

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -13,7 +13,7 @@ class TestCollect(unittest.TestCase):
     def test_get_pcmk_log_no_config(self, mock_isfile, mock_warning):
         mock_isfile.side_effect = [False, False, False]
         res = collect.get_pcmk_log()
-        self.assertEqual(res, "")
+        self.assertIsNone(res)
         mock_isfile.assert_has_calls([
             mock.call(constants.PCMKCONF),
             mock.call("/var/log/pacemaker/pacemaker.log"),
@@ -74,7 +74,7 @@ PCMK_logfile=/var/log/pacemaker/pacemaker.log
     def test_get_corosync_log_not_exist(self, mock_conf, mock_exists, mock_warning):
         mock_conf.return_value = "/etc/corosync/corosync.conf"
         mock_exists.return_value = False
-        self.assertEqual(collect.get_corosync_log(), "")
+        self.assertIsNone(collect.get_corosync_log())
 
     @mock.patch('crmsh.corosync.get_value')
     @mock.patch('os.path.exists')


### PR DESCRIPTION
backport #1821 