### PR TITLE
[crmsh-4.6] Fix: bootstrap: should fallback to default user when `core.hosts` is not availabe from the seed node (bsc#1245343)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2059,10 +2059,13 @@ def setup_passwordless_with_other_nodes(init_node, remote_user):
     # Swap ssh public key between join node and other cluster nodes
     if not _context.use_ssh_agent:
         for node in (node for node in cluster_nodes_list if node != out):
-            remote_user_to_swap = utils.user_of(node)
-            remote_privileged_user = remote_user_to_swap
+            try:
+                remote_privileged_user = utils.user_of(node)
+            except UserNotFoundError:
+                remote_privileged_user = local_user
             utils.ssh_copy_id(local_user, remote_privileged_user, node)
-            swap_public_ssh_key(node, local_user, remote_user_to_swap, local_user, remote_privileged_user)
+            user_by_host.add(remote_privileged_user, node)
+            swap_public_ssh_key(node, local_user, remote_privileged_user, local_user, remote_privileged_user)
             if local_user != 'hacluster':
                 change_user_shell('hacluster', node)
                 swap_public_ssh_key(node, 'hacluster', 'hacluster', local_user, remote_privileged_user, add=True)

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -268,3 +268,17 @@ Feature: Regression test for bootstrap bugs
     And     Expected "hacluster:haclient" in stdout
     And     Run "stat -c '%U:%G' ~hacluster/.ssh/authorized_keys" OK on "hanode2"
     And     Expected "hacluster:haclient" in stdout
+
+  @clean
+  Scenario: Join when `core.hosts` is not available from the seed node (bsc#1245343)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Run "rm -r /root/.config/crm" on "hanode1,hanode2"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode3"
+    Then    Cluster service is "started" on "hanode3"
+    When    Run "crm cluster stop --all" on "hanode3"
+    Then    Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Cluster service is "stopped" on "hanode3"


### PR DESCRIPTION
If the cluster is bootstrapped with a previous version without non-root support, `core.hosts` will not be available.