### PR TITLE
Dev: options: Change 'force' option to be session-only (bsc#1254892)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -29,6 +29,8 @@ import socket
 from string import Template
 from lxml import etree
 
+import crmsh.options
+
 from . import config, constants, ssh_key, sh, cibquery, user_of_host
 from . import utils
 from . import xmlutil
@@ -251,7 +253,7 @@ class Context(object):
 
             if not with_sbd_option and self.yes_to_all:
                 utils.fatal("Stage sbd should specify sbd device by -s or diskless sbd by -S option")
-            if ServiceManager().service_is_active(constants.SBD_SERVICE) and not config.core.force:
+            if ServiceManager().service_is_active(constants.SBD_SERVICE) and not crmsh.options.force:
                 utils.fatal("Can't configure stage sbd: sbd.service already running! Please use crm option '-F' if need to redeploy")
 
         elif with_sbd_option:
@@ -443,7 +445,7 @@ def prompt_for_string(msg, match=None, default='', valid_func=None, prev_value=[
 
 
 def confirm(msg):
-    if config.core.force or (_context and _context.yes_to_all):
+    if crmsh.options.force or (_context and _context.yes_to_all):
         return True
     disable_completion()
     rc = logger_utils.confirm(msg)
@@ -2435,7 +2437,7 @@ def bootstrap_remove(context):
     """
     global _context
     _context = context
-    force_flag = config.core.force or _context.force
+    force_flag = crmsh.options.force or _context.force
 
     init()
 

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -280,7 +280,7 @@ class CibObjectSet(object):
                 s = open(tmp).read()
                 if hash(s) != filehash:
                     ok = self.save(self._post_edit(s))
-                    if not ok and config.core.force:
+                    if not ok and options.force:
                         logger.error("Save failed and --force is set, aborting edit to avoid infinite loop")
                     elif not ok and utils.ask("Edit or discard changes (yes to edit, no to discard)?"):
                         continue
@@ -3964,7 +3964,7 @@ class CibFactory(object):
                 # to remove doesn't exist. This should help scripted
                 # workflows without compromising an interactive
                 # use.
-                if not config.core.force:
+                if not options.force:
                     logger_utils.no_object_err(obj_id)
                     rc = False
                 continue

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -248,7 +248,6 @@ DEFAULTS = {
         'wait': opt_boolean('no'),
         'add_quotes': opt_boolean('yes'),
         'manage_children': opt_choice('ask', ('ask', 'never', 'always')),
-        'force': opt_boolean('no'),
         'debug': opt_boolean('no'),
         'ptest': opt_program('', ('ptest', 'crm_simulate')),
         'dotty': opt_program('', ('dotty',)),

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -313,7 +313,7 @@ def parse_options():
     options.profile = opts.profile or options.profile
     options.regression_tests = opts.regression_tests or options.regression_tests
     config.color.style = opts.display or config.color.style
-    config.core.force = opts.force or config.core.force
+    options.force = opts.force
     if opts.filename:
         logger_utils.reset_lineno()
         options.input_file, options.batch, options.interactive = opts.filename, True, False

--- a/crmsh/options.py
+++ b/crmsh/options.py
@@ -16,3 +16,4 @@ shadow = ""
 scriptdir = ""
 # set to true when completing non-interactively
 shell_completion = False
+force = False

--- a/crmsh/ui_cib.py
+++ b/crmsh/ui_cib.py
@@ -69,7 +69,7 @@ class CibShadow(command.UI):
             new_cmd = "%s -e '%s'" % (self.extcmd, name)
         else:
             new_cmd = "%s -c '%s'" % (self.extcmd, name)
-        if constants.tmp_cib or config.core.force or "force" in opt_l or "--force" in opt_l:
+        if constants.tmp_cib or options.force or "force" in opt_l or "--force" in opt_l:
             new_cmd = "%s --force" % new_cmd
         if utils.ext_cmd(new_cmd) == 0:
             context.info("%s shadow CIB created" % name)
@@ -213,7 +213,7 @@ class CibShadow(command.UI):
             # user made changes and now wants to switch to a
             # different and unequal CIB; we refuse to cooperate
             context.error_message("the requested CIB is different from the current one")
-            if config.core.force:
+            if options.force:
                 context.info("CIB overwrite forced")
             elif not utils.ask("All changes will be dropped. Do you want to proceed?"):
                 self._use(saved_cib, '')  # revert to the previous CIB

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -567,8 +567,8 @@ Remove one or more nodes from the cluster.
 
 This command can remove the last node in the cluster,
 thus effectively removing the whole cluster. To remove
-the last node, pass --force argument to crm or set
-the config.core.force option.""",
+the last node, pass --force argument to crm.
+""",
                 usage="remove [options] [<node> ...]", add_help=False, formatter_class=RawDescriptionHelpFormatter)
         parser.add_argument("-h", "--help", action="store_true", dest="help", help="Show this help message")
         parser.add_argument("-q", "--quiet", help="Be quiet (don't describe what's happening, just do it)", action="store_true", dest="quiet")

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -896,7 +896,7 @@ class CibConfig(command.UI):
         argl = list(args)
         arg_force = any((x in ('-f', '--force')) for x in argl)
         argl = [x for x in argl if x not in ('-f', '--force')]
-        if arg_force or config.core.force:
+        if arg_force or options.force:
             if self._stop_if_running(argl) > 0:
                 utils.wait_dc_stable(what="Stopping %s" % (", ".join(argl)))
         cib_factory.ensure_cib_updated()
@@ -963,7 +963,7 @@ class CibConfig(command.UI):
 
         if rc1 and bool(verify_result):
             return cib_factory.commit(replace=replace)
-        if force or config.core.force:
+        if force or options.force:
             logger.info("commit forced")
             return cib_factory.commit(force=True, replace=replace)
         if utils.ask("Do you still want to commit?"):
@@ -989,10 +989,10 @@ class CibConfig(command.UI):
     @command.completers(compl.choice(['force']))
     def do_upgrade(self, context, force=None):
         "usage: upgrade <force>"
-        if (not force or force != "force") and not config.core.force:
+        if (not force or force != "force") and not options.force:
             context.fatal_error("'force' option is required")
         cib_factory.ensure_cib_updated()
-        if cib_factory.upgrade_validate_with(force or config.core.force):
+        if cib_factory.upgrade_validate_with(force or options.force):
             logger.info("Current schema version is %s", cib_factory.get_schema(refresh=True))
             return True
         return False

--- a/crmsh/ui_maintenance.py
+++ b/crmsh/ui_maintenance.py
@@ -3,10 +3,10 @@
 
 from . import command
 from . import completers as compl
-from . import config
 from . import cibconfig
 from . import utils
 from . import xmlutil
+from . import options
 
 _compl_actions = compl.choice(['start', 'stop', 'monitor', 'meta-data', 'validate-all',
                                'promote', 'demote', 'notify', 'reload', 'migrate_from',
@@ -75,7 +75,7 @@ class Maintenance(command.UI):
             context.fatal_error("Resource not found: %s" % (resource))
         if not xmlutil.is_resource(obj.node):
             context.fatal_error("Not a resource: %s" % (resource))
-        if not config.core.force and not self._in_maintenance_mode(obj):
+        if not options.force and not self._in_maintenance_mode(obj):
             context.fatal_error("Not in maintenance mode.")
 
         if ssh is None:

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 import os
-import re
 import copy
 import subprocess
 from lxml import etree
@@ -18,6 +17,7 @@ from . import idmgmt
 from .cliformat import cli_nvpairs, nvpairs2list
 from . import term
 from . import cibconfig
+from . import options
 from .sh import ShellUtils
 from . import log
 
@@ -443,7 +443,7 @@ class NodeMgmt(command.UI):
         if not utils.has_stonith_running():
             logger.error("fence command requires stonith device configured and running")
             return False
-        if not config.core.force and \
+        if not options.force and \
                 not utils.ask("Fencing %s will shut down the node and migrate any resources that are running on it! Do you want to fence %s?" % (node, node)):
             return False
         if xmlutil.is_remote_node(node):
@@ -459,7 +459,7 @@ class NodeMgmt(command.UI):
             node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
-        if not config.core.force and \
+        if not options.force and \
                 not utils.ask("Do you really want to drop state for node %s?" % node):
             return False
 
@@ -493,7 +493,7 @@ class NodeMgmt(command.UI):
                 rc = False
         cmd = "%s --force -R %s" % (cls.crm_node, node)
         if not rc:
-            if config.core.force:
+            if options.force:
                 logger.info('proceeding with node %s removal', node)
             else:
                 return False
@@ -515,7 +515,7 @@ class NodeMgmt(command.UI):
     def do_delete(self, context, node):
         'usage: delete <node>'
         logger.warning('`crm node delete` is deprecated and will very likely be dropped in the near future. It is auto-replaced as `crm cluster remove -c {}`.'.format(node))
-        if config.core.force:
+        if options.force:
             args = ['crm', 'cluster', 'remove', '-F', '-c', node]
         else:
             args = ['crm', 'cluster', 'remove', '-c', node]

--- a/crmsh/ui_options.py
+++ b/crmsh/ui_options.py
@@ -20,7 +20,6 @@ _legacy_map = {
     'wait': ('core', 'wait'),
     'add_quotes': ('core', 'add_quotes'),
     'manage_children': ('core', 'manage_children'),
-    'force': ('core', 'force'),
     'debug': ('core', 'debug'),
     'ptest': ('core', 'ptest'),
     'dotty': ('core', 'dotty'),

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -401,7 +401,7 @@ class RscMgmt(command.UI):
         lifetime = None
 
         argl = list(args)
-        force = "force" in utils.fetch_opts(argl, ["force"]) or config.core.force
+        force = "force" in utils.fetch_opts(argl, ["force"]) or options.force
         if len(argl) >= 3:
             context.fatal_error(usage)
         if len(argl) == 2:  # must be <node> <lifetime>
@@ -423,7 +423,7 @@ class RscMgmt(command.UI):
             opts = "--node '%s'" % node
         if lifetime:
             opts = "%s --lifetime '%s'" % (opts, lifetime)
-        if force or config.core.force:
+        if force or options.force:
             opts = "%s --force" % opts
         rc = utils.ext_cmd(action_cmd % (rsc, opts))
         if rc == 0:

--- a/crmsh/ui_site.py
+++ b/crmsh/ui_site.py
@@ -5,9 +5,9 @@
 import time
 from . import command
 from . import completers as compl
-from . import config
 from . import utils
 from . import log
+from . import options
 
 
 logger = log.setup_logger(__name__)
@@ -60,7 +60,7 @@ class Site(command.UI):
         "usage: ticket {grant|revoke|standby|activate|show|time|delete} <ticket>"
 
         base_cmd = "crm_ticket"
-        if config.core.force:
+        if options.force:
             base_cmd += " --force"
 
         attr_cmd = _ticket_commands.get(subcmd)

--- a/crmsh/ui_template.py
+++ b/crmsh/ui_template.py
@@ -102,9 +102,8 @@ class Template(command.UI):
         if not self.config_exists(name):
             return False
         if name == self.curr_conf:
-            if not force and not config.core.force and \
-                    not utils.ask("Do you really want to remove config %s which is in use?" %
-                                  self.curr_conf):
+            if not force and not options.force and \
+                not utils.ask("Config %s is currently in use. Do you really want to delete it?" % name):
                 return False
             else:
                 self.curr_conf = ''

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -266,10 +266,10 @@ def ask(msg, background_wait=True, cancel_option=False):
     block until the process is brought to foreground.
 
     Global Options:
-    * core.force: always return true without asking
+    * options.force: always return true without asking
     * options.ask_no: do not ask and return false
     """
-    if config.core.force:
+    if options.force:
         logger.info("%s [YES]", msg)
         return True
     if not can_ask(background_wait):
@@ -2843,7 +2843,7 @@ def leverage_maintenance_mode() -> typing.Generator[bool, None, None]:
         logger.info("Cluster is already in maintenance mode")
         yield True
         return
-    if not config.core.force:
+    if not options.force:
         yield False
         return
 

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -3111,7 +3111,7 @@ in that container, then the container is deleted as well. Any
 related constraints are removed as well.
 
 If the object is a started resource, it will not be deleted unless the
-+--force+ flag is passed to the command, or the +force+ option is set.
++--force+ flag is passed to the command.
 
 Usage:
 ...............

--- a/etc/crm.conf.in
+++ b/etc/crm.conf.in
@@ -12,7 +12,6 @@
 ; wait = no
 ; add_quotes = yes
 ; manage_children = ask
-; force = no
 ; debug = no
 ; ptest = ptest, crm_simulate
 ; dotty = dotty

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -272,8 +272,7 @@ Remove one or more nodes from the cluster.
 
 This command can remove the last node in the cluster,
 thus effectively removing the whole cluster. To remove
-the last node, pass --force argument to crm or set
-the config.core.force option.
+the last node, pass --force argument to crm.
 
 options:
   -h, --help            Show this help message

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -13,7 +13,7 @@ from unittest import mock
 from itertools import chain
 
 import crmsh.utils
-from crmsh import utils, config, tmpfiles, constants, parallax
+from crmsh import utils, config, tmpfiles, constants, options
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -1355,7 +1355,7 @@ def test_check_user_access_cluster(mock_user, mock_in, mock_sudo, mock_error):
 @mock.patch('logging.Logger.warning')
 @mock.patch('crmsh.utils.is_dc_idle')
 def test_leverage_maintenance_mode_skip(mock_idle, mock_warn):
-    config.core.force = True
+    options.force = True
     mock_idle.return_value = False
     with utils.leverage_maintenance_mode() as result:
         assert result is False
@@ -1367,7 +1367,7 @@ def test_leverage_maintenance_mode_skip(mock_idle, mock_warn):
 @mock.patch('logging.Logger.info')
 @mock.patch('crmsh.utils.is_dc_idle')
 def test_leverage_maintenance_mode(mock_idle, mock_info, mock_set, mock_delete):
-    config.core.force = True
+    options.force = True
     mock_idle.return_value = True
     with utils.leverage_maintenance_mode() as result:
         assert result is True


### PR DESCRIPTION
Previously, the '--force' option was persisted to the configuration file ('crm.conf') via 'config.core.force'. This caused subsequent commands to also run in forced mode unexpectedly if the configuration was saved.

This change moves the 'force' option from 'crmsh.config' (persistent) to 'crmsh.options' (session-only).

- Removed 'force' from 'config.DEFAULTS' and 'etc/crm.conf.in'.
- Added 'force' to 'options.py'.
- Updated 'main.py' to set 'options.force' from CLI arguments.
- Replaced all usages of 'config.core.force' with 'options.force' across the codebase.
- Updated documentation and tests to reflect that 'force' is no longer a configuration option.