### PR TITLE
Dev: sbd: Check if fence-agents-sbd is installed for other cases

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -242,8 +242,11 @@ class Context(object):
             if ServiceManager().service_is_active(constants.SBD_SERVICE) and not config.core.force:
                 utils.fatal("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")
 
-        elif with_sbd_option and not utils.package_is_installed("sbd"):
-            utils.fatal(SBDManager.SBD_NOT_INSTALLED_MSG)
+        elif with_sbd_option:
+            if not utils.package_is_installed("sbd"):
+                utils.fatal(SBDManager.SBD_NOT_INSTALLED_MSG)
+            if self.sbd_devices and not utils.package_is_installed("fence-agents-sbd"):
+                utils.fatal(SBDManager.FENCE_SBD_NOT_INSTALLED_MSG)
 
     def _validate_nodes_option(self):
         """

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -743,11 +743,16 @@ class SBDManager:
             service_manager.disable_service(constants.SBD_SERVICE)
             return
 
+        if not utils.package_is_installed("sbd"):
+            utils.fatal(self.SBD_NOT_INSTALLED_MSG)
+        dev_list = SBDUtils.get_sbd_device_from_config()
+        if dev_list and not utils.package_is_installed("fence-agents-sbd"):
+            utils.fatal(self.FENCE_SBD_NOT_INSTALLED_MSG)
+
         from .watchdog import Watchdog
         self._watchdog_inst = Watchdog(remote_user=remote_user, peer_host=peer_host)
         self._watchdog_inst.join_watchdog()
 
-        dev_list = SBDUtils.get_sbd_device_from_config()
         if dev_list:
             SBDUtils.verify_sbd_device(dev_list, [peer_host])
         else:

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -658,9 +658,14 @@ class SBDManager:
         configured_devices = SBDUtils.get_sbd_device_from_config()
         # return empty list if already configured and user doesn't want to overwrite
         if configured_devices and not self._wants_to_overwrite(configured_devices):
-            return []
+            return_devices = []
+        else:
+            return_devices = self._prompt_for_sbd_device()
 
-        return self._prompt_for_sbd_device()
+        if not self.diskless_sbd and not utils.package_is_installed("fence-agents-sbd"):
+            utils.fatal(self.FENCE_SBD_NOT_INSTALLED_MSG)
+
+        return return_devices
 
     def get_sbd_device_from_bootstrap(self):
         '''

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -173,7 +173,6 @@ class TestContext(unittest.TestCase):
     def test_validate_sbd_option_error_sbd_stage(self, mock_check_all, mock_installed, mock_list, mock_fatal):
         mock_fatal.side_effect = ValueError
         mock_list.return_value = ["node1", "node2"]
-        options = mock.Mock(stage="sbd", diskless_sbd=True, cluster_is_running=True)
         mock_installed.side_effect = [True, False]
         ctx = crmsh.bootstrap.Context()
         ctx.stage = "sbd"
@@ -186,6 +185,47 @@ class TestContext(unittest.TestCase):
             mock.call("sbd", "node1"),
             mock.call("sbd", "node2")
         ])
+
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.utils.package_is_installed')
+    @mock.patch('crmsh.utils.list_cluster_nodes')
+    @mock.patch('crmsh.utils.check_all_nodes_reachable')
+    def test_validate_sbd_option_sbd_package_not_installed(self, mock_check_all, mock_list, mock_installed, mock_fatal):
+        mock_fatal.side_effect = ValueError
+        mock_list.return_value = ["node1", "node2"]
+        mock_installed.return_value = False
+        ctx = crmsh.bootstrap.Context()
+        ctx.stage = "sbd"
+        ctx.diskless_sbd = True
+        ctx.cluster_is_running = True
+
+        with self.assertRaises(ValueError):
+            ctx._validate_sbd_option()
+
+        mock_check_all.assert_called_once_with("setup SBD")
+        mock_installed.assert_called_once_with("sbd", "node1")
+        mock_fatal.assert_called_once_with(sbd.SBDManager.SBD_NOT_INSTALLED_MSG + " on node1")
+
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.utils.package_is_installed')
+    @mock.patch('crmsh.utils.this_node')
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    def test_validate_sbd_option_fence_sbd_package_not_installed(self, mock_verify, mock_this_node, mock_installed, mock_fatal):
+        mock_fatal.side_effect = ValueError
+        mock_this_node.return_value = "node1"
+        mock_installed.side_effect = [True, False]
+        ctx = crmsh.bootstrap.Context()
+        ctx.sbd_devices = ["/dev/sda1"]
+        ctx.stage = "sbd"
+
+        with self.assertRaises(ValueError):
+            ctx._validate_sbd_option()
+
+        mock_installed.assert_has_calls([
+            mock.call("sbd", "node1"),
+            mock.call("fence-agents-sbd", "node1")
+        ])
+        mock_fatal.assert_called_once_with(sbd.SBDManager.FENCE_SBD_NOT_INSTALLED_MSG + " on node1")
 
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('socket.gethostbyname')

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -664,13 +664,15 @@ class TestSBDManager(unittest.TestCase):
         mock_exists.assert_called_once_with(sbd.SBDManager.SYSCONFIG_SBD)
         mock_ServiceManager.return_value.disable_service.assert_called_once_with(constants.SBD_SERVICE)
 
+    @patch('crmsh.utils.package_is_installed')
     @patch('logging.Logger.info')
     @patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
     @patch('crmsh.watchdog.Watchdog')
     @patch('os.path.exists')
     @patch('crmsh.sbd.ServiceManager')
-    def test_join_sbd_diskbased(self, mock_ServiceManager, mock_exists, mock_Watchdog, mock_get_sbd_device_from_config, mock_verify_sbd_device, mock_logger_info):
+    def test_join_sbd_diskbased(self, mock_ServiceManager, mock_exists, mock_Watchdog, mock_get_sbd_device_from_config, mock_verify_sbd_device, mock_logger_info, mock_package_is_installed):
+        mock_package_is_installed.side_effect = [True, True]
         mock_exists.return_value = True
         mock_ServiceManager.return_value.service_is_enabled.return_value = True
         mock_Watchdog.return_value.join_watchdog = Mock()
@@ -681,13 +683,15 @@ class TestSBDManager(unittest.TestCase):
 
         mock_logger_info.assert_called_once_with("Got SBD configuration")
 
+    @patch('crmsh.utils.package_is_installed')
     @patch('logging.Logger.info')
     @patch('crmsh.sbd.SBDUtils.get_sbd_device_from_config')
     @patch('crmsh.watchdog.Watchdog')
     @patch('os.path.exists')
     @patch('crmsh.sbd.ServiceManager')
-    def test_join_sbd_diskless(self, mock_ServiceManager, mock_exists, mock_Watchdog, mock_get_sbd_device_from_config, mock_logger_info):
+    def test_join_sbd_diskless(self, mock_ServiceManager, mock_exists, mock_Watchdog, mock_get_sbd_device_from_config, mock_logger_info, mock_package_is_installed):
         mock_exists.return_value = True
+        mock_package_is_installed.return_value = True
         mock_ServiceManager.return_value.service_is_enabled.return_value = True
         mock_Watchdog.return_value.join_watchdog = Mock()
         mock_get_sbd_device_from_config.return_value = []


### PR DESCRIPTION
This PR is a follow-up to #1905, addressing additional cases that were not covered in the previous PR.
- Dev: sbd: Check if fence-agents-sbd is installed for non sbd stage
```
# crm cluster init -s /dev/sda5 -y
ERROR: cluster.init: Package fence-agents-sbd is not installed
```
- Dev: sbd: Check if fence-agents-sbd is installed on interactive mode
```
# crm cluster init
...
Do you wish to use SBD (y/n)? y
SBD_DEVICE in /etc/sysconfig/sbd is already configured to use '/dev/sda5' - overwrite (y/n)? y
Path to storage device (e.g. /dev/disk/by-id/...), or "none" for diskless sbd, use ";" as separator for multi path []/dev/sda6
WARNING: All data on /dev/sda6 will be destroyed
Are you sure you wish to use this device (y/n)? y
ERROR: cluster.init: Package fence-agents-sbd is not installed
```
- Dev: sbd: Check if fence-agents-sbd is installed on join node
```
# crm cluster join -c alp-1 -y
...
ERROR: cluster.join: Package fence-agents-sbd is not installed
```