### PR TITLE
Dev: bootstrap: Still set deprecated properties during bootstrap

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1496,7 +1496,7 @@ def init_cluster():
 
     logger.info("Loading initial cluster configuration")
 
-    crm_configure_load("update", """property cib-bootstrap-options: fencing-enabled=false
+    crm_configure_load("update", """property cib-bootstrap-options: stonith-enabled=false
 op_defaults op-options: timeout=600
 rsc_defaults rsc-options: resource-stickiness=1 migration-threshold=3
 """)
@@ -2805,7 +2805,7 @@ def adjust_fencing_timeout():
     """
     value = get_fencing_timeout_generally_expected()
     if value:
-        utils.set_property("fencing-timeout", value, conditional=True)
+        utils.set_property("stonith-timeout", value, conditional=True)
 
 
 def adjust_properties():

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -122,7 +122,8 @@ class FenceInfo(object):
         action_result = crmshutils.get_property("fencing-action")
         supported_actions = ra.get_property_options("fencing-action")
         if action_result is None or action_result not in supported_actions:
-            msg_error(f"Cluster property \"fencing-action\" should be {'|'.join(supported_actions)}")
+            current_action_term = crmshutils.DeprecatedTermTranslator.get_working_term("stonith-action")
+            msg_error(f"Cluster property \"{current_action_term}\" should be {'|'.join(supported_actions)}")
             return None
         return action_result
 

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -545,7 +545,7 @@ class QDevice(object):
                 sbd_watchdog_timeout_qdevice = sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
                 sbd.SBDManager.update_sbd_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
                 if self.is_stage:
-                    utils.set_property("fencing-watchdog-timeout", 2*sbd_watchdog_timeout_qdevice)
+                    utils.set_property("stonith-watchdog-timeout", 2*sbd_watchdog_timeout_qdevice)
 
     @qnetd_lock_for_same_cluster_name
     def certificate_and_config_qdevice(self):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -660,9 +660,9 @@ class SBDConfigChecker(SBDTimeout):
 
 
     def _get_current_terms(self):
-        self.current_watchdog_timeout_term = utils.DeprecatedTermTranslator.get_working_term("fencing-watchdog-timeout")
-        self.current_timeout_term = utils.DeprecatedTermTranslator.get_working_term("fencing-timeout")
-        self.current_enabled_term = utils.DeprecatedTermTranslator.get_working_term("fencing-enabled")
+        self.current_watchdog_timeout_term = utils.DeprecatedTermTranslator.get_working_term("stonith-watchdog-timeout")
+        self.current_timeout_term = utils.DeprecatedTermTranslator.get_working_term("stonith-timeout")
+        self.current_enabled_term = utils.DeprecatedTermTranslator.get_working_term("stonith-enabled")
 
     def check_and_fix(self) -> CheckResult:
         if not ServiceManager().service_is_active(constants.SBD_SERVICE):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -254,7 +254,7 @@ def _prim_params_completer(agent, args):
     elif '=' in completing:
         return []
     command.enable_custom_sort_order()
-    return utils.filter_keys(agent.get_param_list_without_deprecated(), args)
+    return utils.filter_keys(agent.params(), args)
 
 
 def _prim_meta_completer(agent, args):
@@ -632,7 +632,7 @@ class CibConfig(command.UI):
     @command.name("get_property")
     @command.alias("get-property")
     @command.skill_level('administrator')
-    @command.completers_repeating(compl.call(ra.get_properties_without_deprecated))
+    @command.completers_repeating(compl.call(ra.get_properties_list))
     def do_get_property(self, context, *args):
         "usage: get-property [-t|--true [<name>...]"
         utils.load_cib_file_env()
@@ -640,7 +640,7 @@ class CibConfig(command.UI):
         truth = any(a for a in args if a in ('-t', '--true'))
 
         if not properties:
-            utils.multicolumn(ra.get_properties_without_deprecated())
+            utils.multicolumn(ra.get_properties_list())
             return
 
         def print_value(v):
@@ -1174,7 +1174,7 @@ class CibConfig(command.UI):
         "usage: property [$id=<set_id>] <option>=<value>"
         self.__override_lower_level_attrs(*args)
         if not args:
-            utils.multicolumn(ra.get_properties_without_deprecated())
+            utils.multicolumn(ra.get_properties_list())
             return
         return self.__conf_object(context.get_command_name(), *args)
 

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -115,11 +115,6 @@ Feature: configure sbd delay start correctly
 
     When    Try "crm configure property fencing-watchdog-timeout=1" on "hanode1"
     Then    Except "It's required to set fencing-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
-    # Expect successfully set stonith-watchdog-timeout=5 since already set fencing-watchdog-timeout
-    When    Run "crm configur proerty stonith-watchdog-timeout=5" on "hanode1"
-    Then    Cluster property "fencing-watchdog-timeout" is "30"
-    When    Try "crm -F configure filter "sed 's/fencing-watchdog-timeout=30/#fencing-watchdog-timeout=30/g'"" on "hanode1"
-    Then    Expected "It's required to set stonith-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
     Then    Cluster property "fencing-watchdog-timeout" is "30"
 
   @clean
@@ -402,11 +397,11 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster init sbd -S -y" on "hanode1"
     Then    Service "sbd" is "started" on "hanode1"
     And     Service "sbd" is "started" on "hanode2"
-    # Delete fencing-watchdog-timeout
-    When    Delete property "fencing-watchdog-timeout" from cluster
+    # Delete stonith-watchdog-timeout
+    When    Delete property "stonith-watchdog-timeout" from cluster
     When    Try "crm sbd configure show" on "hanode1"
-    Then    Expected "It's required that fencing-watchdog-timeout is set to 30, now is not set" in stderr
+    Then    Expected "It's required that stonith-watchdog-timeout is set to 30, now is not set" in stderr
     When    Try "crm cluster health sbd" on "hanode1"
-    Then    Expected "It's required that fencing-watchdog-timeout is set to 30, now is not set" in stderr
+    Then    Expected "It's required that stonith-watchdog-timeout is set to 30, now is not set" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
     Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout

--- a/test/features/sbd_ui.feature
+++ b/test/features/sbd_ui.feature
@@ -111,11 +111,11 @@ Feature: crm sbd ui test cases
     When    Run "crm sbd configure crashdump-watchdog-timeout=60" on "hanode1"
     Then    Run "crm sbd configure show sysconfig |grep SBD_TIMEOUT_ACTION=flush,crashdump" OK
     Then    Run "crm sbd configure show sysconfig |grep "SBD_OPTS=\"-C 60 -Z\""" OK
-    Then    Run "crm sbd configure show property |grep fencing-watchdog-timeout=75" OK
+    Then    Run "crm sbd configure show property |grep stonith-watchdog-timeout=75" OK
     When    Run "crm sbd configure crashdump-watchdog-timeout=60" on "hanode1"
     Then    Expected "No change in SBD configuration" in stdout
     When    Run "crm sbd configure crashdump-watchdog-timeout=10" on "hanode1"
-    Then    Run "crm sbd configure show property |grep fencing-watchdog-timeout=30" OK
+    Then    Run "crm sbd configure show property |grep stonith-watchdog-timeout=30" OK
     # Purge crashdump
     When    Run "crm sbd purge crashdump" on "hanode1"
     When    Try "crm sbd configure show sysconfig |grep SBD_TIMEOUT_ACTION=flush,crashdump"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1498,7 +1498,7 @@ done
     def test_adjust_fencing_timeout(self, mock_get_timeout, mock_set):
         mock_get_timeout.return_value = 30
         bootstrap.adjust_fencing_timeout()
-        mock_set.assert_called_once_with("fencing-timeout", 30, conditional=True)
+        mock_set.assert_called_once_with("stonith-timeout", 30, conditional=True)
 
     @mock.patch('crmsh.utils.set_property')
     def test_adjust_priority_in_rsc_defaults_2node(self, mock_set):

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -76,12 +76,14 @@ class TestFenceInfo(TestCase):
         self.assertEqual(res, True)
         mock_get_property.assert_called_once_with("fencing-enabled")
 
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator.get_working_term')
     @mock.patch('crmsh.crash_test.utils.msg_error')
     @mock.patch('crmsh.ra.get_property_options')
     @mock.patch('crmsh.crash_test.utils.crmshutils.get_property')
-    def test_fence_action_none(self, mock_get_property, mock_get_property_options, mock_error):
+    def test_fence_action_none(self, mock_get_property, mock_get_property_options, mock_error, mock_get_working_term):
         mock_get_property_options.return_value = ["off", "reboot"]
         mock_get_property.return_value = None
+        mock_get_working_term.return_value = "fencing-action"
         res = self.fence_info_inst.fence_action
         self.assertEqual(res, None)
         mock_get_property.assert_called_once_with("fencing-action")

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -708,7 +708,7 @@ Membership information
 
         mock_get_sbd_value.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
         mock_update_config.assert_called_once_with({"SBD_WATCHDOG_TIMEOUT": str(sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)})
-        mock_set.assert_called_once_with("fencing-watchdog-timeout", 2*sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)
+        mock_set.assert_called_once_with("stonith-watchdog-timeout", 2*sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)
 
     @mock.patch('crmsh.sh.cluster_shell')
     @mock.patch('crmsh.utils.cluster_run_cmd')


### PR DESCRIPTION
Based on backward compatibility concerns, make such changes:
- Dev: bootstrap: Still set deprecated properties during bootstrap
- Dev: ui_configure: Don't hide deprecated properties from the completion results