### PR TITLE
[crmsh-4.6] Dev: bootstrap: Load profiles if needed

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2575,7 +2575,8 @@ def bootstrap_init(context):
 
     init()
 
-    _context.load_profiles()
+    if not stage or stage in ('corosync', 'sbd'):
+        _context.load_profiles()
     _context.init_sbd_manager()
 
     if stage in ('csync2_remote', 'qnetd_remote'):


### PR DESCRIPTION
Load profiles when not in the stage, or in corosync and sbd stages. Since other stages don't need the data of profiles.

Backport from:
- #2102 