### PR TITLE
Dev: behave_agent: Prevent client hang behind firewall during long cluster joins

### DIFF
--- a/test/features/steps/behave_agent.py
+++ b/test/features/steps/behave_agent.py
@@ -61,6 +61,11 @@ class SocketIO(io.RawIOBase):
 def call(host: str, port: int, cmdline: str, user: typing.Optional[str] = None):
     family, type, proto, _, sockaddr =  socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)[0]
     with socket.socket(family, type, proto) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30)   # start after 30s idle
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)  # probe every 10s
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)     # 3 probes
         s.connect(sockaddr)
         sout = io.BufferedWriter(SocketIO(s), 4096)
         Message.write(sout, MSG_USER, user.encode('utf-8') if user else _getuser().encode('utf-8'))


### PR DESCRIPTION
The behave_agent client could hang when a `crm cluster join` command took a long time (~100s) to finish. In that case the TCP connection to port 1122 sat idle long enough for firewalld/conntrack to drop the flow, so the server’s response (RC/OUT/ERR/EOF) never reached the client and the call blocked indefinitely in `recv()`.

Fix this by enabling aggressive TCP keepalive on the client socket:

- SO_KEEPALIVE = 1
- TCP_KEEPIDLE  = 30s  (start keepalive probes after 30s idle)
- TCP_KEEPINTVL = 10s  (send probes every 10s)
- TCP_KEEPCNT   = 3    (3 failed probes before the OS considers the connection dead)

These keepalive probes keep the connection active in the firewall’s state table, so long‑running `crm cluster join` operations (~100s) now complete successfully without the client hanging.