### PR TITLE
[crmsh-4.5] Fix: corosync: Reuse nodeid from cmap to avoid nodeid and ip address mix-up (bsc#1259683)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2091,7 +2091,7 @@ def join_cluster(seed_host, remote_user):
                 break
         invoke("rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*")
         try:
-            corosync.add_node_ucast(ringXaddr_res)
+            corosync.add_node_ucast(ringXaddr_res, remote=seed_host)
         except corosync.IPAlreadyConfiguredError as e:
             logger.warning(e)
         sync_file(corosync.conf())

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -123,6 +123,7 @@ def query_qnetd_status():
 
 
 def add_nodelist_from_cmaptool():
+    # Retrieving nodelist from cmap is unreliable (bsc#1259683). DO NOT USE THIS WITH UNICAST.
     for nodeid, iplist in utils.get_nodeinfo_from_cmaptool().items():
         try:
             add_node_ucast(iplist, nodeid)
@@ -427,16 +428,34 @@ def diff_configuration(nodes, checksum=False):
         utils.remote_diff(local_path, nodes)
 
 
-def get_free_nodeid(parser):
-    ids = parser.get_all('nodelist.node.nodeid')
+def get_free_nodeid(parser, remote=None):
+    ids = {int(i) for i in parser.get_all('nodelist.node.nodeid')}
+    cmap_nodes = utils.get_nodeinfo_from_cmaptool(remote=remote)
+    for node_id in cmap_nodes.keys():
+        if node_id.isdigit():
+            ids.add(int(node_id))
+
     if not ids:
         return 1
-    ids = [int(i) for i in ids]
+
     max_id = max(ids) + 1
     for i in range(1, max_id):
         if i not in ids:
             return i
     return max_id
+
+
+def get_nodeid_by_ip_from_cmap(ip_list, remote=None):
+    """
+    Check if any IP in ip_list is already in cmap runtime info,
+    if yes, return the nodeid.
+    """
+    ip_set = set(ip_list)
+    cmap_nodes = utils.get_nodeinfo_from_cmaptool(remote=remote)
+    for nid, ips in cmap_nodes.items():
+        if any(ip in ip_set for ip in ips):
+            return int(nid)
+    return None
 
 
 def get_ip(node):
@@ -471,7 +490,7 @@ class IPAlreadyConfiguredError(Exception):
     pass
 
 
-def find_configured_ip(ip_list):
+def assert_ip_not_configured(ip_list):
     """
     find if the same IP already configured
     If so, raise IPAlreadyConfiguredError
@@ -500,13 +519,15 @@ def find_configured_ip(ip_list):
         raise IPAlreadyConfiguredError("IP {} was already configured".format(','.join(configured_ip)))
 
 
-def add_node_ucast(ip_list, node_id=None):
+def add_node_ucast(ip_list, node_id=None, remote=None):
 
-    find_configured_ip(ip_list)
+    assert_ip_not_configured(ip_list)
 
     p = Parser(utils.read_from_file(conf()))
     if node_id is None:
-        node_id = get_free_nodeid(p)
+        node_id = get_nodeid_by_ip_from_cmap(ip_list, remote=remote)
+    if node_id is None:
+        node_id = get_free_nodeid(p, remote=remote)
     node_value = []
     for i, addr in enumerate(ip_list):
         node_value += make_value('nodelist.node.ring{}_addr'.format(i), addr)
@@ -524,7 +545,7 @@ def add_node_ucast(ip_list, node_id=None):
     utils.str2file(p.to_string(), conf())
 
 
-def add_node(addr, name=None):
+def add_node(addr, name=None, remote=None):
     '''
     Add node to corosync.conf
     '''
@@ -554,7 +575,9 @@ def add_node(addr, name=None):
     p = Parser(utils.read_from_file(conf()))
 
     node_addr = addr
-    node_id = get_free_nodeid(p)
+    node_id = get_nodeid_by_ip_from_cmap([ipaddr], remote=remote) if ipaddr else None
+    if node_id is None:
+        node_id = get_free_nodeid(p)
     node_name = name
     node_value = (make_value('nodelist.node.ring0_addr', node_addr) +
                   make_value('nodelist.node.nodeid', str(node_id)))

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2413,9 +2413,13 @@ def is_qdevice_tls_on():
     return corosync.get_value("quorum.device.net.tls") == "on"
 
 
-def get_nodeinfo_from_cmaptool():
+def get_nodeinfo_from_cmaptool(remote=None):
     nodeid_ip_dict = {}
-    rc, out = get_stdout("corosync-cmapctl -b runtime.totem.pg.mrp.srp.members")
+    cmd = "corosync-cmapctl -b runtime.totem.pg.mrp.srp.members"
+    if remote:
+        rc, out, _ = get_stdout_stderr_auto_ssh_no_input(remote, cmd)
+    else:
+        rc, out = get_stdout(cmd)
     if rc != 0:
         return nodeid_ip_dict
 

--- a/test/features/bootstrap_bugs.feature
+++ b/test/features/bootstrap_bugs.feature
@@ -221,3 +221,26 @@ Feature: Regression test for bootstrap bugs
     And     Expected "hacluster:haclient" in stdout
     And     Run "stat -c '%U:%G' ~hacluster/.ssh/authorized_keys" OK on "hanode2"
     And     Expected "hacluster:haclient" in stdout
+
+  @clean
+  Scenario: Avoid mixed up of nodeid and ip addresses after node removal and rejoin (bsc#1259683)
+    Given   Cluster service is "stopped" on "hanode1"
+    And     Cluster service is "stopped" on "hanode2"
+    And     Cluster service is "stopped" on "hanode3"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2,hanode3"
+    Then    Cluster service is "started" on "hanode2"
+    And     Cluster service is "started" on "hanode3"
+    When    Run "crm cluster remove hanode2 -y" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode2"
+    When    Run "crm cluster remove hanode3 -y" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode3"
+    When    Wait "5" seconds
+    When    Run "crm cluster join -c hanode1 -y" on "hanode3"
+    Then    Cluster service is "started" on "hanode3"
+    When    Run "crm cluster join -c hanode1 -y" on "hanode2"
+    Then    Cluster service is "started" on "hanode2"
+    When    Run "crm cluster remove hanode3 -y" on "hanode1"
+    Then    Cluster service is "stopped" on "hanode3"
+    And     Online nodes are "hanode1 hanode2"

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -346,7 +346,7 @@ class TestCorosyncParser(unittest.TestCase):
     @mock.patch("crmsh.corosync.Parser")
     @mock.patch("crmsh.corosync.conf")
     @mock.patch("crmsh.utils.read_from_file")
-    def test_find_configured_ip_no_exception(self, mock_read_file, mock_conf, mock_parser, mock_search, mock_isv6, mock_ip_local):
+    def test_assert_ip_not_configured_no_exception(self, mock_read_file, mock_conf, mock_parser, mock_search, mock_isv6, mock_ip_local):
         mock_conf.return_value = "/etc/corosync/corosync.conf"
         mock_parser_inst = mock.Mock()
         mock_parser.return_value = mock_parser_inst
@@ -357,7 +357,7 @@ class TestCorosyncParser(unittest.TestCase):
         mock_isv6.return_value = False
         mock_ip_local.return_value = ["192.168.1.1", "10.10.10.2", "20.20.20.2"]
 
-        corosync.find_configured_ip(["10.10.10.2"])
+        corosync.assert_ip_not_configured(["10.10.10.2"])
 
         mock_conf.assert_called_once_with()
         mock_parser.assert_called_once_with("data")
@@ -373,7 +373,7 @@ class TestCorosyncParser(unittest.TestCase):
     @mock.patch("crmsh.corosync.Parser")
     @mock.patch("crmsh.corosync.conf")
     @mock.patch("crmsh.utils.read_from_file")
-    def test_find_configured_ip_exception(self, mock_read_file, mock_conf, mock_parser, mock_search, mock_isv6, mock_ip_local):
+    def test_assert_ip_not_configured_exception(self, mock_read_file, mock_conf, mock_parser, mock_search, mock_isv6, mock_ip_local):
         mock_conf.return_value = "/etc/corosync/corosync.conf"
         mock_parser_inst = mock.Mock()
         mock_parser.return_value = mock_parser_inst
@@ -385,7 +385,7 @@ class TestCorosyncParser(unittest.TestCase):
         mock_ip_local.return_value = ["192.168.1.1", "10.10.10.2", "20.20.20.2"]
 
         with self.assertRaises(corosync.IPAlreadyConfiguredError) as err:
-            corosync.find_configured_ip(["10.10.10.2"])
+            corosync.assert_ip_not_configured(["10.10.10.2"])
         self.assertEqual("IP 10.10.10.2 was already configured", str(err.exception))
 
         mock_conf.assert_called_once_with()
@@ -402,16 +402,18 @@ class TestCorosyncParser(unittest.TestCase):
     @mock.patch("crmsh.corosync.get_values")
     @mock.patch("crmsh.corosync.make_value")
     @mock.patch("crmsh.corosync.get_free_nodeid")
+    @mock.patch("crmsh.corosync.get_nodeid_by_ip_from_cmap")
     @mock.patch("crmsh.corosync.Parser")
     @mock.patch("crmsh.utils.read_from_file")
     @mock.patch("crmsh.corosync.conf")
-    @mock.patch("crmsh.corosync.find_configured_ip")
-    def test_add_node_ucast(self, mock_find_ip, mock_conf, mock_read_file, mock_parser,
-            mock_free_id, mock_make_value, mock_get_values, mock_make_section, mock_str2file):
+    @mock.patch("crmsh.corosync.assert_ip_not_configured")
+    def test_add_node_ucast(self, mock_assert_ip, mock_conf, mock_read_file, mock_parser,
+            mock_get_node_id_by_ip, mock_free_id, mock_make_value, mock_get_values, mock_make_section, mock_str2file):
         mock_parser_inst = mock.Mock()
         mock_conf.side_effect = ["corosync.conf", "corosync.conf"]
         mock_read_file.return_value = "data"
         mock_parser.return_value = mock_parser_inst
+        mock_get_node_id_by_ip.return_value = None
         mock_free_id.return_value = 2
         mock_make_value.side_effect = [["value1"], ["value2"]]
         mock_get_values.return_value = []
@@ -422,9 +424,10 @@ class TestCorosyncParser(unittest.TestCase):
 
         corosync.add_node_ucast(['10.10.10.1'])
 
-        mock_find_ip.assert_called_once_with(['10.10.10.1'])
+        mock_assert_ip.assert_called_once_with(['10.10.10.1'])
         mock_parser.assert_called_once_with("data")
-        mock_free_id.assert_called_once_with(mock_parser_inst)
+        mock_get_node_id_by_ip.assert_called_once_with(['10.10.10.1'], remote=None)
+        mock_free_id.assert_called_once_with(mock_parser_inst, remote=None)
         mock_make_value.assert_has_calls([
             mock.call('nodelist.node.ring0_addr', '10.10.10.1'),
             mock.call('nodelist.node.nodeid', '2')
@@ -477,7 +480,16 @@ class TestCorosyncParser(unittest.TestCase):
         _valid(p)
         self.assertEqual(p.count('service.ver'), 1)
 
-    def test_get_free_nodeid(self):
+    @mock.patch('crmsh.utils.get_nodeinfo_from_cmaptool')
+    def test_get_nodeid_by_ip_from_cmap(self, mock_cmap):
+        mock_cmap.return_value = {'1': ['192.0.2.1'], '2': ['192.0.2.2']}
+        self.assertEqual(1, corosync.get_nodeid_by_ip_from_cmap(['192.0.2.1']))
+        self.assertEqual(2, corosync.get_nodeid_by_ip_from_cmap(['192.0.2.2']))
+        self.assertEqual(None, corosync.get_nodeid_by_ip_from_cmap(['192.0.2.3']))
+
+    @mock.patch('crmsh.utils.get_nodeinfo_from_cmaptool')
+    def test_get_free_nodeid(self, mock_cmap):
+        mock_cmap.return_value = {}
         def ids(*lst):
             class Ids(object):
                 def get_all(self, _arg):
@@ -486,6 +498,11 @@ class TestCorosyncParser(unittest.TestCase):
         self.assertEqual(1, corosync.get_free_nodeid(ids('2', '5')))
         self.assertEqual(3, corosync.get_free_nodeid(ids('1', '2', '5')))
         self.assertEqual(4, corosync.get_free_nodeid(ids('1', '2', '3')))
+
+        mock_cmap.return_value = {'2': ['192.0.2.2'], '3': ['192.0.2.3']}
+        self.assertEqual(4, corosync.get_free_nodeid(ids('1')))
+        self.assertEqual(1, corosync.get_free_nodeid(ids()))
+        self.assertEqual(5, corosync.get_free_nodeid(ids('1', '4')))
 
 
 if __name__ == '__main__':

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -460,6 +460,15 @@ def test_get_nodeinfo_from_cmaptool(mock_get_stdout, mock_search, mock_findall):
         mock.call(r'[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}', 'runtime.totem.pg.mrp.srp.members.2.ip (str) = r(0) ip(192.168.43.128)')
     ])
 
+
+@mock.patch("crmsh.utils.get_stdout_stderr_auto_ssh_no_input")
+def test_get_nodeinfo_from_cmaptool_remote(mock_get_stdout):
+    mock_get_stdout.return_value = (0, 'runtime.totem.pg.mrp.srp.members.1.ip (str) = r(0) ip(192.0.2.1)', None)
+
+    result = utils.get_nodeinfo_from_cmaptool(remote="node1")
+    assert result['1'] == ["192.0.2.1"]
+    mock_get_stdout.assert_called_once_with("node1", "corosync-cmapctl -b runtime.totem.pg.mrp.srp.members")
+
 @mock.patch("crmsh.utils.get_nodeinfo_from_cmaptool")
 @mock.patch("crmsh.utils.service_is_active")
 def test_valid_nodeid_false_service_not_active(mock_is_active, mock_nodeinfo):


### PR DESCRIPTION
When a node is removed and then added back, crmsh should reuse the original nodeid if it's still present in corosync's runtime state (cmap). Reusing a different node's previous nodeid can cause corosync to incorrectly map IP addresses, leading to unexpected node removals or fencing when a node is later removed.

- Add `remote` parameter support to `get_nodeinfo_from_cmaptool`, `add_node_ucast`, and related functions, to retrieve nodeinfo from seed host during joining
- Add get_nodeid_by_ip_from_cmap() to lookup nodeid in cmap
- Update get_free_nodeid() to exclude nodeids currently in cmap
- Update add_node_ucast() and add_node() to reuse nodeid from cmap
- Add support for remote cmap lookup in utils.get_nodeinfo_from_cmaptool()
- Rename find_configured_ip to assert_ip_not_configured for clarity
- Add unit tests to verify the new logic and remote lookup functionality