### PR TITLE
Dev: ui_cluster: Improve 'rename' subcommand

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -271,7 +271,11 @@ class QDevice(object):
             cmd = f"corosync-qnetd-tool -l -c {self.cluster_name}"
             if shell.get_stdout_or_raise_error(cmd, self.qnetd_addr):
                 exception_msg = f"This cluster's name \"{self.cluster_name}\" already exists on qnetd server!"
-                suggestion_msg = "Please consider to use the different cluster-name property"
+                if self.is_stage:
+                    suggestion_msg = "Please consider to use `crm cluster rename` to change a different cluster name."
+                else:
+                    suggestion_msg = "Please consider to use -n option to specify a different cluster name."
+                suggestion_msg += "\nOr, run `crm cluster remove --qdevice` on the existing cluster beforehand."
         else:
             exception_msg = f"Package \"corosync-qnetd\" not installed on {self.qnetd_addr}!"
             suggestion_msg = f"Please install \"corosync-qnetd\" on {self.qnetd_addr}"

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -611,23 +611,19 @@ Finally run `crm cluster init qdevice` on any node in the cluster to re-deploy t
             logger.info(suggestion)
             return
 
-        cib_factory = cibconfig.cib_factory_instance()
-        old_name = cib_factory.get_property('cluster-name')
+        old_name = corosync.get_value('totem.cluster_name')
         if old_name and new_name == old_name:
-            context.fatal_error("Expected a different name")
-
-        # Update config file with the new name on all nodes
-        nodes = utils.list_cluster_nodes()
+            context.fatal_error("Expected a different cluster name")
+        logger.info("Setting totem.cluster_name to %s in corosync.conf", new_name)
         corosync.set_value('totem.cluster_name', new_name)
+
+        nodes = utils.list_cluster_nodes_except_me()
         if len(nodes) > 1:
-            nodes.remove(utils.this_node())
-            context.info("Copy cluster config file to \"{}\"".format(' '.join(nodes)))
+            logger.info("Syncing corosync.conf to other nodes in the cluster")
             corosync.push_configuration(nodes)
 
-        # Change the cluster-name property in the CIB
-        cib_factory.create_object("property", "cluster-name={}".format(new_name))
-        if not cib_factory.commit():
-            context.fatal_error("Change property cluster-name failed!")
+        logger.info("Setting cluster-name property to %s in CIB", new_name)
+        utils.set_property("cluster-name", new_name)
 
         if xmlutil.CrmMonXmlParser().is_non_stonith_resource_running():
             context.info("To apply the change, restart the cluster service at convenient time")

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -295,7 +295,7 @@ class TestQDevice(unittest.TestCase):
         mock_cluster_shell.return_value = mock_cluster_inst
         mock_cluster_inst.get_stdout_or_raise_error.return_value = "data"
         mock_installed.return_value = True
-        excepted_err_string = "This cluster's name \"cluster1\" already exists on qnetd server!\nPlease consider to use the different cluster-name property"
+        excepted_err_string = "This cluster's name \"cluster1\" already exists on qnetd server!\nPlease consider to use `crm cluster rename` to change a different cluster name.\nOr, run `crm cluster remove --qdevice` on the existing cluster beforehand."
 
         with self.assertRaises(ValueError) as err:
             self.qdevice_with_stage_cluster_name.validate_and_start_qnetd()


### PR DESCRIPTION
Changes:
- To compare the input new name with the current cluster name, get the value from corosync.conf, instead of cluster property
- Improve the log to increase clarity
- Hint the user to use `crm cluster rename` command when detecting cluster name conflict
