### PR TITLE
Dev: qdevice: Configure "-p <port>" for /etc/sysconfig/corosync-qnetd on qnetd server

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1559,7 +1559,7 @@ def configure_qdevice_interactive():
     ssh_user, qnetd_host = utils.parse_user_at_host(qnetd_addr_input)
     qdevice.QDevice.check_qnetd_addr(qnetd_host)
     _context.qnetd_addr_input = qnetd_addr_input
-    qdevice_port = prompt_for_string("TCP PORT of QNetd server", default=5403,
+    qdevice_port = prompt_for_string("TCP PORT of QNetd server",
             valid_func=qdevice.QDevice.check_qdevice_port)
     qdevice_algo = prompt_for_string("QNetd decision ALGORITHM (ffsplit/lms)", default="ffsplit",
             valid_func=qdevice.QDevice.check_qdevice_algo)

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -112,6 +112,7 @@ class Context(object):
         self.qdevice_inst = None
         self.qnetd_addr_input = None
         self.qdevice_port = None
+        self.qnetd_port = None
         self.qdevice_algo = None
         self.qdevice_tie_breaker = None
         self.qdevice_tls = None
@@ -161,10 +162,13 @@ class Context(object):
         """
         if not self.qnetd_addr_input:
             return
+        if self.qdevice_port is not None:
+            logger.warning("Option --qdevice-port is deprecated and will be removed in future release, please use --qnetd-port instead")
+        qnetd_port = self.qnetd_port or self.qdevice_port
         ssh_user, qnetd_host = utils.parse_user_at_host(self.qnetd_addr_input)
         self.qdevice_inst = qdevice.QDevice(
                 qnetd_addr=qnetd_host,
-                port=self.qdevice_port,
+                port=qnetd_port,
                 algo=self.qdevice_algo,
                 tie_breaker=self.qdevice_tie_breaker,
                 tls=self.qdevice_tls,
@@ -1559,8 +1563,8 @@ def configure_qdevice_interactive():
     ssh_user, qnetd_host = utils.parse_user_at_host(qnetd_addr_input)
     qdevice.QDevice.check_qnetd_addr(qnetd_host)
     _context.qnetd_addr_input = qnetd_addr_input
-    qdevice_port = prompt_for_string("TCP PORT of QNetd server",
-            valid_func=qdevice.QDevice.check_qdevice_port)
+    qnetd_port = prompt_for_string("TCP PORT of QNetd server",
+            valid_func=qdevice.QDevice.check_qnetd_port)
     qdevice_algo = prompt_for_string("QNetd decision ALGORITHM (ffsplit/lms)", default="ffsplit",
             valid_func=qdevice.QDevice.check_qdevice_algo)
     qdevice_tie_breaker = prompt_for_string("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest",
@@ -1575,7 +1579,7 @@ def configure_qdevice_interactive():
 
     _context.qdevice_inst = qdevice.QDevice(
             qnetd_host,
-            port=qdevice_port,
+            port=qnetd_port,
             algo=qdevice_algo,
             tie_breaker=qdevice_tie_breaker,
             tls=qdevice_tls,

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -156,14 +156,33 @@ class Context(object):
         ctx.initialize_user()
         return ctx
 
+    def _any_qdevice_options_set(self):
+        return any([
+            self.qdevice_port,
+            self.qnetd_port,
+            self.qdevice_algo,
+            self.qdevice_tie_breaker,
+            self.qdevice_tls,
+            self.qdevice_heuristics,
+            self.qdevice_heuristics_mode,
+        ])
+
     def _initialize_qdevice(self):
         """
         Initialize qdevice instance
         """
         if not self.qnetd_addr_input:
+            if self._any_qdevice_options_set() or self.stage == "qdevice":
+                utils.fatal("Option --qnetd-hostname is required if want to configure qdevice")
             return
+
         if self.qdevice_port is not None:
             logger.warning("Option --qdevice-port is deprecated and will be removed in future release, please use --qnetd-port instead")
+            if self.qnetd_port is not None:
+                utils.fatal("Options --qdevice-port and --qnetd-port can't be used together")
+        if self.qdevice_heuristics_mode and not self.qdevice_heuristics:
+            utils.fatal("Option --qdevice-heuristics is required if want to configure heuristics mode")
+
         qnetd_port = self.qnetd_port or self.qdevice_port
         ssh_user, qnetd_host = utils.parse_user_at_host(self.qnetd_addr_input)
         self.qdevice_inst = qdevice.QDevice(

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -212,9 +212,9 @@ class QDevice(object):
 
 
     @staticmethod
-    def check_qdevice_port(qdevice_port):
-        if qdevice_port and not utils.valid_port(qdevice_port):
-            raise ValueError("invalid qdevice port range(1024 - 65535)")
+    def check_qnetd_port(qnetd_port):
+        if qnetd_port and not utils.valid_port(qnetd_port):
+            raise ValueError("invalid qnetd port range(1024 - 65535)")
 
     @staticmethod
     def check_qdevice_algo(qdevice_algo):
@@ -262,7 +262,7 @@ class QDevice(object):
             utils.check_all_nodes_reachable("setup Qdevice")
         self.check_corosync_qdevice_available()
         self.check_qnetd_addr(self.qnetd_addr)
-        self.check_qdevice_port(self.port)
+        self.check_qnetd_port(self.port)
         self.check_qdevice_algo(self.algo)
         self.check_qdevice_tie_breaker(self.tie_breaker)
         self.check_qdevice_tls(self.tls)
@@ -526,7 +526,7 @@ class QDevice(object):
             port_in_qnetd = int(res.group(1))
             if self.port is not None and self.port != port_in_qnetd:
                 error_msg = f"The port {self.port} is different from the port {port_in_qnetd} that corosync-qnetd is using"
-                suggestion_msg = f"Please use '--qdevice-port {port_in_qnetd}' to keep consistent"
+                suggestion_msg = f"Please use '--qnetd-port {port_in_qnetd}' to keep consistent"
                 raise ValueError(f"{error_msg}\n{suggestion_msg}")
             else:
                 self.port = port_in_qnetd
@@ -555,7 +555,7 @@ class QDevice(object):
                     port_in_sysconfig = int(res.group(1))
                     if self.port is not None and self.port != port_in_sysconfig:
                         error_msg = f"The port {self.port} is different from the port {port_in_sysconfig} in {self.SYSCONFIG_QNETD}"
-                        suggestion_msg = f"Please use '--qdevice-port {port_in_sysconfig}' to keep consistent"
+                        suggestion_msg = f"Please use '--qnetd-port {port_in_sysconfig}' to keep consistent"
                         raise ValueError(f"{error_msg}\n{suggestion_msg}")
                     else:
                         self.port = port_in_sysconfig

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -105,12 +105,16 @@ def get_node_list(is_stage: bool) -> list[str]:
         return [me]
 
 
+QNETD_DEFAULT_PORT = 5403
+
+
 class QDevice(object):
     """Class to manage qdevice configuration and services
 
     Call `certificate_process_on_init` to generate all of CA, server, and client certs.
     """
 
+    SYSCONFIG_QNETD = "/etc/sysconfig/corosync-qnetd"
     qnetd_service = "corosync-qnetd.service"
     qnetd_cacert_filename = "qnetd-cacert.crt"
     qdevice_crq_filename = "qdevice-net-node.crq"
@@ -119,7 +123,7 @@ class QDevice(object):
     qdevice_path = "/etc/corosync/qdevice/net"
     qdevice_db_path = "/etc/corosync/qdevice/net/nssdb"
 
-    def __init__(self, qnetd_addr, port=5403, algo="ffsplit", tie_breaker="lowest",
+    def __init__(self, qnetd_addr, port=None, algo="ffsplit", tie_breaker="lowest",
             tls="on", ssh_user=None, cmds=None, mode=None, cluster_name=None, is_stage=False):
         """
         Init function
@@ -209,7 +213,7 @@ class QDevice(object):
 
     @staticmethod
     def check_qdevice_port(qdevice_port):
-        if not utils.valid_port(qdevice_port):
+        if qdevice_port and not utils.valid_port(qdevice_port):
             raise ValueError("invalid qdevice port range(1024 - 65535)")
 
     @staticmethod
@@ -289,8 +293,11 @@ class QDevice(object):
             raise ValueError(f"{exception_msg}\n{suggestion_msg}")
 
     def start_qnetd(self):
+        service_manager = ServiceManager()
+        if service_manager.service_is_active(self.qnetd_service, self.qnetd_addr):
+            return
         logger.info("Starting and enable corosync-qnetd.service on %s" % self.qnetd_addr)
-        ServiceManager().start_service(self.qnetd_service, enable=True, remote_addr=self.qnetd_addr)
+        service_manager.start_service(self.qnetd_service, enable=True, remote_addr=self.qnetd_addr)
 
     def set_cluster_name(self):
         if not self.cluster_name:
@@ -511,10 +518,80 @@ class QDevice(object):
         cmd = "test -f {crq_file} && rm -f {crq_file}".format(crq_file=cls_inst.qdevice_crq_on_qnetd)
         shell.get_stdout_or_raise_error(cmd, qnetd_host)
 
+    def _handle_port_when_qnetd_active(self):
+        cmd = "corosync-qnetd-tool -s"
+        out = sh.cluster_shell().get_stdout_or_raise_error(cmd, self.qnetd_addr)
+        res = re.search(r'QNetd address:\s+\S+:(\d+)', out)
+        if res:
+            port_in_qnetd = int(res.group(1))
+            if self.port is not None and self.port != port_in_qnetd:
+                error_msg = f"The port {self.port} is different from the port {port_in_qnetd} that corosync-qnetd is using"
+                suggestion_msg = f"Please use '--qdevice-port {port_in_qnetd}' to keep consistent"
+                raise ValueError(f"{error_msg}\n{suggestion_msg}")
+            else:
+                self.port = port_in_qnetd
+        else:
+            # this should not happen, just in case
+            raise ValueError(f"Failed to get qnetd port from corosync-qnetd-tool output on {self.qnetd_addr}")
+
+    def _handle_port_when_qnetd_inactive(self):
+        shell = sh.cluster_shell()
+        action_cmd = ""
+
+        cmd = f"test -f {self.SYSCONFIG_QNETD}"
+        rc, _, _ = shell.get_rc_stdout_stderr_without_input(self.qnetd_addr, cmd)
+        if rc != 0:
+            port_option = "" if self.port is None else f"-p {self.port}"
+            options = f"COROSYNC_QNETD_OPTIONS=\"{port_option}\"\nCOROSYNC_QNETD_RUNAS=\"\""
+            logger.info(f"Write qnetd options to {self.SYSCONFIG_QNETD} on {self.qnetd_addr}: {options.strip()}")
+            action_cmd = f"echo -e '{options}' > {self.SYSCONFIG_QNETD}"
+
+        else:
+            cmd = f"grep '^[[:space:]]*COROSYNC_QNETD_OPTIONS=' {self.SYSCONFIG_QNETD}"
+            rc, out, _ = shell.get_rc_stdout_stderr_without_input(self.qnetd_addr, cmd)
+            if rc == 0 and out:
+                res = re.search(r'-p\s+(\d+)', out)
+                if res:
+                    port_in_sysconfig = int(res.group(1))
+                    if self.port is not None and self.port != port_in_sysconfig:
+                        error_msg = f"The port {self.port} is different from the port {port_in_sysconfig} in {self.SYSCONFIG_QNETD}"
+                        suggestion_msg = f"Please use '--qdevice-port {port_in_sysconfig}' to keep consistent"
+                        raise ValueError(f"{error_msg}\n{suggestion_msg}")
+                    else:
+                        self.port = port_in_sysconfig
+
+                elif self.port is not None:
+                    value_of_options = out.strip().split('=', 1)[1].strip('"')
+                    if value_of_options:
+                        options = f'COROSYNC_QNETD_OPTIONS="{value_of_options} -p {self.port}"'
+                    else:
+                        options = f'COROSYNC_QNETD_OPTIONS="-p {self.port}"'
+                    logger.info(f"Update qnetd options in {self.SYSCONFIG_QNETD} on {self.qnetd_addr} to: {options}")
+                    action_cmd = f"sed -i 's|COROSYNC_QNETD_OPTIONS=.*|{options}|' {self.SYSCONFIG_QNETD}"
+            else:
+                options = "COROSYNC_QNETD_OPTIONS=\"\"" if self.port is None else f"COROSYNC_QNETD_OPTIONS=\"-p {self.port}\""
+                logger.info(f"Add qnetd options to {self.SYSCONFIG_QNETD} on {self.qnetd_addr}: {options}")
+                action_cmd = f"echo '{options}' >> {self.SYSCONFIG_QNETD}"
+
+        if action_cmd:
+            shell.get_stdout_or_raise_error(action_cmd, self.qnetd_addr)
+
+    def config_qnetd_port_in_sysconfig(self):
+        if ServiceManager().service_is_active("corosync-qnetd.service", self.qnetd_addr):
+            self._handle_port_when_qnetd_active()
+        else:
+            self._handle_port_when_qnetd_inactive()
+
+        if self.port is None:
+            self.port = QNETD_DEFAULT_PORT
+        logger.info(f"Use port {self.port} for corosync-qnetd on {self.qnetd_addr}")
+
     def config_qnetd_port(self):
         """
         Enable qnetd port in firewalld
         """
+        self.config_qnetd_port_in_sysconfig()
+
         if not ServiceManager().service_is_active("firewalld.service", self.qnetd_addr):
             return
         if utils.check_port_open(self.qnetd_addr, self.port):

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -105,9 +105,6 @@ def get_node_list(is_stage: bool) -> list[str]:
         return [me]
 
 
-QNETD_DEFAULT_PORT = 5403
-
-
 class QDevice(object):
     """Class to manage qdevice configuration and services
 
@@ -115,6 +112,7 @@ class QDevice(object):
     """
 
     SYSCONFIG_QNETD = "/etc/sysconfig/corosync-qnetd"
+    QNETD_DEFAULT_PORT = 5403
     qnetd_service = "corosync-qnetd.service"
     qnetd_cacert_filename = "qnetd-cacert.crt"
     qdevice_crq_filename = "qdevice-net-node.crq"
@@ -123,19 +121,19 @@ class QDevice(object):
     qdevice_path = "/etc/corosync/qdevice/net"
     qdevice_db_path = "/etc/corosync/qdevice/net/nssdb"
 
-    def __init__(self, qnetd_addr, port=None, algo="ffsplit", tie_breaker="lowest",
-            tls="on", ssh_user=None, cmds=None, mode=None, cluster_name=None, is_stage=False):
+    def __init__(self, qnetd_addr, port=None, algo=None, tie_breaker=None,
+            tls=None, ssh_user=None, cmds=None, mode=None, cluster_name=None, is_stage=False):
         """
         Init function
         """
         self.qnetd_addr = qnetd_addr
         self.port = port
-        self.algo = algo
-        self.tie_breaker = tie_breaker
-        self.tls = tls
+        self.algo = algo or "ffsplit"
+        self.tie_breaker = tie_breaker or "lowest"
+        self.tls = tls or "on"
         self.ssh_user = ssh_user
         self.cmds = cmds
-        self.mode = mode
+        self.mode = mode or "sync"
         self.cluster_name = cluster_name
         self.qdevice_reload_policy = QdevicePolicy.QDEVICE_RESTART
         self.is_stage = is_stage
@@ -583,7 +581,7 @@ class QDevice(object):
             self._handle_port_when_qnetd_inactive()
 
         if self.port is None:
-            self.port = QNETD_DEFAULT_PORT
+            self.port = self.QNETD_DEFAULT_PORT
         logger.info(f"Use port {self.port} for corosync-qnetd on {self.qnetd_addr}")
 
     def config_qnetd_port(self):

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -460,6 +460,8 @@ Examples:
         qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr_input", metavar="[USER@]HOST",
                                    help="User and host of the QNetd server. The host can be specified in either hostname or IP address.")
         qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int,
+                                   help=f"TCP PORT of QNetd server (default:{qdevice.QNETD_DEFAULT_PORT}, deprecated, use --qnetd-port instead)")
+        qdevice_group.add_argument("--qnetd-port", dest="qnetd_port", metavar="PORT", type=int,
                                    help=f"TCP PORT of QNetd server (default:{qdevice.QNETD_DEFAULT_PORT})")
         qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", default="ffsplit", choices=['ffsplit', 'lms'],
                                    help="QNetd decision ALGORITHM (ffsplit/lms, default:ffsplit)")

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -459,8 +459,8 @@ Examples:
         qdevice_group = parser.add_argument_group("QDevice configuration", re.sub('  ', '', constants.QDEVICE_HELP_INFO) + "\n\nOptions for configuring QDevice and QNetd.")
         qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr_input", metavar="[USER@]HOST",
                                    help="User and host of the QNetd server. The host can be specified in either hostname or IP address.")
-        qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int, default=5403,
-                                   help="TCP PORT of QNetd server (default:5403)")
+        qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int,
+                                   help=f"TCP PORT of QNetd server (default:{qdevice.QNETD_DEFAULT_PORT})")
         qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", default="ffsplit", choices=['ffsplit', 'lms'],
                                    help="QNetd decision ALGORITHM (ffsplit/lms, default:ffsplit)")
         qdevice_group.add_argument("--qdevice-tie-breaker", dest="qdevice_tie_breaker", metavar="TIE_BREAKER", default="lowest",

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -460,14 +460,14 @@ Examples:
         qdevice_group.add_argument("--qnetd-hostname", dest="qnetd_addr_input", metavar="[USER@]HOST",
                                    help="User and host of the QNetd server. The host can be specified in either hostname or IP address.")
         qdevice_group.add_argument("--qdevice-port", dest="qdevice_port", metavar="PORT", type=int,
-                                   help=f"TCP PORT of QNetd server (default:{qdevice.QNETD_DEFAULT_PORT}, deprecated, use --qnetd-port instead)")
+                                   help=f"TCP PORT of QNetd server (default:{qdevice.QDevice.QNETD_DEFAULT_PORT}, deprecated, use --qnetd-port instead)")
         qdevice_group.add_argument("--qnetd-port", dest="qnetd_port", metavar="PORT", type=int,
-                                   help=f"TCP PORT of QNetd server (default:{qdevice.QNETD_DEFAULT_PORT})")
-        qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", default="ffsplit", choices=['ffsplit', 'lms'],
+                                   help=f"TCP PORT of QNetd server (default:{qdevice.QDevice.QNETD_DEFAULT_PORT})")
+        qdevice_group.add_argument("--qdevice-algo", dest="qdevice_algo", metavar="ALGORITHM", choices=['ffsplit', 'lms'],
                                    help="QNetd decision ALGORITHM (ffsplit/lms, default:ffsplit)")
-        qdevice_group.add_argument("--qdevice-tie-breaker", dest="qdevice_tie_breaker", metavar="TIE_BREAKER", default="lowest",
+        qdevice_group.add_argument("--qdevice-tie-breaker", dest="qdevice_tie_breaker", metavar="TIE_BREAKER",
                                    help="QNetd TIE_BREAKER (lowest/highest/valid_node_id, default:lowest)")
-        qdevice_group.add_argument("--qdevice-tls", dest="qdevice_tls", metavar="TLS", default="on", choices=['on', 'off', 'required'],
+        qdevice_group.add_argument("--qdevice-tls", dest="qdevice_tls", metavar="TLS", choices=['on', 'off', 'required'],
                                    help="Whether using TLS on QDevice (on/off/required, default:on)")
         qdevice_group.add_argument("--qdevice-heuristics", dest="qdevice_heuristics", metavar="COMMAND",
                                    help="COMMAND to run with absolute path. For multiple commands, use \";\" to separate (details about heuristics can see man 8 corosync-qdevice)")
@@ -495,13 +495,6 @@ Examples:
         stage = ""
         if len(args):
             stage = args[0]
-
-        if options.qnetd_addr_input:
-            if options.qdevice_heuristics_mode and not options.qdevice_heuristics:
-                parser.error("Option --qdevice-heuristics is required if want to configure heuristics mode")
-            options.qdevice_heuristics_mode = options.qdevice_heuristics_mode or "sync"
-        elif re.search("--qdevice-.*", ' '.join(sys.argv)) or (stage == "qdevice" and options.yes_to_all):
-            parser.error("Option --qnetd-hostname is required if want to configure qdevice")
 
         # if options.geo and options.name == "hacluster":
         #    parser.error("For a geo cluster, each cluster must have a unique name (use --name to set)")

--- a/test/features/qdevice_validate.feature
+++ b/test/features/qdevice_validate.feature
@@ -26,9 +26,14 @@ Feature: corosync qdevice/qnetd options validate
     Then    Except "ERROR: cluster.init: host "node-without-ssh" is unreachable via SSH"
 
   @clean
-  Scenario: Option "--qdevice-port" set wrong port
-    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-port=1"
-    Then    Except "ERROR: cluster.init: invalid qdevice port range(1024 - 65535)"
+  Scenario: Option "--qnetd-port" set wrong port
+    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qnetd-port=1"
+    Then    Except "ERROR: cluster.init: invalid qnetd port range(1024 - 65535)"
+
+  @clean
+  Scenario: Option "--qnetd-port" and "--qdevice-port" can't be used together
+    When    Try "crm cluster init --qnetd-hostname=qnetd-node --qnetd-port=1234 --qdevice-port=1234"
+    Then    Expected "Options --qdevice-port and --qnetd-port can't be used together" in stderr
 
   @clean
   Scenario: Option "--qdevice-tie-breaker" set wrong value
@@ -44,21 +49,13 @@ Feature: corosync qdevice/qnetd options validate
 
   @clean
   Scenario: Option "--qnetd-hostname" is required by other qdevice options
-    When    Try "crm cluster init --qdevice-port=1234"
-    Then    Expected multiple lines in stderr
-      """
-      usage: init [options] [STAGE]
-      crm: error: Option --qnetd-hostname is required if want to configure qdevice
-      """
+    When    Try "crm cluster init --qnetd-port=1234"
+    Then    Except "ERROR: cluster.init: Option --qnetd-hostname is required if want to configure qdevice"
 
   @clean
   Scenario: Option --qdevice-heuristics is required if want to configure heuristics mode
     When    Try "crm cluster init --qnetd-hostname=qnetd-node --qdevice-heuristics-mode="on""
-    Then    Expected multiple lines in stderr
-      """
-      usage: init [options] [STAGE]
-      crm: error: Option --qdevice-heuristics is required if want to configure heuristics mode
-      """
+    Then    Except "ERROR: cluster.init: Option --qdevice-heuristics is required if want to configure heuristics mode"
 
   @clean
   Scenario: Node for qnetd not installed corosync-qnetd
@@ -101,11 +98,7 @@ Feature: corosync qdevice/qnetd options validate
     When    Run "crm cluster init -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     When    Try "crm cluster init qdevice -y"
-    Then    Expected multiple lines in stderr
-      """
-      usage: init [options] [STAGE]
-      crm: error: Option --qnetd-hostname is required if want to configure qdevice
-      """
+    Then    Except "ERROR: cluster.init: Option --qnetd-hostname is required if want to configure qdevice"
 
   @clean
   Scenario: Setup qdevice on a single node cluster with RA running(bsc#1181415)
@@ -142,3 +135,36 @@ Feature: corosync qdevice/qnetd options validate
     When    Run "crm -F cluster remove --qdevice -y" on "hanode1"
     Then    Cluster service is "started" on "hanode1"
     And     Service "corosync-qdevice" is "stopped" on "hanode1"
+
+  @clean
+  Scenario: Port conflict between qnetd and corosync
+    Given   Service "corosync-qnetd" is "started" on "qnetd-node"
+    When    Run "crm cluster init -y" on "hanode1"
+    Then    Cluster service is "started" on "hanode1"
+    When    Try "crm cluster init qdevice --qnetd-hostname=qnetd-node --qnetd-port 5402 -y" on "hanode1"
+    Then    Expected multiple lines in stderr
+      """
+      The port 5402 is different from the port 5403 that corosync-qnetd is using
+      Please use '--qnetd-port 5403' to keep consistent
+      """
+    Then    Service "corosync-qdevice" is "stopped" on "hanode1"
+    When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node --qnetd-port 5403 -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
+
+    When    Run "crm cluster remove --qdevice -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "stopped" on "hanode1"
+    When    Run "systemctl stop corosync-qnetd" on "qnetd-node"
+    Then    Service "corosync-qnetd" is "stopped" on "qnetd-node"
+    When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node --qnetd-port 5402 -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"
+    And     Run "cat /etc/sysconfig/corosync-qnetd|grep "\-p 5402"" OK on "qnetd-node"
+
+    When    Run "crm cluster remove --qdevice -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "stopped" on "hanode1"
+    When    Run "systemctl stop corosync-qnetd" on "qnetd-node"
+    Then    Service "corosync-qnetd" is "stopped" on "qnetd-node"
+    When    Run "crm cluster init qdevice --qnetd-hostname=qnetd-node -y" on "hanode1"
+    Then    Service "corosync-qdevice" is "started" on "hanode1"
+    And     Service "corosync-qnetd" is "started" on "qnetd-node"
+    And     Run "cat /etc/corosync/corosync.conf|grep "port: 5402"" OK on "hanode1"

--- a/test/features/steps/const.py
+++ b/test/features/steps/const.py
@@ -116,7 +116,9 @@ QDevice configuration:
   --qnetd-hostname [USER@]HOST
                         User and host of the QNetd server. The host can be
                         specified in either hostname or IP address.
-  --qdevice-port PORT   TCP PORT of QNetd server (default:5403)
+  --qdevice-port PORT   TCP PORT of QNetd server (default:5403, deprecated,
+                        use --qnetd-port instead)
+  --qnetd-port PORT     TCP PORT of QNetd server (default:5403)
   --qdevice-algo ALGORITHM
                         QNetd decision ALGORITHM (ffsplit/lms,
                         default:ffsplit)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -113,7 +113,7 @@ class TestContext(unittest.TestCase):
     def test_initialize_qdevice(self, mock_qdevice):
         ctx = crmsh.bootstrap.Context()
         ctx.qnetd_addr_input = "node3"
-        ctx.qdevice_port = 123
+        ctx.qnetd_port = 123
         ctx.stage = ""
         ctx._initialize_qdevice()
         mock_qdevice.assert_called_once_with(qnetd_addr='node3', port=123, ssh_user=None, algo=None, tie_breaker=None, tls=None, cmds=None, mode=None, is_stage=False)
@@ -122,7 +122,7 @@ class TestContext(unittest.TestCase):
     def test_initialize_qdevice_with_user(self, mock_qdevice):
         ctx = crmsh.bootstrap.Context()
         ctx.qnetd_addr_input = "alice@node3"
-        ctx.qdevice_port = 123
+        ctx.qnetd_port = 123
         ctx.stage = ""
         ctx._initialize_qdevice()
         mock_qdevice.assert_called_once_with(qnetd_addr='node3', port=123, ssh_user='alice', algo=None, tie_breaker=None, tls=None, cmds=None, mode=None, is_stage=False)
@@ -1357,8 +1357,8 @@ done
         mock_confirm.assert_called_once_with("Do you want to configure QDevice?")
         mock_prompt.assert_has_calls([
             mock.call("HOST or IP of the QNetd server to be used"),
-            mock.call("TCP PORT of QNetd server", default=5403,
-                valid_func=qdevice.QDevice.check_qdevice_port),
+            mock.call("TCP PORT of QNetd server",
+                valid_func=qdevice.QDevice.check_qnetd_port),
             mock.call("QNetd decision ALGORITHM (ffsplit/lms)", default="ffsplit",
                 valid_func=qdevice.QDevice.check_qdevice_algo),
             mock.call("QNetd TIE_BREAKER (lowest/highest/valid node id)", default="lowest",

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -226,11 +226,11 @@ class TestQDevice(unittest.TestCase):
         qdevice.QDevice.check_qnetd_addr("qnetd-node")
 
     @mock.patch('crmsh.utils.valid_port')
-    def test_check_qdevice_port(self, mock_port):
+    def test_check_qnetd_port(self, mock_port):
         mock_port.return_value = False
         with self.assertRaises(ValueError) as err:
-            qdevice.QDevice.check_qdevice_port("1")
-        excepted_err_string = "invalid qdevice port range(1024 - 65535)"
+            qdevice.QDevice.check_qnetd_port("1")
+        excepted_err_string = "invalid qnetd port range(1024 - 65535)"
         self.assertEqual(excepted_err_string, str(err.exception))
 
     def test_check_qdevice_algo(self):
@@ -278,7 +278,7 @@ class TestQDevice(unittest.TestCase):
     @mock.patch('crmsh.qdevice.QDevice.check_qdevice_tls')
     @mock.patch('crmsh.qdevice.QDevice.check_qdevice_tie_breaker')
     @mock.patch('crmsh.qdevice.QDevice.check_qdevice_algo')
-    @mock.patch('crmsh.qdevice.QDevice.check_qdevice_port')
+    @mock.patch('crmsh.qdevice.QDevice.check_qnetd_port')
     @mock.patch('crmsh.qdevice.QDevice.check_qnetd_addr')
     @mock.patch('crmsh.qdevice.QDevice.check_corosync_qdevice_available')
     def test_valid_qdevice_options(self, mock_installed, mock_check_qnetd, mock_check_port,
@@ -326,8 +326,10 @@ class TestQDevice(unittest.TestCase):
         mock_installed.assert_called_once_with("corosync-qnetd", remote_addr="10.10.10.123")
         mock_init_tls_certs_on_qnetd.assert_called_once()
 
+    @mock.patch("crmsh.service_manager.ServiceManager.service_is_active")
     @mock.patch("crmsh.service_manager.ServiceManager.start_service")
-    def test_start_qnetd(self, mock_start):
+    def test_start_qnetd(self, mock_start, mock_active):
+        mock_active.return_value = False
         self.qdevice_with_ip.start_qnetd()
         mock_start.assert_called_once_with("corosync-qnetd.service", enable=True, remote_addr="10.10.10.123")
 
@@ -685,6 +687,7 @@ Membership information
         mock_service_instance = mock.Mock()
         mock_service.return_value = mock_service_instance
         mock_service_instance.service_is_active.return_value = False
+        self.qdevice_with_ip.config_qnetd_port_in_sysconfig = mock.Mock()
 
         self.qdevice_with_ip.config_qnetd_port()
 
@@ -704,6 +707,7 @@ Membership information
         mock_cluster_shell.return_value = mock_cluster_shell_instance
         mock_cluster_shell_instance.get_rc_stdout_stderr_without_input = mock.Mock(return_value=(0, None, None))
         mock_cluster_shell_instance.get_stdout_or_raise_error = mock.Mock(return_value=None)
+        self.qdevice_with_ip.config_qnetd_port_in_sysconfig = mock.Mock()
         self.qdevice_with_ip.port = 5403
 
         self.qdevice_with_ip.config_qnetd_port()


### PR DESCRIPTION
Changes include:
- Configure "-p <port>" for /etc/sysconfig/corosync-qnetd on qnetd server if needed
- Raise an error if the given port is different from the port that the qnetd server is using
- Add --qnetd-port option and deprecate --qdevice-port option
- Refactor qdevice options validation

Fix the issue:
- #2092 