### PR TITLE
Dev: bootstrap: Load profiles if needed

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2270,7 +2270,8 @@ def bootstrap_init(context):
 
     init()
 
-    _context.load_profiles()
+    if not stage or stage in ('corosync', 'sbd'):
+        _context.load_profiles()
     _context.init_sbd_manager()
 
     if stage in ('qnetd_remote', ):


### PR DESCRIPTION
Load profiles when not in the stage, or in corosync and sbd stages. Since other stages don't need the data of profiles.