### PR TITLE
[crmsh-4.6] Fix: sbd: Avoid negative value for the property 'stonith-watchdog-timeout' (bsc#1246622) 

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -19,7 +19,6 @@ class SBDTimeout(object):
     """
     Consolidate sbd related timeout methods and constants
     """
-    STONITH_WATCHDOG_TIMEOUT_DEFAULT = -1
     SBD_WATCHDOG_TIMEOUT_DEFAULT = 5
     SBD_WATCHDOG_TIMEOUT_DEFAULT_S390 = 15
     SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE = 35
@@ -33,7 +32,7 @@ class SBDTimeout(object):
         self.sbd_msgwait = None
         self.stonith_timeout = None
         self.sbd_watchdog_timeout = self.SBD_WATCHDOG_TIMEOUT_DEFAULT
-        self.stonith_watchdog_timeout = self.STONITH_WATCHDOG_TIMEOUT_DEFAULT
+        self.stonith_watchdog_timeout = None
         self.sbd_delay_start = None
         self.two_node_without_qdevice = False
 
@@ -113,10 +112,10 @@ class SBDTimeout(object):
         """
         For non-bootstrap case, get stonith-watchdog-timeout value from cluster property
         """
-        default = SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT
+        default = 2 * SBDTimeout.get_sbd_watchdog_timeout()
         if not ServiceManager().service_is_active("pacemaker.service"):
             return default
-        value = utils.get_property("stonith-watchdog-timeout")
+        value = utils.get_property("stonith-watchdog-timeout", get_default=False)
         return int(value.strip('s')) if value else default
 
     def _load_configurations(self):
@@ -462,7 +461,7 @@ class SBDManager(object):
         else:
             logger.warning("To start sbd.service, need to restart cluster service manually on each node")
             if self.diskless_sbd:
-                cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, SBDTimeout.get_stonith_timeout())
+                cmd = self.DISKLESS_CRM_CMD.format(SBDTimeout.get_stonith_watchdog_timeout(), SBDTimeout.get_stonith_timeout())
                 logger.warning("Then run \"{}\" on any node".format(cmd))
             else:
                 self.configure_sbd_resource_and_properties()
@@ -534,7 +533,7 @@ class SBDManager(object):
             if self.timeout_inst is None:
                 self.timeout_inst = SBDTimeout(self._context)
                 self.timeout_inst.initialize_timeout()
-            cmd = self.DISKLESS_CRM_CMD.format(self.timeout_inst.stonith_watchdog_timeout, constants.STONITH_TIMEOUT_DEFAULT)
+            cmd = self.DISKLESS_CRM_CMD.format(SBDTimeout.get_stonith_watchdog_timeout(), constants.STONITH_TIMEOUT_DEFAULT)
             shell.get_stdout_or_raise_error(cmd)
 
         # in sbd stage

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2867,13 +2867,15 @@ def is_2node_cluster_without_qdevice():
     return (current_num + qdevice_num) == 2
 
 
-def get_property(name, property_type="crm_config", peer=None):
+def get_property(name, property_type="crm_config", peer=None, get_default=True):
     """
     Get cluster properties
 
     "property_type" can be crm_config|rsc_defaults|op_defaults
+    "get_default" is used to get the default value from cluster metadata,
+    when it is False, the property value will be got from cib
     """
-    if property_type == "crm_config":
+    if property_type == "crm_config" and get_default:
         cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
         cmd = "CIB_file={} sudo --preserve-env=CIB_file crm configure get_property {}".format(cib_path, name)
     else:

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -228,7 +228,7 @@ Feature: configure sbd delay start correctly
     And     SBD option "SBD_DELAY_START" value is "81"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "35"
     And     Cluster property "stonith-timeout" is "95"
-    And     Cluster property "stonith-watchdog-timeout" is "-1"
+    And     Cluster property "stonith-watchdog-timeout" is "70"
 
   @clean
   Scenario: Add and remove qdevice from cluster with sbd running

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -116,15 +116,18 @@ class TestSBDTimeout(unittest.TestCase):
         mock_get.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
 
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    def test_get_stonith_watchdog_timeout_return(self, mock_active):
+    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
+    def test_get_stonith_watchdog_timeout_return(self, mock_get_sbd_watchdog_timeout, mock_active):
+        mock_get_sbd_watchdog_timeout.return_value = 2
         mock_active.return_value = False
         res = sbd.SBDTimeout.get_stonith_watchdog_timeout()
-        assert res == sbd.SBDTimeout.STONITH_WATCHDOG_TIMEOUT_DEFAULT
+        assert res == 4
         mock_active.assert_called_once_with("pacemaker.service")
 
     @mock.patch('crmsh.utils.get_property')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    def test_get_stonith_watchdog_timeout(self, mock_active, mock_get_property):
+    @mock.patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
+    def test_get_stonith_watchdog_timeout(self, mock_get_sbd_watchdog_timeout, mock_active, mock_get_property):
         mock_active.return_value = True
         mock_get_property.return_value = "60s"
         res = sbd.SBDTimeout.get_stonith_watchdog_timeout()
@@ -623,16 +626,18 @@ class TestSBDManager(unittest.TestCase):
         mock_config_sbd_ra.assert_called_once_with()
 
     @mock.patch('crmsh.sbd.SBDTimeout.get_stonith_timeout')
+    @mock.patch('crmsh.sbd.SBDTimeout.get_stonith_watchdog_timeout')
     @mock.patch('logging.Logger.warning')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_restart_cluster_on_needed_diskless(self, mock_parser, mock_warn, mock_get_timeout):
+    def test_restart_cluster_on_needed_diskless(self, mock_parser, mock_warn, mock_get_stonith_watchdog_timeout, mock_get_timeout):
         mock_parser().is_any_resource_running.return_value = True
         mock_get_timeout.return_value = 60
         self.sbd_inst_diskless.timeout_inst = mock.Mock(stonith_watchdog_timeout=-1)
+        mock_get_stonith_watchdog_timeout.return_value = 2
         self.sbd_inst_diskless._restart_cluster_and_configure_sbd_ra()
         mock_warn.assert_has_calls([
             mock.call("To start sbd.service, need to restart cluster service manually on each node"),
-            mock.call("Then run \"crm configure property stonith-enabled=true stonith-watchdog-timeout=-1 stonith-timeout=60\" on any node")
+            mock.call("Then run \"crm configure property stonith-enabled=true stonith-watchdog-timeout=2 stonith-timeout=60\" on any node")
             ])
 
     @mock.patch('crmsh.sbd.SBDManager.configure_sbd_resource_and_properties')


### PR DESCRIPTION
backport #1865 