### PR TITLE
[crmsh-4.6] Dev: corosync: Get value from runtime.config prefix

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -749,12 +749,13 @@ def create_configuration(clustername="hacluster",
     utils.str2file(_COROSYNC_CONF_TEMPLATE % config_common, conf())
 
 
-def get_corosync_value(key):
+def get_corosync_value(key, cmapctl_prefix="runtime.config"):
     """
     Get corosync configuration value from corosync-cmapctl or corosync.conf
     """
     try:
-        out = sh.cluster_shell().get_stdout_or_raise_error("corosync-cmapctl {}".format(key))
+        cmapctl_prefix = f"{cmapctl_prefix.strip('.')}." if cmapctl_prefix else ""
+        out = sh.cluster_shell().get_stdout_or_raise_error(f"corosync-cmapctl {cmapctl_prefix}{key}")
         res = re.search(r'{}\s+.*=\s+(.*)'.format(key), out)
         return res.group(1) if res else None
     except ValueError:

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -266,7 +266,7 @@ def test_get_corosync_value_raise(mock_run, mock_get_value):
     mock_run.side_effect = ValueError
     mock_get_value.return_value = None
     assert corosync.get_corosync_value("xxx") is None
-    mock_run.assert_called_once_with("corosync-cmapctl xxx")
+    mock_run.assert_called_once_with("corosync-cmapctl runtime.config.xxx")
     mock_get_value.assert_called_once_with("xxx")
 
 
@@ -274,7 +274,7 @@ def test_get_corosync_value_raise(mock_run, mock_get_value):
 def test_get_corosync_value(mock_run):
     mock_run.return_value = "totem.token = 10000"
     assert corosync.get_corosync_value("totem.token") == "10000"
-    mock_run.assert_called_once_with("corosync-cmapctl totem.token")
+    mock_run.assert_called_once_with("corosync-cmapctl runtime.config.totem.token")
 
 
 class TestCorosyncParser(unittest.TestCase):


### PR DESCRIPTION
backport #1853 