### PR TITLE
Dev: sbd: Check and fix SBD_PACEMAKER in sysconfig

### DIFF
--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -532,6 +532,7 @@ class SBDCheckItem(IntEnum):
     FENCE_SBD_AGENT = auto()
     FENCE_SBD_AGENT_PARAMETERS = auto()
     SBD_DELAY_START = auto()
+    SBD_PACEMAKER = auto()
     SBD_SYSTEMD_START_TIMEOUT = auto()
     FENCING_WATCHDOG_TIMEOUT_PROPERTY = auto()
     FENCING_TIMEOUT_PROPERTY = auto()
@@ -627,6 +628,14 @@ class SBDConfigChecker(SBDTimeout):
                     SBDCheckItem.SBD_WATCHDOG_TIMEOUT,
                     SBDCheckItem.FENCE_SBD_AGENT_PARAMETERS
                 ]
+            ),
+
+            (
+                "SBD_PACEMAKER",
+                self._check_sbd_pacemaker_in_sysconfig,
+                self._fix_sbd_pacemaker_in_sysconfig,
+                False,
+                []
             ),
 
             (
@@ -865,6 +874,64 @@ class SBDConfigChecker(SBDTimeout):
     def _fix_sbd_delay_start(self):
         advised_value = str(self.sbd_delay_start_value_expected)
         SBDManager.update_sbd_configuration({"SBD_DELAY_START": advised_value})
+
+    def _check_sbd_pacemaker_in_sysconfig(self) -> CheckResult:
+        common_warning_msg = "It's highly recommended to enable SBD_PACEMAKER to prevent unexpected self-fencing during temporary storage loss"
+
+        # -P in SBD_OPTS is to enable SBD_PACEMAKER, -PP is to disable it
+        # option in SBD_OPTS will override the value in SBD_PACEMAKER
+        value_from_opts = SBDUtils.get_sbd_value_from_config("SBD_OPTS")
+        if value_from_opts:
+            try:
+                opts_list = shlex.split(value_from_opts)
+            except ValueError:
+                opts_list = value_from_opts.split()
+            if "-PP" in opts_list:
+                self._log_when_not_quiet(
+                    logging.WARNING,
+                    common_warning_msg
+                )
+                self._log_when_not_quiet(
+                    logging.WARNING,
+                    "In %s, SBD_OPTS contains -PP, which disables SBD_PACEMAKER, please use -P to enable it",
+                    SBDManager.SYSCONFIG_SBD
+                )
+                return CheckResult.WARNING
+
+            elif "-P" in opts_list:
+                return CheckResult.SUCCESS
+
+        value = SBDUtils.get_sbd_value_from_config("SBD_PACEMAKER")
+        if not value or value in ("yes", "true"):
+            return CheckResult.SUCCESS
+
+        self._log_when_not_quiet(
+            logging.WARNING,
+            common_warning_msg
+        )
+        self._log_when_not_quiet(
+            logging.WARNING,
+            "In %s, SBD_PACEMAKER is set to %s, please set it to yes or true",
+            SBDManager.SYSCONFIG_SBD, value
+        )
+        return CheckResult.WARNING
+
+    def _fix_sbd_pacemaker_in_sysconfig(self):
+        value_from_opts = SBDUtils.get_sbd_value_from_config("SBD_OPTS")
+        if value_from_opts:
+            try:
+                opts_list = shlex.split(value_from_opts)
+            except ValueError:
+                opts_list = value_from_opts.split()
+            if "-PP" in opts_list:
+                opts_list = ["-P" if opt == "-PP" else opt for opt in opts_list]
+                new_opts_value = shlex.join(opts_list)
+                logger.info("Replacing -PP with -P in SBD_OPTS in %s", SBDManager.SYSCONFIG_SBD)
+                SBDManager.update_sbd_configuration({"SBD_OPTS": new_opts_value})
+                return
+
+        logger.info("Setting SBD_PACEMAKER in %s to yes", SBDManager.SYSCONFIG_SBD)
+        SBDManager.update_sbd_configuration({"SBD_PACEMAKER": "yes"})
 
     def _check_sbd_systemd_start_timeout(self) -> CheckResult:
         expected_start_timeout = self.sbd_systemd_start_timeout_expected

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -359,6 +359,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check._check_fencing_enabled = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_check._check_sbd_delay_start_unset_dropin = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_check._check_sbd_service_is_enabled = Mock(return_value=sbd.CheckResult.SUCCESS)
+        self.instance_check._check_sbd_pacemaker_in_sysconfig = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_check._get_current_terms = Mock(side_effect=self.fake_get_current_terms(self.instance_check))
 
         res = self.instance_check.check_and_fix()
@@ -410,6 +411,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_fix._check_fencing_enabled = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_fix._check_sbd_delay_start_unset_dropin = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_fix._check_sbd_service_is_enabled = Mock(return_value=sbd.CheckResult.SUCCESS)
+        self.instance_fix._check_sbd_pacemaker_in_sysconfig = Mock(return_value=sbd.CheckResult.SUCCESS)
         self.instance_fix._get_current_terms = Mock(side_effect=self.fake_get_current_terms(self.instance_fix))
 
         res = self.instance_fix.check_and_fix()
@@ -675,6 +677,70 @@ class TestSBDConfigChecker(unittest.TestCase):
     def test_fix_sbd_delay_start_unset_dropin(self, mock_logger_info, mock_unset_sbd_delay_start):
         self.instance_check._fix_sbd_delay_start_unset_dropin()
         mock_logger_info.assert_called_once_with("Createing runtime drop-in file %s to unset SBD_DELAY_START", sbd.SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig(self, mock_get_sbd_value_from_config):
+        for value in ("yes", "true"):
+            with self.subTest(value=value):
+                mock_get_sbd_value_from_config.side_effect = [None, value]
+                self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.SUCCESS)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig_warning(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.side_effect = [None, "no"]
+        self.instance_check._log_when_not_quiet = Mock()
+
+        self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
+        self.instance_check._log_when_not_quiet.assert_any_call(
+            logging.WARNING,
+            "In %s, SBD_PACEMAKER is set to %s, please set it to yes or true",
+            sbd.SBDManager.SYSCONFIG_SBD, "no"
+        )
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig_not_set(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.side_effect = [None, None]
+        self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.SUCCESS)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig_uppercase_warning(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.side_effect = [None, "YES"]
+        self.instance_check._log_when_not_quiet = Mock()
+        self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig_sbd_opts_p(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = "-S 1 -P"
+        self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.SUCCESS)
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    def test_check_sbd_pacemaker_in_sysconfig_sbd_opts_pp(self, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = "-S 1 -PP"
+        self.instance_check._log_when_not_quiet = Mock()
+        self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
+        self.instance_check._log_when_not_quiet.assert_any_call(
+            logging.WARNING,
+            "In %s, SBD_OPTS contains -PP, which disables SBD_PACEMAKER, please use -P to enable it",
+            sbd.SBDManager.SYSCONFIG_SBD
+        )
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    @patch('logging.Logger.info')
+    @patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    def test_fix_sbd_pacemaker_in_sysconfig(self, mock_update_sbd_configuration, mock_logger_info, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = None
+        self.instance_fix._fix_sbd_pacemaker_in_sysconfig()
+        mock_logger_info.assert_called_once_with("Setting SBD_PACEMAKER in %s to yes", sbd.SBDManager.SYSCONFIG_SBD)
+        mock_update_sbd_configuration.assert_called_once_with({"SBD_PACEMAKER": "yes"})
+
+    @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
+    @patch('logging.Logger.info')
+    @patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    def test_fix_sbd_pacemaker_in_sysconfig_replace_pp(self, mock_update_sbd_configuration, mock_logger_info, mock_get_sbd_value_from_config):
+        mock_get_sbd_value_from_config.return_value = "-S 1 -PP"
+        self.instance_fix._fix_sbd_pacemaker_in_sysconfig()
+        mock_logger_info.assert_called_once_with("Replacing -PP with -P in SBD_OPTS in %s", sbd.SBDManager.SYSCONFIG_SBD)
+        mock_update_sbd_configuration.assert_called_once_with({"SBD_OPTS": "-S 1 -P"})
 
     def test_check_fence_sbd_diskless(self):
         self.instance_check.disk_based = False


### PR DESCRIPTION
 Add an SBD health check item for SBD_PACEMAKER in /etc/sysconfig/sbd.
    
Accept an unset value as SBD's default enabled behavior, and accept explicit lowercase yes or true.
    
Also check SBD_OPTS: treat -P as enabled and warn on -PP, which disables SBD_PACEMAKER and overrides the SBD_PACEMAKER setting.
    
Report disabled or invalid values as warnings. Running `crm cluster health --fix` will set SBD_PACEMAKER to yes, or replace -PP with -P in SBD_OPTS if present.