### PR TITLE
Dev: help: Show alias command info

### DIFF
--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -77,13 +77,14 @@ class HelpFilter(object):
 
 
 class HelpEntry(object):
-    def __init__(self, short_help, long_help='', alias_for=None, generated=False):
+    def __init__(self, short_help, long_help='', alias_for=None, alias_name=None, generated=False):
         if short_help:
             self.short = short_help[0].upper() + short_help[1:]
         else:
             self.short = 'Help'
         self._long_help = long_help
         self.alias_for = alias_for
+        self.alias_name = alias_name
         self.generated = generated
 
     @property
@@ -113,7 +114,9 @@ class HelpEntry(object):
 
         prefix = ''
         if self.is_alias():
-            prefix = helpfilter("(Redirected from `%s` to `%s`)\n" % self.alias_for)
+            msg_alias = f"Command `{self.alias_name}` is an alias for `{self.alias_for}`"
+            msg_deprecated = f"`{self.alias_name}` is deprecated and will be removed in a future release"
+            prefix = helpfilter(f"({msg_alias}. {msg_deprecated})\n")
 
         utils.page_string(short_help + '\n' + prefix + long_help)
 
@@ -124,6 +127,20 @@ class HelpEntry(object):
 
     def __repr__(self):
         return str(self)
+
+
+class AliasHelpEntry(HelpEntry):
+    """
+    Represents an alias help entry.
+    Delegates long_help to the target HelpEntry to preserve lazy loading.
+    """
+    def __init__(self, target: HelpEntry, alias_for: str, alias_name: str):
+        super().__init__(target.short, alias_for=alias_for, alias_name=alias_name, generated=target.generated)
+        self.target = target
+
+    @property
+    def long_help(self):
+        return self.target.long_help
 
 
 class LazyHelpEntryFromCli(HelpEntry):
@@ -441,9 +458,20 @@ def _load_help():
         "add help for aliases"
         for name, childinfo in childinfo.children.items():
             if name in help_node.children:
+                if name != childinfo.name:  # Skip alias entries during canonical traversal
+                    continue
                 fixup_help_aliases(help_node.children[name], childinfo)
                 for alias in childinfo.aliases:
-                    help_node.children[alias] = help_node.children[name]
+                    target = help_node.children[name]
+                    help_node.children[alias] = SubcommandTreeNode(
+                        alias,
+                        AliasHelpEntry(
+                            target.help,
+                            alias_for=target.name,
+                            alias_name=alias
+                        ),
+                        target.children
+                    )
         return
 
     def fixup_topics():

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -356,8 +356,8 @@ def help_contextual(levels: typing.Sequence[str]):
             else:
                 raise ValueError(f"Unknown property '{property_name}'")
         return None
-    else:
-        topic = levels[0].lower()
+    elif len(levels) <= 2:
+        topic = levels[-1].lower()
         t = utils.fuzzy_get(_TOPICS, topic)
         if t:
             return t

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -77,14 +77,12 @@ class HelpFilter(object):
 
 
 class HelpEntry(object):
-    def __init__(self, short_help, long_help='', alias_for=None, alias_name=None, generated=False):
+    def __init__(self, short_help, long_help='', generated=False):
         if short_help:
             self.short = short_help[0].upper() + short_help[1:]
         else:
             self.short = 'Help'
         self._long_help = long_help
-        self.alias_for = alias_for
-        self.alias_name = alias_name
         self.generated = generated
 
     @property
@@ -95,8 +93,8 @@ class HelpEntry(object):
     def long_help(self, value):
         self._long_help = value
 
-    def is_alias(self):
-        return self.alias_for is not None
+    def get_prefix(self):
+        return ''
 
     def paginate(self):
         '''
@@ -112,12 +110,7 @@ class HelpEntry(object):
             if not long_help.startswith('\n'):
                 long_help = '\n' + long_help
 
-        prefix = ''
-        if self.is_alias():
-            msg_alias = f"Command `{self.alias_name}` is an alias for `{self.alias_for}`"
-            msg_deprecated = f"`{self.alias_name}` is deprecated and will be removed in a future release"
-            prefix = helpfilter(f"({msg_alias}. {msg_deprecated})\n")
-
+        prefix = self.get_prefix()
         utils.page_string(short_help + '\n' + prefix + long_help)
 
     def __str__(self):
@@ -135,12 +128,20 @@ class AliasHelpEntry(HelpEntry):
     Delegates long_help to the target HelpEntry to preserve lazy loading.
     """
     def __init__(self, target: HelpEntry, alias_for: str, alias_name: str):
-        super().__init__(target.short, alias_for=alias_for, alias_name=alias_name, generated=target.generated)
+        super().__init__(target.short, generated=target.generated)
         self.target = target
+        self.alias_for = alias_for
+        self.alias_name = alias_name
 
     @property
     def long_help(self):
         return self.target.long_help
+
+    def get_prefix(self):
+        helpfilter = HelpFilter()
+        msg_alias = f"Command `{self.alias_name}` is an alias for `{self.alias_for}`"
+        msg_deprecated = f"`{self.alias_name}` is deprecated and will be removed in a future release"
+        return helpfilter(f"({msg_alias}. {msg_deprecated})\n")
 
 
 class LazyHelpEntryFromCli(HelpEntry):
@@ -149,9 +150,9 @@ class LazyHelpEntryFromCli(HelpEntry):
             self,
             short_help: str,
             cmd_args: typing.Sequence[str],
-            alias_for=None, generated=False,
+            generated=False,
     ):
-        super().__init__(short_help, '', alias_for, generated)
+        super().__init__(short_help, '', generated)
         self._cmd_args = cmd_args
 
     @functools.cached_property
@@ -186,7 +187,7 @@ class SubcommandTreeNode:
 
 HELP_FILE = os.path.join(config.path.sharedir, 'crm.8.adoc')
 
-_DEFAULT = HelpEntry('No help available', long_help='', alias_for=None, generated=True)
+_DEFAULT = HelpEntry('No help available', long_help='', generated=True)
 _REFERENCE_RE = re.compile(r'<<[^,]+,(.+)>>')
 
 # loaded on demand

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1837,6 +1837,8 @@ unmigrate <rsc>
 unban <rsc>
 ...............
 
+Note: `migrate` is an alias for `move` command, `unmigrate`, `unban` are aliases for `clear` command.
+
 [[cmdhelp.resource.constraints,Show constraints affecting a resource]]
 ==== `constraints`
 
@@ -3263,7 +3265,7 @@ above.
 **************************
 
 [[cmdhelp.configure.get_property,Get property value]]
-==== `get-property`
+==== `get_property`
 
 Show the value of the given property. If the value is not set, the
 command will print the default value for the property, if known.
@@ -3275,19 +3277,19 @@ If the property is set multiple times, for example using multiple
 property sets with different rule expressions, the output of this
 command is undefined.
 
-Pass the argument +-t+ or +--true+ to `get-property` to translate
+Pass the argument +-t+ or +--true+ to `get_property` to translate
 the argument value into +true+ or +false+. If the value is not
 set, the command will print +false+.
 
 Usage:
 ...............
-get-property [-t|--true] [<name>]
+get_property [-t|--true] [<name>]
 ...............
 
 Example:
 ...............
-get-property fencing-enabled
-get-property -t maintenance-mode
+get_property fencing-enabled
+get_property -t maintenance-mode
 ...............
 
 [[cmdhelp.configure.graph,generate a directed graph]]


### PR DESCRIPTION
When requesting help for a command alias, add a short note to indicate the canonical command name that the alias resolves to.

For example:
```
crm resource help unmigrate
```
will now show:
```
(Command unmigrate is an alias for clear. unmigrate is deprecated and will be removed in a future release)
```

Other changes:
```
Dev: crm.8.adoc: Improve crm.8.adoc
- In help of `crm resource clear` command, add note about which commands are aliases
- Replace `get-property` with `get_property` since the former is the alias of the latter

Dev: help.py: Give the correct level index to fuzzy search for topic help
  Problem: When running `crm resource help xxx`, expected to get the error
  '''
  No help found for "crm resource xxx"
  '''
  But actually get the help of topic 'ResourceSet'
    
  Should use the correct level index levels[-1] to fuzzy search for topic help, instead of levels[0]
```

Fix issue:
- #2127