### PR TITLE
Fix: sbd: Avoid negative value for the property 'stonith-watchdog-timeout' (bsc#1246622)

### DIFF
--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -232,7 +232,7 @@ Feature: configure sbd delay start correctly
     And     SBD option "SBD_DELAY_START" value is "81"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "35"
     And     Cluster property "stonith-timeout" is "95"
-    And     Cluster property "stonith-watchdog-timeout" is "-1"
+    And     Cluster property "stonith-watchdog-timeout" is "70"
 
   @clean
   Scenario: Add and remove qdevice from cluster with sbd running

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -213,14 +213,18 @@ class TestSBDTimeout(unittest.TestCase):
         self.assertEqual(result, 5)
 
     @patch('crmsh.sbd.ServiceManager')
-    def test_get_stonith_watchdog_timeout_default(self, mock_ServiceManager):
+    @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
+    def test_get_stonith_watchdog_timeout_default(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager):
+        mock_get_sbd_watchdog_timeout.return_value = 1
         mock_ServiceManager.return_value.service_is_active = MagicMock(return_value=False)
         result = sbd.SBDTimeout.get_stonith_watchdog_timeout()
-        self.assertEqual(result, sbd.SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT)
+        self.assertEqual(result, 2)
 
     @patch('crmsh.utils.get_property')
     @patch('crmsh.sbd.ServiceManager')
-    def test_get_stonith_watchdog_timeout(self, mock_ServiceManager, mock_get_property):
+    @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
+    def test_get_stonith_watchdog_timeout(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager, mock_get_property):
+        mock_get_sbd_watchdog_timeout.return_value = 1
         mock_ServiceManager.return_value.service_is_active = MagicMock(return_value=True)
         mock_get_property.return_value = "5"
         result = sbd.SBDTimeout.get_stonith_watchdog_timeout()
@@ -730,11 +734,13 @@ class TestSBDManager(unittest.TestCase):
 
     @patch('crmsh.utils.set_property')
     @patch('crmsh.sbd.ServiceManager')
-    def test_configure_sbd_diskless(self, mock_ServiceManager, mock_set_property):
+    @patch('crmsh.sbd.SBDTimeout.get_stonith_watchdog_timeout')
+    def test_configure_sbd_diskless(self, mock_get_stonith_watchdog_timeout, mock_ServiceManager, mock_set_property):
+        mock_get_stonith_watchdog_timeout.return_value = 2
         sbdmanager_instance = SBDManager(diskless_sbd=True)
         sbdmanager_instance.configure_sbd()
         mock_set_property.assert_has_calls([
-            call("stonith-watchdog-timeout", sbd.SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT),
+            call("stonith-watchdog-timeout", 2),
             call("stonith-enabled", "true")
         ])
 


### PR DESCRIPTION
## Problem
Previously, when configuring diskless SBD with crmsh bootstrap, the option `stonith-watchdog-timeout` was set to -1 to prompt Pacemaker to automatically calculate the appropriate value.

However, Pacemaker now raises a warning when a negative value is used for timeout or duration options such as `stonith-watchdog-timeout`:

```
pacemaker-fenced[...]:  warning: '-1' is not a valid time duration: Negative
pacemaker-controld[...]:  warning: '-1' is not a valid time duration: Negative
```
## Changes
Set the default value of `stonith-watchdog-timeout` to 2*SBD_WATCHDOG_TIMEOUT. The value of SBD_WATCHDOG_TIMEOUT is stored in /etc/sysconfig/sbd and can be kept consistent across all nodes using crmsh.