### PR TITLE
Dev: log: Lower corosync config tokenizer log level to reduce noise and decouple logging from config

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -13,6 +13,7 @@ import codecs
 import dataclasses
 import io
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -56,7 +57,7 @@ from . import watchdog
 import crmsh.healthcheck
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 import copy
+import logging
 import os
 import sys
 import re
@@ -31,7 +32,7 @@ from . import cliformat
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/cibstatus.py
+++ b/crmsh/cibstatus.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import os
 from tempfile import mkstemp
 from lxml import etree
@@ -11,7 +11,7 @@ from . import config
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_tag_by_id(node, tag, ident):

--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2014 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import re
 from .sh import ShellUtils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 cib_verify = "crm_verify -VV -p"
 VALIDATE_RE = re.compile(r"^Entity: line (\d)+: element (\w+): " +
                          r"Relax-NG validity error : (.+)$")

--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from contextlib import contextmanager
 from . import utils, sh
@@ -10,7 +11,7 @@ from . import constants
 from . import sbd
 from .service_manager import ServiceManager
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -7,6 +7,7 @@
 #   inside the functions.
 
 import inspect
+import logging
 import re
 import ctypes.util
 from . import help as help_module
@@ -16,7 +17,7 @@ from . import constants
 from . import utils
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def name(n):

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -413,6 +413,26 @@ class _Configuration(object):
 _configuration = _Configuration()
 
 
+_change_listeners = {}
+
+
+def add_change_listener(section, option, callback):
+    """Register a callback for when a specific option is changed."""
+    key = (section, option)
+    if key not in _change_listeners:
+        _change_listeners[key] = []
+    _change_listeners[key].append(callback)
+    # Notify immediately with current value
+    callback(get_option(section, option))
+
+
+def _notify_change_listeners(section, option, value):
+    """Notify all registered listeners for an option."""
+    listeners = _change_listeners.get((section, option), [])
+    for callback in listeners:
+        callback(value)
+
+
 class _Section(object):
     def __init__(self, section):
         object.__setattr__(self, 'section', section)
@@ -422,6 +442,7 @@ class _Section(object):
 
     def __setattr__(self, name, value):
         _configuration.set(self.section, name, value)
+        _notify_change_listeners(self.section, name, get_option(self.section, name))
 
     def items(self):
         return _configuration.items(self.section)
@@ -443,6 +464,7 @@ def save():
 def set_option(section, option, value):
     if not isinstance(value, List):
         _configuration.set(section, option, value)
+        _notify_change_listeners(section, option, get_option(section, option))
         return
     string = ""
     first = True
@@ -453,6 +475,7 @@ def set_option(section, option, value):
             string += ", "
         string += str(item)
     _configuration.set(section, option, string)
+    _notify_change_listeners(section, option, get_option(section, option))
 
 
 def get_option(section, option, raw=False):

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -5,6 +5,7 @@ Functions that abstract creating and editing the corosync.conf
 configuration file, and also the corosync-* utilities.
 '''
 import dataclasses
+import logging
 import os
 import re
 import typing
@@ -20,7 +21,7 @@ from . import qdevice
 from .sh import ShellUtils
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 COROSYNC_TOKEN_DEFAULT = 3000  # in ms units

--- a/crmsh/corosync_config_format.py
+++ b/crmsh/corosync_config_format.py
@@ -3,8 +3,9 @@
 
 import logging
 import re
-from io import StringIO
 import typing
+
+from .log import DEBUG2
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ class Parser:
                 tokens = self._tokenize(line)
             except ValueError as e:
                 raise MalformedLineException(lineno, line)
-            logger.debug('tokens: %s', tokens)
+            logger.log(DEBUG2, 'tokens: %s', tokens)
             if tokens[1] == '#':
                 fake_key = f'{COMMENT_PREFIX}_{lineno}'
                 self.on_key_value(fake_key, tokens[2])

--- a/crmsh/crash_test/main.py
+++ b/crmsh/crash_test/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import argparse
@@ -9,7 +10,7 @@ from crmsh import utils as crmshutils
 from crmsh import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Context(object):

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -243,8 +243,8 @@ class TaskCheck(Task):
         """
         Define the format of results to stdout
         """
-        with utils.manage_handler("file", keep=False):
-            utils.get_handler(logger, "stream").setFormatter(utils.MyLoggingFormatter(flush=False))
+        with utils.block_log_filter(log.LOGFILE_FILTER):
+            utils.get_handler(logger, "console").setFormatter(utils.MyLoggingFormatter(flush=False))
 
             if self.passed:
                 message = "{} [{}]".format(self.description, utils.CGREEN + "Pass" + utils.CEND)
@@ -255,7 +255,7 @@ class TaskCheck(Task):
             for msg in self.messages:
                 logger.log(utils.LEVEL[msg[0]], msg[1], extra={'timestamp': '  '})
 
-            utils.get_handler(logger, "stream").setFormatter(utils.MyLoggingFormatter())
+            utils.get_handler(logger, "console").setFormatter(utils.MyLoggingFormatter())
 
     def to_json(self):
         """

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 import threading
@@ -13,7 +14,7 @@ from . import config
 from ..service_manager import ServiceManager
 from ..sh import ShellUtils
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class TaskError(Exception):

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -14,7 +14,7 @@ from crmsh import constants
 from crmsh import xmlutil
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 CRED = constants.RED

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -60,23 +60,24 @@ def now(form="%Y/%m/%d %H:%M:%S"):
 
 
 @contextmanager
-def manage_handler(_type, keep=True):
+def block_log_filter(filter: log.LevelFilter):
     """
-    Define a contextmanager to remove specific logging handler temporarily
+    Define a contextmanager to block a logging filter temporarily
     """
+    saved_level = filter.level
+    filter.level = logging.CRITICAL + 1
     try:
-        handler = get_handler(logger, _type)
-        if not keep:
-            logger.removeHandler(handler)
         yield
     finally:
-        if not keep:
-            logger.addHandler(handler)
+        filter.level = saved_level
 
 
 def msg_raw(level, msg, to_stdout=True):
-    with manage_handler("console", to_stdout):
+    if to_stdout:
         logger.log(level, msg)
+    else:
+        with block_log_filter(log.CONSOLE_FILTER):
+            logger.log(level, msg)
 
 
 def msg_info(msg, to_stdout=True):
@@ -169,13 +170,16 @@ def str_to_datetime(str_time, fmt):
     return datetime.strptime(str_time, fmt)
 
 
-def get_handler(logger, _type):
+def get_handler(logger, name):
     """
-    Get logger specific handler
+    Find a handler by name from crmsh.crash_test logger.
     """
-    for h in logger.handlers:
-        if getattr(h, '_name') == _type:
+    if hasattr(logging, 'getHandlerByName'):
+        return logging.getHandlerByName(name)
+    for h in logging.getLogger("crmsh.crash_test").handlers:
+        if getattr(h, 'name', None) == name or getattr(h, '_name', None) == name:
             return h
+    return None
 
 
 def is_root():

--- a/crmsh/crm_gv.py
+++ b/crmsh/crm_gv.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2013 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import re
 from . import config
 from . import tmpfiles
@@ -8,7 +8,7 @@ from . import utils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 # graphviz stuff
 
 

--- a/crmsh/crm_pssh.py
+++ b/crmsh/crm_pssh.py
@@ -10,7 +10,7 @@ For each node, this essentially does an "ssh host -l user prog [arg0] [arg1]
 directory.  Each output file in that directory will be named by the
 corresponding remote node's hostname or IP address.
 """
-
+import logging
 import os
 import glob
 import typing
@@ -19,7 +19,7 @@ from . import config
 from . import log
 from .prun import prun
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _DEFAULT_TIMEOUT = 60

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -27,6 +27,7 @@ Help for the level itself is like this:
 import dataclasses
 import functools
 import io
+import logging
 import os
 import re
 import typing
@@ -39,7 +40,7 @@ from . import log
 from . import ra
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class HelpFilter(object):

--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013-2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import time
 import re
@@ -18,7 +18,7 @@ from .sh import ShellUtils
 from crmsh.report import core
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _LOG_FILES = ("ha-log.txt", "messages", "ha-log", "cluster-log.txt", "journal.log", "pacemaker.log")

--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -2,7 +2,7 @@
 # See COPYING for license information.
 #
 # Make sure that ids are unique.
-
+import logging
 import re
 import copy
 from . import constants
@@ -10,7 +10,7 @@ from . import xmlutil
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 _id_store = {}
 _state = []

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2020 Xin Liang <XLiang@suse.com>
 # See COPYING for license information.
-
-
+import logging
 import re
 import time
 from contextlib import contextmanager
@@ -13,7 +12,7 @@ from . import xmlutil
 from .sh import ShellUtils
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class SSHError(Exception):

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -92,6 +92,18 @@ class ConsoleCustomHandler(logging.StreamHandler):
         stream.write(self.terminator)
 
 
+class LevelFilter(logging.Filter):
+    """
+    A filter to block log records
+    """
+    def __init__(self, level: int):
+        super().__init__()
+        self.level = level
+
+    def filter(self, record):
+        return record.levelno >= self.level
+
+
 class NoBacktraceFormatter(logging.Formatter):
     """Suppress backtrace unless option debug is set."""
     def format(self, record):
@@ -195,6 +207,11 @@ LOGFILE_FORMATTER = {
 }
 
 
+CONSOLE_FILTER = LevelFilter(DEBUG2)
+BUFFERED_FILTER = LevelFilter(logging.CRITICAL + 1)
+LOGFILE_FILTER = LevelFilter(DEBUG2)
+
+
 LOGGING_CFG = {
     "version": 1,
     "disable_existing_loggers": "False",
@@ -223,28 +240,41 @@ LOGGING_CFG = {
         },
         "console_report": {
             "()": ConsoleCustomHandler,
-            "formatter": "console_report"
+            "formatter": "console_report",
+            "filters": [
+                CONSOLE_FILTER,
+            ]
         },
         "console": {
             "()": ConsoleCustomHandler,
-            "formatter": "console"
+            "formatter": "console",
+            "filters": [
+                CONSOLE_FILTER,
+            ]
         },
-        "buffer": {
+        "buffered_console": {
             "class": "logging.handlers.MemoryHandler",
             "capacity": 1024*100,
             "flushLevel": logging.CRITICAL,
+            "target": "console",
+            "filters": [
+                BUFFERED_FILTER,
+            ]
         },
         "file": {
             "()": GroupWriteRotatingFileHandler,
             "filename": CRMSH_LOG_FILE,
             "formatter": "file",
             "maxBytes": 1*1024*1024,
-            "backupCount": 10
+            "backupCount": 10,
+            "filters": [
+                LOGFILE_FILTER,
+            ]
         }
     },
     "loggers": {
         "crmsh": {
-            "handlers": ["null", "file", "console", "buffer"],
+            "handlers": ["null", "file", "console", "buffered_console"],
             "level": "INFO"
         },
         "crmsh.crash_test": {
@@ -294,22 +324,23 @@ class LoggerUtils(object):
         # used in regression test
         self.__save_lineno = 0
 
-    def get_handler(self, _type):
+    def get_handler(self, name):
         """
-        Get logger specific handler
+        Find a handler by name from known root loggers.
         """
-        for h in self.logger.handlers:
-            if getattr(h, '_name') == _type:
-                return h
-        else:
-            raise ValueError("Failed to find \"{}\" handler in logger \"{}\"".format(_type, self.logger.name))
+        if hasattr(logging, 'getHandlerByName'):
+            return logging.getHandlerByName(name)
+        for logger_name in ("crmsh", "crmsh.report"):
+            for h in logging.getLogger(logger_name).handlers:
+                if getattr(h, 'name', None) == name or getattr(h, '_name', None) == name:
+                    return h
+        raise KeyError(f'Log handler not found: {name}')
 
     def disable_info_in_console(self):
         """
         Set log level as warning in console
         """
-        console_handler = self.get_handler("console")
-        console_handler.setLevel(logging.WARNING)
+        CONSOLE_FILTER.level = logging.WARNING
 
     def reset_lineno(self, to=0):
         """
@@ -328,12 +359,12 @@ class LoggerUtils(object):
         """
         Only log to file in bootstrap logger
         """
-        console_handler = self.get_handler("console")
+        saved_level = CONSOLE_FILTER.level
+        CONSOLE_FILTER.level = logging.CRITICAL + 1
         try:
-            self.logger.removeHandler(console_handler)
             yield
         finally:
-            self.logger.addHandler(console_handler)
+            CONSOLE_FILTER.level = saved_level
 
     def log_only_to_file(self, msg, level=logging.INFO):
         if self.logger.isEnabledFor(logging.DEBUG):
@@ -347,21 +378,18 @@ class LoggerUtils(object):
         """
         Keep log messages in memory and finally show them in console
         """
-        console_handler = self.get_handler("console")
-        buffer_handler = self.get_handler("buffer")
+        buffer_handler = self.get_handler("buffered_console")
+        saved_console_level = CONSOLE_FILTER.level
         try:
-            # remove console handler temporarily
-            self.logger.removeHandler(console_handler)
             buffer_handler.buffer.clear()
-            # set the target of buffer handler as console
-            buffer_handler.setTarget(console_handler)
+            CONSOLE_FILTER.level = logging.CRITICAL + 1
+            BUFFERED_FILTER.level = DEBUG2
             yield
         finally:
             empty = not buffer_handler.buffer
-            # close the buffer handler(flush to console handler)
-            buffer_handler.close()
-            # add console handler back
-            self.logger.addHandler(console_handler)
+            BUFFERED_FILTER.level = logging.CRITICAL + 1
+            CONSOLE_FILTER.level = saved_console_level
+            buffer_handler.flush()
             if not empty and not options.batch:
                 try:
                     input("Press enter to continue... ")
@@ -553,12 +581,8 @@ def setup_logger(name):
     """
     Get the logger
     name could be any module name
-    should assign parent's handlers for inherit
     """
-    logger = logging.getLogger(name)
-    logger.handlers = logger.parent.handlers
-    logger.propagate = False
-    return logger
+    return logging.getLogger(name)
 
 
 def setup_report_logger(name):

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from . import options
 from . import constants
 
-DEBUG2 = logging.DEBUG + 5
+DEBUG2 = logging.DEBUG - 1
 CRMSH_LOG_FILE = "/var/log/crmsh/crmsh.log"
 
 
@@ -108,8 +108,7 @@ class NoBacktraceFormatter(logging.Formatter):
         it is formatted using formatException() and appended to the message.
         """
         if record.exc_info or record.stack_info:
-            from crmsh import config
-            if config.core.debug:
+            if logging.getLogger('crmsh').isEnabledFor(logging.DEBUG):
                 return super().format(record)
             else:
                 record.message = record.getMessage()
@@ -161,20 +160,6 @@ class LeveledFormatter(logging.Formatter):
         if formatter is None:
             formatter = self.default_formatter
         return formatter.format(record)
-
-
-class DebugCustomFilter(logging.Filter):
-    """
-    A custom filter for debug and debug2 messages
-    """
-    def filter(self, record):
-        from .config import core, report
-        if record.levelno == logging.DEBUG:
-            return core.debug or int(report.verbosity) >= 1
-        elif record.levelno == DEBUG2:
-            return int(report.verbosity) > 1
-        else:
-            return True
 
 
 class GroupWriteRotatingFileHandler(logging.handlers.RotatingFileHandler):
@@ -232,24 +217,17 @@ LOGGING_CFG = {
         },
         "file": LOGFILE_FORMATTER
     },
-    "filters": {
-        "filter": {
-            "()": DebugCustomFilter
-        },
-    },
     "handlers": {
         'null': {
             'class': 'logging.NullHandler'
         },
         "console_report": {
             "()": ConsoleCustomHandler,
-            "formatter": "console_report",
-            "filters": ["filter"]
+            "formatter": "console_report"
         },
         "console": {
             "()": ConsoleCustomHandler,
-            "formatter": "console",
-            "filters": ["filter"]
+            "formatter": "console"
         },
         "buffer": {
             "class": "logging.handlers.MemoryHandler",
@@ -260,7 +238,6 @@ LOGGING_CFG = {
             "()": GroupWriteRotatingFileHandler,
             "filename": CRMSH_LOG_FILE,
             "formatter": "file",
-            "filters": ["filter"],
             "maxBytes": 1*1024*1024,
             "backupCount": 10
         }
@@ -268,17 +245,15 @@ LOGGING_CFG = {
     "loggers": {
         "crmsh": {
             "handlers": ["null", "file", "console", "buffer"],
-            "level": "DEBUG"
+            "level": "INFO"
         },
         "crmsh.crash_test": {
             "handlers": ["null", "file", "console"],
-            "propagate": False,
-            "level": "DEBUG"
+            "propagate": False
         },
         "crmsh.report": {
             "handlers": ["null", "file", "console_report"],
-            "propagate": False,
-            "level": "DEBUG"
+            "propagate": False
         }
     }
 }
@@ -361,8 +336,7 @@ class LoggerUtils(object):
             self.logger.addHandler(console_handler)
 
     def log_only_to_file(self, msg, level=logging.INFO):
-        from .config import core
-        if core.debug:
+        if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.log(logging.DEBUG, msg)
         else:
             with self.only_file():

--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -575,19 +575,3 @@ def setup_logging(only_help=False):
     if not all(os.isatty(fd) for fd in range(3)):
         LOGGING_CFG['formatters'] = NO_COLOR_FORMATTERS
     logging.config.dictConfig(LOGGING_CFG)
-
-
-def setup_logger(name):
-    """
-    Get the logger
-    name could be any module name
-    """
-    return logging.getLogger(name)
-
-
-def setup_report_logger(name):
-    """
-    Get the logger for crm report
-    """
-    logger = setup_logger(name)
-    return logger

--- a/crmsh/logparser.py
+++ b/crmsh/logparser.py
@@ -3,6 +3,7 @@
 
 import bz2
 import gzip
+import logging
 import re
 import os
 import sys
@@ -17,7 +18,7 @@ from . import log_patterns
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _METADATA_FILENAME = "__meta.json"

--- a/crmsh/logtime.py
+++ b/crmsh/logtime.py
@@ -4,7 +4,7 @@
 """
 Helpers for handling log timestamps.
 """
-
+import logging
 import re
 import time
 import datetime
@@ -12,7 +12,7 @@ from . import utils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 YEAR = None

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import sys
 import os
 import atexit
@@ -19,7 +19,7 @@ from . import ui_context
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -23,6 +23,17 @@ logger = log.setup_logger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 
+def _update_core_debug(enabled):
+    """
+    Update crmsh logger level based on core.debug
+    """
+    level = log.logging.DEBUG if enabled else log.logging.INFO
+    log.logging.getLogger('crmsh').setLevel(level)
+
+
+config.add_change_listener('core', 'debug', _update_core_debug)
+
+
 random.seed()
 
 

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013-2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import shlex
 import re
 import inspect
@@ -16,7 +16,7 @@ from . import cibconfig
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -1,5 +1,6 @@
 import ipaddress
 import json
+import logging
 import os
 import re
 import socket
@@ -20,7 +21,7 @@ from . import sbd
 from .service_manager import ServiceManager
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import os
 import subprocess
 import copy
@@ -18,7 +18,7 @@ from .sh import ShellUtils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 #

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -2,6 +2,7 @@
 Define functions to collect log and info
 Function starts with "collect_" will be called in parallel
 """
+import logging
 import sys
 import os
 import shutil
@@ -19,8 +20,7 @@ from crmsh.report import constants, utils, core
 from crmsh.sh import ShellUtils
 from crmsh.service_manager import ServiceManager
 
-
-logger = log.setup_report_logger(__name__)
+logger = logging.getLogger(__name__)
 DIVIDER = "=" * 50
 
 

--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -6,6 +6,7 @@ import argparse
 import multiprocessing
 import os
 import re
+import logging
 import subprocess
 import sys
 import shutil
@@ -475,10 +476,21 @@ def _interactive_ssh_run_as_root(host: str, ssh_user: str, cmd: str):
 
 def adjust_verbosity(context: Context) -> None:
     if context.debug > 0:
-        config.report.verbosity = context.debug
+        config.report.verbosity = str(context.debug)
     elif config.core.debug:
-        config.report.verbosity = 1
+        config.report.verbosity = "1"
         context.debug = 1
+
+    verbosity = int(config.report.verbosity)
+
+    if verbosity > 1:
+        level = log.DEBUG2
+    elif verbosity == 1:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    logging.getLogger('crmsh').setLevel(level)
 
 
 def parse_arguments(context: Context) -> None:

--- a/crmsh/report/core.py
+++ b/crmsh/report/core.py
@@ -24,8 +24,7 @@ from crmsh import constants as crmconstants
 from crmsh import config, log, tmpfiles, ui_cluster
 from crmsh.sh import ShellUtils
 
-
-logger = log.setup_report_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Context:

--- a/crmsh/report/utils.py
+++ b/crmsh/report/utils.py
@@ -3,6 +3,7 @@
 
 import datetime
 import glob
+import logging
 import os
 import re
 import shutil
@@ -18,8 +19,7 @@ from crmsh import corosync, log, userdir, tmpfiles, config, sh
 from crmsh.report import constants, collect, core
 from crmsh.sh import ShellUtils
 
-
-logger = log.setup_report_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LogType(Enum):

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import os
 import sys
 from .utils import rmdir_r, quote, this_node, ext_cmd
@@ -8,7 +8,7 @@ from .xmlutil import get_topmost_rsc, get_op_timeout, get_child_nvset_node, is_m
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 #
 # Resource testing suite

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -17,7 +17,7 @@ from . import cibquery
 from .service_manager import ServiceManager
 from .sh import ShellUtils
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class SBDUtils:

--- a/crmsh/schema.py
+++ b/crmsh/schema.py
@@ -1,13 +1,13 @@
 # Copyright (C) 2012 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import re
 from . import config
 from .pacemaker import CrmSchema, PacemakerError
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 PCMK_MIN_SCHEMA_VERSION = 1.0
 
 

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import re
 import subprocess
@@ -31,7 +31,7 @@ from .sh import ShellUtils
 import crmsh.parallax
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _script_cache = None

--- a/crmsh/template.py
+++ b/crmsh/template.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
-
+import logging
 import os
 import re
 from . import config
@@ -8,7 +8,7 @@ from . import userdir
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_var(l, key):

--- a/crmsh/ui_cib.py
+++ b/crmsh/ui_cib.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import glob
 from . import command
@@ -19,7 +19,7 @@ from . import completers as compl
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 _NEWARGS = ('force', '--force', 'withstatus', 'empty')
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import sys
 import re
@@ -34,7 +34,7 @@ from . import log
 from .utils import TerminateSubCommand
 import crmsh.options
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse_options(parser, args):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import re
 import time
@@ -34,7 +34,7 @@ from .ui_node import get_resources_on_nodes, remove_redundant_attrs
 
 
 from . import log
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import shlex
 import sys
 from . import config
@@ -13,7 +13,7 @@ from . import log
 from . import main
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 _NON_FUNCTIONAL_COMMANDS = {'help', 'ls'}

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -4,6 +4,7 @@ import dataclasses
 import io
 import ipaddress
 import json
+import logging
 import re
 import subprocess
 import os
@@ -20,7 +21,7 @@ from . import constants
 from .prun import prun
 from .service_manager import ServiceManager
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _push_completer(args):

--- a/crmsh/ui_history.py
+++ b/crmsh/ui_history.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import sys
 import time
@@ -22,7 +22,7 @@ from . import cmd_status
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
+import logging
 import os
 import copy
 import subprocess
@@ -22,7 +23,7 @@ from .sh import ShellUtils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013-2018 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import re
 from . import command
 from . import completers as compl
@@ -16,7 +16,7 @@ from .sh import ShellUtils
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ui_script.py
+++ b/crmsh/ui_script.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
-
+import logging
 import sys
 
 try:
@@ -18,7 +17,7 @@ from . import completers as compl
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ConsolePrinter(object):

--- a/crmsh/ui_site.py
+++ b/crmsh/ui_site.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import time
 from . import command
 from . import completers as compl
@@ -10,7 +10,7 @@ from . import log
 from . import options
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 _ticket_commands = {
     'grant': "%s -t '%s' -g",

--- a/crmsh/ui_template.py
+++ b/crmsh/ui_template.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import re
 import shlex
@@ -17,7 +17,7 @@ from .cibconfig import mkset_obj, cib_factory
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import re
 import inspect
 from . import utils
@@ -9,7 +9,7 @@ from . import log
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/userdir.py
+++ b/crmsh/userdir.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
-
+import logging
 import os
 import typing
 import pwd
@@ -8,7 +8,7 @@ import pwd
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def getuser():

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2,6 +2,7 @@
 # See COPYING for license information.
 import asyncio
 import errno
+import logging
 import os
 import sys
 import typing
@@ -52,7 +53,7 @@ from .prun import prun
 from .sh import ShellUtils
 from .service_manager import ServiceManager
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -4,6 +4,8 @@
 
 # import annotations to avoid circular import issues when using type hints
 from __future__ import annotations
+
+import logging
 import os
 import subprocess
 import typing
@@ -26,7 +28,7 @@ from . import sbd
 from . import log
 
 
-logger = log.setup_logger(__name__)
+logger = logging.getLogger(__name__)
 logger_utils = log.LoggerUtils(logger)
 
 

--- a/test/unittests/test_crashtest_task.py
+++ b/test/unittests/test_crashtest_task.py
@@ -7,6 +7,7 @@ except ImportError:
     import mock
 from datetime import datetime
 
+from crmsh import log
 from crmsh import utils as crmshutils
 from crmsh.crash_test import utils, main, config, task
 
@@ -226,10 +227,10 @@ class TestTaskCheck(TestCase):
 
     @mock.patch('crmsh.crash_test.utils.MyLoggingFormatter')
     @mock.patch('crmsh.crash_test.utils.get_handler')
-    @mock.patch('crmsh.crash_test.utils.manage_handler')
-    def test_to_stdout(self, mock_manage_handler, mock_get_handler, mock_myformatter):
-        mock_manage_handler.return_value.__enter__ = mock.Mock()
-        mock_manage_handler.return_value.__exit__ = mock.Mock()
+    @mock.patch('crmsh.crash_test.utils.block_log_filter')
+    def test_to_stdout(self, mock_block_log_filter, mock_get_handler, mock_myformatter):
+        mock_block_log_filter.return_value.__enter__ = mock.Mock()
+        mock_block_log_filter.return_value.__exit__ = mock.Mock()
 
         task.logger = mock.Mock()
         task.logger.info = mock.Mock()
@@ -252,10 +253,10 @@ class TestTaskCheck(TestCase):
 
         self.task_check_inst.to_stdout()
 
-        mock_manage_handler.assert_called_once_with("file", keep=False)
+        mock_block_log_filter.assert_called_once_with(log.LOGFILE_FILTER)
         mock_get_handler.assert_has_calls([
-            mock.call(task.logger, "stream"),
-            mock.call(task.logger, "stream")
+            mock.call(task.logger, "console"),
+            mock.call(task.logger, "console")
             ])
         get_handler_inst1.setFormatter.assert_called_once_with(myformatter_inst1)
         get_handler_inst2.setFormatter.assert_called_once_with(myformatter_inst2)

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -8,6 +8,7 @@ except ImportError:
     import mock
 import logging
 
+from crmsh import log
 from crmsh.crash_test import utils, main, config
 
 
@@ -152,26 +153,10 @@ class TestUtils(TestCase):
         mock_datetime.now.assert_called_once_with()
         mock_now.strftime.assert_called_once_with("%Y/%m/%d %H:%M:%S")
 
-    @mock.patch('crmsh.crash_test.utils.get_handler')
-    def test_manage_handler(self, mock_get_handler):
-        mock_get_handler.return_value = "handler"
-        utils.logger = mock.Mock()
-        utils.logger.removeHandler = mock.Mock()
-        utils.logger.addHandler = mock.Mock()
-
-        with utils.manage_handler("type1", keep=False):
-            pass
-
-        mock_get_handler.assert_called_once_with(utils.logger, "type1")
-        utils.logger.removeHandler.assert_called_once_with("handler")
-        utils.logger.addHandler.assert_called_once_with("handler")
-
-    @mock.patch('crmsh.crash_test.utils.manage_handler')
-    def test_msg_raw(self, mock_handler):
+    def test_msg_raw(self):
         utils.logger = mock.Mock()
         utils.logger.log = mock.Mock()
         utils.msg_raw("level1", "msg1")
-        mock_handler.assert_called_once_with("console", True)
         utils.logger.log.assert_called_once_with("level1", "msg1")
 
     @mock.patch('crmsh.crash_test.utils.msg_raw')
@@ -233,12 +218,23 @@ class TestUtils(TestCase):
         utils.str_to_datetime("Mon Nov  2 15:37:11 2020", "%a %b %d %H:%M:%S %Y")
         mock_datetime.strptime.assert_called_once_with("Mon Nov  2 15:37:11 2020", "%a %b %d %H:%M:%S %Y")
 
-    def test_get_handler(self):
+    @mock.patch('logging.getLogger')
+    def test_get_handler(self, mock_get_logger):
         mock_handler1 = mock.Mock(_name="test1_handler")
         mock_handler2 = mock.Mock(_name="test2_handler")
-        mock_logger = mock.Mock(handlers=[mock_handler1, mock_handler2])
-        res = utils.get_handler(mock_logger, "test1_handler")
-        self.assertEqual(res, mock_handler1)
+        mock_get_logger.return_value = mock.Mock(handlers=[mock_handler1, mock_handler2])
+
+        # If getHandlerByName exists (Python 3.12+), it will be called first
+        if hasattr(logging, 'getHandlerByName'):
+            with mock.patch('logging.getHandlerByName') as mock_get_handler_by_name:
+                mock_get_handler_by_name.return_value = mock_handler1
+                res = utils.get_handler(None, "test1_handler")
+                self.assertEqual(res, mock_handler1)
+                mock_get_handler_by_name.assert_called_once_with("test1_handler")
+        else:
+            res = utils.get_handler(None, "test1_handler")
+            self.assertEqual(res, mock_handler1)
+            mock_get_logger.assert_called_once_with("crmsh.crash_test")
 
     @mock.patch('os.getuid')
     def test_is_root(self, mock_getuid):


### PR DESCRIPTION
This PR reduces log noise when standard debug logging is enabled and refactors the logging architecture to be more standard and decoupled from global configuration.

### Key Changes:

#### 1. Corosync Config Tokenizer Log Level
- Lowered the level of debug logs from the tokenizer in `corosync_config_format` to `DEBUG2` (defined as `logging.DEBUG - 1`). 
- These logs are now hidden by default even when standard debug logging is active, significantly reducing noise unless specifically debugging the parser.

#### 2. Logging Architecture & Decoupling
- **Decoupled from Config**: Introduced a listener mechanism in `crmsh.config` to notify observers of configuration changes. `crmsh.log` now operates independently, with `crmsh.main` syncing logger levels via the listener.
- **Filter-based Output Control**: Refactored `LoggerUtils` to use standard Python `logging` filters (e.g., `BlockingFilter`) instead of dynamically adding/removing handlers to control output.
- **Standardization**: Replaced the custom `crmsh.log.setup_logger` with standard `logging.getLogger(__name__)` calls across the entire codebase.

#### 3. Crash Test Logging Refactoring
- Refactored `crash_test` to use the new log filtering mechanism to toggle output instead of temporarily removing handlers, leading to more robust state management during tests.