### PR TITLE
Dev: utils: Improve check_port_open to concurrently try all addresses (bsc#1262094)

### DIFF
--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -25,6 +25,7 @@ import bz2
 import lzma
 import json
 import socket
+import selectors
 from pathlib import Path
 from collections import defaultdict
 from contextlib import contextmanager, closing
@@ -2087,21 +2088,63 @@ def check_ssh_passwd_need(local_user, remote_user, host, shell: sh.LocalShell = 
     return rc != 0
 
 
-def check_port_open(host, port, timeout=3) -> bool:
+def check_port_open(host, port, timeout=1.0, retry=3) -> bool:
     """
     Check whether the port is open on the host
     Use getaddrinfo to support both IPv4 and IPv6
     """
     try:
-        addrinfo = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        af, socktype, proto, canonname, sa = addrinfo[0]
-        with closing(socket.socket(af, socktype, proto)) as sock:
-            sock.settimeout(timeout)
-            if sock.connect_ex(sa) == 0:
-                return True
-        return False
+        addrinfos = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
     except socket.error:
         return False
+
+    for i in range(retry):
+        start_time = time.time()
+        sel = selectors.DefaultSelector()
+        sockets = []
+
+        for addrinfo in addrinfos:
+            af, socktype, proto, canonname, sa = addrinfo
+            sock = None
+            try:
+                sock = socket.socket(af, socktype, proto)
+                sock.setblocking(False)
+                if hasattr(socket, 'TCP_SYNCNT'):
+                    try:
+                        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_SYNCNT, 1)
+                    except OSError:
+                        pass
+
+                err = sock.connect_ex(sa)
+                if err == 0:
+                    sel.close()
+                    for s in sockets:
+                        s.close()
+                    sock.close()
+                    return True
+
+                sel.register(sock, selectors.EVENT_WRITE)
+                sockets.append(sock)
+            except socket.error:
+                if sock:
+                    sock.close()
+
+        try:
+            events = sel.select(timeout)
+            for key, mask in events:
+                if key.fileobj.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0:
+                    return True
+        finally:
+            sel.close()
+            for sock in sockets:
+                sock.close()
+
+        if i < retry - 1:
+            elapsed = time.time() - start_time
+            if elapsed < timeout:
+                time.sleep(timeout - elapsed)
+
+    return False
 
 
 def valid_port(port):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -250,35 +250,43 @@ def test_sysconfig_set_bsc1145823():
 
 @mock.patch("socket.getaddrinfo")
 @mock.patch("socket.socket")
-@mock.patch("crmsh.utils.closing")
-def test_check_port_open_false(mock_closing, mock_socket, mock_getaddrinfo):
+@mock.patch("selectors.DefaultSelector")
+@mock.patch("time.sleep")
+def test_check_port_open_false(mock_sleep, mock_selector_cls, mock_socket, mock_getaddrinfo):
     sock_inst = mock.Mock()
     mock_socket.return_value = sock_inst
-    mock_closing.return_value.__enter__.return_value = sock_inst
     sock_inst.connect_ex.return_value = 1
     mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 22))]
 
+    mock_selector = mock.Mock()
+    mock_selector_cls.return_value = mock_selector
+    mock_selector.select.return_value = []
+
     assert utils.check_port_open("localhost", 22) is False
 
-    mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM, 6)
-    mock_closing.assert_called_once_with(sock_inst)
-    sock_inst.connect_ex.assert_called_once_with(("127.0.0.1", 22))
+    assert mock_socket.call_count == 3
+    assert sock_inst.connect_ex.call_count == 3
+    assert mock_selector_cls.call_count == 3
+    assert mock_selector.select.call_count == 3
+    assert mock_sleep.call_count == 2
 
 @mock.patch("socket.getaddrinfo")
 @mock.patch("socket.socket")
-@mock.patch("crmsh.utils.closing")
-def test_check_port_open_true(mock_closing, mock_socket, mock_getaddrinfo):
+@mock.patch("selectors.DefaultSelector")
+def test_check_port_open_true(mock_selector_cls, mock_socket, mock_getaddrinfo):
     sock_inst = mock.Mock()
     mock_socket.return_value = sock_inst
-    mock_closing.return_value.__enter__.return_value = sock_inst
     sock_inst.connect_ex.return_value = 0
     mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 22))]
 
+    mock_selector = mock.Mock()
+    mock_selector_cls.return_value = mock_selector
+
     assert utils.check_port_open("localhost", 22) is True
 
-    mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM, 6)
-    mock_closing.assert_called_once_with(sock_inst)
-    sock_inst.connect_ex.assert_called_once_with(("127.0.0.1", 22))
+    assert mock_socket.call_count == 1
+    assert sock_inst.connect_ex.call_count == 1
+    assert mock_selector_cls.call_count == 1
 
 def test_valid_port():
     assert utils.valid_port(1) is False


### PR DESCRIPTION
Modify check_port_open to use a non-blocking loop with selectors to concurrently try all addresses returned by getaddrinfo. This mimics tcping behavior by using a fixed interval and disabling kernel-level SYN retries via TCP_SYNCNT.
