### PR TITLE
Dev: bootstrap: Find and show failed services

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -726,7 +726,9 @@ def init_cluster_local():
         logger.warning("You should change the hacluster password to something more secure!")
 
     if not start_pacemaker(enable_flag=True):
-        utils.fatal("Failed to start cluster services")
+        failed_services = get_failed_services()
+        failed_services_str = f" Please check failed services: {', '.join(failed_services)}" if failed_services else ""
+        utils.fatal(f"Failed to start cluster services.{failed_services_str}")
 
     if _context and _context.type == "init":
         if corosync.is_qdevice_configured():
@@ -2902,4 +2904,20 @@ def get_files_to_sync():
             sbd.SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_DIR
         ) + STATIC_FILES_TO_SYNC
     )
+
+
+def get_failed_services(peer=None) -> list[str]:
+    failed_services = []
+    shell = sh.cluster_shell()
+    for service in (
+        constants.COROSYNC_SERVICE,
+        constants.COROSYNC_QDEVICE_SERVICE,
+        constants.SBD_SERVICE,
+        constants.PCMK_SERVICE
+    ):
+        cmd = f"systemctl is-failed {service}"
+        rc, _, _ = shell.get_rc_stdout_stderr_without_input(peer, cmd)
+        if rc == 0:
+            failed_services.append(service)
+    return failed_services
 # EOF

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -732,8 +732,9 @@ def init_cluster_local():
 
     if _context and _context.type == "init":
         if corosync.is_qdevice_configured():
-            logger.info("Starting and enable corosync-qdevice.service on %s", utils.this_node())
-            service_manager.start_service("corosync-qdevice.service", enable=True)
+            logger.info("Starting and enable %s on %s", constants.COROSYNC_QDEVICE_SERVICE, utils.this_node())
+            if not service_manager.start_service(constants.COROSYNC_QDEVICE_SERVICE, enable=True):
+                logger.error("Failed to start %s on %s", constants.COROSYNC_QDEVICE_SERVICE, utils.this_node())
         elif service_manager.service_is_enabled("corosync-qdevice.service"):
             service_manager.disable_service("corosync-qdevice.service")
 
@@ -2911,7 +2912,6 @@ def get_failed_services(peer=None) -> list[str]:
     shell = sh.cluster_shell()
     for service in (
         constants.COROSYNC_SERVICE,
-        constants.COROSYNC_QDEVICE_SERVICE,
         constants.SBD_SERVICE,
         constants.PCMK_SERVICE
     ):

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -440,6 +440,8 @@ COROSYNC_STATUS_TYPES = ("ring", "quorum", "qdevice", "qnetd", "cpg")
 
 NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mode."
 
+COROSYNC_SERVICE = "corosync.service"
+COROSYNC_QDEVICE_SERVICE = "corosync-qdevice.service"
 PCMK_SERVICE = "pacemaker.service"
 SBD_SERVICE = "sbd.service"
 # vim:ts=4:sw=4:et:

--- a/crmsh/service_manager.py
+++ b/crmsh/service_manager.py
@@ -37,9 +37,13 @@ class ServiceManager(object):
         Return success node list
         """
         if enable:
-            cmd = "systemctl enable --now '{}'".format(name)
+            cmd = (
+                f"systemctl enable --now '{name}' && "
+                f"systemctl is-enabled '{name}' && "
+                f"systemctl is-active '{name}'"
+            )
         else:
-            cmd = "systemctl start '{}'".format(name)
+            cmd = f"systemctl start '{name}' && systemctl is-active '{name}'"
         return self._call(remote_addr, node_list, cmd)
 
     def _call(self, remote_addr: str, node_list: typing.List[str], cmd: str) -> typing.List[str]:

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -196,8 +196,10 @@ class Cluster(command.UI):
         success_list = bootstrap.start_pacemaker(node_list=node_list)
         for node in node_list:
             if node not in success_list:
+                failed_services = bootstrap.get_failed_services(node)
+                failed_services_str = f" Please check failed services: {', '.join(failed_services)}" if failed_services else ""
+                logger.error("The cluster stack failed to start on %s.%s", node, failed_services_str)
                 success_flag = False
-                logger.error("The cluster stack failed to start on %s", node)
                 continue
             logger.info("The cluster stack started on %s", node)
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -190,7 +190,10 @@ class Cluster(command.UI):
             return
 
         if start_qdevice:
-            service_manager.start_service("corosync-qdevice", node_list=node_list)
+            success_list = service_manager.start_service("corosync-qdevice", node_list=node_list)
+            for node in node_list:
+                if node not in success_list:
+                    logger.error("Failed to start %s on %s", constants.COROSYNC_QDEVICE_SERVICE, node)
 
         success_flag = True
         success_list = bootstrap.start_pacemaker(node_list=node_list)

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1560,6 +1560,25 @@ done
         mock_parser_inst.get_node_list.assert_called_once_with(online=True, node_type="member")
         mock_cluster_copy.assert_called_once_with("/file1", nodes=["node1", "node2"])
 
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_get_failed_services(self, mock_cluster_shell):
+        mock_cluster_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_cluster_shell_inst
+        mock_cluster_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (1, None, None),
+            (0, None, None),
+            (1, None, None)
+        ]
+
+        res = bootstrap.get_failed_services()
+        self.assertEqual(res, [constants.SBD_SERVICE])
+        mock_cluster_shell.assert_called_once_with()
+        mock_cluster_shell_inst.get_rc_stdout_stderr_without_input.assert_has_calls([
+            mock.call(None, f"systemctl is-failed {constants.COROSYNC_SERVICE}"),
+            mock.call(None, f"systemctl is-failed {constants.SBD_SERVICE}"),
+            mock.call(None, f"systemctl is-failed {constants.PCMK_SERVICE}")
+        ])
+
 
 class TestValidation(unittest.TestCase):
     """

--- a/test/unittests/test_service_manager.py
+++ b/test/unittests/test_service_manager.py
@@ -56,17 +56,17 @@ class TestServiceManager(unittest.TestCase):
     def test_start_service(self, mock_call_with_parallax: mock.MagicMock):
         self.service_manager._call.return_value = ['node1']
         self.assertEqual(['node1'], self.service_manager.start_service('service1', remote_addr='node1'))
-        self.service_manager._call.assert_called_once_with('node1', [], "systemctl start 'service1'")
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl start 'service1' && systemctl is-active 'service1'")
 
     def test_start_service_on_multiple_host(self, mock_call_with_parallax: mock.MagicMock):
         self.service_manager._call.return_value = ['node1', 'node2']
         self.assertEqual(['node1', 'node2'], self.service_manager.start_service('service1', node_list=['node1', 'node2']))
-        self.service_manager._call.assert_called_once_with(None, ['node1', 'node2'], "systemctl start 'service1'")
+        self.service_manager._call.assert_called_once_with(None, ['node1', 'node2'], "systemctl start 'service1' && systemctl is-active 'service1'")
 
     def test_start_and_enable_service(self, mock_call_with_parallax: mock.MagicMock):
         self.service_manager._call.return_value = ['node1']
         self.assertEqual(['node1'], self.service_manager.start_service('service1', enable=True, remote_addr='node1'))
-        self.service_manager._call.assert_called_once_with('node1', [], "systemctl enable --now 'service1'")
+        self.service_manager._call.assert_called_once_with('node1', [], "systemctl enable --now 'service1' && systemctl is-enabled 'service1' && systemctl is-active 'service1'")
 
     def test_stop_service(self, mock_call_with_parallax: mock.MagicMock):
         self.service_manager._call.return_value = ['node1']

--- a/test/unittests/test_ui_cluster.py
+++ b/test/unittests/test_ui_cluster.py
@@ -56,6 +56,7 @@ class TestCluster(unittest.TestCase):
             mock.call("The cluster stack already started on node2")
             ])
 
+    @mock.patch('crmsh.bootstrap.get_failed_services')
     @mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
     @mock.patch('crmsh.bootstrap.start_pacemaker')
     @mock.patch('logging.Logger.error')
@@ -64,12 +65,14 @@ class TestCluster(unittest.TestCase):
     @mock.patch('crmsh.service_manager.ServiceManager.start_service')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
     @mock.patch('crmsh.ui_utils.parse_and_validate_node_args')
-    def test_do_start(self, mock_parse_nodes, mock_active, mock_start, mock_qdevice_configured, mock_info, mock_error, mock_start_pacemaker, mock_check_qdevice):
+    def test_do_start(self, mock_parse_nodes, mock_active, mock_start, mock_qdevice_configured, mock_info, mock_error, mock_start_pacemaker, mock_check_qdevice, mock_get_failed_services):
         context_inst = mock.Mock()
         mock_start_pacemaker.return_value = ["node1"]
         mock_parse_nodes.return_value = ["node1", "node2"], False
         mock_active.side_effect = [False, False, False, False]
         mock_qdevice_configured.return_value = True
+        mock_get_failed_services.return_value = []
+        mock_start.return_value = ["node1", "node2"]
 
         self.ui_cluster_inst.do_start(context_inst, "node1", "node2")
 
@@ -82,7 +85,7 @@ class TestCluster(unittest.TestCase):
         mock_start.assert_called_once_with("corosync-qdevice", node_list=["node1", "node2"])
         mock_qdevice_configured.assert_called_once_with()
         mock_info.assert_called_once_with("The cluster stack started on %s", "node1")
-        mock_error.assert_called_once_with("The cluster stack failed to start on %s", "node2")
+        mock_error.assert_called_once_with("The cluster stack failed to start on %s.%s", "node2", '')
 
     @mock.patch('crmsh.utils.wait_for_dc')
     @mock.patch('crmsh.ui_cluster.Cluster._node_ready_to_stop_cluster_service')


### PR DESCRIPTION
Changes:
-  Dev: bootstrap: Find and show failed services
- Dev: service_manager: Use 'systemctl is-active' to make sure the service is really active
- Dev: Separately check if corosync-qdevice.service is successfully started

Fix issue:
- #2101 