### PR TITLE
[crmsh-4.6] Fix: bootstrap: Ensure robust node identification when removing from cluster (bsc#1259683)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -13,6 +13,7 @@
 # TODO: Configuration file for bootstrap?
 import codecs
 import io
+import json
 import os
 import subprocess
 import sys
@@ -39,6 +40,7 @@ from . import corosync
 from . import tmpfiles
 from . import lock
 from . import userdir
+from . import iproute2
 from .constants import QDEVICE_HELP_INFO, STONITH_TIMEOUT_DEFAULT,\
         REJOIN_COUNT, REJOIN_INTERVAL, PCMK_DELAY_MAX, CSYNC2_SERVICE, WAIT_TIMEOUT_MS_DEFAULT
 from . import cluster_fs
@@ -2359,23 +2361,24 @@ def start_qdevice_on_join_node(seed_host):
         ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).start_service("corosync-qdevice.service", enable=True)
 
 
-def get_cluster_node_ip(node: str) -> str:
+def get_cluster_node_ips(node: str) -> list:
     """
-    ringx_addr might be hostname or IP
-    _context.cluster_node by now is always hostname
-
-    If ring0_addr is IP, we should get the configured iplist which belong _context.cluster_node
-    Then filter out which one is configured as ring0_addr
-    At last assign that ip to _context.cluster_node_ip which will be removed later
+    Get all IP addresses of the target node remotely.
+    If it fails, fall back to utils.get_iplist_from_name(node).
     """
-    addr_list = corosync.get_values('nodelist.node.ring0_addr')
-    if node in addr_list:
-        return
+    rc, out, err = sh.cluster_shell().get_rc_stdout_stderr_without_input(node, "ip -j addr show")
+    if rc == 0:
+        try:
+            addr_info = iproute2.IPAddr(json.loads(out))
+            ips = []
+            for iface in addr_info.interfaces():
+                for addr in iface.addr_info:
+                    ips.append(str(addr.ip))
+            return ips
+        except Exception as e:
+            logger.warning("Failed to parse ip output from node {}: {}".format(node, e))
 
-    ip_list = utils.get_iplist_from_name(node)
-    for ip in ip_list:
-        if ip in addr_list:
-            return ip
+    return utils.get_iplist_from_name(node)
 
 
 def stop_and_disable_services(remote_addr=None):
@@ -2428,7 +2431,7 @@ def remove_node_from_cluster(node, dead_node=False):
         remove_pacemaker_remote_node_from_cluster(node)
         return
 
-    node_ip = get_cluster_node_ip(node)
+    nodeid = utils.get_nodeid_from_name(node)
     if not dead_node:
         stop_and_disable_services(remote_addr=node)
         qdevice.QDevice.remove_qdevice_db([node])
@@ -2444,7 +2447,15 @@ def remove_node_from_cluster(node, dead_node=False):
 
     # Remove node from nodelist
     if corosync.get_values("nodelist.node.ring0_addr"):
-        corosync.del_node(node_ip if node_ip is not None else node)
+        if corosync.del_node_by_name(node):
+            pass
+        elif nodeid and corosync.del_node_by_nodeid(nodeid):
+            pass
+        else:
+            node_ips = get_cluster_node_ips(node)
+            node_ips.append(node)
+            if not corosync.del_node(node_ips):
+                utils.fatal("Failed to remove node {} from corosync configuration".format(node))
 
     decrease_expected_votes()
 

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -575,14 +575,14 @@ def add_node(addr, name=None):
                            "str", node_name], shell=False)
 
 
-def del_node(addr):
+def del_node_by_name(name):
     '''
-    Remove node from corosync
+    Remove node from corosync by node name
     '''
     p = Parser(utils.read_from_file(conf()))
-    nth = p.remove_section_where('nodelist.node', 'ring0_addr', addr)
+    nth = p.remove_section_where('nodelist.node', 'name', name)
     if nth == -1:
-        return
+        return False
 
     num_nodes = p.count('nodelist.node')
     p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
@@ -590,6 +590,50 @@ def del_node(addr):
         p.set('quorum.two_node', '0')
 
     utils.str2file(p.to_string(), conf())
+    return True
+
+
+def del_node_by_nodeid(nodeid):
+    '''
+    Remove node from corosync by nodeid
+    '''
+    p = Parser(utils.read_from_file(conf()))
+    nth = p.remove_section_where('nodelist.node', 'nodeid', str(nodeid))
+    if nth == -1:
+        return False
+
+    num_nodes = p.count('nodelist.node')
+    p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
+    if p.get("quorum.device.model") == "net":
+        p.set('quorum.two_node', '0')
+
+    utils.str2file(p.to_string(), conf())
+    return True
+
+
+def del_node(addrs):
+    '''
+    Remove node from corosync
+    '''
+    p = Parser(utils.read_from_file(conf()))
+    if not isinstance(addrs, list):
+        addrs = [addrs]
+    nth = -1
+    for addr in addrs:
+        nth = p.remove_section_where('nodelist.node', 'ring0_addr', addr)
+        if nth != -1:
+            break
+
+    if nth == -1:
+        return False
+
+    num_nodes = p.count('nodelist.node')
+    p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
+    if p.get("quorum.device.model") == "net":
+        p.set('quorum.two_node', '0')
+
+    utils.str2file(p.to_string(), conf())
+    return True
 
 
 _COROSYNC_CONF_TEMPLATE_HEAD = """# Please read the corosync.conf.5 manual page

--- a/crmsh/iproute2.py
+++ b/crmsh/iproute2.py
@@ -1,0 +1,28 @@
+"""Interface to iproute2 commands"""
+import ipaddress
+
+
+class IPInterface:
+    def __init__(self, ifname, flags, addr_info):
+        self.ifname = ifname
+        self.flags = flags
+        self.addr_info = addr_info
+
+
+class IPAddr:
+    def __init__(self, json):
+        # json: the output of 'ip -j addr'
+        self._json = json
+
+    def interfaces(self):
+        return [
+            IPInterface(
+                interface['ifname'],
+                set(interface['flags']),
+                {
+                    ipaddress.ip_interface(f'{x["local"]}/{x["prefixlen"]}')
+                    for x in interface['addr_info']
+                },
+            )
+            for interface in self._json
+        ]

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1807,22 +1807,25 @@ class TestValidation(unittest.TestCase):
             mock.call('cp /usr/share/fillup-templates/sysconfig.sbd /etc/sysconfig/sbd', None)
             ])
 
+    @mock.patch('crmsh.sh.cluster_shell')
     @mock.patch('crmsh.utils.get_iplist_from_name')
-    @mock.patch('crmsh.corosync.get_values')
-    def test_get_cluster_node_ip_host(self, mock_get_values, mock_get_iplist):
-        mock_get_values.return_value = ["node1", "node2"]
-        self.assertIsNone(bootstrap.get_cluster_node_ip('node1'))
-        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
-        mock_get_iplist.assert_not_called()
-
-    @mock.patch('crmsh.utils.get_iplist_from_name')
-    @mock.patch('crmsh.corosync.get_values')
-    def test_get_cluster_node_ip(self, mock_get_values, mock_get_iplist):
-        mock_get_values.return_value = ["10.10.10.1", "10.10.10.2"]
+    def test_get_cluster_node_ips_fallback(self, mock_get_iplist, mock_cluster_shell):
+        mock_get_remote_stdout = mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input
+        mock_get_remote_stdout.return_value = (1, "", "")
         mock_get_iplist.return_value = ["10.10.10.1"]
-        self.assertEqual("10.10.10.1", bootstrap.get_cluster_node_ip('node1'))
-        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        self.assertEqual(["10.10.10.1"], bootstrap.get_cluster_node_ips('node1'))
+        mock_get_remote_stdout.assert_called_once_with('node1', 'ip -j addr show')
         mock_get_iplist.assert_called_once_with('node1')
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    @mock.patch('crmsh.utils.get_iplist_from_name')
+    def test_get_cluster_node_ips_success(self, mock_get_iplist, mock_cluster_shell):
+        mock_get_remote_stdout = mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input
+        json_out = '[{"ifname":"eth0","flags":[],"addr_info":[{"local":"10.10.10.1","prefixlen":24}]}]'
+        mock_get_remote_stdout.return_value = (0, json_out, "")
+        self.assertEqual(["10.10.10.1"], bootstrap.get_cluster_node_ips('node1'))
+        mock_get_remote_stdout.assert_called_once_with('node1', 'ip -j addr show')
+        mock_get_iplist.assert_not_called()
 
     @mock.patch('crmsh.service_manager.ServiceManager.disable_service')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_enabled')
@@ -1861,13 +1864,13 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
+    @mock.patch('crmsh.utils.get_nodeid_from_name')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_remove_node_from_cluster_rm_node_failed(self, mock_crm_mon_parser, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_error, mock_rm_conf_files, mock_call_delnode):
+    def test_remove_node_from_cluster_rm_node_failed(self, mock_crm_mon_parser, mock_get_nodeid, mock_stop, mock_status, mock_invoke, mock_error, mock_rm_conf_files, mock_call_delnode):
         mock_crm_mon_parser_inst = mock.Mock()
         mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
         mock_crm_mon_parser_inst.is_node_remote.return_value = False
-        mock_get_ip.return_value = '192.0.2.100'
+        mock_get_nodeid.return_value = '1'
         mock_call_delnode.return_value = False
         mock_error.side_effect = SystemExit
 
@@ -1875,7 +1878,7 @@ class TestValidation(unittest.TestCase):
             bootstrap._context = mock.Mock(rm_list=["file1", "file2"])
             bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with('node1')
+        mock_get_nodeid.assert_called_once_with('node1')
         mock_status.assert_called_once_with("Removing node %s from CIB", "node1")
         mock_stop.assert_called_once_with(remote_addr="node1")
         mock_invoke.assert_not_called()
@@ -1889,13 +1892,13 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
+    @mock.patch('crmsh.utils.get_nodeid_from_name')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_remove_node_from_cluster_rm_csync_failed(self, mock_crm_mon_parser, mock_get_ip, mock_stop, mock_status, mock_invoke, mock_invokerc, mock_error, mock_rm_conf_files, mock_call_delnode):
+    def test_remove_node_from_cluster_rm_csync_failed(self, mock_crm_mon_parser, mock_get_nodeid, mock_stop, mock_status, mock_invoke, mock_invokerc, mock_error, mock_rm_conf_files, mock_call_delnode):
         mock_crm_mon_parser_inst = mock.Mock()
         mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
         mock_crm_mon_parser_inst.is_node_remote.return_value = False
-        mock_get_ip.return_value = '192.0.2.100'
+        mock_get_nodeid.return_value = '1'
         mock_call_delnode.return_value = True
         mock_invokerc.return_value = False
         mock_error.side_effect = SystemExit
@@ -1904,7 +1907,7 @@ class TestValidation(unittest.TestCase):
             bootstrap._context = mock.Mock(rm_list=["file1", "file2"])
             bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with('node1')
+        mock_get_nodeid.assert_called_once_with('node1')
         mock_status.assert_called_once_with("Removing node %s from CIB", "node1")
         mock_stop.assert_called_once_with(remote_addr="node1")
         mock_invoke.assert_not_called()
@@ -1922,32 +1925,35 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.adjust_priority_in_rsc_defaults')
     @mock.patch('crmsh.bootstrap.sync_file')
     @mock.patch('crmsh.bootstrap.decrease_expected_votes')
-    @mock.patch('crmsh.corosync.del_node')
+    @mock.patch('crmsh.corosync.del_node_by_nodeid')
     @mock.patch('crmsh.corosync.get_values')
     @mock.patch('crmsh.utils.fatal')
     @mock.patch('crmsh.bootstrap.invokerc')
     @mock.patch('crmsh.bootstrap.invoke')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
-    @mock.patch('crmsh.bootstrap.get_cluster_node_ip')
+    @mock.patch('crmsh.corosync.del_node_by_name')
+    @mock.patch('crmsh.utils.get_nodeid_from_name')
     @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_remove_node_from_cluster_hostname(self, mock_crm_mon_parser, mock_get_ip, mock_stop, mock_status,
-            mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del, mock_decrease, mock_csync2,
+    def test_remove_node_from_cluster_hostname(self, mock_crm_mon_parser, mock_get_nodeid, mock_del_by_name, mock_stop, mock_status,
+            mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del_by_id, mock_decrease, mock_csync2,
             mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_host_user_config):
         mock_crm_mon_parser_inst = mock.Mock()
         mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
         mock_crm_mon_parser_inst.is_node_remote.return_value = False
-        mock_get_ip.return_value = "10.10.10.1"
+        mock_del_by_name.return_value = False
+        mock_get_nodeid.return_value = "1"
         mock_cal_delnode.return_value = True
         mock_invoke.side_effect = [(True, None, None)]
         mock_invokerc.return_value = True
         mock_get_values.return_value = ["10.10.10.1"]
         mock_is_active.return_value = False
+        mock_del_by_id.return_value = True
 
         bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
         bootstrap.remove_node_from_cluster('node1')
 
-        mock_get_ip.assert_called_once_with('node1')
+        mock_get_nodeid.assert_called_once_with('node1')
         mock_status.assert_has_calls([
             mock.call("Removing node %s from CIB", "node1"),
             mock.call("Propagating configuration changes across the remaining nodes")
@@ -1960,9 +1966,104 @@ class TestValidation(unittest.TestCase):
         mock_invokerc.assert_called_once_with("sed -i /node1/d {}".format(bootstrap.CSYNC2_CFG))
         mock_error.assert_not_called()
         mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
-        mock_del.assert_called_once_with("10.10.10.1")
+        mock_del_by_id.assert_called_once_with("1")
         mock_decrease.assert_called_once_with()
         mock_csync2.assert_has_calls([
             mock.call(bootstrap.CSYNC2_CFG),
             mock.call("/etc/corosync/corosync.conf")
             ])
+
+    @mock.patch('crmsh.bootstrap.get_cluster_node_ips')
+    @mock.patch('crmsh.corosync.del_node')
+    @mock.patch('crmsh.utils.HostUserConfig')
+    @mock.patch.object(NodeMgmt, 'call_delnode')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.bootstrap.rm_configuration_files')
+    @mock.patch('crmsh.bootstrap.adjust_priority_fencing_delay')
+    @mock.patch('crmsh.bootstrap.adjust_priority_in_rsc_defaults')
+    @mock.patch('crmsh.bootstrap.sync_file')
+    @mock.patch('crmsh.bootstrap.decrease_expected_votes')
+    @mock.patch('crmsh.corosync.del_node_by_nodeid')
+    @mock.patch('crmsh.corosync.get_values')
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.bootstrap.invokerc')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.bootstrap.stop_and_disable_services')
+    @mock.patch('crmsh.corosync.del_node_by_name')
+    @mock.patch('crmsh.utils.get_nodeid_from_name')
+    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    def test_remove_node_from_cluster_fallback_success(self, mock_crm_mon_parser, mock_get_nodeid, mock_del_by_name, mock_stop, mock_status,
+            mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del_by_id, mock_decrease, mock_csync2,
+            mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_host_user_config,
+            mock_del_node, mock_get_ips):
+        mock_crm_mon_parser_inst = mock.Mock()
+        mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
+        mock_crm_mon_parser_inst.is_node_remote.return_value = False
+        mock_is_active.return_value = False
+        mock_del_by_name.return_value = False
+        mock_get_nodeid.return_value = "1"
+        mock_cal_delnode.return_value = True
+        mock_invoke.side_effect = [(True, None, None)]
+        mock_invokerc.return_value = True
+        mock_get_values.return_value = ["10.10.10.1"]
+        mock_del_by_id.return_value = False
+        mock_get_ips.return_value = ["10.10.10.2"]
+        mock_del_node.return_value = True
+
+        bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
+        bootstrap.remove_node_from_cluster('node1')
+
+        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_del_by_id.assert_called_once_with("1")
+        mock_get_ips.assert_called_once_with("node1")
+        mock_del_node.assert_called_once_with(["10.10.10.2", "node1"])
+        mock_error.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.get_cluster_node_ips')
+    @mock.patch('crmsh.corosync.del_node')
+    @mock.patch('crmsh.utils.HostUserConfig')
+    @mock.patch.object(NodeMgmt, 'call_delnode')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.bootstrap.rm_configuration_files')
+    @mock.patch('crmsh.bootstrap.adjust_priority_fencing_delay')
+    @mock.patch('crmsh.bootstrap.adjust_priority_in_rsc_defaults')
+    @mock.patch('crmsh.bootstrap.sync_file')
+    @mock.patch('crmsh.bootstrap.decrease_expected_votes')
+    @mock.patch('crmsh.corosync.del_node_by_nodeid')
+    @mock.patch('crmsh.corosync.get_values')
+    @mock.patch('crmsh.utils.fatal')
+    @mock.patch('crmsh.bootstrap.invokerc')
+    @mock.patch('crmsh.bootstrap.invoke')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.bootstrap.stop_and_disable_services')
+    @mock.patch('crmsh.corosync.del_node_by_name')
+    @mock.patch('crmsh.utils.get_nodeid_from_name')
+    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    def test_remove_node_from_cluster_del_node_failed(self, mock_crm_mon_parser, mock_get_nodeid, mock_del_by_name, mock_stop, mock_status,
+            mock_invoke, mock_invokerc, mock_error, mock_get_values, mock_del_by_id, mock_decrease, mock_csync2,
+            mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_host_user_config,
+            mock_del_node, mock_get_ips):
+        mock_crm_mon_parser_inst = mock.Mock()
+        mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
+        mock_crm_mon_parser_inst.is_node_remote.return_value = False
+        mock_is_active.return_value = False
+        mock_del_by_name.return_value = False
+        mock_get_nodeid.return_value = None
+        mock_cal_delnode.return_value = True
+        mock_invoke.side_effect = [(True, None, None)]
+        mock_invokerc.return_value = True
+        mock_get_values.return_value = ["10.10.10.1"]
+        mock_get_ips.return_value = ["10.10.10.2"]
+        mock_del_node.return_value = False
+        mock_error.side_effect = SystemExit
+
+        bootstrap._context = mock.Mock(cluster_node="node1", rm_list=["file1", "file2"])
+        with self.assertRaises(SystemExit):
+            bootstrap.remove_node_from_cluster('node1')
+
+        mock_get_values.assert_called_once_with("nodelist.node.ring0_addr")
+        mock_del_by_id.assert_not_called()
+        mock_get_ips.assert_called_once_with("node1")
+        mock_del_node.assert_called_once_with(["10.10.10.2", "node1"])
+        mock_error.assert_called_once_with("Failed to remove node node1 from corosync configuration")

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -475,5 +475,184 @@ class TestCorosyncParser(unittest.TestCase):
         self.assertEqual(4, corosync.get_free_nodeid(ids('1', '2', '3')))
 
 
+@mock.patch("crmsh.utils.str2file")
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_by_name(mock_conf, mock_read, mock_str2file):
+    mock_conf.return_value = "corosync.conf"
+    conf_name = """
+nodelist {
+    node {
+        ring0_addr: 10.16.35.101
+        name: node1
+        nodeid: 1
+    }
+    node {
+        ring0_addr: 10.16.35.102
+        name: node2
+        nodeid: 2
+    }
+    node {
+        ring0_addr: 10.16.35.103
+        name: node3
+        nodeid: 3
+    }
+}
+quorum {
+    provider: corosync_votequorum
+}
+"""
+    mock_read.return_value = conf_name
+
+    assert corosync.del_node_by_name("node2") is True
+
+    args, _ = mock_str2file.call_args
+    updated_conf = args[0]
+    assert "name: node2" not in updated_conf
+    assert "name: node1" in updated_conf
+    assert "name: node3" in updated_conf
+    # 3 -> 2 nodes, two_node should be 1
+    assert "two_node: 1" in updated_conf
+
+
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_by_name_not_found(mock_conf, mock_read):
+    mock_conf.return_value = "corosync.conf"
+    mock_read.return_value = F2
+
+    assert corosync.del_node_by_name("nonexistent") is False
+
+
+@mock.patch("crmsh.utils.str2file")
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_by_nodeid(mock_conf, mock_read, mock_str2file):
+    mock_conf.return_value = "corosync.conf"
+    mock_read.return_value = F2
+
+    # F2 has 5 nodes. Nodeid 1 and 2 exist.
+    assert corosync.del_node_by_nodeid(2) is True
+
+    args, _ = mock_str2file.call_args
+    updated_conf = args[0]
+    # Check nodeid 2 is gone
+    assert "nodeid: 2" not in updated_conf
+    assert "nodeid: 1" in updated_conf
+    # 5 -> 4 nodes, two_node should be 0
+    assert "two_node: 0" in updated_conf
+
+
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_by_nodeid_not_found(mock_conf, mock_read):
+    mock_conf.return_value = "corosync.conf"
+    mock_read.return_value = F2
+
+    assert corosync.del_node_by_nodeid(99) is False
+
+
+@mock.patch("crmsh.utils.str2file")
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_list(mock_conf, mock_read, mock_str2file):
+    mock_conf.return_value = "corosync.conf"
+    mock_read.return_value = F2
+
+    # Test list-based removal, stop at first match
+    # IPs in F2: 10.16.35.101 to 105
+    assert corosync.del_node(["10.16.35.200", "10.16.35.103"]) is True
+
+    args, _ = mock_str2file.call_args
+    updated_conf = args[0]
+    assert "ring0_addr: 10.16.35.103" not in updated_conf
+    assert "ring0_addr: 10.16.35.101" in updated_conf
+    assert "ring0_addr: 10.16.35.102" in updated_conf
+
+
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_not_found(mock_conf, mock_read):
+    mock_conf.return_value = "corosync.conf"
+    mock_read.return_value = F2
+
+    assert corosync.del_node(["10.16.35.200", "10.16.35.201"]) is False
+
+
+@mock.patch("crmsh.utils.str2file")
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_two_node_update(mock_conf, mock_read, mock_str2file):
+    mock_conf.return_value = "corosync.conf"
+    # Create a config with 3 nodes
+    conf_3 = """
+nodelist {
+    node {
+        ring0_addr: 1.1.1.1
+        nodeid: 1
+    }
+    node {
+        ring0_addr: 1.1.1.2
+        nodeid: 2
+    }
+    node {
+        ring0_addr: 1.1.1.3
+        nodeid: 3
+    }
+}
+quorum {
+    provider: corosync_votequorum
+    two_node: 0
+}
+"""
+    mock_read.return_value = conf_3
+
+    assert corosync.del_node_by_nodeid(3) is True
+
+    args, _ = mock_str2file.call_args
+    updated_conf = args[0]
+    # Now 2 nodes, two_node should be 1
+    assert "two_node: 1" in updated_conf
+
+
+@mock.patch("crmsh.utils.str2file")
+@mock.patch("crmsh.utils.read_from_file")
+@mock.patch("crmsh.corosync.conf")
+def test_del_node_qdevice_net(mock_conf, mock_read, mock_str2file):
+    mock_conf.return_value = "corosync.conf"
+    # Create a config with 3 nodes and qdevice net
+    conf_3_qdev = """
+nodelist {
+    node {
+        ring0_addr: 1.1.1.1
+        nodeid: 1
+    }
+    node {
+        ring0_addr: 1.1.1.2
+        nodeid: 2
+    }
+    node {
+        ring0_addr: 1.1.1.3
+        nodeid: 3
+    }
+}
+quorum {
+    provider: corosync_votequorum
+    two_node: 0
+    device {
+        model: net
+    }
+}
+"""
+    mock_read.return_value = conf_3_qdev
+
+    assert corosync.del_node_by_nodeid(3) is True
+
+    args, _ = mock_str2file.call_args
+    updated_conf = args[0]
+    # Even with 2 nodes, two_node should remain 0 because of qdevice net
+    assert "two_node: 0" in updated_conf
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
port:

* #2061