### PR TITLE
Dev: qdevice: Improve local address check for qnetd (bsc#1262094)

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -1,3 +1,5 @@
+import ipaddress
+import json
 import os
 import re
 import socket
@@ -6,7 +8,7 @@ import typing
 from enum import Enum
 
 import crmsh.parallax
-from . import sh
+from . import sh, iproute2
 from . import utils
 from . import parallax
 from . import corosync
@@ -185,22 +187,25 @@ class QDevice(object):
 
     @staticmethod
     def check_qnetd_addr(qnetd_addr):
-        qnetd_ip = None
-        try:
-            # socket.getaddrinfo works for both ipv4 and ipv6 address
-            # The function returns a list of 5-tuples with the following structure:
-            # (family, type, proto, canonname, sockaddr)
-            # sockaddr is a tuple describing a socket address, whose format depends on the returned family
-            # (a (address, port) 2-tuple for AF_INET, a (address, port, flow info, scope id) 4-tuple for AF_INET6)
-            res = socket.getaddrinfo(qnetd_addr, None)
-            qnetd_ip = res[0][-1][0]
-        except socket.error:
-            raise ValueError("host \"{}\" is unreachable".format(qnetd_addr))
-
         utils.ssh_port_reachable_check(qnetd_addr)
+        try:
+            qnetd_ip_addresses = [
+                ipaddress.ip_address(sockaddr[0])
+                for af, tpe, proto, canonname, sockaddr in socket.getaddrinfo(qnetd_addr, None)
+            ]
+        except socket.error as e:
+            raise ValueError(f"{e}: {qnetd_addr}")
+        try:
+            local_interfaces = iproute2.IPAddr(json.loads(
+                sh.LocalShell().get_stdout_or_raise_error(None, 'ip -j addr show')
+            ))
+        except ValueError:
+            return
+        local_ip_addresses = set(addr_info.ip for interface in local_interfaces.interfaces() for addr_info in interface.addr_info)
+        for ip_addr in qnetd_ip_addresses:
+            if ip_addr in local_ip_addresses:
+                raise ValueError("host for qnetd must be a remote one")
 
-        if utils.InterfacesInfo.ip_in_local(qnetd_ip):
-            raise ValueError("host for qnetd must be a remote one")
 
     @staticmethod
     def check_qdevice_port(qdevice_port):

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -1,5 +1,6 @@
 import unittest
 import socket
+import json
 
 try:
     from unittest import mock
@@ -184,24 +185,45 @@ class TestQDevice(unittest.TestCase):
         res = self.qdevice_with_ip.qdevice_p12_on_local
         self.assertEqual(res, "/etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12")
 
-    @mock.patch('crmsh.utils.InterfacesInfo.ip_in_local')
+    @mock.patch('crmsh.sh.LocalShell')
     @mock.patch('crmsh.utils.ssh_port_reachable_check')
     @mock.patch('socket.getaddrinfo')
-    def test_check_qnetd_addr_local(self, mock_getaddrinfo, mock_reachable, mock_in_local):
-        mock_getaddrinfo.return_value = [(None, ("10.10.10.123",)),]
-        mock_in_local.return_value = True
+    def test_check_qnetd_addr_local(self, mock_getaddrinfo, mock_reachable, mock_shell):
+        mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', ("10.10.10.123", 0)),]
+        mock_shell.return_value.get_stdout_or_raise_error.return_value = json.dumps([
+            {
+                "ifname": "eth0",
+                "flags": ["UP", "LOWER_UP"],
+                "addr_info": [{"local": "10.10.10.123", "prefixlen": 24}]
+            }
+        ])
         with self.assertRaises(ValueError) as err:
             qdevice.QDevice.check_qnetd_addr("qnetd-node")
         excepted_err_string = "host for qnetd must be a remote one"
         self.assertEqual(excepted_err_string, str(err.exception))
 
+    @mock.patch('crmsh.utils.ssh_port_reachable_check')
     @mock.patch('socket.getaddrinfo')
-    def test_check_qnetd_addr(self, mock_getaddrinfo):
-        mock_getaddrinfo.side_effect = socket.error
+    def test_check_qnetd_addr(self, mock_getaddrinfo, mock_reachable):
+        mock_getaddrinfo.side_effect = socket.error("getaddrinfo failed")
         with self.assertRaises(ValueError) as err:
             qdevice.QDevice.check_qnetd_addr("qnetd-node")
-        excepted_err_string = "host \"qnetd-node\" is unreachable"
+        excepted_err_string = "getaddrinfo failed: qnetd-node"
         self.assertEqual(excepted_err_string, str(err.exception))
+
+    @mock.patch('crmsh.sh.LocalShell')
+    @mock.patch('crmsh.utils.ssh_port_reachable_check')
+    @mock.patch('socket.getaddrinfo')
+    def test_check_qnetd_addr_success(self, mock_getaddrinfo, mock_reachable, mock_shell):
+        mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', ("10.10.10.124", 0)),]
+        mock_shell.return_value.get_stdout_or_raise_error.return_value = json.dumps([
+            {
+                "ifname": "eth0",
+                "flags": ["UP", "LOWER_UP"],
+                "addr_info": [{"local": "10.10.10.123", "prefixlen": 24}]
+            }
+        ])
+        qdevice.QDevice.check_qnetd_addr("qnetd-node")
 
     @mock.patch('crmsh.utils.valid_port')
     def test_check_qdevice_port(self, mock_port):


### PR DESCRIPTION
- Refactor check_qnetd_addr to use ipaddress and iproute2 for local address check.
- Use 'ip -j addr show' to get all local IP addresses.
- Support both IPv4 and IPv6 check.
- Update unit tests for check_qnetd_addr.
