### PR TITLE
Dev: sbd: Add pcmk_delay_max back to calculate SBD_DELAY_START

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -305,6 +305,7 @@ class SBDTimeout(object):
         if dev_list:  # disk-based
             self.disk_based = True
             self.msgwait = SBDTimeout.get_sbd_msgwait(dev_list[0])
+            self.pcmk_delay_max = utils.get_pcmk_delay_max(self.two_node_without_qdevice)
         else:  # disk-less
             self.disk_based = False
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
@@ -342,12 +343,12 @@ class SBDTimeout(object):
         '''
         Get the value for SBD_DELAY_START, formulas are:
 
-        SBD_DELAY_START = (token + consensus + msgwait)  # for disk-based sbd
+        SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
         SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
         '''
         token_and_consensus_timeout = corosync.token_and_consensus_timeout()
         if self.disk_based:
-            value = token_and_consensus_timeout + self.msgwait
+            value = token_and_consensus_timeout + self.pcmk_delay_max + self.msgwait
         else:
             value = token_and_consensus_timeout + 2*self.sbd_watchdog_timeout
         return value

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2776,6 +2776,15 @@ def is_2node_cluster_without_qdevice():
     return (current_num + qdevice_num) == 2
 
 
+def get_pcmk_delay_max(two_node_without_qdevice=False):
+    """
+    Get value of pcmk_delay_max
+    """
+    if ServiceManager().service_is_active("pacemaker.service") and two_node_without_qdevice:
+        return constants.PCMK_DELAY_MAX
+    return 0
+
+
 def get_property(name, property_type="crm_config", peer=None, get_default=True):
     """
     Get cluster properties

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -29,8 +29,8 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     Service "sbd" is "started" on "hanode2"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
-    And     SBD option "SBD_DELAY_START" value is "41"
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
@@ -43,9 +43,9 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode3"
     Then    Cluster service is "started" on "hanode3"
     And     Service "sbd" is "started" on "hanode3"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
     # runtime value is "41", we keep the larger one here
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
@@ -57,7 +57,7 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster remove hanode3 -y" on "hanode1"
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"
@@ -125,8 +125,8 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     Service "sbd" is "started" on "hanode2"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
-    And     SBD option "SBD_DELAY_START" value is "131"
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     # stonith-timeout >= 1.2 * msgwait  # for disk-based sbd
@@ -136,31 +136,31 @@ Feature: configure sbd delay start correctly
     # since SBD_DELAY_START value(161s) > default systemd startup value(1min 30s)
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     # 1.2*SBD_DELAY_START
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
 
     Given   Has disk "/dev/sda1" on "hanode3"
     Given   Cluster service is "stopped" on "hanode3"
     When    Run "crm cluster join -c hanode1 -y" on "hanode3"
     Then    Cluster service is "started" on "hanode3"
     And     Service "sbd" is "started" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "131"
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     And     Cluster property "stonith-timeout" is "155"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
 
     When    Run "crm cluster remove hanode3 -y" on "hanode1"
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "131"
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     And     Cluster property "stonith-timeout" is "155"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     When    Run "sed -i 's/watchdog_timeout: 60/watchdog_timeout: 15/g' /etc/crm/profiles.yml" on "hanode1"
 
   @clean
@@ -181,7 +181,7 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster init sbd -s /dev/sda1 -y" on "hanode1"
     Then    Service "sbd" is "started" on "hanode1"
     Then    Service "sbd" is "started" on "hanode2"
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -337,9 +337,10 @@ class TestSBDTimeout(unittest.TestCase):
     def test_get_sbd_delay_start_expected_diskbased(self, mock_token_and_consensus_timeout):
         inst = sbd.SBDTimeout()
         inst.disk_based = True
+        inst.pcmk_delay_max = 10
         inst.msgwait = 5
         mock_token_and_consensus_timeout.return_value = 10
-        self.assertEqual(inst.get_sbd_delay_start_expected(), 15)
+        self.assertEqual(inst.get_sbd_delay_start_expected(), 25)
 
     @patch('crmsh.corosync.token_and_consensus_timeout')
     def test_get_sbd_delay_start_expected_diskless(self, mock_token_and_consensus_timeout):


### PR DESCRIPTION
In PR #1740, the parameter `pcmk_delay_max` was removed. However, the formula for `SBD_DELAY_START` still needs to account for the `pcmk_delay_max` factor [1]. This PR restores the use of `pcmk_delay_max` in the calculation.

[1] https://github.com/ClusterLabs/crmsh/pull/1740#discussion_r2221356833