### PR TITLE
Revert "Dev: Update Docker image"

### DIFF
--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -206,6 +206,7 @@ deploy_ha_node() {
 	podman_exec $node_name "rm -rf /run/nologin"
 	podman_exec $node_name "echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config"
 	podman_exec $node_name "systemctl start sshd.service"
+	podman_exec $node_name "systemctl stop firewalld.service"
 
 	if [[ "$node_name" != "qnetd-node" && ! "$node_name" =~ ^pcmk-remote-node[0-9]$ ]];then
 	  podman cp $PROJECT_PATH $node_name:/opt/crmsh


### PR DESCRIPTION
- This reverts commit 643ee08dd2833bcd34a5ff2746bede06a05e78aa.
- Stop firewalld.service before running tests. The CI image now enables firewalld.service, which causes tests that expect firewalld to be inactive to fail. We already exercise the "high-availability" firewalld service in test/features/bootstrap_firewalld.feature, so explicitly stop firewalld.service during test setup.