### PR TITLE
Dev: Drop 'crm configure user' command

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -2298,7 +2298,6 @@ cib_object_map = {
     "op_defaults": ("op_defaults", CibProperty, "op_defaults", "op-options"),
     "fencing-topology": ("fencing_topology", CibFencingOrder, "configuration"),
     "acl_role": ("role", CibAcl, "acls"),
-    "acl_user": ("user", CibAcl, "acls"),
     "acl_target": ("acl_target", CibAcl, "acls"),
     "acl_group": ("acl_group", CibAcl, "acls"),
     "tag": ("tag", CibTag, "tags"),

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -17,7 +17,6 @@ cib_cli_map = {
     "op_defaults": "op_defaults",
     "acl_target": "acl_target",
     "acl_group": "acl_group",
-    "acl_user": "user",
     "acl_role": "role",
     "fencing-topology": "fencing_topology",
     "tag": "tag",

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -1323,22 +1323,10 @@ def parse_tag(self, cmd):
     return out
 
 
-@parser_for('user', 'role', 'acl_target', 'acl_group')
+@parser_for('role', 'acl_target', 'acl_group')
 class AclParser(BaseParser):
     def parse(self, cmd):
         return self.begin_dispatch(cmd, min_args=2)
-
-    def parse_user(self):
-        out = xmlutil.new('acl_user')
-        out.set('id', self.match_identifier())
-        while self.has_tokens():
-            # role identifier
-            if self.try_match(_ROLE_REF_RE):
-                xmlutil.child(out, 'role_ref', id=self.matched(1))
-            # acl right rule
-            else:
-                out.append(self._add_rule())
-        return out
 
     def parse_acl_target(self):
         out = xmlutil.new('acl_target')

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1208,17 +1208,6 @@ class CibConfig(command.UI):
         return self.__conf_object(context.get_command_name(), *args)
 
     @command.skill_level('expert')
-    @command.completers_repeating(compl.null, compl.choice(["role:", "read", "write", "deny"]))
-    def do_user(self, context, *args):
-        """user <uid> {roles|rules}
-
-        roles :: role:<role-ref> [role:<role-ref> ...]
-        rules :: rule [rule ...]
-
-        (See the role command for details on rules.)"""
-        return self.__conf_object(context.get_command_name(), *args)
-
-    @command.skill_level('expert')
     @command.completers_repeating(compl.null, compl.choice(["read", "write", "deny"]))
     def do_role(self, context, *args):
         """role <role-id> rule [rule ...]

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -893,7 +893,7 @@ _sort_xml_order = make_sort_map('node',
                                 ['rsc_location', 'rsc_colocation', 'rsc_order'],
                                 ['rsc_ticket', 'fencing-topology'],
                                 'cluster_property_set', 'rsc_defaults', 'op_defaults',
-                                'acl_role', ['acl_target', 'acl_group', 'acl_user'],
+                                'acl_role', ['acl_target', 'acl_group'],
                                 'alert')
 
 _sort_cli_order = make_sort_map('node',
@@ -903,7 +903,7 @@ _sort_cli_order = make_sort_map('node',
                                 ['location', 'colocation', 'collocation', 'order'],
                                 ['rsc_ticket', 'fencing_topology'],
                                 'property', 'rsc_defaults', 'op_defaults',
-                                'role', ['acl_target', 'acl_group', 'user'],
+                                'role', ['acl_target', 'acl_group'],
                                 'alert')
 
 _SORT_LAST = 1000

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2846,7 +2846,6 @@ Lists (ACL) can be setup to allow access to parts of the CIB for
 users other than +root+ and +hacluster+. The following commands
 manage ACL:
 
-- `user`
 - `role`
 
 In Pacemaker 1.1.12 and up, this command replaces the `user` command
@@ -4126,7 +4125,7 @@ type :: node | primitive | group | clone | rsc_template
       | rsc_ticket
       | property | rsc_defaults | op_defaults
       | fencing_topology
-      | role | user | acl_target
+      | role | acl_target
       | tag
 ...............
 
@@ -4202,32 +4201,6 @@ upgrade <force>
 Example:
 ...............
 upgrade force
-...............
-
-[[cmdhelp.configure.user,define user access rights]]
-==== `user`
-
-Users which normally cannot view or manage cluster configuration
-can be allowed access to parts of the CIB. The access is defined
-by a set of +read+, +write+, and +deny+ rules as in role
-definitions or by referencing roles. The latter is considered
-best practice.
-
-For more information on rule expressions, see
-<<topics.Syntax.RuleExpressions,Syntax: Rule expressions>>.
-
-Usage:
-...............
-user <uid> {roles|rules}
-
-roles :: role:<role-ref> [role:<role-ref> ...]
-rules :: rule [rule ...]
-...............
-Example:
-...............
-user joe \
-    role:app1_admin \
-    role:read_all
 ...............
 
 [[cmdhelp.configure.validate_all,call agent validate-all for resource]]

--- a/test/unittests/test_parse.py
+++ b/test/unittests/test_parse.py
@@ -389,8 +389,6 @@ class TestCliParser(unittest.TestCase):
     def test_acl(self, mock_error):
         out = self._parse('role user-1 error')
         self.assertFalse(out)
-        out = self._parse('user user-1 role:user-1')
-        self.assertNotEqual(out, False)
 
         out = self._parse("role bigdb_admin " +
                           "write meta:bigdb:target-role " +


### PR DESCRIPTION
Remove the deprecated 'crm configure user' ACL command and its supporting infrastructure:

- ui_configure.py: Remove do_user() command handler
- parse.py: Remove parse_user() from AclParser and drop 'user' from parser_for decorator
- cibconfig.py: Remove 'acl_user' entry from cib_object_map
- constants.py: Remove 'acl_user' entry from cib_cli_map
- xmlutil.py: Remove 'acl_user' from XML sort order
- doc/crm.8.adoc: Remove user command documentation
- test/unittests/test_parse.py: Remove test for 'user' parsing