### PR TITLE
Dev: corosync: Default 'crm corosync status' to all components (#2038)

### DIFF
--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -436,7 +436,6 @@ Use multiple -i for more links. Note: Only one link is allowed for the non knet 
 """
 FORCE_HELP = "Make `crm` proceed with applying changes where it would normally ask the user to confirm before proceeding, or the operation risks interfering HA protection. This option is intended primarily for scripts and must be used with care."
 
-COROSYNC_STATUS_TYPES = ("ring", "quorum", "qdevice", "qnetd", "cpg")
 
 NO_SSH_ERROR_MSG = "ssh-related operations are disabled. crmsh works in local mode."
 

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -7,6 +7,8 @@ configuration file, and also the corosync-* utilities.
 import dataclasses
 import os
 import re
+import subprocess
+import sys
 import typing
 from io import StringIO
 
@@ -98,26 +100,40 @@ def cfgtool(*args):
     return ShellUtils().get_stdout(['corosync-cfgtool'] + list(args), shell=False)
 
 
-def query_status(status_type):
+def query_status(status_type=None):
     """
     Query status of corosync
 
     Possible types could be ring/quorum/qdevice/qnetd/cpg
     """
-    status_func_dict = {
-            "ring": query_ring_status,
-            "quorum": query_quorum_status,
-            "qdevice": query_qdevice_status,
-            "qnetd": query_qnetd_status,
-            "cpg": query_cpg_status
-            }
-    if status_type in status_func_dict:
-        out = sh.cluster_shell().get_stdout_or_raise_error("crm_node -l")
-        print(f"{out}\n")
-        print(status_func_dict[status_type]())
-        qdevice.QDevice.check_qdevice_vote()
-    else:
+    if status_type is not None and status_type not in STATUS_FUNC_DICT:
         raise ValueError("Wrong type \"{}\" to query status".format(status_type))
+
+    print(utils.term_render("${BOLD}Node Status${NORMAL}"))
+    print(utils.term_render("${BOLD}===================${NORMAL}"))
+    sys.stdout.flush()
+    ret = subprocess.run(["crm_node", "-l"])
+    if ret.returncode != 0:
+        raise ValueError("Failed to query nodes status")
+    print()
+
+    status_types = [status_type] if status_type else COROSYNC_STATUS_TYPES
+    for st in status_types:
+        try:
+            res = STATUS_FUNC_DICT[st]()
+            if res:
+                header = "{} Status".format(st.capitalize())
+                print(utils.term_render(f"\n${{BOLD}}{header}${{NORMAL}}"))
+                print(utils.term_render(f"${{BOLD}}{'=' * (len(header) + 8)}${{NORMAL}}"))
+                print(f"{res.strip()}\n")
+        except ValueError as e:
+            if status_type is None:
+                logger.warning("\nFailed to query %s status: %s\n", st, e)
+                continue
+            else:
+                raise
+
+    qdevice.QDevice.check_qdevice_vote()
 
 
 def query_ring_status():
@@ -181,6 +197,17 @@ def query_cpg_status():
     """
     cmd = "corosync-cpgtool -e"
     return sh.cluster_shell().get_stdout_or_raise_error(cmd)
+
+
+STATUS_FUNC_DICT = {
+    "ring": query_ring_status,
+    "quorum": query_quorum_status,
+    "qdevice": query_qdevice_status,
+    "cpg": query_cpg_status,
+    "qnetd": query_qnetd_status,
+}
+
+COROSYNC_STATUS_TYPES = tuple(STATUS_FUNC_DICT.keys())
 
 
 def push_configuration(nodes):

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -8,6 +8,8 @@ import dataclasses
 import logging
 import os
 import re
+import subprocess
+import sys
 import typing
 from io import StringIO
 
@@ -90,26 +92,40 @@ def cfgtool(*args):
     return ShellUtils().get_stdout(['corosync-cfgtool'] + list(args), shell=False)
 
 
-def query_status(status_type):
+def query_status(status_type=None):
     """
     Query status of corosync
 
     Possible types could be ring/quorum/qdevice/qnetd/cpg
     """
-    status_func_dict = {
-            "ring": query_ring_status,
-            "quorum": query_quorum_status,
-            "qdevice": query_qdevice_status,
-            "qnetd": query_qnetd_status,
-            "cpg": query_cpg_status
-            }
-    if status_type in status_func_dict:
-        out = sh.cluster_shell().get_stdout_or_raise_error("crm_node -l")
-        print(f"{out}\n")
-        print(status_func_dict[status_type]())
-        qdevice.QDevice.check_qdevice_vote()
-    else:
+    if status_type is not None and status_type not in STATUS_FUNC_DICT:
         raise ValueError("Wrong type \"{}\" to query status".format(status_type))
+
+    print(utils.term_render("${BOLD}Node Status${NORMAL}"))
+    print(utils.term_render("${BOLD}===================${NORMAL}"))
+    sys.stdout.flush()
+    ret = subprocess.run(["crm_node", "-l"])
+    if ret.returncode != 0:
+        raise ValueError("Failed to query nodes status")
+    print()
+
+    status_types = [status_type] if status_type else COROSYNC_STATUS_TYPES
+    for st in status_types:
+        try:
+            res = STATUS_FUNC_DICT[st]()
+            if res:
+                header = "{} Status".format(st.capitalize())
+                print(utils.term_render(f"\n${{BOLD}}{header}${{NORMAL}}"))
+                print(utils.term_render(f"${{BOLD}}{'=' * (len(header) + 8)}${{NORMAL}}"))
+                print(f"{res.strip()}\n")
+        except ValueError as e:
+            if status_type is None:
+                logger.warning("\nFailed to query %s status: %s\n", st, e)
+                continue
+            else:
+                raise
+
+    qdevice.QDevice.check_qdevice_vote()
 
 
 def query_ring_status():
@@ -173,6 +189,17 @@ def query_cpg_status():
     """
     cmd = "corosync-cpgtool -e"
     return sh.cluster_shell().get_stdout_or_raise_error(cmd)
+
+
+STATUS_FUNC_DICT = {
+    "ring": query_ring_status,
+    "quorum": query_quorum_status,
+    "qdevice": query_qdevice_status,
+    "cpg": query_cpg_status,
+    "qnetd": query_qnetd_status,
+}
+
+COROSYNC_STATUS_TYPES = tuple(STATUS_FUNC_DICT.keys())
 
 
 def push_configuration(nodes):

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -316,10 +316,11 @@ class Corosync(command.UI):
     def requires(self):
         return corosync.check_tools()
 
-    @command.completers(completers.choice(constants.COROSYNC_STATUS_TYPES))
-    def do_status(self, context, status_type="ring"):
+    @command.completers(completers.choice(corosync.COROSYNC_STATUS_TYPES))
+    def do_status(self, context, status_type=None):
         '''
-        Quick cluster health status. Corosync status or QNetd status
+        Quick cluster health status. Corosync status or QNetd status.
+        Defaults to all components.
         '''
         if not ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("corosync.service"):
             logger.error("corosync.service is not running!")

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -315,10 +315,11 @@ class Corosync(command.UI):
     def requires(self):
         return corosync.check_tools()
 
-    @command.completers(completers.choice(constants.COROSYNC_STATUS_TYPES))
-    def do_status(self, context, status_type="ring"):
+    @command.completers(completers.choice(corosync.COROSYNC_STATUS_TYPES))
+    def do_status(self, context, status_type=None):
         '''
-        Quick cluster health status. Corosync status or QNetd status
+        Quick cluster health status. Corosync status or QNetd status.
+        Defaults to all components.
         '''
         if not ServiceManager(sh.ClusterShellAdaptorForLocalShell(sh.LocalShell())).service_is_active("corosync.service"):
             logger.error("corosync.service is not running!")

--- a/test/unittests/test_corosync.py
+++ b/test/unittests/test_corosync.py
@@ -16,16 +16,6 @@ def test_query_status_exception():
     assert str(err.value) == "Wrong type \"test\" to query status"
 
 
-@mock.patch('crmsh.sh.cluster_shell')
-@mock.patch('crmsh.corosync.query_ring_status')
-def test_query_status(mock_ring_status, mock_cluster_shell):
-    mock_cluster_shell_inst = mock.Mock()
-    mock_cluster_shell.return_value = mock_cluster_shell_inst
-    mock_cluster_shell_inst.get_stdout_or_raise_error.return_value = "data"
-    corosync.query_status("ring")
-    mock_ring_status.assert_called_once_with()
-
-
 @mock.patch('crmsh.corosync.is_qdevice_configured')
 def test_query_qdevice_status_exception(mock_configured):
     mock_configured.return_value = False
@@ -43,34 +33,99 @@ def test_query_qdevice_status(mock_configured, mock_run):
     mock_run.assert_called_once_with("corosync-qdevice-tool -sv")
 
 
-@mock.patch('crmsh.sh.cluster_shell')
+@mock.patch('subprocess.run')
+@mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
 @mock.patch("crmsh.corosync.query_ring_status")
-def test_query_status_ring(mock_ring_status, mock_cluster_shell):
-    mock_cluster_shell_inst = mock.Mock()
-    mock_cluster_shell.return_value = mock_cluster_shell_inst
-    mock_cluster_shell_inst.get_stdout_or_raise_error.return_value = "data"
-    corosync.query_status("ring")
+def test_query_status_ring(mock_ring_status, mock_check_vote, mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, {'ring': mock_ring_status}):
+        corosync.query_status("ring")
     mock_ring_status.assert_called_once_with()
+    mock_check_vote.assert_called_once()
 
 
-@mock.patch('crmsh.sh.cluster_shell')
+@mock.patch('subprocess.run')
+@mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
 @mock.patch("crmsh.corosync.query_quorum_status")
-def test_query_status_quorum(mock_quorum_status, mock_cluster_shell):
-    mock_cluster_shell_inst = mock.Mock()
-    mock_cluster_shell.return_value = mock_cluster_shell_inst
-    mock_cluster_shell_inst.get_stdout_or_raise_error.return_value = "data"
-    corosync.query_status("quorum")
+def test_query_status_quorum(mock_quorum_status, mock_check_vote, mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, {'quorum': mock_quorum_status}):
+        corosync.query_status("quorum")
     mock_quorum_status.assert_called_once_with()
+    mock_check_vote.assert_called_once()
 
 
-@mock.patch('crmsh.sh.cluster_shell')
+@mock.patch('subprocess.run')
+@mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
 @mock.patch("crmsh.corosync.query_qnetd_status")
-def test_query_status_qnetd(mock_qnetd_status, mock_cluster_shell):
-    mock_cluster_shell_inst = mock.Mock()
-    mock_cluster_shell.return_value = mock_cluster_shell_inst
-    mock_cluster_shell_inst.get_stdout_or_raise_error.return_value = "data"
-    corosync.query_status("qnetd")
+def test_query_status_qnetd(mock_qnetd_status, mock_check_vote, mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, {'qnetd': mock_qnetd_status}):
+        corosync.query_status("qnetd")
     mock_qnetd_status.assert_called_once_with()
+    mock_check_vote.assert_called_once()
+
+
+@mock.patch('subprocess.run')
+@mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
+@mock.patch('crmsh.utils.term_render')
+def test_query_status_all(mock_render, mock_check_vote, mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+    mock_render.side_effect = lambda x: x
+
+    # Mock all status functions
+    mock_funcs = {st: mock.Mock(return_value=f"{st} data") for st in corosync.COROSYNC_STATUS_TYPES}
+
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, mock_funcs):
+        corosync.query_status()
+
+    for st, m in mock_funcs.items():
+        m.assert_called_once()
+    mock_check_vote.assert_called_once()
+    mock_run.assert_called_once_with(["crm_node", "-l"])
+
+
+@mock.patch('subprocess.run')
+def test_query_status_crm_node_fail(mock_run):
+    mock_run.return_value = mock.Mock(returncode=1)
+    with pytest.raises(ValueError) as err:
+        corosync.query_status()
+    assert str(err.value) == "Failed to query nodes status"
+
+
+@mock.patch('subprocess.run')
+@mock.patch('crmsh.qdevice.QDevice.check_qdevice_vote')
+def test_query_status_value_error_continue(mock_check_vote, mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+
+    # Mock status functions: 'ring' fails with ValueError, 'quorum' succeeds
+    mock_ring = mock.Mock(side_effect=ValueError("ring error"))
+    mock_quorum = mock.Mock(return_value="quorum data")
+
+    mock_funcs = {
+        'ring': mock_ring,
+        'quorum': mock_quorum
+    }
+
+    # Need to make sure COROSYNC_STATUS_TYPES includes 'ring' and 'quorum'
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, mock_funcs):
+        with mock.patch('crmsh.corosync.COROSYNC_STATUS_TYPES', ('ring', 'quorum')):
+            corosync.query_status()
+
+    mock_ring.assert_called_once()
+    mock_quorum.assert_called_once()
+    mock_check_vote.assert_called_once()
+
+
+@mock.patch('subprocess.run')
+def test_query_status_single_fail_fast(mock_run):
+    mock_run.return_value = mock.Mock(returncode=0)
+    mock_ring = mock.Mock(side_effect=ValueError("ring error"))
+
+    with mock.patch.dict(corosync.STATUS_FUNC_DICT, {'ring': mock_ring}):
+        with pytest.raises(ValueError) as err:
+            corosync.query_status("ring")
+        assert str(err.value) == "ring error"
 
 
 def test_query_status_except():


### PR DESCRIPTION
- Update 'crm corosync status' to show all components by default
- Refactor COROSYNC_STATUS_TYPES from constants.py to corosync.py
- Optimize crm_node -l to use subprocess.run directly
- Ensure ValueError is raised on status query failures for 'fail fast' behavior

Fixes: #2038