### PR TITLE
Dev: utils: Add class MultipathInspector to inspect multipath devices

### DIFF
--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -129,6 +129,7 @@ class ClusterFSManager(object):
                 raise Error(f"{dev} is a Logical Volume, cannot be used with the -C option")
             if utils.has_disk_mounted(dev):
                 raise Error(f"{dev} is already mounted")
+            utils.MultipathInspector.check_device_under_multipath(dev)
 
     def _check_if_already_configured(self):
         """

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -89,12 +89,17 @@ class SBDUtils:
     def verify_sbd_device(dev_list, node_list=None, compare_uuid=False):
         if len(dev_list) > SBDManager.SBD_DEVICE_MAX:
             raise ValueError(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}")
+
         for dev in dev_list:
             failed_nodes = utils.get_non_block_device_nodes(dev, node_list)
             if failed_nodes:
                 raise ValueError(f"{dev} is not a block device on {', '.join(failed_nodes)}")
+
+            utils.MultipathInspector.check_device_under_multipath(dev)
+
             if compare_uuid:
                 SBDUtils.compare_device_uuid(dev, node_list)
+
         utils.detect_duplicate_device_path(dev_list)
 
     @staticmethod

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3632,4 +3632,58 @@ class DeprecatedTermTranslator:
         if not self._resolve_res:
             return False
         return not self._resolve_res.using_deprecated
+
+
+@dataclass(frozen=True)
+class DeviceInfo:
+    device: str
+    parent_device: str|None
+    under_multipath: bool
+
+
+class MultipathInspector:
+    def __init__(self, dev):
+        self._shell = sh.cluster_shell()
+        self._device_info = self._inspect(dev)
+
+    def _get_parent_device(self, dev) -> str:
+        resolved = Path(dev).resolve()
+        cmd = f"lsblk -dn -o PKNAME {shlex.quote(str(resolved))}"
+        _, out, _ = self._shell.get_rc_stdout_stderr_without_input(None, cmd)
+        return out or resolved.name
+
+    def _get_multipath_mapping(self) -> dict[str, str]:
+        cmd = "multipathd show paths format \"%d %m\""
+        rc, out, _ = self._shell.get_rc_stdout_stderr_without_input(None, cmd)
+        mapping = dict()
+        if rc != 0:
+            return mapping
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            dev_name, map_name = parts[0], parts[1]
+            if (dev_name, map_name) == ("dev", "multipath"):
+                continue
+            mapping[dev_name] = map_name
+        return mapping
+
+    def _inspect(self, dev: str) -> DeviceInfo:
+        parent = self._get_parent_device(dev)
+        mapping = self._get_multipath_mapping()
+        return DeviceInfo(
+            device=dev,
+            parent_device=parent,
+            under_multipath=parent in mapping
+        )
+
+    def _is_under_multipath(self) -> bool:
+        return self._device_info.under_multipath
+
+    @classmethod
+    def check_device_under_multipath(cls, dev):
+        inspector = cls(dev)
+        if inspector._is_under_multipath():
+            error_msg = f"Device {dev} is under multipath, please provide the multipath device instead"
+            raise ValueError(error_msg)
 # vim:ts=4:sw=4:et:

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1478,3 +1478,105 @@ node1(1): member
     assert res == ["node2"]
 
     mock_error.assert_called_once_with("From the view of node '%s', node '%s' is not a member of the cluster", 'node1', 'node2')
+
+
+class TestMultipathInspector(unittest.TestCase):
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_init(self, mock_cluster_shell):
+        """Test MultipathInspector initialization"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),  # lsblk output for parent device
+            (0, "dev multipath\nsda mpatha", "")  # multipathd show paths output
+        ]
+
+        inspector = utils.MultipathInspector("/dev/sda1")
+
+        assert inspector._shell == mock_shell_inst
+        assert inspector._device_info.device == "/dev/sda1"
+        assert inspector._device_info.parent_device == "sda"
+        assert inspector._device_info.under_multipath is True
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_get_parent_device(self, mock_cluster_shell):
+        """Test _get_parent_device method"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),  # lsblk output for __init__
+            (0, "", ""),  # multipathd show paths output for __init__
+            (0, "sda", "")  # lsblk output for test call
+        ]
+
+        inspector = utils.MultipathInspector("/dev/sda1")
+        parent = inspector._get_parent_device("/dev/sda1")
+
+        assert parent == "sda"
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_get_multipath_mapping(self, mock_cluster_shell):
+        """Test _get_multipath_mapping method with valid output"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        multipathd_output = """dev multipath
+sda mpatha
+sdb mpatha
+sdc mpathb"""
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),  # lsblk for __init__
+            (0, multipathd_output, ""),  # multipathd for __init__
+            (0, multipathd_output, "")  # multipathd for test call
+        ]
+
+        inspector = utils.MultipathInspector("/dev/sda1")
+        mapping = inspector._get_multipath_mapping()
+
+        assert mapping == {"sda": "mpatha", "sdb": "mpatha", "sdc": "mpathb"}
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_inspect_device_under_multipath(self, mock_cluster_shell):
+        """Test _inspect method when device is under multipath"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),
+            (0, "dev multipath\nsda mpatha", "")
+        ]
+
+        inspector = utils.MultipathInspector("/dev/sda1")
+        device_info = inspector._device_info
+
+        assert device_info.device == "/dev/sda1"
+        assert device_info.parent_device == "sda"
+        assert device_info.under_multipath is True
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_is_under_multipath_true(self, mock_cluster_shell):
+        """Test _is_under_multipath returns True"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),
+            (0, "dev multipath\nsda mpatha", "")
+        ]
+
+        inspector = utils.MultipathInspector("/dev/sda1")
+
+        assert inspector._is_under_multipath() is True
+
+    @mock.patch('crmsh.sh.cluster_shell')
+    def test_check_device_under_multipath_raises_error(self, mock_cluster_shell):
+        """Test check_device_under_multipath raises ValueError when device is under multipath"""
+        mock_shell_inst = mock.Mock()
+        mock_cluster_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_rc_stdout_stderr_without_input.side_effect = [
+            (0, "sda", ""),
+            (0, "dev multipath\nsda mpatha", "")
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            utils.MultipathInspector.check_device_under_multipath("/dev/sda1")
+
+        assert str(exc_info.value) == "Device /dev/sda1 is under multipath, please provide the multipath device instead"


### PR DESCRIPTION
Verify whether the given sbd/ocfs2/gfs2 device is under multipath, and if so, remind users to use the multipath device instead of the underlying device.

```
# crm cluster init sbd -s /dev/sda5 -y
ERROR: cluster.init: Device /dev/sda5 is under multipath, please provide the multipath device instead
```