### PR TITLE
Fix: sh: Use sh_helper.py for su commands (bsc#1254757)

### DIFF
--- a/crmsh/prun/prun.py
+++ b/crmsh/prun/prun.py
@@ -1,7 +1,9 @@
 # prun.py - run command or copy files on multiple hosts concurrently
 import os
 import random
+import shlex
 import socket
+import sys
 import tempfile
 import typing
 
@@ -12,6 +14,8 @@ from crmsh.user_of_host import UserOfHost
 from crmsh.sh import Utils
 
 _DEFAULT_CONCURRENCY = 32
+
+_SH_HELPER = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'sh_helper.py')
 
 _SUDO_SFTP_SERVER_OPTION = '-s \'sudo --preserve-env=SSH_AUTH_SOCK PATH=/usr/lib/ssh:/usr/lib/openssh:/usr/libexec/ssh:/usr/libexec/openssh /bin/sh -c "exec sftp-server"\''
 
@@ -125,7 +129,9 @@ def _build_run_task(remote: str, cmdline: str) -> Task:
         if local_sudoer == crmsh.userdir.getuser():
             args = ['/bin/sh', '-c', shell]
         elif os.geteuid() == 0:
-            args = ['su', local_sudoer, '--login', '-c', shell, '-w', 'SSH_AUTH_SOCK']
+            helper_args = [sys.executable, _SH_HELPER, '--preserve-env', 'SSH_AUTH_SOCK', shell]
+            shell_cmd = ' '.join(shlex.quote(a) for a in helper_args)
+            args = ['su', '-s', '/bin/sh', '-w', 'SSH_AUTH_SOCK', '-c', shell_cmd, local_sudoer]
         else:
             raise AssertionError('trying to run su as a non-root user')
         return Task(

--- a/crmsh/sh.py
+++ b/crmsh/sh.py
@@ -22,8 +22,10 @@ import logging
 import os
 import pwd
 import re
+import shlex
 import socket
 import subprocess
+import sys
 import typing
 from io import StringIO
 from functools import cache
@@ -35,6 +37,8 @@ from .user_of_host import UserOfHost
 import crmsh.options
 
 logger = logging.getLogger(__name__)
+
+_SH_HELPER = os.path.join(os.path.dirname(__file__), 'sh_helper.py')
 
 
 class Error(ValueError):
@@ -140,12 +144,19 @@ class LocalShell:
         if user is None or self.get_effective_user_name() == user:
             args = ['/bin/sh', '-c', cmd]
         elif 0 == self.geteuid():
-            args = ['su', user, '--login', '-s', '/bin/sh', '-c', cmd]
+            helper_args = [sys.executable, _SH_HELPER]
+            if self.preserve_env:
+                helper_args.extend(['--preserve-env', ','.join(self.preserve_env)])
+            helper_args.append(cmd)
+            shell_cmd = ' '.join(shlex.quote(a) for a in helper_args)
+
+            args = ['su', '-s', '/bin/sh']
             if tty:
                 args.append('--pty')
             if self.preserve_env:
                 args.append('-w')
                 args.append(','.join(self.preserve_env))
+            args.extend(['-c', shell_cmd, user])
         else:
             raise AuthorizationError(
                 cmd, None, user,

--- a/crmsh/sh_helper.py
+++ b/crmsh/sh_helper.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import pwd
+import sys
+
+
+def main():
+    argument_parser = argparse.ArgumentParser(description="Helper script to run command in a clean environment")
+    argument_parser.add_argument('--preserve-env', help="Environment variables to preserve, separated by comma")
+    argument_parser.add_argument('command', help="Command to execute")
+    args = argument_parser.parse_args()
+
+    # Get user info for USER, LOGNAME, and HOME
+    pw = pwd.getpwuid(os.getuid())
+    user_name = pw.pw_name
+    user_home = pw.pw_dir
+
+    # Prepare a clean environment
+    new_env = {}
+
+    # 1. Keep TERM if it exists
+    if 'TERM' in os.environ:
+        new_env['TERM'] = os.environ['TERM']
+
+    # 2. Keep SHELL if it was initialized by su (or previous environment)
+    if 'SHELL' in os.environ:
+        new_env['SHELL'] = os.environ['SHELL']
+
+    # 3. Setup USER, LOGNAME and HOME
+    new_env['USER'] = user_name
+    new_env['LOGNAME'] = user_name
+    new_env['HOME'] = user_home
+
+    # Handle preserve_env
+    if args.preserve_env:
+        for var in args.preserve_env.split(','):
+            var = var.strip()
+            val = os.environ.get(var)
+            if val is not None:
+                new_env[var] = val
+
+    # Default PATH if not preserved
+    if 'PATH' not in new_env:
+        # A sensible default path
+        new_env['PATH'] = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+    
+    # Change to user's home directory
+    try:
+        os.chdir(new_env['HOME'])
+    except Exception as e:
+        print(f"Warning: Could not change directory to {new_env['HOME']}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Replace the current process with /bin/bash -c <command>
+    try:
+        os.execve('/bin/bash', ['/bin/bash', '-c', args.command], new_env)
+    except Exception as e:
+        print(f"Failed to execute command: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -295,3 +295,15 @@ Feature: Regression test for bootstrap bugs
     Then    Cluster service is "stopped" on "hanode1"
     And     Cluster service is "stopped" on "hanode2"
     And     Cluster service is "stopped" on "hanode3"
+
+  # skip non-root as non-root user cannot write to `/etc/profile`
+  @skip_non_root
+  @clean
+  Scenario: When '/etc/profile' prints garbages (bsc#1254757)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    When    Run "echo 'echo Boom!' > /etc/profile" on "hanode1,hanode2"
+    When    Run "crm cluster init -y" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode1"
+    Then    Cluster service is "started" on "hanode2"

--- a/test/unittests/test_prun.py
+++ b/test/unittests/test_prun.py
@@ -1,4 +1,6 @@
 import typing
+import sys
+import shlex
 
 import crmsh.constants
 import crmsh.prun.prun
@@ -38,16 +40,26 @@ class TestPrun(unittest.TestCase):
             mock.call("host1"),
             mock.call("host2"),
         ])
+        shell1 = 'ssh -A {} bob@host1 sudo -H /bin/bash'.format(crmsh.constants.SSH_OPTION)
+        helper_args1 = [sys.executable, crmsh.prun.prun._SH_HELPER, '--preserve-env', 'SSH_AUTH_SOCK', shell1]
+        shell_cmd1 = ' '.join(shlex.quote(a) for a in helper_args1)
+        args1 = ['su', '-s', '/bin/sh', '-w', 'SSH_AUTH_SOCK', '-c', shell_cmd1, 'alice']
+
+        shell2 = 'ssh -A {} bob@host2 sudo -H /bin/bash'.format(crmsh.constants.SSH_OPTION)
+        helper_args2 = [sys.executable, crmsh.prun.prun._SH_HELPER, '--preserve-env', 'SSH_AUTH_SOCK', shell2]
+        shell_cmd2 = ' '.join(shlex.quote(a) for a in helper_args2)
+        args2 = ['su', '-s', '/bin/sh', '-w', 'SSH_AUTH_SOCK', '-c', shell_cmd2, 'alice']
+
         mock_runner_add_task.assert_has_calls([
             mock.call(TaskArgumentsEq(
-                ['su', 'alice', '--login', '-c', 'ssh -A {} bob@host1 sudo -H /bin/bash'.format(crmsh.constants.SSH_OPTION), '-w', 'SSH_AUTH_SOCK'],
+                args1,
                 b'foo',
                 stdout=crmsh.prun.runner.Task.Capture,
                 stderr=crmsh.prun.runner.Task.Capture,
                 context={"host": 'host1', "ssh_user": 'bob'},
             )),
             mock.call(TaskArgumentsEq(
-                ['su', 'alice', '--login', '-c', 'ssh -A {} bob@host2 sudo -H /bin/bash'.format(crmsh.constants.SSH_OPTION), '-w', 'SSH_AUTH_SOCK'],
+                args2,
                 b'bar',
                 stdout=crmsh.prun.runner.Task.Capture,
                 stderr=crmsh.prun.runner.Task.Capture,

--- a/test/unittests/test_sh.py
+++ b/test/unittests/test_sh.py
@@ -1,3 +1,6 @@
+import os
+import sys
+import shlex
 import subprocess
 import unittest
 import pickle
@@ -23,8 +26,11 @@ class TestLocalShell(unittest.TestCase):
             'alice', 'foo',
             input=b'bar',
         )
+        sh_helper = os.path.join(os.path.dirname(crmsh.sh.__file__), 'sh_helper.py')
+        helper_args = [sys.executable, sh_helper, 'foo']
+        shell_cmd = ' '.join(shlex.quote(a) for a in helper_args)
         mock_run.assert_called_once_with(
-            ['su', 'alice', '--login', '-s', '/bin/sh', '-c', 'foo'],
+            ['su', '-s', '/bin/sh', '-c', shell_cmd, 'alice'],
             input=b'bar',
             env=mock_environ,
         )


### PR DESCRIPTION
Introduce sh_helper.py to run commands in a clean environment when switching users via su. This ensures consistent behavior without using login shell, which runs commands written in `/etc/profile`, ...

- Added crmsh/sh_helper.py: Helper script to sanitize environment.
- Updated crmsh/sh.py: Use sh_helper.py in LocalShell.su_subprocess_run.
- Updated crmsh/prun/prun.py: Use sh_helper.py in _build_run_task.
- Updated unit tests in test_prun.py and test_sh.py to match new su structure.
- Added a functional test case to bootstrap_bugs.feature