### PR TITLE
Fix: bootstrap: Refine qnetd passwordless configuration logic (bsc#1245387)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2004,10 +2004,11 @@ def join_cluster(seed_host, remote_user):
 
     shell = sh.cluster_shell()
 
-    if is_qdevice_configured and not _context.use_ssh_agent:
-        # trigger init_qnetd_remote on init node
-        cmd = f"crm cluster init qnetd_remote {utils.this_node()} -y"
-        shell.get_stdout_or_raise_error(cmd, seed_host)
+    if is_qdevice_configured:
+        if not _context.use_ssh_agent or not _keys_from_ssh_agent():
+            # trigger init_qnetd_remote on init node
+            cmd = f"crm cluster init qnetd_remote {utils.this_node()} -y"
+            shell.get_stdout_or_raise_error(cmd, seed_host)
 
     shutil.copy(corosync.conf(), COROSYNC_CONF_ORIG)
 


### PR DESCRIPTION
Previously, the qnetd_remote stage was only triggered if ssh-agent usage was disabled (use_ssh_agent=False).
However, the use_ssh_agent flag defaults to True, which could skip the configuration even if the necessary SSH key is not available in the agent.

This change updates the condition to also trigger the qnetd_remote stage when the SSH key is not found in the agent, ensuring that the join node's key is correctly added to the qnetd's authorized_keys file when needed.