### PR TITLE
Dev: bootstrap: Skip inactive cluster node when calling restart_cluster function

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2873,8 +2873,17 @@ def sync_path(path, peer_node=None):
 
 
 def restart_cluster():
+    service_manager = ServiceManager()
+    node_list = utils.list_cluster_nodes()
+    for node in node_list[:]:
+        if not service_manager.service_is_active(constants.PCMK_SERVICE, remote_addr=node):
+            logger.warning("Cluster is inactive on %s, skip restarting cluster service on it", node)
+            node_list.remove(node)
+    if not node_list:
+        return
+
     logger.info("Restarting cluster service")
-    utils.cluster_run_cmd("crm cluster restart")
+    utils.cluster_run_cmd("crm cluster restart", node_list)
     wait_for_cluster()
 
 


### PR DESCRIPTION
Fix issue:
- #2040 