### PR TITLE
[crmsh-4.6] Dev: bootstrap: Remove user@host item from /root/.config/crm/crm.conf when removing node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2409,6 +2409,10 @@ def remove_node_from_cluster(node):
     # Trigger corosync config reload to ensure expected_votes is propagated
     invoke("corosync-cfgtool -R")
 
+    user_by_host = utils.HostUserConfig()
+    user_by_host.remove(node)
+    user_by_host.save_remote(utils.list_cluster_nodes())
+
 
 def decrease_expected_votes():
     '''

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3128,6 +3128,10 @@ class HostUserConfig:
     def get(self, host):
         return self._hosts_users[host]
 
+    def remove(self, host):
+        if host in self._hosts_users:
+            del self._hosts_users[host]
+
     def add(self, user, host):
         self._hosts_users[host] = user
 

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1870,6 +1870,7 @@ class TestValidation(unittest.TestCase):
             ])
         mock_error.assert_called_once_with("Removing the node node1 from {} failed".format(bootstrap.CSYNC2_CFG))
 
+    @mock.patch('crmsh.utils.HostUserConfig')
     @mock.patch.object(NodeMgmt, 'call_delnode')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.bootstrap.rm_configuration_files')
@@ -1887,7 +1888,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
     def test_remove_node_from_cluster_hostname(self, mock_get_ip, mock_stop, mock_status,
             mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2,
-            mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode):
+            mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_host_user_config):
         mock_get_ip.return_value = "10.10.10.1"
         mock_cal_delnode.return_value = True
         mock_invoke.side_effect = [(True, None, None)]


### PR DESCRIPTION
backport #1838 