### PR TITLE
[crmsh-4.6] Dev: sbd: Add pcmk_delay_max back to calculate SBD_DELAY_START

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -128,6 +128,7 @@ class SBDTimeout(object):
         if dev_list:  # disk-based
             self.disk_based = True
             self.msgwait = SBDTimeout.get_sbd_msgwait(dev_list[0])
+            self.pcmk_delay_max = utils.get_pcmk_delay_max(self.two_node_without_qdevice)
         else:  # disk-less
             self.disk_based = False
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
@@ -165,12 +166,12 @@ class SBDTimeout(object):
         """
         Get the value for SBD_DELAY_START, formulas are:
 
-        SBD_DELAY_START = (token + consensus + msgwait)  # for disk-based sbd
+        SBD_DELAY_START = (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
         SBD_DELAY_START = (token + consensus + 2*SBD_WATCHDOG_TIMEOUT) # for disk-less sbd
         """
         token_and_consensus_timeout = corosync.token_and_consensus_timeout()
         if self.disk_based:
-            value = token_and_consensus_timeout + self.msgwait
+            value = token_and_consensus_timeout + self.pcmk_delay_max + self.msgwait
         else:
             value = token_and_consensus_timeout + 2*self.sbd_watchdog_timeout
         return value

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2867,6 +2867,15 @@ def is_2node_cluster_without_qdevice():
     return (current_num + qdevice_num) == 2
 
 
+def get_pcmk_delay_max(two_node_without_qdevice=False):
+    """
+    Get value of pcmk_delay_max
+    """
+    if ServiceManager().service_is_active("pacemaker.service") and two_node_without_qdevice:
+        return constants.PCMK_DELAY_MAX
+    return 0
+
+
 def get_property(name, property_type="crm_config", peer=None, get_default=True):
     """
     Get cluster properties

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -27,8 +27,8 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     Service "sbd" is "started" on "hanode2"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
-    And     SBD option "SBD_DELAY_START" value is "41"
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
@@ -41,9 +41,9 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode3"
     Then    Cluster service is "started" on "hanode3"
     And     Service "sbd" is "started" on "hanode3"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
     # runtime value is "41", we keep the larger one here
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
@@ -55,7 +55,7 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster remove hanode3 -y" on "hanode1"
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"
@@ -121,8 +121,8 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     And     Service "sbd" is "started" on "hanode2"
-    # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
-    And     SBD option "SBD_DELAY_START" value is "131"
+    # SBD_DELAY_START >= (token + consensus + pcmk_delay_max + msgwait)  # for disk-based sbd
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     # stonith-timeout >= 1.2 * msgwait  # for disk-based sbd
@@ -132,31 +132,31 @@ Feature: configure sbd delay start correctly
     # since SBD_DELAY_START value(161s) > default systemd startup value(1min 30s)
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     # 1.2*SBD_DELAY_START
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
 
     Given   Has disk "/dev/sda1" on "hanode3"
     Given   Cluster service is "stopped" on "hanode3"
     When    Run "crm cluster join -c hanode1 -y" on "hanode3"
     Then    Cluster service is "started" on "hanode3"
     And     Service "sbd" is "started" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "131"
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     And     Cluster property "stonith-timeout" is "172"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
 
     When    Run "crm cluster remove hanode3 -y" on "hanode1"
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
-    And     SBD option "SBD_DELAY_START" value is "131"
+    And     SBD option "SBD_DELAY_START" value is "161"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     And     Cluster property "stonith-timeout" is "172"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
-    And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
+    And     Run "grep 'TimeoutSec=193' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     When    Run "sed -i 's/watchdog_timeout: 60/watchdog_timeout: 15/g' /etc/crm/profiles.yml" on "hanode1"
 
   @clean
@@ -177,7 +177,7 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster init sbd -s /dev/sda1 -y" on "hanode1"
     Then    Service "sbd" is "started" on "hanode1"
     Then    Service "sbd" is "started" on "hanode2"
-    And     SBD option "SBD_DELAY_START" value is "41"
+    And     SBD option "SBD_DELAY_START" value is "71"
     And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -16,7 +16,7 @@ Feature: configure sbd delay start correctly
     And     Service "sbd" is "started" on "hanode1"
     And     Resource "stonith-sbd" type "external/sbd" is "Started"
     And     SBD option "SBD_DELAY_START" value is "no"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # calculated and set by sbd RA
     And     Cluster property "stonith-timeout" is "43"
@@ -29,7 +29,7 @@ Feature: configure sbd delay start correctly
     And     Service "sbd" is "started" on "hanode2"
     # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
     And     SBD option "SBD_DELAY_START" value is "41"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
     # stonith_timeout >= max(value_from_sbd, constants.STONITH_TIMEOUT_DEFAULT) + token + consensus
@@ -44,7 +44,7 @@ Feature: configure sbd delay start correctly
     # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
     # runtime value is "41", we keep the larger one here
     And     SBD option "SBD_DELAY_START" value is "41"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     # value_from_sbd >= 1.2 * msgwait  # for disk-based sbd
     # stonith_timeout >= max(value_from_sbd, constants.STONITH_TIMEOUT_DEFAULT) + token + consensus
@@ -56,7 +56,7 @@ Feature: configure sbd delay start correctly
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
     And     SBD option "SBD_DELAY_START" value is "41"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
@@ -110,7 +110,7 @@ Feature: configure sbd delay start correctly
     And     Service "sbd" is "started" on "hanode1"
     And     Resource "stonith-sbd" type "external/sbd" is "Started"
     And     SBD option "SBD_DELAY_START" value is "no"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     # calculated and set by sbd RA
     And     Cluster property "stonith-timeout" is "172"
@@ -123,11 +123,11 @@ Feature: configure sbd delay start correctly
     And     Service "sbd" is "started" on "hanode2"
     # SBD_DELAY_START >= (token + consensus + msgwait)  # for disk-based sbd
     And     SBD option "SBD_DELAY_START" value is "131"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
     # stonith-timeout >= 1.2 * msgwait  # for disk-based sbd
     # stonith_timeout >= max(value_from_sbd, constants.STONITH_TIMEOUT_DEFAULT) + token + consensus
-    And     Cluster property "stonith-timeout" is "155"
+    And     Cluster property "stonith-timeout" is "172"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
     # since SBD_DELAY_START value(161s) > default systemd startup value(1min 30s)
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
@@ -140,9 +140,9 @@ Feature: configure sbd delay start correctly
     Then    Cluster service is "started" on "hanode3"
     And     Service "sbd" is "started" on "hanode3"
     And     SBD option "SBD_DELAY_START" value is "131"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
-    And     Cluster property "stonith-timeout" is "155"
+    And     Cluster property "stonith-timeout" is "172"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
@@ -151,9 +151,9 @@ Feature: configure sbd delay start correctly
     Then    Cluster service is "stopped" on "hanode3"
     And     Service "sbd" is "stopped" on "hanode3"
     And     SBD option "SBD_DELAY_START" value is "131"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "60"
     And     SBD option "msgwait" value for "/dev/sda1" is "120"
-    And     Cluster property "stonith-timeout" is "155"
+    And     Cluster property "stonith-timeout" is "172"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
     And     Run "test -f /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
     And     Run "grep 'TimeoutSec=157' /etc/systemd/system/sbd.service.d/sbd_delay_start.conf" OK
@@ -178,7 +178,7 @@ Feature: configure sbd delay start correctly
     Then    Service "sbd" is "started" on "hanode1"
     Then    Service "sbd" is "started" on "hanode2"
     And     SBD option "SBD_DELAY_START" value is "41"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"
     And     Parameter "pcmk_delay_max" configured in "stonith-sbd"
@@ -203,7 +203,7 @@ Feature: configure sbd delay start correctly
     And     Service "sbd" is "started" on "hanode2"
 
     And     SBD option "SBD_DELAY_START" value is "41"
-    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "5"
+    And     SBD option "SBD_WATCHDOG_TIMEOUT" value is "15"
     And     SBD option "msgwait" value for "/dev/sda1" is "30"
     And     Cluster property "stonith-timeout" is "71"
     And     Parameter "pcmk_delay_max" not configured in "stonith-sbd"

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -200,9 +200,10 @@ class TestSBDTimeout(unittest.TestCase):
     def test_get_sbd_delay_start_expected(self, mock_corosync):
         mock_corosync.return_value = 30
         self.sbd_timeout_inst.disk_based = True
+        self.sbd_timeout_inst.pcmk_delay_max = 10
         self.sbd_timeout_inst.msgwait = 30
         res = self.sbd_timeout_inst.get_sbd_delay_start_expected()
-        assert res == 60
+        assert res == 70
 
     @mock.patch('crmsh.corosync.token_and_consensus_timeout')
     def test_get_sbd_delay_start_expected_diskless(self, mock_corosync):


### PR DESCRIPTION
Changes:
-  Dev: behave: Change the expected value of SBD_WATCHDOG_TIMEOUT and stonith-timeout
   These values in testcases in file bootstrap_sbd_delay.feature should be updated first before backport

- backport #1873 