### PR TITLE
[crmsh-4.6] Fix: sbd: Compare SBD device UUID when adding SBD via sbd stage

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1,6 +1,8 @@
 import os
 import re
 import shutil
+import shlex
+from typing import Optional
 from . import utils, sh
 from . import bootstrap
 from .bootstrap import SYSCONFIG_SBD, SBD_SYSTEMD_DELAY_START_DIR
@@ -305,15 +307,16 @@ class SBDManager(object):
         self.no_update_config = False
 
     @staticmethod
-    def _get_device_uuid(dev, node=None):
+    def _get_device_uuid(dev, node=None) -> Optional[str]:
         """
         Get UUID for specific device and node
         """
-        out = sh.cluster_shell().get_stdout_or_raise_error("sbd -d {} dump".format(dev), node)
+        cmd = f"sbd -d {shlex.quote(dev)} dump"
+        rc, out, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(node, cmd)
+        if rc != 0 or not out:
+            return None
         res = re.search("UUID\s*:\s*(.*)\n", out)
-        if not res:
-            raise ValueError("Cannot find sbd device UUID for {}".format(dev))
-        return res.group(1)
+        return res.group(1) if res else None
 
     def _compare_device_uuid(self, dev, node_list):
         """
@@ -322,12 +325,16 @@ class SBDManager(object):
         if not node_list:
             return
         local_uuid = self._get_device_uuid(dev)
+        if not local_uuid:
+            raise ValueError(f"Cannot get sbd device UUID for {dev} on {utils.this_node()}")
         for node in node_list:
             remote_uuid = self._get_device_uuid(dev, node)
+            if not remote_uuid:
+                raise ValueError(f"Cannot get sbd device UUID for {dev} on {node}")
             if local_uuid != remote_uuid:
                 raise ValueError("Device {} doesn't have the same UUID with {}".format(dev, node))
 
-    def _verify_sbd_device(self, dev_list, compare_node_list=[]):
+    def _verify_sbd_device(self, dev_list, compare_node_list=None):
         """
         Verify sbd device
         """
@@ -441,6 +448,12 @@ class SBDManager(object):
             rc, _, err = bootstrap.invoke("sbd {} -d {} create".format(opt, dev))
             if not rc:
                 utils.fatal("Failed to initialize SBD device {}: {}".format(dev, err))
+
+        if self._context.cluster_is_running:
+            nodes = utils.list_cluster_nodes_except_me()
+            if nodes:
+                for dev in self._sbd_devices:
+                    self._compare_device_uuid(dev, nodes)
 
     def _update_sbd_configuration(self):
         """
@@ -576,7 +589,7 @@ class SBDManager(object):
         self._watchdog_inst.join_watchdog()
         dev_list = self._get_sbd_device_from_config()
         if dev_list:
-            self._verify_sbd_device(dev_list, [peer_host])
+            self._verify_sbd_device(dev_list, compare_node_list=[peer_host])
         else:
             self._warn_diskless_sbd(peer_host)
         logger.info("Got {}SBD configuration".format("" if dev_list else "diskless "))

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -453,7 +453,7 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("/dev/sdc1 doesn't look like a block device", str(err.exception))
 
         mock_block_device.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdc1")])
-        mock_compare.assert_called_once_with("/dev/sdb1", [])
+        mock_compare.assert_called_once_with("/dev/sdb1", None)
 
     @mock.patch('crmsh.sbd.SBDManager._verify_sbd_device')
     def test_get_sbd_device_from_option(self, mock_verify):
@@ -751,7 +751,7 @@ class TestSBDManager(unittest.TestCase):
         mock_exists.assert_called_once_with("/etc/sysconfig/sbd")
         mock_invoke.assert_called_once_with("systemctl enable sbd.service")
         mock_get_device.assert_called_once_with()
-        mock_verify.assert_called_once_with(["/dev/sdb1"], ["node1"])
+        mock_verify.assert_called_once_with(["/dev/sdb1"], compare_node_list=["node1"])
         mock_enabled.assert_called_once_with("sbd.service", "node1")
         mock_status.assert_called_once_with("Got SBD configuration")
         mock_watchdog.assert_called_once_with(remote_user="alice", peer_host="node1")
@@ -818,15 +818,14 @@ class TestSBDManager(unittest.TestCase):
         self.assertEqual("Device /dev/sdb1 doesn't have the same UUID with node1", str(err.exception))
         mock_get_uuid.assert_has_calls([mock.call("/dev/sdb1"), mock.call("/dev/sdb1", "node1")])
 
-    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_get_device_uuid_not_match(self, mock_run):
-        mock_run.return_value = "data"
-        with self.assertRaises(ValueError) as err:
-            self.sbd_inst._get_device_uuid("/dev/sdb1")
-        self.assertEqual("Cannot find sbd device UUID for /dev/sdb1", str(err.exception))
-        mock_run.assert_called_once_with("sbd -d /dev/sdb1 dump", None)
+        mock_run.return_value = 1, None, None
+        res = self.sbd_inst._get_device_uuid("/dev/sdb1")
+        self.assertIsNone(res)
+        mock_run.assert_called_once_with(None, "sbd -d /dev/sdb1 dump")
 
-    @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.sh.ClusterShell.get_rc_stdout_stderr_without_input')
     def test_get_device_uuid(self, mock_run):
         output = """
         ==Dumping header on disk /dev/sda1
@@ -840,10 +839,10 @@ class TestSBDManager(unittest.TestCase):
         Timeout (msgwait)  : 10
         ==Header on disk /dev/sda1 is dumped
         """
-        mock_run.return_value = output
+        mock_run.return_value = 0, output, None
         res = self.sbd_inst._get_device_uuid("/dev/sda1", node="node1")
         self.assertEqual(res, "a2e9a92c-cc72-4ef9-ac55-ccc342f3546b")
-        mock_run.assert_called_once_with("sbd -d /dev/sda1 dump", "node1")
+        mock_run.assert_called_once_with("node1", "sbd -d /dev/sda1 dump")
 
     @mock.patch('crmsh.sbd.SBDManager._get_sbd_device_from_config')
     @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')


### PR DESCRIPTION
The previous code only compared SBD device UUID when joining the cluster, that's not enough. When adding SBD via sbd stage, after initializing the SBD device, also need to compare SBD device UUID between cluster nodes

Backport from:
- #2120 