### PR TITLE
Dev: log: Add quiet-aware logger adapter

### DIFF
--- a/crmsh/log.py
+++ b/crmsh/log.py
@@ -26,6 +26,20 @@ class DEBUG2Logger(logging.Logger):
             self._log(DEBUG2, msg, args, **kwargs)
 
 
+class QuietLoggerAdapter(logging.LoggerAdapter):
+    def __init__(self, logger, quiet):
+        super().__init__(logger, {})
+        self.quiet = quiet
+
+    def log(self, level, msg, *args, **kwargs):
+        quiet = self.quiet
+        if callable(quiet):
+            quiet = quiet()
+        if quiet:
+            return
+        self.logger.log(level, msg, *args, **kwargs)
+
+
 class NumberedLoggerInterface(DEBUG2Logger):
     """
     Interface to prepend a number to the message, used for regression test. When this class is used directly, no numbers are prepend.

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -255,11 +255,9 @@ class SBDTimeout(object):
         self.quiet = False
         if self.context:
             self.quiet = self.context.quiet
+        self.logger = log.QuietLoggerAdapter(logger, quiet=lambda: self.quiet)
+        if self.context:
             self._initialize_timeout_from_bootstrap()
-
-    def _log_when_not_quiet(self, level, message, *args, **kwargs):
-        if not self.quiet:
-            logger.log(level, message, *args, **kwargs)
 
     def _initialize_timeout_from_bootstrap(self):
         self._set_sbd_watchdog_timeout()
@@ -276,8 +274,7 @@ class SBDTimeout(object):
         if "sbd.watchdog_timeout" in self.context.profiles_dict:
             self.sbd_watchdog_timeout = int(self.context.profiles_dict["sbd.watchdog_timeout"])
         if self.context.is_s390 and self.sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390:
-            self._log_when_not_quiet(
-                logging.WARNING,
+            self.logger.warning(
                 "sbd watchdog_timeout is set to %d for s390, it was %d",
                 self.SBD_WATCHDOG_TIMEOUT_DEFAULT_S390, self.sbd_watchdog_timeout
             )
@@ -293,8 +290,7 @@ class SBDTimeout(object):
         if "sbd.msgwait" in self.context.profiles_dict:
             sbd_msgwait = int(self.context.profiles_dict["sbd.msgwait"])
             if sbd_msgwait < sbd_msgwait_default:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "sbd msgwait is set to %d, it was %d",
                     sbd_msgwait_default, sbd_msgwait
                 )
@@ -310,8 +306,7 @@ class SBDTimeout(object):
             qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
             if self.sbd_watchdog_timeout <= qdevice_sync_timeout:
                 watchdog_timeout_with_qdevice = qdevice_sync_timeout + self.QDEVICE_SYNC_TIMEOUT_MARGIN
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "SBD_WATCHDOG_TIMEOUT should not less than %d for qdevice, it was %d",
                     watchdog_timeout_with_qdevice, self.sbd_watchdog_timeout
                 )
@@ -319,8 +314,7 @@ class SBDTimeout(object):
         # add sbd and qdevice together from beginning
         elif self.context.qdevice_inst:
             if self.sbd_watchdog_timeout < self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "SBD_WATCHDOG_TIMEOUT should not less than %d for qdevice, it was %d",
                     self.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE, self.sbd_watchdog_timeout
                 )
@@ -801,15 +795,13 @@ class SBDConfigChecker(SBDTimeout):
         if self.disk_based:
             self.sbd_watchdog_timeout_expected, self.sbd_msgwait_expected = SBDTimeout.get_sbd_metadata_expected()
             if self.sbd_watchdog_timeout < self.sbd_watchdog_timeout_expected:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that SBD watchdog timeout(now %d) >= %d",
                     self.sbd_watchdog_timeout, self.sbd_watchdog_timeout_expected
                 )
                 return CheckResult.ERROR
             if self.sbd_msgwait < self.sbd_msgwait_expected:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that SBD msgwait(now %d) >= %d",
                     self.sbd_msgwait, self.sbd_msgwait_expected
                 )
@@ -832,8 +824,7 @@ class SBDConfigChecker(SBDTimeout):
         if not self.disk_based:
             self.sbd_watchdog_timeout_expected = SBDTimeout.get_sbd_watchdog_timeout_expected(diskless=True)
             if self.sbd_watchdog_timeout < self.sbd_watchdog_timeout_expected:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that SBD_WATCHDOG_TIMEOUT(now %d) >= %d",
                     self.sbd_watchdog_timeout, self.sbd_watchdog_timeout_expected
                 )
@@ -850,22 +841,19 @@ class SBDConfigChecker(SBDTimeout):
             return CheckResult.SUCCESS
         elif config_value.isdigit() and expected_value.isdigit():
             if int(config_value) < int(expected_value):
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that SBD_DELAY_START is set to %s, now is %s",
                     expected_value, config_value
                 )
                 return CheckResult.ERROR
             else:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that SBD_DELAY_START is set to %s, now is %s",
                     expected_value, config_value
                 )
                 return CheckResult.WARNING
         else:
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "It's required that SBD_DELAY_START is set to %s, now is %s",
                 expected_value, config_value
             )
@@ -887,12 +875,8 @@ class SBDConfigChecker(SBDTimeout):
             except ValueError:
                 opts_list = value_from_opts.split()
             if "-PP" in opts_list:
-                self._log_when_not_quiet(
-                    logging.WARNING,
-                    common_warning_msg
-                )
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(common_warning_msg)
+                self.logger.warning(
                     "In %s, SBD_OPTS contains -PP, which disables SBD_PACEMAKER, please use -P to enable it",
                     SBDManager.SYSCONFIG_SBD
                 )
@@ -905,12 +889,8 @@ class SBDConfigChecker(SBDTimeout):
         if not value or value in ("yes", "true"):
             return CheckResult.SUCCESS
 
-        self._log_when_not_quiet(
-            logging.WARNING,
-            common_warning_msg
-        )
-        self._log_when_not_quiet(
-            logging.WARNING,
+        self.logger.warning(common_warning_msg)
+        self.logger.warning(
             "In %s, SBD_PACEMAKER is set to %s, please set it to yes or true",
             SBDManager.SYSCONFIG_SBD, value
         )
@@ -941,15 +921,13 @@ class SBDConfigChecker(SBDTimeout):
             if actual_start_timeout == expected_start_timeout:
                 check_res_list.append(CheckResult.SUCCESS)
             elif actual_start_timeout < expected_start_timeout:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s",
                     expected_start_timeout, actual_start_timeout, node
                 )
                 check_res_list.append(CheckResult.ERROR)
             else:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s",
                     expected_start_timeout, actual_start_timeout, node
                 )
@@ -969,8 +947,7 @@ class SBDConfigChecker(SBDTimeout):
         current_term = self.current_watchdog_timeout_term
         value = utils.get_property(current_term)
         if value and int(value) == -1:
-            self._log_when_not_quiet(
-                logging.WARNING,
+            self.logger.warning(
                 "It's recommended that %s is set to %d, now is -1",
                 current_term, self.fencing_watchdog_timeout
             )
@@ -978,30 +955,26 @@ class SBDConfigChecker(SBDTimeout):
         value = int(utils.crm_msec(value)/1000)
         if self.disk_based:
             if value > 0:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that %s is not set when using disk-based SBD",
                     current_term
                 )
                 return CheckResult.WARNING
         else:
             if value == 0:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that %s is set to %d, now is not set",
                     current_term, self.fencing_watchdog_timeout
                 )
                 return CheckResult.ERROR
             if value < self.fencing_watchdog_timeout:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that %s is set to %d, now is %d",
                     current_term, self.fencing_watchdog_timeout, value
                 )
                 return CheckResult.ERROR
             elif value > self.fencing_watchdog_timeout:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that %s is set to %d, now is %d",
                     current_term, self.fencing_watchdog_timeout, value
                 )
@@ -1027,15 +1000,13 @@ class SBDConfigChecker(SBDTimeout):
         # will get default value from pacemaker metadata if not set
         value = int(utils.crm_msec(value)/1000)
         if value < expected_value:
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "It's required that %s is set to %d, now is %d",
                 current_term, expected_value, value
             )
             return CheckResult.ERROR
         elif value > expected_value:
-            self._log_when_not_quiet(
-                logging.WARNING,
+            self.logger.warning(
                 "It's recommended that %s is set to %d, now is %d",
                 current_term, expected_value, value
             )
@@ -1052,8 +1023,7 @@ class SBDConfigChecker(SBDTimeout):
         current_term = self.current_enabled_term
         value = utils.get_property(current_term, get_default=False)
         if value == "false": # have to check if the value is explicitly set to false
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "It's required that %s is set to true, now is false",
                 current_term
             )
@@ -1077,8 +1047,7 @@ class SBDConfigChecker(SBDTimeout):
             if rc == 0:
                 check_res_list.append(CheckResult.SUCCESS)
             else:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "Runtime drop-in file %s to unset SBD_DELAY_START is missing on node %s",
                     SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE, node
                 )
@@ -1098,8 +1067,7 @@ class SBDConfigChecker(SBDTimeout):
             if service_manager.service_is_enabled(constants.SBD_SERVICE, node):
                 check_res_list.append(CheckResult.SUCCESS)
             else:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "%s is not enabled on node %s",
                     constants.SBD_SERVICE, node
                 )
@@ -1125,22 +1093,19 @@ class SBDConfigChecker(SBDTimeout):
             if configured:
                 return CheckResult.SUCCESS
             else:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "Fence agent %s is not configured",
                     SBDManager.SBD_RA
                 )
                 return CheckResult.ERROR
         if not xml_inst.is_resource_configured(SBDManager.SBD_RA):
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "Fence agent %s is not configured",
                 SBDManager.SBD_RA
             )
             return CheckResult.ERROR
         elif not xml_inst.is_resource_started(SBDManager.SBD_RA) and not utils.is_cluster_in_maintenance_mode():
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "Fence agent %s is not started",
                 SBDManager.SBD_RA
             )
@@ -1179,8 +1144,7 @@ class SBDConfigChecker(SBDTimeout):
         if not self.disk_based:
             return CheckResult.SUCCESS
         if not self.fence_sbd_parameters:
-            self._log_when_not_quiet(
-                logging.ERROR,
+            self.logger.error(
                 "Fence agent %s is not configured",
                 SBDManager.SBD_RA
             )
@@ -1190,30 +1154,26 @@ class SBDConfigChecker(SBDTimeout):
         for fence_sbd_param in self.fence_sbd_parameters:
             res_id, crashdump, pcmk_delay_max = fence_sbd_param.values()
             if utils.is_boolean_false(crashdump) and self.crashdump_watchdog_timeout:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that crashdump parameter is set to '1' in resource %s when sbd crashdump is configured, now is not set",
                     res_id
                 )
                 result_list.append(CheckResult.ERROR)
             elif utils.is_boolean_true(crashdump) and not self.crashdump_watchdog_timeout:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that crashdump parameter should not be set in resource %s when sbd crashdump is not configured",
                     res_id
                 )
                 result_list.append(CheckResult.WARNING)
 
             if self.two_node_without_qdevice and not pcmk_delay_max:
-                self._log_when_not_quiet(
-                    logging.ERROR,
+                self.logger.error(
                     "It's required that pcmk_delay_max parameter is set to %ds in resource %s for 2-node cluster without qdevice, now is not set",
                     constants.PCMK_DELAY_MAX, res_id
                 )
                 result_list.append(CheckResult.ERROR)
             elif pcmk_delay_max and not self.two_node_without_qdevice:
-                self._log_when_not_quiet(
-                    logging.WARNING,
+                self.logger.warning(
                     "It's recommended that pcmk_delay_max parameter should not be set in resource %s for clusters other than 2-node cluster without qdevice",
                     res_id
                 )

--- a/data-manifest
+++ b/data-manifest
@@ -200,6 +200,7 @@ test/unittests/test_crashtest_utils.py
 test/unittests/test_gv.py
 test/unittests/test_handles.py
 test/unittests/test_lock.py
+test/unittests/test_log.py
 test/unittests/test_migration.py
 test/unittests/test_network_utils.py
 test/unittests/test_objset.py

--- a/test/unittests/test_log.py
+++ b/test/unittests/test_log.py
@@ -1,0 +1,37 @@
+import logging
+import unittest
+from unittest import mock
+
+from crmsh import log
+
+
+class TestQuietLogging(unittest.TestCase):
+
+    def test_quiet_logger_adapter_logs_when_not_quiet(self):
+        logger = mock.Mock()
+        adapter = log.QuietLoggerAdapter(logger, quiet=False)
+
+        adapter.error("message %s", "value")
+
+        logger.log.assert_called_once_with(logging.ERROR, "message %s", "value")
+
+    def test_quiet_logger_adapter_drops_when_quiet(self):
+        logger = mock.Mock()
+        adapter = log.QuietLoggerAdapter(logger, quiet=True)
+
+        adapter.warning("message")
+
+        logger.log.assert_not_called()
+
+    def test_quiet_logger_adapter_resolves_callable_quiet(self):
+        quiet = False
+        logger = mock.Mock()
+        adapter = log.QuietLoggerAdapter(logger, quiet=lambda: quiet)
+
+        adapter.warning("visible")
+        logger.log.assert_called_once_with(logging.WARNING, "visible")
+
+        quiet = True
+        logger.log.reset_mock()
+        adapter.warning("hidden")
+        logger.log.assert_not_called()

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 from unittest.mock import patch, MagicMock, call, Mock
 from crmsh.sbd import SBDUtils, SBDManager
@@ -274,6 +273,12 @@ class TestSBDConfigChecker(unittest.TestCase):
     def setUp(self):
         self.instance_check = sbd.SBDConfigChecker(fix=False)
         self.instance_fix = sbd.SBDConfigChecker(fix=True)
+        self.quiet_logger_error_patcher = patch('crmsh.sbd.log.QuietLoggerAdapter.error')
+        self.mock_quiet_logger_error = self.quiet_logger_error_patcher.start()
+        self.addCleanup(self.quiet_logger_error_patcher.stop)
+        self.quiet_logger_warning_patcher = patch('crmsh.sbd.log.QuietLoggerAdapter.warning')
+        self.mock_quiet_logger_warning = self.quiet_logger_warning_patcher.start()
+        self.addCleanup(self.quiet_logger_warning_patcher.stop)
 
     @staticmethod
     def fake_get_current_terms(inst):
@@ -304,7 +309,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_service_manager_inst = Mock()
         mock_service_manager.return_value = mock_service_manager_inst
         mock_service_manager_inst.service_is_active = Mock(return_value=False)
-        with self.assertRaises(sbd.FixAborted) as context: 
+        with self.assertRaises(sbd.FixAborted) as context:
             self.instance_check.check_and_fix()
         self.assertTrue("sbd.service is not active" in str(context.exception))
         mock_service_manager_inst.service_is_active.assert_called_once_with(constants.SBD_SERVICE)
@@ -455,21 +460,19 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.sbd.SBDTimeout.get_sbd_metadata_expected')
     def test_check_sbd_disk_metadata_failure(self, mock_get_sbd_metadata_expected):
         self.instance_check.disk_based = True
-        self.instance_check._log_when_not_quiet = Mock()
         mock_get_sbd_metadata_expected.return_value = (15, 30)
         self.instance_check.sbd_watchdog_timeout = 10
         self.assertEqual(self.instance_check._check_sbd_disk_metadata(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that SBD watchdog timeout(now %d) >= %d", 10, 15)    
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that SBD watchdog timeout(now %d) >= %d", 10, 15)
 
     @patch('crmsh.sbd.SBDTimeout.get_sbd_metadata_expected')
     def test_check_sbd_disk_metadata_failure_msgwait(self, mock_get_sbd_metadata_expected):
         self.instance_check.disk_based = True
-        self.instance_check._log_when_not_quiet = Mock()
         mock_get_sbd_metadata_expected.return_value = (10, 25)
         self.instance_check.sbd_watchdog_timeout = 10
         self.instance_check.sbd_msgwait = 20
         self.assertEqual(self.instance_check._check_sbd_disk_metadata(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that SBD msgwait(now %d) >= %d", 20, 25)
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that SBD msgwait(now %d) >= %d", 20, 25)
 
     @patch('crmsh.sbd.SBDTimeout.get_sbd_metadata_expected')
     def test_check_sbd_disk_metadata_success(self, mock_get_sbd_metadata_expected):
@@ -493,11 +496,10 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout_expected')
     def test_check_sbd_watchdog_timeout_failure(self, mock_get_sbd_watchdog_timeout_expected):
         self.instance_check.disk_based = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_get_sbd_watchdog_timeout_expected.return_value = 10
         self.instance_check.sbd_watchdog_timeout = 3
         self.assertEqual(self.instance_check._check_sbd_watchdog_timeout(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that SBD_WATCHDOG_TIMEOUT(now %d) >= %d", 3, 10)
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that SBD_WATCHDOG_TIMEOUT(now %d) >= %d", 3, 10)
 
     @patch('crmsh.sbd.SBDTimeout.get_sbd_watchdog_timeout_expected')
     def test_check_sbd_watchdog_timeout_success(self, mock_get_sbd_watchdog_timeout_expected):
@@ -515,9 +517,8 @@ class TestSBDConfigChecker(unittest.TestCase):
     def test_check_sbd_delay_start_failure(self):
         self.instance_check.sbd_delay_start_value_expected = "100"
         self.instance_check.sbd_delay_start_value_from_config = "30"
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_sbd_delay_start(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that SBD_DELAY_START is set to %s, now is %s", "100", "30")
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that SBD_DELAY_START is set to %s, now is %s", "100", "30")
 
     def test_check_sbd_delay_start_success(self):
         self.instance_check.sbd_delay_start_value_expected = "50"
@@ -527,9 +528,8 @@ class TestSBDConfigChecker(unittest.TestCase):
     def test_check_sbd_delay_start_warning(self):
         self.instance_check.sbd_delay_start_value_expected = "70"
         self.instance_check.sbd_delay_start_value_from_config = "80"
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_sbd_delay_start(), sbd.CheckResult.WARNING)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.WARNING, "It's recommended that SBD_DELAY_START is set to %s, now is %s", "70", "80")
+        self.mock_quiet_logger_warning.assert_called_once_with("It's recommended that SBD_DELAY_START is set to %s, now is %s", "70", "80")
 
     @patch('crmsh.sbd.SBDManager.update_sbd_configuration')
     def test_fix_sbd_delay_start(self, mock_update_sbd_configuration):
@@ -545,16 +545,17 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check.sbd_systemd_start_timeout_expected = 60
         self.instance_check.peer_node_list = ['node2', 'node3']
         self.instance_check.quiet = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_get_sbd_systemd_start_timeout.side_effect = [60, 50, 70]
         mock_return_helper.return_value = sbd.CheckResult.ERROR
 
         self.assertEqual(self.instance_check._check_sbd_systemd_start_timeout(), sbd.CheckResult.ERROR)
 
-        self.instance_check._log_when_not_quiet.assert_has_calls([
-            call(logging.ERROR, "It's required that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s", 60, 50, 'node2'),
-            call(logging.WARNING, "It's recommended that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s", 60, 70, 'node3')
-        ])
+        self.mock_quiet_logger_error.assert_called_once_with(
+            "It's required that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s", 60, 50, 'node2'
+        )
+        self.mock_quiet_logger_warning.assert_called_once_with(
+            "It's recommended that systemd start timeout for sbd.service is set to %ds, now is %ds on node %s", 60, 70, 'node3'
+        )
 
     @patch('crmsh.utils.cluster_run_cmd')
     @patch('crmsh.bootstrap.sync_path')
@@ -573,9 +574,8 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check.current_watchdog_timeout_term = "fencing-watchdog-timeout"
         self.instance_check.disk_based = True
         mock_get_property.return_value = 5
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_fencing_watchdog_timeout(), sbd.CheckResult.WARNING)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.WARNING, "It's recommended that %s is not set when using disk-based SBD", "fencing-watchdog-timeout")
+        self.mock_quiet_logger_warning.assert_called_once_with("It's recommended that %s is not set when using disk-based SBD", "fencing-watchdog-timeout")
 
     @patch('crmsh.utils.get_property')
     def test_check_fencing_watchdog_timeout_disk_less_failure(self, mock_get_property):
@@ -583,9 +583,8 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check.disk_based = False
         self.instance_check.fencing_watchdog_timeout = 15
         mock_get_property.return_value = ""
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_fencing_watchdog_timeout(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that %s is set to %d, now is not set", "fencing-watchdog-timeout", 15)
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that %s is set to %d, now is not set", "fencing-watchdog-timeout", 15)
 
     @patch('crmsh.utils.get_property')
     def test_check_fencing_watchdog_timeout_success(self, mock_get_property):
@@ -619,18 +618,16 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check.current_timeout_term = "fencing-timeout"
         self.instance_check.get_fencing_timeout_expected = Mock(return_value=60)
         mock_get_property.return_value = 30
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_fencing_timeout(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that %s is set to %d, now is %d", "fencing-timeout", 60, 30)
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that %s is set to %d, now is %d", "fencing-timeout", 60, 30)
 
     @patch('crmsh.utils.get_property')
     def test_check_fencing_timeout_warning(self, mock_get_property):
         self.instance_check.current_timeout_term = "fencing-timeout"
         self.instance_check.get_fencing_timeout_expected = Mock(return_value=80)
         mock_get_property.return_value = 90
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_fencing_timeout(), sbd.CheckResult.WARNING)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.WARNING, "It's recommended that %s is set to %d, now is %d", "fencing-timeout", 80, 90)
+        self.mock_quiet_logger_warning.assert_called_once_with("It's recommended that %s is set to %d, now is %d", "fencing-timeout", 80, 90)
 
     @patch('crmsh.utils.get_property')
     def test_check_fencing_timeout_success(self, mock_get_property):
@@ -664,13 +661,12 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_cluster_shell.return_value = mock_cluster_shell_inst
         self.instance_check.peer_node_list = ['node2']
         self.instance_check.quiet = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_cluster_shell_inst.get_rc_and_error.side_effect = [(0, None), (1, None)]
         mock_return_helper.return_value = sbd.CheckResult.WARNING
 
         self.assertEqual(self.instance_check._check_sbd_delay_start_unset_dropin(), sbd.CheckResult.WARNING)
 
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.WARNING, "Runtime drop-in file %s to unset SBD_DELAY_START is missing on node %s", sbd.SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE, 'node2')
+        self.mock_quiet_logger_warning.assert_called_once_with("Runtime drop-in file %s to unset SBD_DELAY_START is missing on node %s", sbd.SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE, 'node2')
 
     @patch('crmsh.sbd.SBDManager.unset_sbd_delay_start')
     @patch('logging.Logger.info')
@@ -688,11 +684,8 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
     def test_check_sbd_pacemaker_in_sysconfig_warning(self, mock_get_sbd_value_from_config):
         mock_get_sbd_value_from_config.side_effect = [None, "no"]
-        self.instance_check._log_when_not_quiet = Mock()
-
         self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
-        self.instance_check._log_when_not_quiet.assert_any_call(
-            logging.WARNING,
+        self.mock_quiet_logger_warning.assert_any_call(
             "In %s, SBD_PACEMAKER is set to %s, please set it to yes or true",
             sbd.SBDManager.SYSCONFIG_SBD, "no"
         )
@@ -705,7 +698,6 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
     def test_check_sbd_pacemaker_in_sysconfig_uppercase_warning(self, mock_get_sbd_value_from_config):
         mock_get_sbd_value_from_config.side_effect = [None, "YES"]
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
 
     @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
@@ -716,10 +708,8 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.sbd.SBDUtils.get_sbd_value_from_config')
     def test_check_sbd_pacemaker_in_sysconfig_sbd_opts_pp(self, mock_get_sbd_value_from_config):
         mock_get_sbd_value_from_config.return_value = "-S 1 -PP"
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_sbd_pacemaker_in_sysconfig(), sbd.CheckResult.WARNING)
-        self.instance_check._log_when_not_quiet.assert_any_call(
-            logging.WARNING,
+        self.mock_quiet_logger_warning.assert_any_call(
             "In %s, SBD_OPTS contains -PP, which disables SBD_PACEMAKER, please use -P to enable it",
             sbd.SBDManager.SYSCONFIG_SBD
         )
@@ -755,11 +745,10 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_ServiceManager.return_value = mock_service_manager_inst
         self.instance_check.peer_node_list = ['node2']
         self.instance_check.quiet = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_service_manager_inst.service_is_enabled.side_effect = [True, False]
         mock_return_helper.return_value = sbd.CheckResult.ERROR
         self.assertEqual(self.instance_check._check_sbd_service_is_enabled(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "%s is not enabled on node %s", constants.SBD_SERVICE, 'node2')
+        self.mock_quiet_logger_error.assert_called_once_with("%s is not enabled on node %s", constants.SBD_SERVICE, 'node2')
 
     @patch('logging.Logger.info')
     @patch('crmsh.sbd.ServiceManager')
@@ -775,13 +764,12 @@ class TestSBDConfigChecker(unittest.TestCase):
     def test_check_fence_sbd_not_configured(self, mock_CrmMonXmlParser):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_parser_instance = Mock()
         mock_CrmMonXmlParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = False
         mock_parser_instance.is_resource_configured.return_value = False
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "Fence agent %s is not configured", sbd.SBDManager.SBD_RA)
+        self.mock_quiet_logger_error.assert_called_once_with("Fence agent %s is not configured", sbd.SBDManager.SBD_RA)
 
     @patch('crmsh.cibquery.get_primitives_with_ra')
     @patch('crmsh.cibquery.ResourceAgent')
@@ -791,7 +779,6 @@ class TestSBDConfigChecker(unittest.TestCase):
     def test_check_fence_sbd_not_configured_cluster_offline(self, mock_CrmMonXmlParser, mock_cluster_shell, mock_text2elem, mock_ResourceAgent, mock_get_primitives_with_ra):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_parser_instance = Mock()
         mock_CrmMonXmlParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = True
@@ -803,7 +790,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_ResourceAgent.return_value = mock_resource_agent_instance
         mock_get_primitives_with_ra.return_value = []
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "Fence agent %s is not configured", sbd.SBDManager.SBD_RA)
+        self.mock_quiet_logger_error.assert_called_once_with("Fence agent %s is not configured", sbd.SBDManager.SBD_RA)
 
     @patch('crmsh.cibquery.get_primitives_with_ra')
     @patch('crmsh.cibquery.ResourceAgent')
@@ -830,14 +817,13 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
         mock_is_cluster_in_maintenance_mode.return_value = False
-        self.instance_check._log_when_not_quiet = Mock()
         mock_parser_instance = Mock()
         mock_CrmMonXmlParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = False
         mock_parser_instance.is_resource_configured.return_value = True
         mock_parser_instance.is_resource_started.return_value = False
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "Fence agent %s is not started", sbd.SBDManager.SBD_RA)
+        self.mock_quiet_logger_error.assert_called_once_with("Fence agent %s is not started", sbd.SBDManager.SBD_RA)
 
     @patch('crmsh.xmlutil.CrmMonXmlParser')
     def test_check_fence_sbd_success(self, mock_CrmMonXmlParser):
@@ -894,9 +880,8 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_get_property.return_value = "false"
         mock_is_boolean_false.return_value = True
         self.instance_check.current_enabled_term = "fencing-enabled"
-        self.instance_check._log_when_not_quiet = Mock()
         self.assertEqual(self.instance_check._check_fencing_enabled(), sbd.CheckResult.ERROR)
-        self.instance_check._log_when_not_quiet.assert_called_once_with(logging.ERROR, "It's required that %s is set to true, now is false", "fencing-enabled")
+        self.mock_quiet_logger_error.assert_called_once_with("It's required that %s is set to true, now is false", "fencing-enabled")
 
     @patch('logging.Logger.info')
     @patch('crmsh.utils.set_property')
@@ -905,7 +890,6 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_fix._fix_fencing_enabled()
         mock_logger_info.assert_called_once_with("Setting %s to true", "fencing-enabled")
         mock_set_property.assert_called_once_with('fencing-enabled', 'true')
-
 
 class TestSBDManager(unittest.TestCase):
 
@@ -1260,7 +1244,6 @@ class TestSBDManager(unittest.TestCase):
                 f"echo -e '[Service]\\nUnsetEnvironment=SBD_DELAY_START' > {sbd.SBDManager.SBD_SYSTEMD_DELAY_START_DISABLE_FILE} && " \
                 "systemctl daemon-reload"
         mock_cluster_run_cmd.assert_called_once_with(cmd, ['node1', 'node2'])
-
 
 class TestOutterFunctions(unittest.TestCase):
     """


### PR DESCRIPTION
- Add QuietLoggerAdapter with early quiet filtering
- Let quiet-aware modules use normal logger methods
- Avoid SBD-specific logging helper duplication
- Update SBD checks to use the quiet-aware adapter
- Add unit tests for quiet logging behavior