### PR TITLE
[crmsh-4.6] Improvements for auto convert role and ms command

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -579,6 +579,7 @@ class CibObjectSetCli(CibObjectSet):
         utils.auto_convert_role = True
         with logger_utils.line_number():
             for cli_text in lines2cli(s):
+                cli_text = utils.handle_deprecated_ms_command(cli_text)
                 logger_utils.incr_lineno()
                 node = parse.parse(cli_text, comments=comments)
                 if node not in (False, None):

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -576,6 +576,7 @@ class CibObjectSetCli(CibObjectSet):
         diff = CibDiff(self)
         rc = True
         comments = []
+        utils.auto_convert_role = True
         with logger_utils.line_number():
             for cli_text in lines2cli(s):
                 logger_utils.incr_lineno()

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1100,10 +1100,8 @@ class CibConfig(command.UI):
         """usage: ms <name> <rsc>
         [params <param>=<value> [<param>=<value>...]]
         [meta <attribute>=<value> [<attribute>=<value>...]]"""
-        format_str = " " if "meta" in args else " meta "
-        new_cmd_str = ' '.join(args) + "{}promotable=true".format(format_str)
-        logger.warning('"ms" is deprecated. Please use "clone {}"'.format(new_cmd_str))
-        return self.__conf_object(context.get_command_name(), *args)
+        command, *new_args = utils.handle_deprecated_ms_command("ms " + ' '.join(args)).split()
+        return self.__conf_object(command, *new_args)
 
     @command.skill_level('administrator')
     @command.completers_repeating(compl.attr_id, ui_ra.complete_class_provider_type,

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3301,4 +3301,20 @@ def validate_and_get_reachable_nodes(
             member_list.remove(node)
 
     return member_list + remote_list
+
+
+def handle_deprecated_ms_command(cli_str: str) -> str:
+    if not re.search(r'^ms\s+', cli_str) or not is_ocf_1_1_cib_schema_detected():
+        return cli_str
+
+    meta_str = " " if "meta" in cli_str else " meta "
+    clone_str = re.sub(r'^ms\s+', 'clone ', cli_str)
+    new_cli_str = f"{clone_str}{meta_str}promotable=true"
+
+    if config.core.OCF_1_1_SUPPORT:
+        logger.info("Convert deprecated \"ms\" command to promotable clone: %s", new_cli_str)
+        return new_cli_str
+    else:
+        logger.warning("The \"ms\" command is deprecated, please use: %s", new_cli_str)
+        return cli_str
 # vim:ts=4:sw=4:et:

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -22,19 +22,19 @@
 .INP: clone c d3 	meta clone-max=1
 .INP: primitive d4 ocf:pacemaker:Dummy
 .INP: ms m d4
-WARNING: 19: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
+WARNING: 19: The "ms" command is deprecated, please use: clone m d4 meta promotable=true
 .INP: delete m
 .INP: master m d4
 WARNING: 21: This command 'master' is deprecated, please use 'ms'
 INFO: 21: "master" is accepted as "ms"
-WARNING: 21: "ms" is deprecated. Please use "clone m d4 meta promotable=true"
+WARNING: 21: The "ms" command is deprecated, please use: clone m d4 meta promotable=true
 .INP: primitive s5 ocf:pacemaker:Stateful 	operations $id-ref=d1-ops
 .EXT crm_resource --show-metadata ocf:pacemaker:Stateful
 .INP: primitive s6 ocf:pacemaker:Stateful 	operations $id-ref=d1
 .INP: ms m5 s5
-WARNING: 24: "ms" is deprecated. Please use "clone m5 s5 meta promotable=true"
+WARNING: 24: The "ms" command is deprecated, please use: clone m5 s5 meta promotable=true
 .INP: ms m6 s6
-WARNING: 25: "ms" is deprecated. Please use "clone m6 s6 meta promotable=true"
+WARNING: 25: The "ms" command is deprecated, please use: clone m6 s6 meta promotable=true
 .INP: primitive d7 Dummy 	params rule inf: #uname eq node1 fake=1 	params rule inf: #uname eq node2 fake=2         op start interval=0 timeout=60s         op_params 2: rule #uname eq node1 op_param=dummy         op_params 1: op_param=smart         op_meta 2: rule #ra-version version:gt 1.0 start-delay=120m         op_meta 1: start-delay=60m
 .EXT crm_resource --show-metadata ocf:heartbeat:Dummy
 .INP: primitive d8 ocf:pacemaker:Dummy

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -1147,7 +1147,7 @@ INFO: Stop tracing p0 for operation stop
 WARNING: This command 'rm' is deprecated, please use 'delete'
 INFO: "rm" is accepted as "delete"
 .TRY configure ms msg g
-WARNING: "ms" is deprecated. Please use "clone msg g meta promotable=true"
+WARNING: The "ms" command is deprecated, please use: clone msg g meta promotable=true
 .TRY resource scores
 .EXT crm_simulate -sUL
 2 of 6 resource instances DISABLED and 0 BLOCKED from further action due to failure


### PR DESCRIPTION
## Problem

1. When keeping OCF_1_1_SUPPORT to `no`, see #1918 
2. When setting OCF_1_1_SUPPORT to `yes`, `ms` command should be automatically converted to promotable clone
3. When setting OCF_1_1_SUPPORT to `yes` in /etc/crm/crm.conf, crmsh-4.6 has the same issue which was mentioned in https://github.com/ClusterLabs/crmsh/pull/1919#issue-3430202283

## Changed
- To address problems 1 and 2, introduce utils.handle_deprecated_ms_command function, convert `ms` command to promotable clone if meeting conditions, otherwise, raise warning.
- To address problem 3, backport from #1919