### PR TITLE
Dev: ui_node: Enable standby and maintenance on pacemaker remote node

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2547,7 +2547,7 @@ def bootstrap_remove(context):
         if not force_flag:
             utils.fatal("Removing self requires --force")
         remove_self(force_flag)
-    elif cluster_node in xmlutil.listnodes():
+    elif cluster_node in utils.list_cluster_nodes():
         remove_node_from_cluster(cluster_node)
     else:
         utils.fatal("Specified node {} is not configured in cluster! Unable to remove.".format(cluster_node))
@@ -2560,7 +2560,7 @@ def bootstrap_remove(context):
 def remove_self(force_flag=False):
     me = utils.this_node()
     yes_to_all = _context.yes_to_all
-    nodes = xmlutil.listnodes(include_remote_nodes=False)
+    nodes = utils.list_cluster_nodes()
     othernode = next((x for x in nodes if x != me), None)
     if othernode is not None:
         logger.info("Removing node %s from cluster on %s", me, othernode)

--- a/crmsh/cibquery.py
+++ b/crmsh/cibquery.py
@@ -60,11 +60,7 @@ def get_cluster_nodes(cib: lxml.etree.Element) -> list[ClusterNode]:
         node_id = element.get('id')
         uname = element.get('uname')
         if element.get('type') == 'remote':
-            xpath = "//primitive[@provider='pacemaker' and @type='remote']/instance_attributes/nvpair[@name='server' and @value='{}']".format(
-                uname if uname is not None else node_id
-            )
-            if cib.xpath(xpath):
-                continue
+            continue
         assert node_id
         assert uname
         result.append(ClusterNode(int(node_id), uname))

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -69,8 +69,8 @@ def primitives(args):
     return [x.get("id") for x in nodes if xmlutil.is_primitive(x)]
 
 
-nodes = call(xmlutil.listnodes)
-online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), False)
-standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), True)
+nodes = call(xmlutil.CrmMonXmlParser.get_node_list)
+online_nodes = call(lambda x: xmlutil.CrmMonXmlParser.get_node_list(standby=x), False)
+standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser.get_node_list(standby=x), True)
 
 shadows = call(xmlutil.listshadows)

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -69,8 +69,8 @@ def primitives(args):
     return [x.get("id") for x in nodes if xmlutil.is_primitive(x)]
 
 
-nodes = call(xmlutil.CrmMonXmlParser.get_node_list)
-online_nodes = call(lambda x: xmlutil.CrmMonXmlParser.get_node_list(standby=x), False)
-standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser.get_node_list(standby=x), True)
+nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), None)
+online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), False)
+standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), True)
 
 shadows = call(xmlutil.listshadows)

--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -109,10 +109,13 @@ def check_xml(node):
     return ok
 
 
-def store_xml(node):
+def store_xml(node, thin=True):
     if not check_xml(node):
         return False
-    xmlutil.xmltraverse_thin(node, _store_node)
+    if thin:
+        xmlutil.xmltraverse_thin(node, _store_node)
+    else:
+        xmlutil.xmltraverse(node, _store_node)
     return True
 
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2468,7 +2468,7 @@ def check_all_nodes_reachable(action_to_do: str, peer_node: str = None):
     """
     Check if all cluster nodes are reachable
     """
-    online_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=True, only_member=True, peer=peer_node)
+    online_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=True, node_type="member", peer=peer_node)
     offline_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=False, peer=peer_node)
     dead_nodes = []
     for node in offline_nodes:
@@ -3263,7 +3263,7 @@ def validate_and_get_reachable_nodes(
         fatal("Cannot get the member list of the cluster")
     pcmk_remote_list = []
     if include_remote:
-        pcmk_remote_list = xmlutil.CrmMonXmlParser.get_node_list(online=True, only_remote=True)
+        pcmk_remote_list = xmlutil.CrmMonXmlParser.get_node_list(online=True, node_type="remote")
     for node in nodes_from_args:
         if node not in cluster_member_list and node not in pcmk_remote_list:
             fatal(f"Node '{node}' is not a member of the cluster")

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2468,8 +2468,9 @@ def check_all_nodes_reachable(action_to_do: str, peer_node: str = None):
     """
     Check if all cluster nodes are reachable
     """
-    online_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=True, node_type="member", peer=peer_node)
-    offline_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=False, peer=peer_node)
+    crm_mon_inst = xmlutil.CrmMonXmlParser(peer_node)
+    online_nodes = crm_mon_inst.get_node_list(online=True, node_type="member")
+    offline_nodes = crm_mon_inst.get_node_list(online=False)
     dead_nodes = []
     for node in offline_nodes:
         try:
@@ -3263,7 +3264,7 @@ def validate_and_get_reachable_nodes(
 
     pcmk_remote_list = []
     if include_remote:
-        pcmk_remote_list = xmlutil.CrmMonXmlParser.get_node_list(online=True, node_type="remote")
+        pcmk_remote_list = xmlutil.CrmMonXmlParser().get_node_list(online=True, node_type="remote")
 
     local_node = this_node()
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2466,9 +2466,8 @@ def check_all_nodes_reachable(action_to_do: str, peer_node: str = None):
     """
     Check if all cluster nodes are reachable
     """
-    crm_mon_inst = xmlutil.CrmMonXmlParser(peer_node)
-    online_nodes = crm_mon_inst.get_node_list()
-    offline_nodes = crm_mon_inst.get_node_list(online=False)
+    online_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=True, only_member=True, peer=peer_node)
+    offline_nodes = xmlutil.CrmMonXmlParser.get_node_list(online=False, peer=peer_node)
     dead_nodes = []
     for node in offline_nodes:
         try:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2130,6 +2130,8 @@ def valid_nodeid(nodeid):
 
 
 def get_nodeid_from_name(name):
+    if xmlutil.CrmMonXmlParser().is_node_remote(name):
+        return name
     rc, out = ShellUtils().get_stdout('crm_node -l')
     if rc != 0:
         return None
@@ -2698,8 +2700,7 @@ def is_standby(node):
     """
     Check if the node is already standby
     """
-    out = sh.cluster_shell().get_stdout_or_raise_error("crm_mon -1")
-    return re.search(r'Node\s+{}:\s+standby'.format(node), out) is not None
+    return node in xmlutil.CrmMonXmlParser.get_node_list(standby=True)
 
 
 def get_dlm_option_dict(peer=None):
@@ -3254,7 +3255,8 @@ class VerifyResult(IntFlag):
 
 def validate_and_get_reachable_nodes(
         nodes: typing.List[str] = [],
-        all_nodes: bool = False
+        all_nodes: bool = False,
+        include_remote: bool = False
     ) -> typing.List[str]:
 
     no_cib = False
@@ -3266,6 +3268,8 @@ def validate_and_get_reachable_nodes(
 
     if not cluster_member_list:
         fatal("Cannot get the member list of the cluster")
+    if include_remote:
+        cluster_member_list.extend(xmlutil.CrmMonXmlParser.get_node_list(only_remote=True))
     for node in nodes:
         if node not in cluster_member_list:
             fatal(f"Node '{node}' is not a member of the cluster")

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3258,25 +3258,28 @@ def validate_and_get_reachable_nodes(
         cluster_member_list = get_address_list_from_corosync_conf()
         if cluster_member_list:
             no_cib = True
-
     if not cluster_member_list:
         fatal("Cannot get the member list of the cluster")
+
     pcmk_remote_list = []
     if include_remote:
         pcmk_remote_list = xmlutil.CrmMonXmlParser.get_node_list(online=True, node_type="remote")
-    for node in nodes_from_args:
-        if node not in cluster_member_list and node not in pcmk_remote_list:
-            fatal(f"Node '{node}' is not a member of the cluster")
 
     local_node = this_node()
-    # Return local node if no nodes specified
-    if not nodes_from_args and not all_nodes:
+
+    member_list = []
+    remote_list = []
+    if nodes_from_args:
+        member_list = [node for node in nodes_from_args if node in cluster_member_list]
+        remote_list = [node for node in nodes_from_args if node in pcmk_remote_list]
+        invalid_nodes = set(nodes_from_args) - set(member_list) - set(remote_list)
+        if invalid_nodes:
+            fatal(f"Node \"{', '.join(invalid_nodes)}\" is not in the cluster")
+    elif all_nodes:
+        member_list, remote_list = cluster_member_list, pcmk_remote_list
+    else:
         return [local_node]
 
-    # Use all nodes if no nodes specified and all_nodes is True
-    node_list = nodes_from_args or cluster_member_list + pcmk_remote_list
-    member_list = [node for node in node_list if node not in pcmk_remote_list]
-    remote_list = [node for node in node_list if node in pcmk_remote_list]
     # Filter out unreachable nodes
     member_list = get_reachable_node_list(member_list)
     if no_cib:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2696,13 +2696,6 @@ def fatal(error_msg):
     raise ValueError(error_msg)
 
 
-def is_standby(node):
-    """
-    Check if the node is already standby
-    """
-    return node in xmlutil.CrmMonXmlParser.get_node_list(standby=True)
-
-
 def get_dlm_option_dict(peer=None):
     """
     Get dlm config option dictionary

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3247,7 +3247,7 @@ class VerifyResult(IntFlag):
 
 
 def validate_and_get_reachable_nodes(
-        nodes: typing.List[str] = [],
+        nodes_from_args: typing.List[str] = [],
         all_nodes: bool = False,
         include_remote: bool = False
     ) -> typing.List[str]:
@@ -3261,32 +3261,36 @@ def validate_and_get_reachable_nodes(
 
     if not cluster_member_list:
         fatal("Cannot get the member list of the cluster")
+    pcmk_remote_list = []
     if include_remote:
-        cluster_member_list.extend(xmlutil.CrmMonXmlParser.get_node_list(only_remote=True))
-    for node in nodes:
-        if node not in cluster_member_list:
+        pcmk_remote_list = xmlutil.CrmMonXmlParser.get_node_list(online=True, only_remote=True)
+    for node in nodes_from_args:
+        if node not in cluster_member_list and node not in pcmk_remote_list:
             fatal(f"Node '{node}' is not a member of the cluster")
 
     local_node = this_node()
     # Return local node if no nodes specified
-    if not nodes and not all_nodes:
+    if not nodes_from_args and not all_nodes:
         return [local_node]
-    # Use all cluster members if no nodes specified and all_nodes is True
-    node_list = nodes or cluster_member_list
+
+    # Use all nodes if no nodes specified and all_nodes is True
+    node_list = nodes_from_args or cluster_member_list + pcmk_remote_list
+    member_list = [node for node in node_list if node not in pcmk_remote_list]
+    remote_list = [node for node in node_list if node in pcmk_remote_list]
     # Filter out unreachable nodes
-    node_list = get_reachable_node_list(node_list)
+    member_list = get_reachable_node_list(member_list)
     if no_cib:
-        return node_list
+        return member_list
 
     shell = sh.cluster_shell()
     crm_mon_inst = xmlutil.CrmMonXmlParser()
-    for node in node_list[:]:
+    for node in member_list[:]:
         if node == local_node or crm_mon_inst.is_node_online(node):
             continue
         out = shell.get_stdout_or_raise_error("crm node show", node)
         if not re.search(rf"^{local_node}\(\d\): member", out, re.M):
             logger.error("From the view of node '%s', node '%s' is not a member of the cluster", node, local_node)
-            node_list.remove(node)
+            member_list.remove(node)
 
-    return node_list
+    return member_list + remote_list
 # vim:ts=4:sw=4:et:

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1519,6 +1519,13 @@ class CrmMonXmlParser(object):
         xpath = f'//node[@name="{node}" and @online="true"]'
         return bool(self.xml_elem.xpath(xpath))
 
+    def is_node_remote(self, node):
+        """
+        Check if a node is remote
+        """
+        xpath = f'//node[@name="{node}" and @type="remote"]'
+        return bool(self.xml_elem.xpath(xpath))
+
     @classmethod
     def get_node_list(
             cls,

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -5,6 +5,7 @@
 import os
 import subprocess
 import typing
+from typing import Optional
 
 from lxml import etree, doctestcompare
 import copy
@@ -1543,12 +1544,11 @@ class CrmMonXmlParser(object):
     @classmethod
     def get_node_list(
             cls,
-            online: bool = None,
-            standby: bool = None,
-            maintenance: bool = None,
-            only_member: bool = False,
-            only_remote: bool = False,
-            peer: str = None
+            online: Optional[bool] = None,
+            standby: Optional[bool] = None,
+            maintenance: Optional[bool] = None,
+            node_type: Optional[str] = None,
+            peer: Optional[str] = None
         ) -> list[str]:
         """
         Get a list of nodes based on the given attribute
@@ -1566,10 +1566,8 @@ class CrmMonXmlParser(object):
             for key, value in filters.items() if value is not None
         ]
 
-        if only_member:
-            conditions.append('@type="member"')
-        elif only_remote:
-            conditions.append('@type="remote"')
+        if node_type:
+            conditions.append(f'@type="{node_type}"')
 
         if conditions:
             xpath_str += '[' + ' and '.join(conditions) + ']'

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -367,7 +367,7 @@ def is_our_node(s):
 
     Includes remote nodes as well
     '''
-    for n in CrmMonXmlParser.get_node_list():
+    for n in CrmMonXmlParser().get_node_list():
         if n.lower() == s.lower():
             return True
     return False
@@ -1511,7 +1511,7 @@ class CrmMonXmlParser(object):
         Load xml output of crm_mon
         """
         _, output, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(self.peer, constants.CRM_MON_XML_OUTPUT)
-        return text2elem(output)
+        return text2elem(output) if output else None
 
     def is_node_online(self, node):
         """
@@ -1541,20 +1541,17 @@ class CrmMonXmlParser(object):
         xpath = f'//node[@name="{node}" and @type="remote"]'
         return bool(self.xml_elem.xpath(xpath))
 
-    @classmethod
     def get_node_list(
-            cls,
+            self,
             online: Optional[bool] = None,
             standby: Optional[bool] = None,
             maintenance: Optional[bool] = None,
-            node_type: Optional[str] = None,
-            peer: Optional[str] = None
+            node_type: Optional[str] = None
         ) -> list[str]:
         """
         Get a list of nodes based on the given attribute
         Return all nodes if no attributes are given
         """
-        instance = cls(peer)
         xpath_str = '//nodes/node'
         filters = {
             "online": online,
@@ -1571,7 +1568,7 @@ class CrmMonXmlParser(object):
 
         if conditions:
             xpath_str += '[' + ' and '.join(conditions) + ']'
-        return [elem.get('name') for elem in instance.xml_elem.xpath(xpath_str)]
+        return [elem.get('name') for elem in self.xml_elem.xpath(xpath_str)]
 
     def is_resource_configured(self, ra_type):
         """

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1519,6 +1519,20 @@ class CrmMonXmlParser(object):
         xpath = f'//node[@name="{node}" and @online="true"]'
         return bool(self.xml_elem.xpath(xpath))
 
+    def is_node_standby(self, node):
+        """
+        Check if a node is in standby mode
+        """
+        xpath = f'//node[@name="{node}" and @standby="true"]'
+        return bool(self.xml_elem.xpath(xpath))
+
+    def is_node_maintenance(self, node):
+        """
+        Check if a node is in maintenance mode
+        """
+        xpath = f'//node[@name="{node}" and @maintenance="true"]'
+        return bool(self.xml_elem.xpath(xpath))
+
     def is_node_remote(self, node):
         """
         Check if a node is remote
@@ -1531,6 +1545,7 @@ class CrmMonXmlParser(object):
             cls,
             online: bool = None,
             standby: bool = None,
+            maintenance: bool = None,
             only_member: bool = False,
             only_remote: bool = False,
             peer: str = None
@@ -1541,14 +1556,16 @@ class CrmMonXmlParser(object):
         """
         instance = cls(peer)
         xpath_str = '//nodes/node'
-        conditions = []
+        filters = {
+            "online": online,
+            "standby": standby,
+            "maintenance": maintenance
+        }
+        conditions = [
+            f'@{key}="{str(value).lower()}"'
+            for key, value in filters.items() if value is not None
+        ]
 
-        if online is not None:
-            online_value = 'true' if online else 'false'
-            conditions.append(f'@online="{online_value}"')
-        if standby is not None:
-            standby_value = 'true' if standby else 'false'
-            conditions.append(f'@standby="{standby_value}"')
         if only_member:
             conditions.append('@type="member"')
         elif only_remote:

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -186,7 +186,7 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "started" on "hanode2"
 
     When    Try "crm cluster start xxx"
-    Then    Except "ERROR: cluster.start: Node 'xxx' is not a member of the cluster"
+    Then    Except "ERROR: cluster.start: Node "xxx" is not in the cluster"
 
   @clean
   Scenario: Can't stop all nodes' cluster service when local node's service is down(bsc#1213889)

--- a/test/features/pacemaker_remote.feature
+++ b/test/features/pacemaker_remote.feature
@@ -16,16 +16,26 @@ Feature: Test deployment of pacemaker remote
     And     Run "scp -rp /etc/pacemaker pcmk-remote-node2:/etc" on "hanode1"
     And     Run "systemctl start pacemaker_remote" on "pcmk-remote-node1"
     And     Run "systemctl start pacemaker_remote" on "pcmk-remote-node2"
-    And     Run "crm configure primitive remote-node1 ocf:pacemaker:remote params server=pcmk-remote-node1 reconnect_interval=10m op monitor interval=30s" on "hanode1"
-    And     Run "crm configure primitive remote-node2 ocf:pacemaker:remote params server=pcmk-remote-node2 reconnect_interval=10m op monitor interval=30s" on "hanode1"
+    And     Run "crm configure primitive pcmk-remote-node1 ocf:pacemaker:remote params server=pcmk-remote-node1 reconnect_interval=10m op monitor interval=30s" on "hanode1"
+    And     Run "crm configure primitive pcmk-remote-node2 ocf:pacemaker:remote params server=pcmk-remote-node2 reconnect_interval=10m op monitor interval=30s" on "hanode1"
     And     Wait "5" seconds
-    Then    Remote online nodes are "remote-node1 remote-node2"
+    Then    Remote online nodes are "pcmk-remote-node1 pcmk-remote-node2"
+
+  Scenario: Test standby/online/maintenance/ready remote node
+    When    Run "crm node standby pcmk-remote-node1" on "hanode1"
+    Then    Node "pcmk-remote-node1" is standby
+    When    Run "crm node online pcmk-remote-node1" on "hanode1"
+    Then    Node "pcmk-remote-node1" is online
+    When    Run "crm node maintenance pcmk-remote-node1" on "hanode1"
+    Then    Node "pcmk-remote-node1" is maintenance
+    When    Run "crm node ready pcmk-remote-node1" on "hanode1"
+    Then    Node "pcmk-remote-node1" is ready
 
   Scenario: Prevent adding remote RA to group, order and colocation
     When    Run "crm configure primitive d Dummy" on "hanode1"
-    When    Try "crm configure group g d remote-node1"
-    Then    Expected "Cannot put remote resource 'remote-node1' in a group" in stderr
-    When    Try "crm configure order o1 d remote-node1"
-    Then    Expected "Cannot put remote resource 'remote-node1' in order constraint" in stderr
-    When    Try "crm configure colocation c1 inf: d remote-node1"
-    Then    Expected "Cannot put remote resource 'remote-node1' in colocation constraint" in stderr
+    When    Try "crm configure group g d pcmk-remote-node1"
+    Then    Expected "Cannot put remote resource 'pcmk-remote-node1' in a group" in stderr
+    When    Try "crm configure order o1 d pcmk-remote-node1"
+    Then    Expected "Cannot put remote resource 'pcmk-remote-node1' in order constraint" in stderr
+    When    Try "crm configure colocation c1 inf: d pcmk-remote-node1"
+    Then    Expected "Cannot put remote resource 'pcmk-remote-node1' in colocation constraint" in stderr

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -10,6 +10,7 @@ from behave import given, when, then
 import behave_agent
 from crmsh import corosync, userdir, bootstrap
 from crmsh import utils as crmutils
+from crmsh import xmlutil
 from crmsh import sbd
 from crmsh import ui_configure
 from crmsh.sh import ShellUtils
@@ -257,12 +258,22 @@ def step_impl(context, nodelist):
 
 @then('Node "{node}" is standby')
 def step_impl(context, node):
-    assert crmutils.is_standby(node) is True
+    assert xmlutil.CrmMonXmlParser().is_node_standby(node) is True
 
 
 @then('Node "{node}" is online')
 def step_impl(context, node):
-    assert crmutils.is_standby(node) is False
+    assert xmlutil.CrmMonXmlParser().is_node_standby(node) is False
+
+
+@then('Node "{node}" is maintenance')
+def step_impl(context, node):
+    assert xmlutil.CrmMonXmlParser().is_node_maintenance(node) is True
+
+
+@then('Node "{node}" is ready')
+def step_impl(context, node):
+    assert xmlutil.CrmMonXmlParser().is_node_maintenance(node) is False
 
 
 @then('IP "{addr}" is used by corosync on "{node}"')

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1806,7 +1806,7 @@ class TestValidation(unittest.TestCase):
         mock_check_all_nodes.assert_called_once_with("removing a node from the cluster")
 
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -1844,7 +1844,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
     @mock.patch('crmsh.utils.fetch_cluster_node_list_from_node')
     @mock.patch('crmsh.bootstrap.remove_node_from_cluster')
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -1882,7 +1882,7 @@ class TestValidation(unittest.TestCase):
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
-    @mock.patch('crmsh.xmlutil.listnodes')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
     @mock.patch('crmsh.utils.this_node')
     def test_remove_self_other_nodes(self, mock_this_node, mock_list, mock_run, mock_error):
         mock_this_node.return_value = 'node1'
@@ -1894,7 +1894,7 @@ class TestValidation(unittest.TestCase):
             bootstrap._context = mock.Mock(cluster_node="node1", yes_to_all=True)
             bootstrap.remove_self()
 
-        mock_list.assert_called_once_with(include_remote_nodes=False)
+        mock_list.assert_called_once_with()
         mock_run.assert_called_once_with("node2", "crm cluster remove -y -c node1")
         mock_error.assert_called_once_with("Failed to remove this node from node2: err")
 

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -28,7 +28,11 @@ def test_package_is_installed_local(mock_run):
 
 @mock.patch('re.search')
 @mock.patch('crmsh.sh.ShellUtils.get_stdout')
-def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
+@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+def test_get_nodeid_from_name_run_None1(mock_parser, mock_get_stdout, mock_re_search):
+    mock_parser_inst = mock.Mock()
+    mock_parser.return_value = mock_parser_inst
+    mock_parser_inst.is_node_remote.return_value = False
     mock_get_stdout.return_value = (1, None)
     mock_re_search_inst = mock.Mock()
     mock_re_search.return_value = mock_re_search_inst
@@ -40,7 +44,11 @@ def test_get_nodeid_from_name_run_None1(mock_get_stdout, mock_re_search):
 
 @mock.patch('re.search')
 @mock.patch('crmsh.sh.ShellUtils.get_stdout')
-def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
+@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+def test_get_nodeid_from_name_run_None2(mock_parser, mock_get_stdout, mock_re_search):
+    mock_parser_inst = mock.Mock()
+    mock_parser.return_value = mock_parser_inst
+    mock_parser_inst.is_node_remote.return_value = False
     mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
     mock_re_search.return_value = None
     res = utils.get_nodeid_from_name("node111")
@@ -51,7 +59,11 @@ def test_get_nodeid_from_name_run_None2(mock_get_stdout, mock_re_search):
 
 @mock.patch('re.search')
 @mock.patch('crmsh.sh.ShellUtils.get_stdout')
-def test_get_nodeid_from_name(mock_get_stdout, mock_re_search):
+@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+def test_get_nodeid_from_name(mock_parser, mock_get_stdout, mock_re_search):
+    mock_parser_inst = mock.Mock()
+    mock_parser.return_value = mock_parser_inst
+    mock_parser_inst.is_node_remote.return_value = False
     mock_get_stdout.return_value = (0, "172167901 node1 member\n172168231 node2 member")
     mock_re_search_inst = mock.Mock()
     mock_re_search.return_value = mock_re_search_inst
@@ -1000,16 +1012,6 @@ def test_detect_virt(mock_run):
     mock_run.assert_called_once_with("systemd-detect-virt")
 
 
-@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
-def test_is_standby(mock_run):
-    mock_run.return_value = """
-Node List:
-* Node 15sp2-1: standby
-    """
-    assert utils.is_standby("15sp2-1") is True
-    mock_run.assert_called_once_with("crm_mon -1")
-
-
 @mock.patch('crmsh.sh.cluster_shell')
 def test_get_dlm_option_dict(mock_run):
     mock_run_inst = mock.Mock()
@@ -1461,7 +1463,7 @@ def test_validate_and_get_reachable_nodes_not_a_member(mock_list_nodes, mock_fat
     mock_fatal.side_effect = ValueError
     with pytest.raises(ValueError):
         utils.validate_and_get_reachable_nodes(["node3"])
-    mock_fatal.assert_called_once_with("Node 'node3' is not a member of the cluster")
+    mock_fatal.assert_called_once_with("Node \"node3\" is not in the cluster")
 
 
 @mock.patch('crmsh.utils.this_node')

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -1,3 +1,4 @@
+from lxml import etree
 import unittest
 
 try:
@@ -6,6 +7,24 @@ except ImportError:
     import mock
 
 from crmsh import xmlutil, constants
+
+FAKE_XML = '''
+<data>
+  <nodes>
+    <node name="tbw-1" id="1084783148" online="true" standby="true" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="true" resources_running="3" type="member"/>
+    <node name="tbw-2" id="1084783312" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member"/>
+    <node name="tbw-3" id="alp-2" online="true" standby="false" standby_onfail="false" maintenance="true" pending="false" unclean="false" health="green" shutdown="false" expected_up="false" is_dc="false" resources_running="0" type="remote"/>
+  </nodes>
+  <resources>
+    <resource id="ocfs2-dlm" resource_agent="ocf:pacemaker:controld" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+      <node name="tbw-2" id="1084783312" cached="true"/>
+    </resource>
+    <resource id="ocfs2-clusterfs" resource_agent="ocf:heartbeat:Filesystem" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
+      <node name="tbw-2" id="1084783312" cached="true"/>
+    </resource>
+  </resources>
+</data>
+'''
 
 
 class TestCrmMonXmlParser(unittest.TestCase):
@@ -17,32 +36,20 @@ class TestCrmMonXmlParser(unittest.TestCase):
         """
         Test setUp.
         """
-        data = '''
-<data>
-  <nodes>
-    <node name="tbw-1" id="1084783148" online="true" standby="true" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="true" resources_running="3" type="member"/>
-    <node name="tbw-2" id="1084783312" online="false" standby="false" standby_onfail="false" maintenance="false" pending="false" unclean="false" shutdown="false" expected_up="true" is_dc="false" resources_running="2" type="member"/>
-  </nodes>
-  <resources>
-    <resource id="ocfs2-dlm" resource_agent="ocf:pacemaker:controld" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
-      <node name="tbw-2" id="1084783312" cached="true"/>
-    </resource>
-    <resource id="ocfs2-clusterfs" resource_agent="ocf:heartbeat:Filesystem" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
-      <node name="tbw-2" id="1084783312" cached="true"/>
-    </resource>
-  </resources>
-</data>
-        '''
-        mock_cluster_shell().get_rc_stdout_stderr_without_input.return_value = (0, data, '')
+        mock_cluster_shell().get_rc_stdout_stderr_without_input.return_value = (0, FAKE_XML, '')
         self.parser_inst = xmlutil.CrmMonXmlParser()
 
     def test_is_node_online(self):
         assert self.parser_inst.is_node_online("tbw-1") is True
         assert self.parser_inst.is_node_online("tbw-2") is False
 
-    def test_get_node_list(self):
-        assert self.parser_inst.get_node_list(standby=True) == ['tbw-1']
-        assert self.parser_inst.get_node_list(online=False) == ['tbw-2']
+    def test_is_node_maintenance(self):
+        assert self.parser_inst.is_node_maintenance("tbw-1") is False
+        assert self.parser_inst.is_node_maintenance("tbw-3") is True
+
+    def test_is_node_remote(self):
+        assert self.parser_inst.is_node_remote("tbw-1") is False
+        assert self.parser_inst.is_node_remote("tbw-3") is True
 
     def test_is_resource_configured(self):
         assert self.parser_inst.is_resource_configured("test") is False
@@ -59,3 +66,10 @@ class TestCrmMonXmlParser(unittest.TestCase):
     def test_get_resource_id_list_via_type(self):
         assert self.parser_inst.get_resource_id_list_via_type("test") == []
         assert self.parser_inst.get_resource_id_list_via_type("ocf:pacemaker:controld")[0] == "ocfs2-dlm"
+
+    def test_get_node_list(self):
+        assert self.parser_inst.get_node_list() == ['tbw-1', 'tbw-2', 'tbw-3']
+        assert self.parser_inst.get_node_list(online=True) == ['tbw-1', 'tbw-3']
+        assert self.parser_inst.get_node_list(maintenance=True) == ['tbw-3']
+        assert self.parser_inst.get_node_list(node_type="remote") == ['tbw-3']
+        assert self.parser_inst.get_node_list(node_type="member") == ['tbw-1', 'tbw-2']


### PR DESCRIPTION
## Problems
- Can't standby pacemaker remote node #1817
- Can't maintenance pacemaker remote node https://github.com/ClusterLabs/crmsh/issues/1817#issuecomment-3026676284
- The way to get remote node's name
```
/cib/status/node_state[@remote_node="true"]/@uname
```
Might have problem:
```
>>> xmlutil.listnodes()
['rm', 'alp-2']
# if the pacemaker remote RA's name changed from `rm` to `rm_node`, then got two remote nodes
>>> xmlutil.listnodes()
['rm', 'rm_node', 'alp-2']
```
## Changes:
-  Drop xmlutil.listnodes function; And refactor xmlutil.CrmMonXmlParser.get_node_list function, get pacemaker remote node from `crm_mon --output-as=xml` looks more accurately
- Enable standby/online pacemaker remote node
- Enable maintenance/ready pacemaker remote node