### PR TITLE
Dev: ui_cluster: Sleep 1s before checking qdevice vote

### DIFF
--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -16,6 +16,7 @@ from . import parallax
 from . import log
 from . import corosync_config_format
 from . import xmlutil
+from . import qdevice
 from .sh import ShellUtils
 
 
@@ -114,6 +115,7 @@ def query_status(status_type):
         out = sh.cluster_shell().get_stdout_or_raise_error("crm_node -l")
         print(f"{out}\n")
         print(status_func_dict[status_type]())
+        qdevice.QDevice.check_qdevice_vote()
     else:
         raise ValueError("Wrong type \"{}\" to query status".format(status_type))
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -11,6 +11,7 @@ import tempfile
 import tarfile
 import subprocess
 import glob
+import time
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import crmsh.parallax
@@ -200,6 +201,7 @@ class Cluster(command.UI):
             logger.info("The cluster stack started on %s", node)
 
         if start_qdevice and success_list:
+            time.sleep(1)
             qdevice.QDevice.check_qdevice_vote()
 
         return success_flag
@@ -911,7 +913,6 @@ to get the geo cluster configuration.""",
     @command.completers_repeating(compl.choice(['10', '60', '600']))
     def do_wait_for_startup(self, context, timeout='10'):
         "usage: wait_for_startup [<timeout>]"
-        import time
         t0 = time.time()
         timeout = float(timeout)
         cmd = 'crm_mon -bD1 >/dev/null 2>&1'


### PR DESCRIPTION
Or for the one-node cluster case, qdevice.QDevice.check_qdevice_vote will give a warning while starting cluster:
>WARNING: Qdevice's vote is 0, which simply means Qdevice can't talk to Qnetd(server1) for various reasons.

Also call qdevice.QDevice.check_qdevice_vote while running `crm corosync status`