### PR TITLE
Fix: sbd: Ensure stonith-watchdog-timeout is >= 2 * SBD_WATCHDOG_TIMEOUT (bsc#1247415)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2828,11 +2828,11 @@ def adjust_pcmk_delay_max(is_2node_wo_qdevice):
             logger.info("Delete parameter 'pcmk_delay_max' for resource '{}'".format(res))
 
 
-def adjust_stonith_timeout():
+def adjust_stonith_timeout(with_sbd: bool = False):
     """
     Adjust stonith-timeout for sbd and other scenarios
     """
-    if ServiceManager().service_is_active(constants.SBD_SERVICE):
+    if ServiceManager().service_is_active(constants.SBD_SERVICE) or with_sbd:
         SBDTimeout.adjust_sbd_timeout_related_cluster_configuration()
     else:
         value = get_stonith_timeout_generally_expected()
@@ -2840,7 +2840,7 @@ def adjust_stonith_timeout():
             utils.set_property("stonith-timeout", value, conditional=True)
 
 
-def adjust_properties():
+def adjust_properties(with_sbd: bool = False):
     """
     Adjust properties for the cluster:
     - pcmk_delay_max
@@ -2858,7 +2858,7 @@ def adjust_properties():
         return
     is_2node_wo_qdevice = utils.is_2node_cluster_without_qdevice()
     adjust_pcmk_delay_max(is_2node_wo_qdevice)
-    adjust_stonith_timeout()
+    adjust_stonith_timeout(with_sbd=with_sbd)
     adjust_priority_in_rsc_defaults(is_2node_wo_qdevice)
     adjust_priority_fencing_delay(is_2node_wo_qdevice)
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -711,7 +711,7 @@ class SBDManager:
 
             if self.cluster_is_running:
                 self.configure_sbd()
-                bootstrap.adjust_properties()
+                bootstrap.adjust_properties(with_sbd=True)
                 SBDManager.restart_cluster_if_possible(with_maintenance_mode=enabled)
 
     def join_sbd(self, remote_user, peer_host):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -284,16 +284,20 @@ class SBDTimeout(object):
         return int(res)
 
     @staticmethod
-    def get_stonith_watchdog_timeout():
+    def get_stonith_watchdog_timeout_expected():
         '''
-        For non-bootstrap case, get stonith-watchdog-timeout value from cluster property
-        The default value is 2 * SBD_WATCHDOG_TIMEOUT
+        Returns the value of the stonith-watchdog-timeout cluster property.
+
+        If the Pacemaker service is inactive, returns the default value (2 * SBD_WATCHDOG_TIMEOUT).
+        If the property is set and its value is equal to or greater than the default, returns the property value.
+        Otherwise, returns the default value.
         '''
         default = 2 * SBDTimeout.get_sbd_watchdog_timeout()
         if not ServiceManager().service_is_active(constants.PCMK_SERVICE):
             return default
         value = utils.get_property("stonith-watchdog-timeout", get_default=False)
-        return int(value.strip('s')) if value else default
+        return_value = value if utils.crm_msec(value) >= utils.crm_msec(default) else default
+        return int(utils.crm_msec(return_value)/1000)  # convert msec to sec
 
     def _load_configurations(self):
         '''
@@ -309,7 +313,7 @@ class SBDTimeout(object):
         else:  # disk-less
             self.disk_based = False
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
-            self.stonith_watchdog_timeout = SBDTimeout.get_stonith_watchdog_timeout()
+            self.stonith_watchdog_timeout = SBDTimeout.get_stonith_watchdog_timeout_expected()
         self.sbd_delay_start_value_expected = self.get_sbd_delay_start_expected() if utils.detect_virt() else "no"
         self.sbd_delay_start_value_from_config = SBDUtils.get_sbd_value_from_config("SBD_DELAY_START")
 
@@ -574,7 +578,7 @@ class SBDManager:
         Configure fence_sbd resource and related properties
         '''
         if self.diskless_sbd:
-            swt_value = self.timeout_dict.get("stonith-watchdog", SBDTimeout.get_stonith_watchdog_timeout())
+            swt_value = self.timeout_dict.get("stonith-watchdog", SBDTimeout.get_stonith_watchdog_timeout_expected())
             utils.set_property("stonith-watchdog-timeout", swt_value)
         else:
             if utils.get_property("stonith-watchdog-timeout", get_default=False):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -710,9 +710,9 @@ class SBDManager:
             SBDManager.enable_sbd_service()
 
             if self.cluster_is_running:
-                SBDManager.restart_cluster_if_possible(with_maintenance_mode=enabled)
                 self.configure_sbd()
                 bootstrap.adjust_properties()
+                SBDManager.restart_cluster_if_possible(with_maintenance_mode=enabled)
 
     def join_sbd(self, remote_user, peer_host):
         '''

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1518,7 +1518,7 @@ done
         bootstrap.adjust_properties()
         mock_is_active.assert_called_once_with("pacemaker.service")
         mock_adj_pcmk.assert_called_once_with(True)
-        mock_adj_stonith.assert_called_once_with()
+        mock_adj_stonith.assert_called_once_with(with_sbd=False)
         mock_adj_priority.assert_called_once_with(True)
         mock_adj_fence.assert_called_once_with(True)
 

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -214,20 +214,20 @@ class TestSBDTimeout(unittest.TestCase):
 
     @patch('crmsh.sbd.ServiceManager')
     @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
-    def test_get_stonith_watchdog_timeout_default(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager):
+    def test_get_stonith_watchdog_timeout_expected_default(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager):
         mock_get_sbd_watchdog_timeout.return_value = 1
         mock_ServiceManager.return_value.service_is_active = MagicMock(return_value=False)
-        result = sbd.SBDTimeout.get_stonith_watchdog_timeout()
+        result = sbd.SBDTimeout.get_stonith_watchdog_timeout_expected()
         self.assertEqual(result, 2)
 
     @patch('crmsh.utils.get_property')
     @patch('crmsh.sbd.ServiceManager')
     @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
-    def test_get_stonith_watchdog_timeout(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager, mock_get_property):
+    def test_get_stonith_watchdog_timeout_expected(self, mock_get_sbd_watchdog_timeout, mock_ServiceManager, mock_get_property):
         mock_get_sbd_watchdog_timeout.return_value = 1
         mock_ServiceManager.return_value.service_is_active = MagicMock(return_value=True)
         mock_get_property.return_value = "5"
-        result = sbd.SBDTimeout.get_stonith_watchdog_timeout()
+        result = sbd.SBDTimeout.get_stonith_watchdog_timeout_expected()
         self.assertEqual(result, 5)
 
     @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout')
@@ -268,7 +268,8 @@ class TestSBDTimeout(unittest.TestCase):
     @patch('crmsh.sbd.SBDTimeout.adjust_stonith_timeout')
     @patch('crmsh.sbd.SBDTimeout.adjust_sbd_delay_start')
     @patch('crmsh.sbd.SBDTimeout._load_configurations')
-    def test_adjust_sbd_timeout_related_cluster_configuration(self, mock_load_configurations, mock_adjust_sbd_delay_start, mock_adjust_stonith_timeout, mock_adjust_systemd_start_timeout):
+    def test_adjust_sbd_timeout_related_cluster_configuration(self, mock_load_configurations, mock_adjust_sbd_delay_start, mock_adjust_stonith_timeout, 
+                                                              mock_adjust_systemd_start_timeout):
         sbd.SBDTimeout.adjust_sbd_timeout_related_cluster_configuration()
         mock_load_configurations.assert_called_once()
         mock_adjust_sbd_delay_start.assert_called_once()
@@ -753,7 +754,7 @@ class TestSBDManager(unittest.TestCase):
 
     @patch('crmsh.utils.set_property')
     @patch('crmsh.sbd.ServiceManager')
-    @patch('crmsh.sbd.SBDTimeout.get_stonith_watchdog_timeout')
+    @patch('crmsh.sbd.SBDTimeout.get_stonith_watchdog_timeout_expected')
     def test_configure_sbd_diskless(self, mock_get_stonith_watchdog_timeout, mock_ServiceManager, mock_set_property):
         mock_get_stonith_watchdog_timeout.return_value = 2
         sbdmanager_instance = SBDManager(diskless_sbd=True)


### PR DESCRIPTION
## Problem
Call `crm sbd configure watchdog-timeout=<new_value>` should also keep the property `stonith-watchdog-timeout` >= 2* SBD_WATCHDOG_TIMEOUT

Example:
```
# crm sbd configure show|grep -E "SBD_WATCHDOG_TIMEOUT|stonith-watchdog-timeout"
SBD_WATCHDOG_TIMEOUT=15
stonith-watchdog-timeout=30

# crm sbd configure watchdog-timeout=20
INFO: Configuring diskless SBD
WARNING: Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice.
INFO: Update SBD_WATCHDOG_TIMEOUT in /etc/sysconfig/sbd: 20
INFO: Already synced /etc/sysconfig/sbd to all nodes
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
...........                                                                                                                                                                                        INFO: END Waiting for cluster
INFO: Update SBD_DELAY_START in /etc/sysconfig/sbd: 51
INFO: Already synced /etc/sysconfig/sbd to all nodes

# crm sbd configure show|grep -E "SBD_WATCHDOG_TIMEOUT|stonith-watchdog-timeout"
SBD_WATCHDOG_TIMEOUT=20
stonith-watchdog-timeout=30
```
## Changed
- Dev: sbd: Ensure stonith-watchdog-timeout is >= 2 * SBD_WATCHDOG_TIMEOUT (bsc#1247415)
    
    - Refactor: Rename get_stonith_watchdog_timeout() to
      get_stonith_watchdog_timeout_expected() for clarity.
    - Logic: Now always enforces stonith-watchdog-timeout to be at least
      twice SBD_WATCHDOG_TIMEOUT.
- Dev: sbd: Restart cluster after configured sbd and adjusted properties
    
    Because some sbd configurations might already updated via
    `self.update_configuration`, then we need also update related
    properties; Otherwise, restart cluster first might meet unexpected
    behavior.
```
# crm sbd configure watchdog-timeout=20
INFO: Configuring diskless SBD
WARNING: Diskless SBD requires cluster with three or more nodes. If you want to use diskless SBD for 2-node cluster, should be combined with QDevice.
INFO: Update SBD_WATCHDOG_TIMEOUT in /etc/sysconfig/sbd: 20
INFO: Already synced /etc/sysconfig/sbd to all nodes
INFO: Restarting cluster service
INFO: BEGIN Waiting for cluster
............                                                                         INFO: END Waiting for cluster
WARNING: "stonith-watchdog-timeout" in crm_config is set to 40, it was 30
INFO: Update SBD_DELAY_START in /etc/sysconfig/sbd: 51
INFO: Already synced /etc/sysconfig/sbd to all nodes

# crm sbd configure show |grep -E "SBD_WATCHDOG_TIMEOUT|stonith-watchdog-timeout"
SBD_WATCHDOG_TIMEOUT=20
stonith-watchdog-timeout=40
```
- Dev: sbd: Add with_sbd parameter for the case when sbd is not active
    
  When adding sbd via sbd stage in a running cluster, sbd.service is not
  started yet, so we need to add a with_sbd parameter to adjust
  stonith-timeout for sbd related timeouts.
