### PR TITLE
[crmsh-5.0] Fix: bootstrap: ignore ssh authentication failure to localhost when merging known_hosts (#1931)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1887,14 +1887,20 @@ def join_ssh_merge(cluster_node, remote_user):
     """
     logger.info("Merging known_hosts")
 
-    hosts = _context.node_list_in_cluster + [utils.this_node()]
-
-    shell = sh.cluster_shell()
     # create local entry in known_hosts
-    shell.ssh_to_localhost(None, 'true')
+    shell = sh.cluster_shell()
+    hostname = shell.local_shell.hostname()
+    local_user, remote_user = shell.user_of_host.user_pair_for_ssh(hostname)
+    shell.local_shell.su_subprocess_run(
+        local_user,
+        f'ssh -o BatchMode=yes {constants.SSH_OPTION} {hostname}',
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
+    hosts = utils.fetch_cluster_node_list_from_node(cluster_node) + [utils.this_node()]
     known_hosts_new: set[str] = set()
-
     cat_cmd = "[ -e ~/.ssh/known_hosts ] && cat ~/.ssh/known_hosts || true"
     for host in hosts:
         known_hosts_content = shell.get_stdout_or_raise_error(cat_cmd, host)

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -405,29 +405,6 @@ class ClusterShell:
         else:
             raise CommandFailure(cmd, host, None, Utils.decode_str(stderr).strip())
 
-    def ssh_to_localhost(self, user: typing.Optional[str], cmd: str, **kwargs):
-        if user is None:
-            user = 'root'
-        host = self.local_shell.hostname()
-        local_user, remote_user = self.user_of_host.user_pair_for_ssh(host)
-        result = self.local_shell.su_subprocess_run(
-            local_user,
-            'ssh {} {} {}@{} sudo -H -u {} {} /bin/sh'.format(
-                '-A' if self.forward_ssh_agent else '',
-                constants.SSH_OPTION,
-                remote_user,
-                host,
-                user,
-                '--preserve-env=SSH_AUTH_SOCK' if self.forward_ssh_agent else '',
-            ),
-            input=cmd.encode('utf-8'),
-            **kwargs,
-        )
-        if self.raise_ssh_error and result.returncode == 255:
-            raise AuthorizationError(cmd, host, remote_user, Utils.decode_str(result.stderr).strip())
-        else:
-            return result
-
 
 class ShellUtils:
     CONTROL_CHARACTER_PATTER = re.compile('[\u0000-\u001F]')

--- a/test/features/steps/bootstrap_steps.py
+++ b/test/features/steps/bootstrap_steps.py
@@ -64,5 +64,6 @@ def step_impl(context, user, node):
         print(stdout.decode('utf-8', errors='backslashreplace'))
         return
     else:
+        print(stdout.decode('utf-8', errors='backslashreplace'))
         print(stderr.decode('utf-8', errors='backslashreplace'))
         assert 0 == rc


### PR DESCRIPTION
backport:

* #1970