### PR TITLE
Fix: sbd: Set bootstrap_context.diskless_sbd to True when diskless SBD is enabled on interactive mode

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1368,6 +1368,7 @@ class SBDManager:
         # else if not use -S option, get sbd device interactively
         if not device_list and not self.bootstrap_context.diskless_sbd:
             device_list = self.get_sbd_device_interactive()
+            self.bootstrap_context.diskless_sbd = self.diskless_sbd
         if not device_list:
             return
 


### PR DESCRIPTION
So that the later SBDTimeout class can set the correct SBD_WATCHDOG_TIMEOUT value for diskless SBD

Fix issue:
- #2100 