### PR TITLE
Dev: sbd: And check and fix methods for fence_sbd pcmk_delay_max and crashdump parameter

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2790,14 +2790,11 @@ def adjust_pcmk_delay_max(is_2node_wo_qdevice):
 
 def adjust_fencing_timeout():
     """
-    Adjust fencing-timeout for sbd and other scenarios
+    Adjust fencing-timeout for non sbd scenarios
     """
-    if ServiceManager().service_is_active(constants.SBD_SERVICE):
-        sbd.SBDConfigChecker(quiet=True, fix=True).check_and_fix()
-    else:
-        value = get_fencing_timeout_generally_expected()
-        if value:
-            utils.set_property("fencing-timeout", value, conditional=True)
+    value = get_fencing_timeout_generally_expected()
+    if value:
+        utils.set_property("fencing-timeout", value, conditional=True)
 
 
 def adjust_properties():
@@ -2814,11 +2811,15 @@ def adjust_properties():
     - remove qdevice
     - add sbd via stage
     """
-    if not ServiceManager().service_is_active("pacemaker.service"):
+    service_manager = ServiceManager()
+    if not service_manager.service_is_active("pacemaker.service"):
         return
     is_2node_wo_qdevice = utils.is_2node_cluster_without_qdevice()
-    adjust_pcmk_delay_max(is_2node_wo_qdevice)
-    adjust_fencing_timeout()
+    if service_manager.service_is_active(constants.SBD_SERVICE):
+        sbd.SBDConfigChecker(quiet=True, fix=True).check_and_fix()
+    else:
+        adjust_pcmk_delay_max(is_2node_wo_qdevice)
+        adjust_fencing_timeout()
     adjust_priority_in_rsc_defaults(is_2node_wo_qdevice)
     adjust_priority_fencing_delay(is_2node_wo_qdevice)
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -187,6 +187,22 @@ class SBDUtils:
         value = utils.get_property("fencing-watchdog-timeout")
         return value and utils.crm_msec(value) > 0
 
+    @staticmethod
+    def get_fence_sbd_parameters() -> list[dict]:
+        configure_show_output = sh.cluster_shell().get_stdout_or_raise_error("crm configure show xml")
+        configure_show_in_xml = xmlutil.text2elem(configure_show_output)
+        ra_inst = cibquery.ResourceAgent("stonith", "", "fence_sbd")
+        res_id_list = cibquery.get_primitives_with_ra(configure_show_in_xml, ra_inst)
+
+        parameter_list = []
+        for res in res_id_list:
+            parameter_list.append({
+                "resource_id": res,
+                "crashdump": cibquery.get_parameter_value(configure_show_in_xml, res, "crashdump"),
+                "pcmk_delay_max": cibquery.get_parameter_value(configure_show_in_xml, res, "pcmk_delay_max"),
+            })
+        return parameter_list
+
 
 class SBDTimeout(object):
     '''
@@ -320,6 +336,7 @@ class SBDTimeout(object):
             self.sbd_msgwait = device_metadata.get("msgwait")
             self.sbd_watchdog_timeout = device_metadata.get("watchdog")
             self.pcmk_delay_max = utils.get_pcmk_delay_max(self.two_node_without_qdevice)
+            self.fence_sbd_parameters = SBDUtils.get_fence_sbd_parameters()
         else:  # disk-less
             self.disk_based = False
             self.sbd_watchdog_timeout = SBDTimeout.get_sbd_watchdog_timeout()
@@ -490,6 +507,7 @@ class SBDCheckItem(IntEnum):
     SBD_DEVICE_METADATA_CONSISTENCY = auto()
     SBD_WATCHDOG_TIMEOUT = auto()
     FENCE_SBD_AGENT = auto()
+    FENCE_SBD_AGENT_PARAMETERS = auto()
     SBD_DELAY_START = auto()
     SBD_SYSTEMD_START_TIMEOUT = auto()
     FENCING_WATCHDOG_TIMEOUT_PROPERTY = auto()
@@ -569,6 +587,14 @@ class SBDConfigChecker(SBDTimeout):
             ),
 
             (
+                "fence_sbd agent parameters",
+                self._check_fence_sbd_parameters,
+                self._fix_fence_sbd_parameters,
+                False,
+                [SBDCheckItem.FENCE_SBD_AGENT]
+            ),
+
+            (
                 "SBD_DELAY_START",
                 self._check_sbd_delay_start,
                 self._fix_sbd_delay_start,
@@ -576,7 +602,7 @@ class SBDConfigChecker(SBDTimeout):
                 [
                     SBDCheckItem.SBD_DISK_METADATA,
                     SBDCheckItem.SBD_WATCHDOG_TIMEOUT,
-                    SBDCheckItem.FENCE_SBD_AGENT
+                    SBDCheckItem.FENCE_SBD_AGENT_PARAMETERS
                 ]
             ),
 
@@ -992,6 +1018,7 @@ class SBDConfigChecker(SBDTimeout):
     def _check_fence_sbd(self) -> CheckResult:
         if not self.disk_based:
             return CheckResult.SUCCESS
+
         xml_inst = xmlutil.CrmMonXmlParser()
         if xml_inst.not_connected():
             cib = xmlutil.text2elem(sh.cluster_shell().get_stdout_or_raise_error("crm configure show xml"))
@@ -1020,6 +1047,7 @@ class SBDConfigChecker(SBDTimeout):
                 SBDManager.SBD_RA
             )
             return CheckResult.ERROR
+
         return CheckResult.SUCCESS
 
     def _fix_fence_sbd(self):
@@ -1029,8 +1057,9 @@ class SBDConfigChecker(SBDTimeout):
             logger.info("Configuring fence agent %s", SBDManager.SBD_RA)
             cmd = f"crm configure primitive {SBDManager.SBD_RA_ID} {SBDManager.SBD_RA}"
             shell.get_stdout_or_raise_error(cmd)
-            is_2node_wo_qdevice = utils.is_2node_cluster_without_qdevice()
-            bootstrap.adjust_pcmk_delay_max(is_2node_wo_qdevice)
+            if self.two_node_without_qdevice:
+                cmd = f"crm resource param {SBDManager.SBD_RA_ID} set pcmk_delay_max {constants.PCMK_DELAY_MAX}s"
+                shell.get_stdout_or_raise_error(cmd)
         elif not xml_inst.is_resource_started(SBDManager.SBD_RA):
             res_id_list = xml_inst.get_resource_id_list_via_type(SBDManager.SBD_RA)
             for res_id in res_id_list:
@@ -1047,6 +1076,77 @@ class SBDConfigChecker(SBDTimeout):
             "stonith-enabled"
         ):
             utils.DeprecatedTermTranslator(prop).check()
+
+    def _check_fence_sbd_parameters(self) -> CheckResult:
+        if not self.disk_based:
+            return CheckResult.SUCCESS
+        if not self.fence_sbd_parameters:
+            self._log_when_not_quiet(
+                logging.ERROR,
+                "Fence agent %s is not configured",
+                SBDManager.SBD_RA
+            )
+            return CheckResult.ERROR
+
+        result_list = []
+        for fence_sbd_param in self.fence_sbd_parameters:
+            res_id, crashdump, pcmk_delay_max = fence_sbd_param.values()
+            if utils.is_boolean_false(crashdump) and self.crashdump_watchdog_timeout:
+                self._log_when_not_quiet(
+                    logging.ERROR,
+                    "It's required that crashdump parameter is set to '1' in resource %s when sbd crashdump is configured, now is not set",
+                    res_id
+                )
+                result_list.append(CheckResult.ERROR)
+            elif utils.is_boolean_true(crashdump) and not self.crashdump_watchdog_timeout:
+                self._log_when_not_quiet(
+                    logging.WARNING,
+                    "It's recommended that crashdump parameter should not be set in resource %s when sbd crashdump is not configured",
+                    res_id
+                )
+                result_list.append(CheckResult.WARNING)
+
+            if self.two_node_without_qdevice and not pcmk_delay_max:
+                self._log_when_not_quiet(
+                    logging.ERROR,
+                    "It's required that pcmk_delay_max parameter is set to %ds in resource %s for 2-node cluster without qdevice, now is not set",
+                    constants.PCMK_DELAY_MAX, res_id
+                )
+                result_list.append(CheckResult.ERROR)
+            elif pcmk_delay_max and not self.two_node_without_qdevice:
+                self._log_when_not_quiet(
+                    logging.WARNING,
+                    "It's recommended that pcmk_delay_max parameter should not be set in resource %s for clusters other than 2-node cluster without qdevice",
+                    res_id
+                )
+                result_list.append(CheckResult.WARNING)
+
+        return SBDConfigChecker._return_helper(result_list)
+
+    def _fix_fence_sbd_parameters(self):
+        shell = sh.cluster_shell()
+        for fence_sbd_param in self.fence_sbd_parameters:
+            cmd_for_crashdump, cmd_for_pcmk_delay_max = None, None
+            res_id, crashdump, pcmk_delay_max = fence_sbd_param.values()
+
+            if utils.is_boolean_false(crashdump) and self.crashdump_watchdog_timeout:
+                logger.info("Setting crashdump parameter to '1' in resource %s", res_id)
+                cmd_for_crashdump = f"crm resource param {res_id} set crashdump 1"
+            elif utils.is_boolean_true(crashdump) and not self.crashdump_watchdog_timeout:
+                logger.info("Removing crashdump parameter in resource %s", res_id)
+                cmd_for_crashdump = f"crm resource param {res_id} delete crashdump"
+            if cmd_for_crashdump:
+                shell.get_stdout_or_raise_error(cmd_for_crashdump)
+
+            if self.two_node_without_qdevice and not pcmk_delay_max:
+                logger.info("Setting pcmk_delay_max parameter to %ds in resource %s", constants.PCMK_DELAY_MAX, res_id)
+                cmd_for_pcmk_delay_max = f"crm resource param {res_id} set pcmk_delay_max {constants.PCMK_DELAY_MAX}s"
+            elif pcmk_delay_max and not self.two_node_without_qdevice:
+                logger.info("Removing pcmk_delay_max parameter in resource %s", res_id)
+                cmd_for_pcmk_delay_max = f"crm resource param {res_id} delete pcmk_delay_max"
+            if cmd_for_pcmk_delay_max:
+                shell.get_stdout_or_raise_error(cmd_for_pcmk_delay_max)
+
 
 class SBDManager:
     SYSCONFIG_SBD = "/etc/sysconfig/sbd"

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -369,6 +369,17 @@ Feature: configure sbd delay start correctly
     Then    Expected "It's required that fencing-timeout is set to 71, now is 50" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
     Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    # check crashdump and pcmk_delay_max
+    When    Run "crm resource param fencing-sbd set crashdump 1" on "hanode1"
+    When    Run "crm resource param fencing-sbd delete pcmk_delay_max" on "hanode1"
+    When    Try "crm cluster health sbd" on "hanode1"
+    Then    Expected multiple lines in stderr
+      """
+      It's recommended that crashdump parameter should not be set in resource fencing-sbd when sbd crashdump is not configured
+      It's required that pcmk_delay_max parameter is set to 30s in resource fencing-sbd for 2-node cluster without qdevice, now is not set
+      """
+    When    Run "crm cluster health sbd --fix" on "hanode1"
+    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
     # Adjust token timeout in corosync.conf
     When    Run "sed -i 's/token: .*/token: 10000/' /etc/corosync/corosync.conf" on "hanode1"
     When    Run "sed -i 's/token: .*/token: 10000/' /etc/corosync/corosync.conf" on "hanode2"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1493,21 +1493,9 @@ done
         bootstrap.adjust_pcmk_delay_max(False)
         mock_run.assert_called_once_with("crm resource param res_1 delete pcmk_delay_max")
 
-    @mock.patch('crmsh.sbd.SBDConfigChecker')
-    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    def test_adjust_fencing_timeout_sbd(self, mock_is_active, mock_sbd_checker):
-        mock_sbd_checker_inst = mock.Mock()
-        mock_sbd_checker.return_value = mock_sbd_checker_inst
-        mock_sbd_checker_inst.check_and_fix = mock.Mock()
-        mock_is_active.return_value = True
-        bootstrap.adjust_fencing_timeout()
-        mock_sbd_checker.assert_called_once_with(quiet=True, fix=True)
-
     @mock.patch('crmsh.utils.set_property')
     @mock.patch('crmsh.bootstrap.get_fencing_timeout_generally_expected')
-    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
-    def test_adjust_fencing_timeout(self, mock_is_active, mock_get_timeout, mock_set):
-        mock_is_active.return_value = False
+    def test_adjust_fencing_timeout(self, mock_get_timeout, mock_set):
         mock_get_timeout.return_value = 30
         bootstrap.adjust_fencing_timeout()
         mock_set.assert_called_once_with("fencing-timeout", 30, conditional=True)
@@ -1549,10 +1537,13 @@ done
     @mock.patch('crmsh.utils.is_2node_cluster_without_qdevice')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     def test_adjust_properties(self, mock_is_active, mock_2node_qdevice, mock_adj_pcmk, mock_adj_fencing, mock_adj_priority, mock_adj_fence):
-        mock_is_active.return_value = True
+        mock_is_active.side_effect = [True, False]
         mock_2node_qdevice.return_value = True
         bootstrap.adjust_properties()
-        mock_is_active.assert_called_once_with("pacemaker.service")
+        mock_is_active.assert_has_calls([
+            mock.call("pacemaker.service"),
+            mock.call("sbd.service")
+        ])
         mock_adj_pcmk.assert_called_once_with(True)
         mock_adj_fencing.assert_called_once_with()
         mock_adj_priority.assert_called_once_with(True)


### PR DESCRIPTION
- Check and fix pcmk_delay_max when missing
```
# crm cluster health sbd
ERROR: It's required that pcmk_delay_max parameter is set to 30s in resource fencing-sbd for 2-node cluster without qdevice, now is not set
INFO: Please run "crm cluster health sbd --fix" to fix the above error on the running cluster
ERROR: SBD: Check sbd timeout configuration: FAIL.

# crm cluster health sbd --fix
INFO: Setting pcmk_delay_max parameter to 30s in resource fencing-sbd
INFO: SBD: Check sbd timeout configuration: OK.
```

- Check and fix pcmk_delay_max when there is no need to have

```
# crm cluster health sbd
WARNING: It's recommended that pcmk_delay_max parameter should not be set in resource fencing-sbd for clusters other than 2-node cluster without qdevice
INFO: Please run "crm cluster health sbd --fix" to fix the above error on the running cluster
ERROR: SBD: Check sbd timeout configuration: FAIL.

# crm cluster health sbd --fix
INFO: Removing pcmk_delay_max parameter in resource fencing-sbd
INFO: SBD: Check sbd timeout configuration: OK.
```
- Check and fix crashdump when missing
```
# crm cluster health sbd
ERROR: It's required that crashdump parameter is set to '1' in resource fencing-sbd when sbd crashdump is configured, now is not set
INFO: Please run "crm cluster health sbd --fix" to fix the above error on the running cluster
ERROR: SBD: Check sbd timeout configuration: FAIL.

# crm cluster health sbd --fix
INFO: Setting crashdump parameter to '1' in resource fencing-sbd
INFO: SBD: Check sbd timeout configuration: OK.
```
- Check and fix crashdump when there is no need to have
```
# crm cluster health sbd
WARNING: It's recommended that crashdump parameter should not be set in resource fencing-sbd when sbd crashdump is not configured
INFO: Please run "crm cluster health sbd --fix" to fix the above error on the running cluster
ERROR: SBD: Check sbd timeout configuration: FAIL.

# crm cluster health sbd --fix
INFO: Removing crashdump parameter in resource fencing-sbd
INFO: SBD: Check sbd timeout configuration: OK.
```