### PR TITLE
Fix: log: Improve function confirm's logic (bsc#1245386)

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -431,8 +431,9 @@ class LoggerUtils(object):
         """
         while True:
             ans = self.wait_input("{} (y/n)? ".format(msg.strip("? ")))
-            if ans:
-                return ans.lower() == "y"
+            if not ans or ans.lower() not in ('y', 'n'):
+                continue
+            return ans.lower() == 'y'
 
     def syntax_err(self, s, token='', context='', msg=''):
         err = "syntax"


### PR DESCRIPTION
 If the answer is empty or not "y" or "n", it will now prompt in a loop, until a valid answer is provided