### PR TITLE
Fix: ui_cluster: Stop dlm in maintenance mode correctly (bsc#1253733)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2796,11 +2796,11 @@ def set_dlm_option(peer=None, **kargs):
             shell.get_stdout_or_raise_error(f'dlm_tool set_config "{option}={value}"', peer)
 
 
-def is_dlm_running(peer=None):
+def is_dlm_running(peer=None, on_node=None):
     """
     Check if dlm ra controld is running
     """
-    return xmlutil.CrmMonXmlParser(peer).is_resource_started(constants.DLM_CONTROLD_RA)
+    return xmlutil.CrmMonXmlParser(peer).is_resource_started(constants.DLM_CONTROLD_RA, node=on_node)
 
 
 def is_dlm_configured(peer=None):

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1631,13 +1631,16 @@ class CrmMonXmlParser(object):
                 return True
         return False
 
-    def is_resource_started(self, ra):
+    def is_resource_started(self, ra, node=None):
         """
         Check if the RA started(in all clone instances if configured as clone)
 
         @ra could be resource id or resource type
+        @node: optional, specify the node name to check if the resource is started on the node
         """
         xpath = f'//resource[(@id="{ra}" or @resource_agent="{ra}") and @active="true" and @role="Started"]'
+        if node:
+            xpath += f"/node[@name='{node}']"
         return bool(self.xml_elem.xpath(xpath))
 
     def get_resource_top_parent_id_set_via_type(self, ra_type):


### PR DESCRIPTION
## Problem
Stopping pacemaker/corosync will trigger unexpected node fencing when 'dlm_controld' is running in maintenance mode. However, `crm cluster stop` action will be aborted even when dlm is not running on that node, which makes no sense
## Changed
Allow to stop cluster service on a specific node when the cluster is in maintenance mode and dlm isn't running on that node

Port from #1977 