### PR TITLE
Fix: sbd: Compare SBD device UUID when adding SBD via sbd stage

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -3,6 +3,7 @@ import re
 import typing
 import shutil
 import time
+import shlex
 import logging
 from enum import Enum, IntEnum, auto
 from . import utils, sh
@@ -29,9 +30,13 @@ class SBDUtils:
         Extract metadata from sbd device header
         '''
         sbd_info = {}
-        pattern = r"UUID\s+:\s+(\S+)|Timeout\s+\((\w+)\)\s+:\s+(\d+)"
 
-        out = sh.cluster_shell().get_stdout_or_raise_error(f"sbd -d {dev} dump", remote)
+        cmd = f"sbd -d {shlex.quote(dev)} dump"
+        rc, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(remote, cmd)
+        if rc != 0 or not out:
+            return sbd_info
+
+        pattern = r"UUID\s+:\s+(\S+)|Timeout\s+\((\w+)\)\s+:\s+(\d+)"
         matches = re.findall(pattern, out)
         for uuid, timeout_type, timeout_value in matches:
             if uuid and not timeout_only:
@@ -47,14 +52,12 @@ class SBDUtils:
         return sbd_info
 
     @staticmethod
-    def get_device_uuid(dev, node=None):
+    def get_device_uuid(dev, node=None) -> str|None:
         '''
         Get UUID for specific device and node
         '''
-        res = SBDUtils.get_sbd_device_metadata(dev, remote=node).get("uuid")
-        if not res:
-            raise ValueError(f"Cannot find sbd device UUID for {dev}")
-        return res
+        metadata_info = SBDUtils.get_sbd_device_metadata(dev, remote=node)
+        return metadata_info.get("uuid")
 
     @staticmethod
     def compare_device_uuid(dev, node_list):
@@ -64,13 +67,17 @@ class SBDUtils:
         if not node_list:
             return
         local_uuid = SBDUtils.get_device_uuid(dev)
+        if not local_uuid:
+            raise ValueError(f"Cannot get sbd device UUID for {dev} on {utils.this_node()}")
         for node in node_list:
             remote_uuid = SBDUtils.get_device_uuid(dev, node)
+            if not remote_uuid:
+                raise ValueError(f"Cannot get sbd device UUID for {dev} on {node}")
             if local_uuid != remote_uuid:
                 raise ValueError(f"Device {dev} doesn't have the same UUID with {node}")
 
     @staticmethod
-    def verify_sbd_device(dev_list, compare_node_list=[]):
+    def verify_sbd_device(dev_list, compare_node_list=None):
         if len(dev_list) > SBDManager.SBD_DEVICE_MAX:
             raise ValueError(f"Maximum number of SBD device is {SBDManager.SBD_DEVICE_MAX}")
         for dev in dev_list:
@@ -1266,6 +1273,12 @@ class SBDManager:
             logger.debug("Running command: %s", cmd)
             shell.get_stdout_or_raise_error(cmd)
 
+        if self.cluster_is_running:
+            nodes = utils.list_cluster_nodes_except_me()
+            if nodes:
+                for dev in self.device_list_to_init:
+                    SBDUtils.compare_device_uuid(dev, nodes)
+
     def enable_sbd_service(self):
         if self.cluster_is_running:
             cluster_nodes = utils.list_cluster_nodes()
@@ -1449,7 +1462,7 @@ class SBDManager:
         self._watchdog_inst.join_watchdog()
 
         if dev_list:
-            SBDUtils.verify_sbd_device(dev_list, [peer_host])
+            SBDUtils.verify_sbd_device(dev_list, compare_node_list=[peer_host])
 
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))
         self.enable_sbd_service()

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -17,31 +17,29 @@ class TestSBDUtils(unittest.TestCase):
 
     @patch('crmsh.sh.cluster_shell')
     def test_get_sbd_device_metadata_success(self, mock_cluster_shell):
-        mock_cluster_shell.return_value.get_stdout_or_raise_error.return_value = self.TEST_DATA
+        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (0, self.TEST_DATA, None)
         result = SBDUtils.get_sbd_device_metadata("/dev/sbd_device")
         expected = {'uuid': '1234-5678', 'watchdog': 5, 'msgwait': 10}
         self.assertEqual(result, expected)
 
     @patch('crmsh.sh.cluster_shell')
     def test_get_sbd_device_metadata_timeout_only(self, mock_cluster_shell):
-        mock_cluster_shell.return_value.get_stdout_or_raise_error.return_value = self.TEST_DATA
+        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (0, self.TEST_DATA, None)
         result = SBDUtils.get_sbd_device_metadata("/dev/sbd_device", timeout_only=True)
         expected = {'watchdog': 5, 'msgwait': 10}
         self.assertNotIn('uuid', result)
         self.assertEqual(result, expected)
+
+    @patch('crmsh.sh.cluster_shell')
+    def test_get_sbd_device_metadata_failure(self, mock_cluster_shell):
+        mock_cluster_shell.return_value.get_rc_stdout_stderr_without_input.return_value = (1, None, None)
+        self.assertEqual(SBDUtils.get_sbd_device_metadata("/dev/sbd_device"), {})
 
     @patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata')
     def test_get_device_uuid_success(self, mock_get_sbd_device_metadata):
         mock_get_sbd_device_metadata.return_value = {'uuid': '1234-5678'}
         result = SBDUtils.get_device_uuid("/dev/sbd_device")
         self.assertEqual(result, '1234-5678')
-
-    @patch('crmsh.sbd.SBDUtils.get_sbd_device_metadata')
-    def test_get_device_uuid_no_uuid_found(self, mock_get_sbd_device_metadata):
-        mock_get_sbd_device_metadata.return_value = {}
-        with self.assertRaises(ValueError) as context:
-            SBDUtils.get_device_uuid("/dev/sbd_device")
-        self.assertTrue("Cannot find sbd device UUID for /dev/sbd_device" in str(context.exception))
 
     @patch('crmsh.sbd.SBDUtils.get_device_uuid')
     def test_compare_device_uuid_empty_node_list(self, mock_get_device_uuid):
@@ -1151,14 +1149,18 @@ class TestSBDManager(unittest.TestCase):
         sbdmanager_instance.initialize_sbd()
         mock_logger_info.assert_called_once_with("Configuring diskless SBD")
 
+    @patch('crmsh.sbd.SBDUtils.compare_device_uuid')
+    @patch('crmsh.utils.list_cluster_nodes_except_me')
     @patch('crmsh.sbd.ServiceManager')
     @patch('logging.Logger.debug')
     @patch('crmsh.sbd.sh.cluster_shell')
     @patch('crmsh.sbd.SBDManager.convert_timeout_dict_to_opt_str')
-    @patch('shutil.which')
     @patch('logging.Logger.info')
-    def test_initialize_sbd_diskbased(self, mock_logger_info, mock_which, mock_convert_timeout_dict_to_opt_str, mock_cluster_shell, mock_logger_debug, mock_ServiceManager):
-        mock_which.return_value = "/sbin/fence_sbd"
+    def test_initialize_sbd_diskbased(self, mock_logger_info, mock_convert_timeout_dict_to_opt_str, mock_cluster_shell, mock_logger_debug, mock_ServiceManager, mock_list_cluster_nodes_except_me, mock_compare_device_uuid):
+        mock_list_cluster_nodes_except_me.return_value = ['node2']
+        mock_ServiceManager_inst = Mock()
+        mock_ServiceManager.return_value = mock_ServiceManager_inst
+        mock_ServiceManager_inst.service_is_active.return_value = True
         sbdmanager_instance = SBDManager(device_list_to_init=['/dev/sbd_device'], timeout_dict={'watchdog': 5, 'msgwait': 10})
         sbdmanager_instance.initialize_sbd()
         mock_logger_info.assert_has_calls([


### PR DESCRIPTION
The previous code only compared SBD device UUID when joining the cluster, that's not enough.  When adding SBD via sbd stage, after initializing the SBD device, also need to compare SBD device UUID between cluster nodes

Fix issue:
- #2121