### PR TITLE
Dev: bootstrap: Warn about deprecating legacy and unencrypted/unauthenticated knet transports (jsc#PED-16433)

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1464,7 +1464,8 @@ def init_corosync() -> None:
 
     if _context.transport != 'knet':
         logger.warning(
-            'Transport %s does not support encryption and message authentication. Corosync traffic will be in cleartext.',
+            'Transport %s is deprecated and does not support encryption and message authentication. '
+            'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.',
             _context.transport,
         )
     config_corosync_conf()

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1468,6 +1468,24 @@ def init_corosync() -> None:
             'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.',
             _context.transport,
         )
+    else:
+        cipher = _context.profiles_dict.get('corosync.totem.crypto_cipher')
+        hash_algo = _context.profiles_dict.get('corosync.totem.crypto_hash')
+        secauth = _context.profiles_dict.get('corosync.totem.secauth')
+
+        is_encrypted = True
+        if secauth == 'on':
+            if cipher == 'none' or hash_algo == 'none':
+                is_encrypted = False
+        else:
+            if not cipher or cipher == 'none' or not hash_algo or hash_algo == 'none':
+                is_encrypted = False
+
+        if not is_encrypted:
+            logger.warning(
+                'It is deprecated to disable knet encryption/authentication. '
+                'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.'
+            )
     config_corosync_conf()
     adjust_corosync_parameters_according_to_profiles()
 

--- a/test/features/bootstrap_options.feature
+++ b/test/features/bootstrap_options.feature
@@ -172,7 +172,8 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -y -t udpu" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
+    Then    Except "Transport udpu is deprecated and does not support encryption and message authentication. Corosync traffic will be in cleartext. Encryption will be enforced in future versions." in stderr
+    And     Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     Then    Cluster is using "udpu" transport mode
@@ -182,7 +183,8 @@ Feature: crmsh bootstrap process - options
     Given   Cluster service is "stopped" on "hanode1"
     Given   Cluster service is "stopped" on "hanode2"
     When    Run "crm cluster init -y -t udp" on "hanode1"
-    Then    Cluster service is "started" on "hanode1"
+    Then    Except "Transport udp is deprecated and does not support encryption and message authentication. Corosync traffic will be in cleartext. Encryption will be enforced in future versions." in stderr
+    And     Cluster service is "started" on "hanode1"
     When    Run "crm cluster join -c hanode1 -y" on "hanode2"
     Then    Cluster service is "started" on "hanode2"
     Then    Cluster is using "udp" transport mode

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1601,9 +1601,52 @@ done
     @mock.patch('os.path.exists')
     def test_init_corosync_no_warning_knet(self, mock_exists, mock_auth, mock_conf, mock_adjust, mock_warning):
         mock_exists.return_value = False
-        bootstrap._context = mock.Mock(transport='knet')
+        profiles = {
+            'corosync.totem.crypto_cipher': 'aes256',
+            'corosync.totem.crypto_hash': 'sha256',
+            'corosync.totem.secauth': None
+        }
+        bootstrap._context = mock.Mock(transport='knet', profiles_dict=profiles)
         bootstrap.init_corosync()
         mock_warning.assert_not_called()
+
+    @mock.patch('crmsh.bootstrap.logger.warning')
+    @mock.patch('crmsh.bootstrap.adjust_corosync_parameters_according_to_profiles')
+    @mock.patch('crmsh.bootstrap.config_corosync_conf')
+    @mock.patch('crmsh.bootstrap.init_corosync_auth')
+    @mock.patch('os.path.exists')
+    def test_init_corosync_knet_warning_disabled(self, mock_exists, mock_auth, mock_conf, mock_adjust, mock_warning):
+        mock_exists.return_value = False
+        profiles = {
+            'corosync.totem.crypto_cipher': 'none',
+            'corosync.totem.crypto_hash': 'sha256',
+            'corosync.totem.secauth': None
+        }
+        bootstrap._context = mock.Mock(transport='knet', profiles_dict=profiles)
+        bootstrap.init_corosync()
+        mock_warning.assert_called_once_with(
+            'It is deprecated to disable knet encryption/authentication. '
+            'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.'
+        )
+
+    @mock.patch('crmsh.bootstrap.logger.warning')
+    @mock.patch('crmsh.bootstrap.adjust_corosync_parameters_according_to_profiles')
+    @mock.patch('crmsh.bootstrap.config_corosync_conf')
+    @mock.patch('crmsh.bootstrap.init_corosync_auth')
+    @mock.patch('os.path.exists')
+    def test_init_corosync_knet_warning_secauth_on_but_none(self, mock_exists, mock_auth, mock_conf, mock_adjust, mock_warning):
+        mock_exists.return_value = False
+        profiles = {
+            'corosync.totem.crypto_cipher': 'none',
+            'corosync.totem.crypto_hash': 'sha256',
+            'corosync.totem.secauth': 'on'
+        }
+        bootstrap._context = mock.Mock(transport='knet', profiles_dict=profiles)
+        bootstrap.init_corosync()
+        mock_warning.assert_called_once_with(
+            'It is deprecated to disable knet encryption/authentication. '
+            'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.'
+        )
 
 
 class TestValidation(unittest.TestCase):

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1579,6 +1579,32 @@ done
             mock.call(None, f"systemctl is-failed {constants.PCMK_SERVICE}")
         ])
 
+    @mock.patch('crmsh.bootstrap.logger.warning')
+    @mock.patch('crmsh.bootstrap.adjust_corosync_parameters_according_to_profiles')
+    @mock.patch('crmsh.bootstrap.config_corosync_conf')
+    @mock.patch('crmsh.bootstrap.init_corosync_auth')
+    @mock.patch('os.path.exists')
+    def test_init_corosync_warning_non_knet(self, mock_exists, mock_auth, mock_conf, mock_adjust, mock_warning):
+        mock_exists.return_value = False
+        bootstrap._context = mock.Mock(transport='udpu')
+        bootstrap.init_corosync()
+        mock_warning.assert_called_once_with(
+            'Transport %s is deprecated and does not support encryption and message authentication. '
+            'Corosync traffic will be in cleartext. Encryption will be enforced in future versions.',
+            'udpu',
+        )
+
+    @mock.patch('crmsh.bootstrap.logger.warning')
+    @mock.patch('crmsh.bootstrap.adjust_corosync_parameters_according_to_profiles')
+    @mock.patch('crmsh.bootstrap.config_corosync_conf')
+    @mock.patch('crmsh.bootstrap.init_corosync_auth')
+    @mock.patch('os.path.exists')
+    def test_init_corosync_no_warning_knet(self, mock_exists, mock_auth, mock_conf, mock_adjust, mock_warning):
+        mock_exists.return_value = False
+        bootstrap._context = mock.Mock(transport='knet')
+        bootstrap.init_corosync()
+        mock_warning.assert_not_called()
+
 
 class TestValidation(unittest.TestCase):
     """


### PR DESCRIPTION
This pull request adds and updates warnings in the bootstrap module regarding the deprecation of legacy and unencrypted/unauthenticated knet transports.

### Changes:
- Update warning about deprecating legacy transports.
- Add warning about deprecating unencrypted/unauthenticated knet transport.