### PR TITLE
Dev: run-functional-tests: Sleep 2s after creating contaier and attaching network

### DIFF
--- a/test/run-functional-tests
+++ b/test/run-functional-tests
@@ -204,6 +204,7 @@ deploy_ha_node() {
 	podman run --rm -d $podman_options $podman_capabilties $podman_security $CONTAINER_IMAGE
         podman network connect ha_network_second $node_name
 
+	sleep 2
 	if [ "$node_name" != "qnetd-node" ];then
 		rm_qnetd_cmd="rpm -q corosync-qnetd && rpm -e corosync-qnetd"
 		podman_exec $node_name "$rm_qnetd_cmd"


### PR DESCRIPTION
To avoid possible race conditions which might lead to "Permission denied" errors when using IPV6 and "No route to host" errors when using IPV4

Fix issue:
- #2006