### PR TITLE
Fix: bootstrap: should fallback to default user when `core.hosts` is not availabe from the seed node (bsc#1245343)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1895,16 +1895,22 @@ def setup_passwordless_with_other_nodes(init_node):
     init_node_hostname = out
     # Swap ssh public key between join node and other cluster nodes
     for node in (node for node in cluster_node_list if node != init_node_hostname):
-        remote_user_to_swap = utils.user_of(node)
-        remote_privileged_user = remote_user_to_swap
+        try:
+            remote_privileged_user = utils.user_of(node)
+        except UserNotFoundError:
+            remote_privileged_user = local_user
         result = ssh_copy_id_no_raise(local_user, remote_privileged_user, node, local_shell)
         if result.returncode != 0:
-            utils.fatal("Failed to login to remote host {}@{}".format(remote_user_to_swap, node))
+            utils.fatal("Failed to login to remote host {}@{}".format(remote_privileged_user, node))
+        else:
+            user_by_host.add(remote_privileged_user, node)
+            user_by_host.save_local()
         if utils.this_node() in cluster_node_list:
             nodes_including_self = cluster_node_list
         else:
             nodes_including_self = [utils.this_node()]
             nodes_including_self.extend(cluster_node_list)
+        # FIXME: 2 layers of loop is unnecessary?
         _merge_ssh_authorized_keys(shell, user_of_host.UserOfHost.instance(), nodes_including_self)
         if local_user != 'hacluster':
             change_user_shell('hacluster', node)

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -287,3 +287,17 @@ Feature: Regression test for bootstrap bugs
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     And     Run "crm configure show" on "hanode1"
     Then    Expected "no-quorum-policy=ignore" not in stdout
+
+  @clean
+  Scenario: Join when `core.hosts` is not available from the seed node (bsc#1245343)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode2"
+    And     Run "rm -r /root/.config/crm" on "hanode1,hanode2"
+    And     Run "crm cluster join -c hanode1 -y" on "hanode3"
+    Then    Cluster service is "started" on "hanode3"
+    When    Run "crm cluster stop --all" on "hanode3"
+    Then    Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Cluster service is "stopped" on "hanode3"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -950,7 +950,7 @@ done
             mock.call('alice', 'node1'),
             mock.call('bob', 'node2'),
         ])
-        mock_host_user_config.return_value.save_local.assert_called_once_with()
+        mock_host_user_config.return_value.save_local.assert_called()
         mock_ssh_copy_id.assert_called_once_with('carol', 'foo', 'node2', mock_local_shell.return_value)
         mock_merge_ssh_authorized_keys.assert_called_once_with(mock_cluster_shell.return_value, mock_user_of_host.instance.return_value, ['node3', 'node1', 'node2'])
         mock_change_user_shell.assert_called_once_with('hacluster', 'node2')


### PR DESCRIPTION
port:

* #1846