### PR TITLE
Fix: ui_node: Use boolean values for node state attrs

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -365,8 +365,8 @@ class NodeMgmt(command.UI):
                     xmlutil.rmnodes(item_to_del)
                 # If the standby nvpair already exists, set and continue
                 item = cib.xpath(xml_query_path.format(node_id=node_id))
-                if item and item[0].get("value") != "on":
-                    item[0].set("value", "on")
+                if item and item[0].get("value") not in ("true", "on"):
+                    item[0].set("value", "true")
                     continue
                 # Create standby nvpair
                 interface_item = xml_item
@@ -374,13 +374,14 @@ class NodeMgmt(command.UI):
                     res_item = xmlutil.get_set_nodes(xml_item, "transient_attributes", create=True)
                     interface_item = res_item[0]
                 res_item = xmlutil.get_set_nodes(interface_item, "instance_attributes", create=True)
-                xmlutil.set_attr(res_item[0], "standby", "on")
+                xmlutil.set_attr(res_item[0], "standby", "true")
 
         rc = utils.diff_and_patch(xmlutil.xml_tostring(orig_cib), xmlutil.xml_tostring(cib))
         if not rc:
             return False
         for node in node_list:
             logger.info("standby node %s", node)
+        logger.info("To restore the node from standby mode, use the `online` command")
 
     @command.wait
     @command.completers(compl.standby_nodes)
@@ -405,8 +406,8 @@ class NodeMgmt(command.UI):
             node_id = utils.get_nodeid_from_name(node)
             for query_path in [constants.XML_NODE_QUERY_STANDBY_PATH, constants.XML_STATUS_QUERY_STANDBY_PATH]:
                 item = cib.xpath(query_path.format(node_id=node_id))
-                if item and item[0].get("value") != "off":
-                    item[0].set("value", "off")
+                if item and item[0].get("value") not in ("false", "off"):
+                    item[0].set("value", "false")
 
         rc = utils.diff_and_patch(xmlutil.xml_tostring(orig_cib), xmlutil.xml_tostring(cib))
         if not rc:
@@ -422,7 +423,11 @@ class NodeMgmt(command.UI):
             node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
-        return self._commit_node_attr(context, node, "maintenance", "true")
+        rc = self._commit_node_attr(context, node, "maintenance", "true")
+        if rc:
+            logger.info("Node %s is now in maintenance mode", node)
+            logger.info("To restore the node from maintenance mode, use the `ready` command")
+        return rc
 
 
     @command.wait
@@ -433,7 +438,10 @@ class NodeMgmt(command.UI):
             node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
-        return utils.ext_cmd(self.node_maint % (node, "off")) == 0
+        rc = self._commit_node_attr(context, node, "maintenance", "false")
+        if rc:
+            logger.info("Node %s is now ready", node)
+        return rc
 
     @command.wait
     @command.completers(compl.nodes)

--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -182,7 +182,9 @@ If --all is specified, {action} on all nodes."""
 \n\nAdditionally, you may specify a lifetime for the standby---if set to
 "reboot", the node will be back online once it reboots. "forever" will
 keep the node in standby after reboot. The life time defaults to
-"forever"."""
+"forever".
+
+To restore the node from standby mode, use the `online` command."""
         addtion_usage = " [lifetime]"
 
     parser = ArgumentParser(

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2376,6 +2376,8 @@ property from them.
 
 The node parameter defaults to the node where the command is run.
 
+To restore the node from maintenance mode, use the `ready` command.
+
 Usage:
 ...............
 maintenance [<node>]

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -160,6 +160,8 @@ op_defaults opsdef2: \
 	record-pending=true
 .INP: commit
 .TRY -F node maintenance node1
+INFO: Node node1 is now in maintenance mode
+INFO: To restore the node from maintenance mode, use the `ready` command
 .TRY -F resource maintenance g1 off
 .TRY -F resource maintenance d1
 .TRY -F configure property maintenance-mode=true

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -75,6 +75,8 @@ node1: member(offline)
 .TRY -F node maintenance node1
 INFO: 'maintenance' attribute already exists in p5. Remove it? [YES]
 INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
+INFO: Node node1 is now in maintenance mode
+INFO: To restore the node from maintenance mode, use the `ready` command
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -95,7 +97,7 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
 </cib>
 
 .TRY node ready node1
-.EXT crm_attribute -t nodes -N 'node1' -n maintenance -v 'off'
+INFO: Node node1 is now ready
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -106,7 +108,7 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>
@@ -127,7 +129,7 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
           <nvpair id="nodes-node1-a1" name="a1" value="1 2 3"/>
         </instance_attributes>
       </node>
@@ -150,7 +152,7 @@ scope=nodes  name=a1 value=1 2 3
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
           <nvpair id="nodes-node1-a1" name="a1" value="1 2 3"/>
         </instance_attributes>
       </node>
@@ -173,7 +175,7 @@ Deleted nodes attribute: id=nodes-node1-a1 name=a1
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>
@@ -193,7 +195,7 @@ Deleted nodes attribute: id=nodes-node1-a1 name=a1
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>


### PR DESCRIPTION
Write standby and maintenance node attributes as true/false while still accepting existing on/off values.

Also add guidance in command output and help text for restoring nodes from standby or maintenance mode.