### PR TITLE
Fix: fix asyncio usage with python 3.14 and later

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3042,7 +3042,7 @@ def retry_with_timeout(callable, timeout_sec: float, interval_sec=1):
             except Exception:
                 pass
             await asyncio.sleep(interval_sec)
-    return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(asyncio.wait_for(wrapper(), timeout_sec))
+    return asyncio.run(asyncio.wait_for(wrapper(), timeout_sec))
 
 
 def fetch_cluster_node_list_from_node(init_node):


### PR DESCRIPTION
From the python 3.14 changes document[1]:

> asyncio.get_event_loop() now raises a RuntimeError if there is no current
> event loop, and no longer implicitly creates an event loop.

Fixes: #2032

1. https://docs.python.org/3/whatsnew/3.14.html#id10