### PR TITLE
Fix: sbd: Allow setting -1 to stonith-watchdog-timeout (bsc#1257143)

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -767,6 +767,10 @@ class SBDTimeoutChecker(SBDTimeout):
 
     def _check_stonith_watchdog_timeout(self) -> CheckResult:
         value = utils.get_property("stonith-watchdog-timeout")
+        if value and int(value) == -1:
+            if not self.quiet:
+                logger.warning("It's recommended that stonith-watchdog-timeout is et to %d, now is -1", self.stonith_watchdog_timeout)
+            return CheckResult.WARNING
         value = int(utils.crm_msec(value)/1000)
         if self.disk_based:
             if value > 0:


### PR DESCRIPTION
To keep backward compatibility with previous versions of crmsh and pacemaker, allow setting -1 to stonith-watchdog-timeout, and give a warning to recommend using 2*SBD_WATCHDOG_TIMEOUT