### PR TITLE
Fix: sbd: Verify sbd devices on all nodes

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -2053,6 +2053,8 @@ def join_cluster(seed_host, remote_user):
     if not os.path.exists(corosync.conf()):
         utils.fatal("{} is not readable. Please ensure that hostnames are resolvable.".format(corosync.conf()))
 
+    _context.sbd_manager.join_sbd(remote_user, seed_host)
+
     ringXaddr_res = []
     for i in range(link_number):
         while True:
@@ -2073,8 +2075,6 @@ def join_cluster(seed_host, remote_user):
         logger.warning(e)
     sync_path(corosync.conf(), seed_host)
     shell.get_stdout_or_raise_error('corosync-cfgtool -R', seed_host)
-
-    _context.sbd_manager.join_sbd(remote_user, seed_host)
 
     # Initialize the cluster before adjusting quorum. This is so
     # that we can query the cluster to find out how many nodes

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -262,8 +262,6 @@ class Context(object):
             utils.fatal("-w option should be used with -s or -S option")
         if self.sbd_devices and self.diskless_sbd:
             utils.fatal("Can't use -s and -S options together")
-        if self.sbd_devices:
-            sbd.SBDUtils.verify_sbd_device(self.sbd_devices)
 
         with_sbd_option = self.sbd_devices or self.diskless_sbd
 
@@ -272,7 +270,10 @@ class Context(object):
             if not utils.calculate_quorate_status():
                 utils.fatal("Cluster is not quorate, can't run 'sbd' stage")
 
-            for node in utils.list_cluster_nodes():
+            node_list = utils.list_cluster_nodes()
+            if self.sbd_devices:
+                sbd.SBDUtils.verify_sbd_device(self.sbd_devices, node_list)
+            for node in node_list:
                 if not utils.package_is_installed("sbd", node):
                     utils.fatal(sbd.SBDManager.SBD_NOT_INSTALLED_MSG + f" on {node}")
                 if self.sbd_devices and not utils.package_is_installed("fence-agents-sbd", node):
@@ -286,8 +287,10 @@ class Context(object):
         elif with_sbd_option:
             if not utils.package_is_installed("sbd"):
                 utils.fatal(sbd.SBDManager.SBD_NOT_INSTALLED_MSG)
-            if self.sbd_devices and not utils.package_is_installed("fence-agents-sbd"):
-                utils.fatal(sbd.SBDManager.FENCE_SBD_NOT_INSTALLED_MSG)
+            if self.sbd_devices:
+                if not utils.package_is_installed("fence-agents-sbd"):
+                    utils.fatal(sbd.SBDManager.FENCE_SBD_NOT_INSTALLED_MSG)
+                sbd.SBDUtils.verify_sbd_device(self.sbd_devices)
 
     def _validate_nodes_option(self):
         """

--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -119,9 +119,11 @@ class ClusterFSManager(object):
         """
         Verify OCFS2/GFS2 devices
         """
+        node_list = utils.list_cluster_nodes() if self.use_stage else [utils.this_node()]
         for dev in self.devices:
-            if not utils.is_block_device(dev):
-                raise Error(f"{dev} doesn't look like a block device")
+            failed_nodes = utils.get_non_block_device_nodes(dev, node_list)
+            if failed_nodes:
+                raise Error(f"{dev} is not a block device on {', '.join(failed_nodes)}")
             if utils.is_dev_used_for_lvm(dev) and self.use_cluster_lvm2:
                 raise Error(f"{dev} is a Logical Volume, cannot be used with the -C option")
             if utils.has_disk_mounted(dev):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -70,6 +70,8 @@ class SBDUtils:
         if not local_uuid:
             raise ValueError(f"Cannot get sbd device UUID for {dev} on {utils.this_node()}")
         for node in node_list:
+            if node == utils.this_node():
+                continue
             remote_uuid = SBDUtils.get_device_uuid(dev, node)
             if not remote_uuid:
                 raise ValueError(f"Cannot get sbd device UUID for {dev} on {node}")
@@ -77,13 +79,14 @@ class SBDUtils:
                 raise ValueError(f"Device {dev} doesn't have the same UUID with {node}")
 
     @staticmethod
-    def verify_sbd_device(dev_list, compare_node_list=None):
+    def verify_sbd_device(dev_list, node_list=None):
         if len(dev_list) > SBDManager.SBD_DEVICE_MAX:
             raise ValueError(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}")
         for dev in dev_list:
-            if not utils.is_block_device(dev):
-                raise ValueError(f"{dev} doesn't look like a block device")
-            SBDUtils.compare_device_uuid(dev, compare_node_list)
+            failed_nodes = utils.get_non_block_device_nodes(dev, node_list)
+            if failed_nodes:
+                raise ValueError(f"{dev} is not a block device on {', '.join(failed_nodes)}")
+            SBDUtils.compare_device_uuid(dev, node_list)
         utils.detect_duplicate_device_path(dev_list)
 
     @staticmethod
@@ -1462,7 +1465,7 @@ class SBDManager:
         self._watchdog_inst.join_watchdog()
 
         if dev_list:
-            SBDUtils.verify_sbd_device(dev_list, compare_node_list=[peer_host])
+            SBDUtils.verify_sbd_device(dev_list, [utils.this_node(), peer_host])
 
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))
         self.enable_sbd_service()

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -25,18 +25,25 @@ class SBDUtils:
     Consolidate sbd related utility methods
     '''
     @staticmethod
+    def get_sbd_device_metadata_raw(dev, remote=None) -> str:
+        '''
+        Get raw metadata info from sbd device header
+        Raise ValueError if the command fails or the output is empty
+        '''
+        cmd = f"sbd -d {shlex.quote(dev)} dump"
+        out = sh.cluster_shell().get_stdout_or_raise_error(cmd, remote)
+        if not out: # might not possible, but just in case to avoid further parsing error
+            raise ValueError(f"Cannot get metadata from SBD device {dev} on {remote or utils.this_node()}")
+        return out
+
+    @staticmethod
     def get_sbd_device_metadata(dev, timeout_only=False, remote=None) -> dict:
         '''
         Extract metadata from sbd device header
         '''
         sbd_info = {}
-
-        cmd = f"sbd -d {shlex.quote(dev)} dump"
-        rc, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(remote, cmd)
-        if rc != 0 or not out:
-            return sbd_info
-
         pattern = r"UUID\s+:\s+(\S+)|Timeout\s+\((\w+)\)\s+:\s+(\d+)"
+        out = SBDUtils.get_sbd_device_metadata_raw(dev, remote)
         matches = re.findall(pattern, out)
         for uuid, timeout_type, timeout_value in matches:
             if uuid and not timeout_only:

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -694,6 +694,14 @@ class SBDConfigChecker(SBDTimeout):
         if not self._check_config_consistency(error_msg):
             raise FixAborted("All other checks aborted due to inconsistent configurations")
 
+        dev_list = SBDUtils.get_sbd_device_from_config()
+        if dev_list:
+            try:
+                nodes_to_check = [utils.this_node()] + (self.peer_node_list or [])
+                SBDUtils.verify_sbd_device(dev_list, nodes_to_check)
+            except ValueError as e:
+                raise FixAborted(f"SBD device verification failed: {e}")
+
         self._load_configurations_from_runtime()
         self._get_current_terms()
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -79,14 +79,15 @@ class SBDUtils:
                 raise ValueError(f"Device {dev} doesn't have the same UUID with {node}")
 
     @staticmethod
-    def verify_sbd_device(dev_list, node_list=None):
+    def verify_sbd_device(dev_list, node_list=None, compare_uuid=False):
         if len(dev_list) > SBDManager.SBD_DEVICE_MAX:
             raise ValueError(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}")
         for dev in dev_list:
             failed_nodes = utils.get_non_block_device_nodes(dev, node_list)
             if failed_nodes:
                 raise ValueError(f"{dev} is not a block device on {', '.join(failed_nodes)}")
-            SBDUtils.compare_device_uuid(dev, node_list)
+            if compare_uuid:
+                SBDUtils.compare_device_uuid(dev, node_list)
         utils.detect_duplicate_device_path(dev_list)
 
     @staticmethod
@@ -698,7 +699,7 @@ class SBDConfigChecker(SBDTimeout):
         if dev_list:
             try:
                 nodes_to_check = [utils.this_node()] + (self.peer_node_list or [])
-                SBDUtils.verify_sbd_device(dev_list, nodes_to_check)
+                SBDUtils.verify_sbd_device(dev_list, nodes_to_check, compare_uuid=True)
             except ValueError as e:
                 raise FixAborted(f"SBD device verification failed: {e}")
 
@@ -1473,7 +1474,7 @@ class SBDManager:
         self._watchdog_inst.join_watchdog()
 
         if dev_list:
-            SBDUtils.verify_sbd_device(dev_list, [utils.this_node(), peer_host])
+            SBDUtils.verify_sbd_device(dev_list, [utils.this_node(), peer_host], compare_uuid=True)
 
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))
         self.enable_sbd_service()

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1328,6 +1328,7 @@ class SBDManager:
     def _wants_to_overwrite(self, configured_devices):
         wants_to_overwrite_msg = f"SBD_DEVICE in {self.SYSCONFIG_SBD} is already configured to use '{';'.join(configured_devices)}' - overwrite?"
         if not bootstrap.confirm(wants_to_overwrite_msg):
+            SBDUtils.verify_sbd_device(configured_devices)
             if not SBDUtils.check_devices_metadata_consistent(configured_devices):
                 raise utils.TerminateSubCommand
             self.overwrite_sysconfig = False

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -467,7 +467,7 @@ class SBD(command.UI):
         Implement sbd device add command, add devices to sbd configuration
         '''
         all_device_list = self.device_list_from_config + devices_to_add
-        sbd.SBDUtils.verify_sbd_device(all_device_list)
+        sbd.SBDUtils.verify_sbd_device(all_device_list, self.cluster_nodes)
 
         devices_to_init, _ = sbd.SBDUtils.handle_input_sbd_devices(
             devices_to_add,

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -2,7 +2,6 @@ import logging
 import typing
 import re
 import os
-import shlex
 
 from crmsh import sbd
 from crmsh import watchdog
@@ -216,9 +215,7 @@ class SBD(command.UI):
         if self.device_list_from_config:
             logger.info("crm sbd configure show disk_metadata")
         for dev in self.device_list_from_config:
-            cmd = f"sbd -d {shlex.quote(dev)} dump"
-            _, out, _ = self.cluster_shell.get_rc_stdout_stderr_without_input(None, cmd)
-            print(out)
+            print(sbd.SBDUtils.get_sbd_device_metadata_raw(dev))
 
     def _show_property(self) -> None:
         '''

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -383,6 +383,8 @@ class SBD(command.UI):
         '''
         Configure disk-based SBD based on input parameters and runtime config
         '''
+        sbd.SBDUtils.verify_sbd_device(self.device_list_from_config, self.cluster_nodes)
+
         update_dict = {}
         watchdog_device = parameter_dict.get("watchdog-device")
         if watchdog_device != self.watchdog_device_from_config:
@@ -406,8 +408,7 @@ class SBD(command.UI):
             result_dict = self._set_sbd_opts(crashdump_watchdog_timeout)
             update_dict = {**update_dict, **result_dict}
 
-        device_list = sbd.SBDUtils.get_sbd_device_from_config()
-        devices_consistent = sbd.SBDUtils.check_devices_metadata_consistent(device_list, quiet=True)
+        devices_consistent = sbd.SBDUtils.check_devices_metadata_consistent(self.device_list_from_config, quiet=True)
         if timeout_dict == self.device_meta_dict_runtime and not update_dict and devices_consistent:
             logger.info("No change in SBD configuration")
             return
@@ -486,6 +487,8 @@ class SBD(command.UI):
         '''
         Implement sbd device remove command, remove devices from sbd configuration
         '''
+        sbd.SBDUtils.verify_sbd_device(self.device_list_from_config, self.cluster_nodes)
+
         for dev in devices_to_remove:
             if dev not in self.device_list_from_config:
                 raise self.SyntaxError(f"Device {dev} is not in config")
@@ -612,6 +615,8 @@ class SBD(command.UI):
         self._load_attributes()
         if not self._service_is_active(constants.SBD_SERVICE):
             return False
+        if self.device_list_from_config:
+            sbd.SBDUtils.verify_sbd_device(self.device_list_from_config, self.cluster_nodes)
 
         args = _handle_force_option(args)
         purge_crashdump = False

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -2,6 +2,7 @@ import logging
 import typing
 import re
 import os
+import shlex
 
 from crmsh import sbd
 from crmsh import watchdog
@@ -215,8 +216,9 @@ class SBD(command.UI):
         if self.device_list_from_config:
             logger.info("crm sbd configure show disk_metadata")
         for dev in self.device_list_from_config:
-            print(self.cluster_shell.get_stdout_or_raise_error(f"sbd -d {dev} dump"))
-            print()
+            cmd = f"sbd -d {shlex.quote(dev)} dump"
+            _, out, _ = self.cluster_shell.get_rc_stdout_stderr_without_input(None, cmd)
+            print(out)
 
     def _show_property(self) -> None:
         '''

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -26,6 +26,7 @@ import lzma
 import json
 import socket
 import selectors
+import shlex
 from pathlib import Path
 from collections import defaultdict
 from contextlib import contextmanager, closing
@@ -2621,15 +2622,21 @@ def re_split_string(reg, string):
     return [x for x in re.split(reg, string) if x]
 
 
-def is_block_device(dev):
+def get_non_block_device_nodes(dev, node_list=None) -> list[str]:
     """
-    Check if dev is a block device
+    Return a list of nodes where the device is not a block device or does not exist
     """
-    try:
-        rc = S_ISBLK(os.stat(dev).st_mode)
-    except OSError:
-        return False
-    return rc
+    shell = sh.cluster_shell()
+    cluster_nodes = node_list or [this_node()]
+    failed_nodes = []
+    for node in cluster_nodes:
+        rc, _, _ = shell.get_rc_stdout_stderr_without_input(
+            node,
+            f"test -b {shlex.quote(dev)}"
+        )
+        if rc != 0:
+            failed_nodes.append(node)
+    return failed_nodes
 
 
 def detect_duplicate_device_path(device_list: typing.List[str]):

--- a/test/features/bootstrap_sbd_normal.feature
+++ b/test/features/bootstrap_sbd_normal.feature
@@ -8,7 +8,7 @@ Feature: crmsh bootstrap sbd management
     When    Try "crm cluster init -s "/dev/sda1;/dev/sda2;/dev/sda3;/dev/sda4" -y"
     Then    Except "ERROR: cluster.init: Maximum number of SBD device is 3"
     When    Try "crm cluster init -s "/dev/sda1;/dev/sdaxxxx" -y"
-    Then    Except "ERROR: cluster.init: /dev/sdaxxxx doesn't look like a block device"
+    Then    Expected "/dev/sdaxxxx is not a block device on" in stderr
     When    Try "crm cluster init -s "/dev/sda1;/dev/sda1" -y"
     Then    Expected multiple lines in stderr
       """

--- a/test/unittests/test_cluster_fs.py
+++ b/test/unittests/test_cluster_fs.py
@@ -88,17 +88,19 @@ class TestClusterFSManager(unittest.TestCase):
             self.gfs2_instance_one_device_with_mount_point._verify_options()
         self.assertIn("Mount point /mnt/gfs2 already mounted", str(context.exception))
 
-    @mock.patch("crmsh.utils.is_block_device")
-    def test_verify_devices_not_block_device(self, mock_is_block_device):
-        mock_is_block_device.return_value = False
+    @mock.patch("crmsh.utils.list_cluster_nodes")
+    @mock.patch("crmsh.utils.get_non_block_device_nodes")
+    def test_verify_devices_not_block_device(self, mock_get_non_block_device_nodes, mock_list_cluster_nodes):
+        mock_list_cluster_nodes.return_value = ["node1", "node2"]
+        mock_get_non_block_device_nodes.return_value = ["node1"]
         with self.assertRaises(cluster_fs.Error) as context:
             self.ocfs2_instance_one_device._verify_devices()
-        self.assertIn("/dev/sda1 doesn't look like a block device", str(context.exception))
+        self.assertIn("/dev/sda1 is not a block device on node1", str(context.exception))
 
     @mock.patch("crmsh.utils.is_dev_used_for_lvm")
-    @mock.patch("crmsh.utils.is_block_device")
-    def test_verify_devices_clvm2_with_lv(self, mock_is_block_device, mock_is_dev_used_for_lvm):
-        mock_is_block_device.return_value = True
+    @mock.patch("crmsh.utils.get_non_block_device_nodes")
+    def test_verify_devices_clvm2_with_lv(self, mock_get_non_block_device_nodes, mock_is_dev_used_for_lvm):
+        mock_get_non_block_device_nodes.return_value = []
         mock_is_dev_used_for_lvm.return_value = True
         with self.assertRaises(cluster_fs.Error) as context:
             self.gfs2_instance_one_device_clvm2._verify_devices()
@@ -106,9 +108,9 @@ class TestClusterFSManager(unittest.TestCase):
 
     @mock.patch("crmsh.utils.has_disk_mounted")
     @mock.patch("crmsh.utils.is_dev_used_for_lvm")
-    @mock.patch("crmsh.utils.is_block_device")
-    def test_verify_devices_already_mounted(self, mock_is_block_device, mock_is_dev_used_for_lvm, mock_has_disk_mounted):
-        mock_is_block_device.return_value = True
+    @mock.patch("crmsh.utils.get_non_block_device_nodes")
+    def test_verify_devices_already_mounted(self, mock_get_non_block_device_nodes, mock_is_dev_used_for_lvm, mock_has_disk_mounted):
+        mock_get_non_block_device_nodes.return_value = []
         mock_is_dev_used_for_lvm.return_value = False
         mock_has_disk_mounted.return_value = True
         with self.assertRaises(cluster_fs.Error) as context:

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -15,25 +15,27 @@ class TestSBDUtils(unittest.TestCase):
     Timeout (msgwait) : 10
     """
 
-    @patch('crmsh.sh.cluster_shell')
-    def test_get_sbd_device_metadata_success(self, mock_cluster_shell):
-        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (0, self.TEST_DATA, None)
+    @patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata_raw')
+    def test_get_sbd_device_metadata_success(self, mock_get_sbd_device_metadata_raw):
+        mock_get_sbd_device_metadata_raw.return_value = self.TEST_DATA
         result = SBDUtils.get_sbd_device_metadata("/dev/sbd_device")
         expected = {'uuid': '1234-5678', 'watchdog': 5, 'msgwait': 10}
         self.assertEqual(result, expected)
 
-    @patch('crmsh.sh.cluster_shell')
-    def test_get_sbd_device_metadata_timeout_only(self, mock_cluster_shell):
-        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (0, self.TEST_DATA, None)
+    @patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata_raw')
+    def test_get_sbd_device_metadata_timeout_only(self, mock_get_sbd_device_metadata_raw):
+        mock_get_sbd_device_metadata_raw.return_value = self.TEST_DATA
         result = SBDUtils.get_sbd_device_metadata("/dev/sbd_device", timeout_only=True)
         expected = {'watchdog': 5, 'msgwait': 10}
         self.assertNotIn('uuid', result)
         self.assertEqual(result, expected)
 
     @patch('crmsh.sh.cluster_shell')
-    def test_get_sbd_device_metadata_failure(self, mock_cluster_shell):
-        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (1, None, None)
-        self.assertEqual(SBDUtils.get_sbd_device_metadata("/dev/sbd_device"), {})
+    def test_get_sbd_device_metadata_raw_failure(self, mock_cluster_shell):
+        mock_cluster_shell.return_value.get_stdout_or_raise_error.side_effect = ValueError("Command failed")
+        with self.assertRaises(ValueError):
+            SBDUtils.get_sbd_device_metadata_raw("/dev/sbd_device")
+        mock_cluster_shell.return_value.get_stdout_or_raise_error.assert_called_once_with("sbd -d /dev/sbd_device dump", None)
 
     @patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata')
     def test_get_device_uuid_success(self, mock_get_sbd_device_metadata):

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -962,10 +962,11 @@ class TestSBDManager(unittest.TestCase):
         sbdmanager_instance._wants_to_overwrite.assert_not_called()
         sbdmanager_instance._prompt_for_sbd_device.assert_called_once()
 
+    @patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @patch('crmsh.sbd.SBDUtils.check_devices_metadata_consistent')
     @patch('crmsh.bootstrap.confirm')
     @patch('crmsh.sbd.ServiceManager')
-    def test_wants_to_overwrite_exception(self, mock_ServiceManager, mock_confirm, mock_check_devices_metadata_consistent):
+    def test_wants_to_overwrite_exception(self, mock_ServiceManager, mock_confirm, mock_check_devices_metadata_consistent, mock_verify_sbd_device):
         sbdmanager_instance = SBDManager()
         mock_confirm.return_value = False
         mock_check_devices_metadata_consistent.return_value = False
@@ -988,10 +989,11 @@ class TestSBDManager(unittest.TestCase):
         sbd.SBDManager.warn_diskless_sbd()
         mock_logger_warning.assert_called_once_with('%s', SBDManager.DISKLESS_SBD_WARNING)
 
+    @patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @patch('crmsh.sbd.SBDUtils.check_devices_metadata_consistent')
     @patch('crmsh.bootstrap.confirm')
     @patch('crmsh.sbd.ServiceManager')
-    def test_wants_to_overwrite_return_false(self, mock_ServiceManager, mock_confirm, mock_check_devices_metadata_consistent):
+    def test_wants_to_overwrite_return_false(self, mock_ServiceManager, mock_confirm, mock_check_devices_metadata_consistent, mock_verify_sbd_device):
         sbdmanager_instance = SBDManager()
         mock_confirm.return_value = False
         mock_check_devices_metadata_consistent.return_value = True

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -57,24 +57,26 @@ class TestSBDUtils(unittest.TestCase):
         with self.assertRaises(ValueError):
             SBDUtils.compare_device_uuid("/dev/sbd_device", ["node1"])
 
-    @patch('crmsh.utils.is_block_device')
+    @patch('crmsh.utils.get_non_block_device_nodes')
     @patch('crmsh.sbd.SBDUtils.compare_device_uuid')
-    def test_verify_sbd_device_exceeds_max(self, mock_compare_device_uuid, mock_is_block_device):
+    def test_verify_sbd_device_exceeds_max(self, mock_compare_device_uuid, mock_get_non_block_device_nodes):
         dev_list = [f"/dev/sbd_device_{i}" for i in range(SBDManager.SBD_DEVICE_MAX + 1)]
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as context:
             SBDUtils.verify_sbd_device(dev_list)
+        self.assertTrue(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}" in str(context.exception))
 
-    @patch('crmsh.utils.is_block_device')
+    @patch('crmsh.utils.get_non_block_device_nodes')
     @patch('crmsh.sbd.SBDUtils.compare_device_uuid')
-    def test_verify_sbd_device_non_block(self, mock_compare_device_uuid, mock_is_block_device):
-        mock_is_block_device.return_value = False
-        with self.assertRaises(ValueError):
+    def test_verify_sbd_device_non_block(self, mock_compare_device_uuid, mock_get_non_block_device_nodes):
+        mock_get_non_block_device_nodes.return_value = ["node1"]
+        with self.assertRaises(ValueError) as context:
             SBDUtils.verify_sbd_device(["/dev/not_a_block_device"])
+        self.assertTrue(f"/dev/not_a_block_device is not a block device on node1" in str(context.exception))
 
-    @patch('crmsh.utils.is_block_device')
+    @patch('crmsh.utils.get_non_block_device_nodes')
     @patch('crmsh.sbd.SBDUtils.compare_device_uuid')
-    def test_verify_sbd_device_valid(self, mock_compare_device_uuid, mock_is_block_device):
-        mock_is_block_device.return_value = True
+    def test_verify_sbd_device_valid(self, mock_compare_device_uuid, mock_get_non_block_device_nodes):
+        mock_get_non_block_device_nodes.return_value = []
         SBDUtils.verify_sbd_device(["/dev/sbd_device"], ["node1", "node2"])
 
     @patch('crmsh.utils.parse_sysconfig')

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -181,15 +181,15 @@ class TestSBD(unittest.TestCase):
             mock_logger_info.assert_called_with("crm sbd configure show sysconfig")
             self.assertEqual(mock_stdout.getvalue(), "KEY1=value1\nKEY2=value2\n")
 
+    @mock.patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata_raw')
     @mock.patch('logging.Logger.info')
-    def test_show_disk_metadata(self, mock_logger_info):
-        self.sbd_instance_diskbased.cluster_shell.get_rc_stdout_stderr_without_input.return_value = (0, "disk metadata: data", None)
+    def test_show_disk_metadata(self, mock_logger_info, mock_get_sbd_device_metadata_raw):
+        mock_get_sbd_device_metadata_raw.return_value = "disk metadata: data"
         with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
             self.sbd_instance_diskbased._show_disk_metadata()
             self.assertTrue(mock_logger_info.called)
             mock_logger_info.assert_called_with("crm sbd configure show disk_metadata")
             self.assertEqual(mock_stdout.getvalue(), "disk metadata: data\n")
-        self.sbd_instance_diskbased.cluster_shell.get_rc_stdout_stderr_without_input.assert_called_with(None, "sbd -d /dev/sda1 dump")
 
     def test_do_configure_no_service(self):
         self.sbd_instance_diskbased._load_attributes = mock.Mock()

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -183,13 +183,13 @@ class TestSBD(unittest.TestCase):
 
     @mock.patch('logging.Logger.info')
     def test_show_disk_metadata(self, mock_logger_info):
-        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.return_value = "disk metadata: data"
+        self.sbd_instance_diskbased.cluster_shell.get_rc_stdout_stderr_without_input.return_value = (0, "disk metadata: data", None)
         with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
             self.sbd_instance_diskbased._show_disk_metadata()
             self.assertTrue(mock_logger_info.called)
             mock_logger_info.assert_called_with("crm sbd configure show disk_metadata")
-            self.assertEqual(mock_stdout.getvalue(), "disk metadata: data\n\n")
-        self.sbd_instance_diskbased.cluster_shell.get_stdout_or_raise_error.assert_called_with("sbd -d /dev/sda1 dump")
+            self.assertEqual(mock_stdout.getvalue(), "disk metadata: data\n")
+        self.sbd_instance_diskbased.cluster_shell.get_rc_stdout_stderr_without_input.assert_called_with(None, "sbd -d /dev/sda1 dump")
 
     def test_do_configure_no_service(self):
         self.sbd_instance_diskbased._load_attributes = mock.Mock()

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -423,7 +423,7 @@ class TestSBD(unittest.TestCase):
         mock_handle_input_sbd_devices.return_value = [["/dev/sda2"], ["/dev/sda1"]]
         mock_SBDManager.return_value.init_and_deploy_sbd = mock.Mock()
         self.sbd_instance_diskbased._device_add(["/dev/sda2"])
-        mock_verify_sbd_device.assert_called_once_with(["/dev/sda1", "/dev/sda2"])
+        mock_verify_sbd_device.assert_called_once_with(["/dev/sda1", "/dev/sda2"], self.sbd_instance_diskbased.cluster_nodes)
         mock_handle_input_sbd_devices.assert_called_once_with(["/dev/sda2"], ["/dev/sda1"])
         mock_SBDManager.assert_called_once_with(
             device_list_to_init=["/dev/sda2"],

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -361,9 +361,10 @@ class TestSBD(unittest.TestCase):
         mock_logger_error.assert_called_once_with('%s', "No argument")
         mock_print.assert_called_once_with("usage data")
 
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.sbd.SBDManager')
-    def test_configure_diskbase(self, mock_SBDManager, mock_logger_info):
+    def test_configure_diskbase(self, mock_SBDManager, mock_logger_info, mock_verify_sbd_device):
         parameter_dict = {"watchdog": 12, "watchdog-device": "/dev/watchdog100", "crashdump-watchdog": 12}
         self.sbd_instance_diskbased._should_configure_crashdump = mock.Mock(return_value=True)
         self.sbd_instance_diskbased._check_kdump_service = mock.Mock()
@@ -381,9 +382,10 @@ class TestSBD(unittest.TestCase):
         self.sbd_instance_diskbased._check_kdump_service.assert_called_once()
         self.sbd_instance_diskbased._set_sbd_opts.assert_called_once()
 
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.sbd.SBDManager')
-    def test_configure_diskbase_no_change(self, mock_SBDManager, mock_logger_info):
+    def test_configure_diskbase_no_change(self, mock_SBDManager, mock_logger_info, mock_verify_sbd_device):
         parameter_dict = {"msgwait": 20, "watchdog": 10, "watchdog-device": "/dev/watchdog0"}
         self.sbd_instance_diskbased._should_configure_crashdump = mock.Mock(return_value=False)
         self.sbd_instance_diskbased._configure_diskbase(parameter_dict)
@@ -432,22 +434,25 @@ class TestSBD(unittest.TestCase):
         )
         mock_logger_info.assert_called_once_with("Append devices: %s", "/dev/sda2")
 
-    def test_device_remove_dev_not_in_config(self):
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    def test_device_remove_dev_not_in_config(self, mock_verify_sbd_device):
         with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
             self.sbd_instance_diskbased._device_remove(["/dev/sda2"])
         self.assertEqual(str(e.exception), "Device /dev/sda2 is not in config")
 
-    def test_device_remove_last_dev(self):
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    def test_device_remove_last_dev(self, mock_verify_sbd_device):
         with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
             self.sbd_instance_diskbased._device_remove(["/dev/sda1"])
         self.assertEqual(str(e.exception), "Not allowed to remove all devices")
 
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @mock.patch('crmsh.utils.able_to_restart_cluster')
     @mock.patch('crmsh.utils.leverage_maintenance_mode')
     @mock.patch('crmsh.bootstrap.restart_cluster')
     @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
     @mock.patch('logging.Logger.info')
-    def test_device_remove(self, mock_logger_info, mock_update_sbd_configuration, mock_restart_cluster, mock_leverage_maintenance_mode, mock_able_to_restart_cluster):
+    def test_device_remove(self, mock_logger_info, mock_update_sbd_configuration, mock_restart_cluster, mock_leverage_maintenance_mode, mock_able_to_restart_cluster, mock_verify_sbd_device):
         enable_value = True
         cm = mock.Mock()
         cm.__enter__ = mock.Mock(return_value=enable_value)
@@ -552,8 +557,9 @@ class TestSBD(unittest.TestCase):
         self.assertFalse(res)
         mock_purge_sbd_from_cluster.assert_not_called()
 
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
-    def test_do_purge(self, mock_check_all_nodes_reachable):
+    def test_do_purge(self, mock_check_all_nodes_reachable, mock_verify_sbd_device):
         self.sbd_instance_diskbased._load_attributes = mock.Mock()
         self.sbd_instance_diskbased._service_is_active = mock.Mock(return_value=True)
         self.sbd_instance_diskbased._purge_sbd = mock.Mock()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -939,28 +939,14 @@ fencing-sbd
     mock_diskless.assert_called_once_with()
 
 
-@mock.patch('crmsh.utils.S_ISBLK')
-@mock.patch('os.stat')
-def test_is_block_device_error(mock_stat, mock_isblk):
-    mock_stat_inst = mock.Mock(st_mode=12345)
-    mock_stat.return_value = mock_stat_inst
-    mock_isblk.side_effect = OSError
-    res = utils.is_block_device("/dev/sda1")
-    assert res is False
-    mock_stat.assert_called_once_with("/dev/sda1")
-    mock_isblk.assert_called_once_with(12345)
-
-
-@mock.patch('crmsh.utils.S_ISBLK')
-@mock.patch('os.stat')
-def test_is_block_device(mock_stat, mock_isblk):
-    mock_stat_inst = mock.Mock(st_mode=12345)
-    mock_stat.return_value = mock_stat_inst
-    mock_isblk.return_value = True
-    res = utils.is_block_device("/dev/sda1")
-    assert res is True
-    mock_stat.assert_called_once_with("/dev/sda1")
-    mock_isblk.assert_called_once_with(12345)
+@mock.patch('crmsh.sh.cluster_shell')
+def test_get_non_block_device_nodes(mock_cluster_shell):
+    mock_cluster_shell_inst = mock.Mock()
+    mock_cluster_shell.return_value = mock_cluster_shell_inst
+    mock_cluster_shell_inst.get_rc_stdout_stderr_without_input.return_value = (1, None, None)
+    res = utils.get_non_block_device_nodes("/dev/sda1", ["node1"])
+    assert res == ["node1"]
+    mock_cluster_shell_inst.get_rc_stdout_stderr_without_input.assert_called_once_with("node1", "test -b /dev/sda1")    
 
 
 @mock.patch('crmsh.utils.ssh_port_reachable_check')


### PR DESCRIPTION
The function `utils.is_block_device()` only checks whether the device is a block device on the local node. When adding an SBD device with `crm sbd device add`, or adding SBD/OCFS2/GFS2 during the stage, errors are not detected early if the specified device is not a block device or does not exist on peer nodes.

 This commit renames the function to `utils.get_non_block_device_nodes` and refactors it to check the device on all nodes in the cluster and return a list of nodes where the device is not a block device or does not exist.
Fix issue:
- #2117

Other changes:
- Dev: bootstrap: Call join_sbd before changing corosync.conf
to avoid potential inconsistency of corosync.conf when join_sbd raises an exception
- Dev: sbd: Call SBDUtils.verify_sbd_device when doing sbd health check
- Dev: sbd: Compare SBD device UUID optionally
- Dev: sbd: Introduce function sbd.SBDUtils.get_sbd_device_metadata_raw
- Dev: ui_sbd: Call SBDUtils.verify_sbd_device in multiple places