### PR TITLE
[crmsh-4.6] Fix: log: Add milliseconds time format to crmsh.log (bsc#1255021)

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -215,7 +215,7 @@ LOGGING_CFG = {
             },
         },
         "file": {
-            "format": "%(asctime)s {} %(name)s: %(levelname)s: %(message)s".format(socket.gethostname()),
+            "format": "%(asctime)s.%(msecs)03d {} %(name)s: %(levelname)s: %(message)s".format(socket.gethostname()),
             "datefmt": "%b %d %H:%M:%S",
         }
     },


### PR DESCRIPTION
Partly backport from 
- #1996 