### PR TITLE
Dev: sbd: Check and fix deprecated properties

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1417,7 +1417,7 @@ def init_cluster():
 
     logger.info("Loading initial cluster configuration")
 
-    crm_configure_load("update", """property cib-bootstrap-options: stonith-enabled=false
+    crm_configure_load("update", """property cib-bootstrap-options: fencing-enabled=false
 op_defaults op-options: timeout=600
 rsc_defaults rsc-options: resource-stickiness=1 migration-threshold=3
 """)
@@ -2708,7 +2708,7 @@ def adjust_fencing_timeout():
     """
     value = get_fencing_timeout_generally_expected()
     if value:
-        utils.set_property("stonith-timeout", value, conditional=True)
+        utils.set_property("fencing-timeout", value, conditional=True)
 
 
 def adjust_properties():

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -123,7 +123,7 @@ class FenceInfo(object):
         action_result = crmshutils.get_property("fencing-action")
         supported_actions = ra.get_property_options("fencing-action")
         if action_result is None or action_result not in supported_actions:
-            current_action_term = crmshutils.DeprecatedTermTranslator.get_working_term("stonith-action")
+            current_action_term = crmshutils.DeprecatedTermTranslator.get_working_term("fencing-action")
             msg_error(f"Cluster property \"{current_action_term}\" should be {'|'.join(supported_actions)}")
             return None
         return action_result

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -630,7 +630,7 @@ class QDevice(object):
                 sbd_watchdog_timeout_qdevice = sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE
                 sbd.SBDManager.update_sbd_configuration({"SBD_WATCHDOG_TIMEOUT": str(sbd_watchdog_timeout_qdevice)})
                 if self.is_stage:
-                    utils.set_property("stonith-watchdog-timeout", 2*sbd_watchdog_timeout_qdevice)
+                    utils.set_property("fencing-watchdog-timeout", 2*sbd_watchdog_timeout_qdevice)
 
     @qnetd_lock_for_same_cluster_name
     def certificate_and_config_qdevice(self):

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -332,9 +332,6 @@ class RAInfo(object):
             if params[name]["deprecated"] == "1"
         }
 
-    def get_all_params_dict(self):
-        """Return non-deprecated parameters with full metadata."""
-        return self.get_active_params()
 
 
     def params(self):

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -143,7 +143,7 @@ def get_properties_list():
 @functools.cache
 def get_properties_without_deprecated():
     try:
-        return get_properties_meta().get_param_list_without_deprecated()
+        return list(get_properties_meta().get_active_params())
     except:
         return []
 
@@ -299,7 +299,30 @@ class RAInfo(object):
             replaced_with = replaced_with_elem.get("name")
         return deprecated, replaced_with
 
-    def get_deprecated_params_dict(self):
+    def get_active_params(self):
+        """Return non-deprecated parameters with full metadata."""
+        params = self.params()
+        if not params:
+            return {}
+        return {
+            name: params[name]
+            for name in params
+            if params[name]["deprecated"] != "1"
+        }
+
+    def get_deprecated_params(self):
+        """Return deprecated parameters with full metadata."""
+        params = self.params()
+        if not params:
+            return {}
+        return {
+            name: params[name]
+            for name in params
+            if params[name]["deprecated"] == "1"
+        }
+
+    def get_deprecated_mapping(self):
+        """Return deprecated parameter names mapped to replacement names."""
         params = self.params()
         if not params:
             return {}
@@ -309,14 +332,10 @@ class RAInfo(object):
             if params[name]["deprecated"] == "1"
         }
 
-    def get_param_list_without_deprecated(self):
-        params = self.params()
-        if not params:
-            return []
-        return [
-            name for name in params
-            if params[name]["deprecated"] != "1"
-        ]
+    def get_all_params_dict(self):
+        """Return non-deprecated parameters with full metadata."""
+        return self.get_active_params()
+
 
     def params(self):
         '''

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -533,9 +533,16 @@ class SBDCheckItem(IntEnum):
     STONITH_ENABLED_PROPERTY = auto()
     UNSET_SBD_DELAY_START_IN_DROPIN = auto()
     ENABLE_SBD_SERVICE = auto()
+    DEPRECATED_PROPERTY = auto()
 
 
 class SBDConfigChecker(SBDTimeout):
+
+    DEPRECATED_PROPERTY_LIST = [
+        "stonith-watchdog-timeout",
+        "stonith-timeout",
+        "stonith-enabled"
+    ]
 
     def __init__(self, quiet=False, fix=False):
         super().__init__()
@@ -556,17 +563,17 @@ class SBDConfigChecker(SBDTimeout):
     @staticmethod
     def log_and_return(check_res: CheckResult, fix_flag: bool = False) -> bool:
         if check_res == CheckResult.SUCCESS:
-            logger.info('SBD: Check sbd timeout configuration: OK.')
+            logger.info('SBD: Check SBD-related configurations: OK.')
             return True
         cmd = "crm cluster health sbd --fix"
         issue_type = "error" if check_res == CheckResult.ERROR else "warning"
         if not fix_flag:
             logger.info(f'Please run "{cmd}" to fix the above {issue_type} on the running cluster')
         if check_res == CheckResult.ERROR:
-            logger.error("SBD: Check sbd timeout configuration: FAIL.")
+            logger.error("SBD: Check SBD-related configurations: FAIL.")
             return False
         elif check_res == CheckResult.WARNING:
-            logger.info('SBD: Check sbd timeout configuration: OK.')
+            logger.info('SBD: Check SBD-related configurations: OK.')
             return True
 
     def _check_and_fix_items(self) -> list[tuple]:
@@ -682,6 +689,14 @@ class SBDConfigChecker(SBDTimeout):
                 True,
                 []
             ),
+
+            (
+                "deprecated property",
+                self._check_deprecated_property,
+                self._fix_deprecated_property,
+                False,
+                []
+            )
         ]
 
 
@@ -693,7 +708,7 @@ class SBDConfigChecker(SBDTimeout):
     def check_and_fix(self) -> CheckResult:
         if not ServiceManager().service_is_active(constants.SBD_SERVICE):
             if self.fix:
-                raise FixAborted("%s is not active, skip fixing SBD timeout issues" % constants.SBD_SERVICE)
+                raise FixAborted("%s is not active, skip fixing SBD-related configuration issues" % constants.SBD_SERVICE)
             elif not SBDUtils.diskbased_sbd_configured() and not SBDUtils.diskless_sbd_configured():
                 raise FixAborted("Neither disk-based nor disk-less SBD is configured, skip checking SBD timeout issues")
 
@@ -744,7 +759,6 @@ class SBDConfigChecker(SBDTimeout):
                 else:
                     raise FixFailure(f"Failed to fix {name} issue")
 
-        SBDConfigChecker._check_deprecated_property()
         SBDManager.warn_diskless_sbd()
 
         return SBDConfigChecker._return_helper(check_res_list)
@@ -1131,14 +1145,18 @@ class SBDConfigChecker(SBDTimeout):
                 shell.get_stdout_or_raise_error(cmd)
         time.sleep(2)
 
-    @staticmethod
-    def _check_deprecated_property() -> None:
-        for prop in (
-            "stonith-watchdog-timeout",
-            "stonith-timeout",
-            "stonith-enabled"
-        ):
-            utils.DeprecatedTermTranslator(prop).check()
+    def _check_deprecated_property(self) -> CheckResult:
+        check_res_list = []
+        for prop in self.DEPRECATED_PROPERTY_LIST:
+            translator_inst = utils.DeprecatedTermTranslator(prop, quiet=self.quiet)
+            check_res = CheckResult.SUCCESS if translator_inst.check() else CheckResult.WARNING
+            check_res_list.append(check_res)
+        return SBDConfigChecker._return_helper(check_res_list)
+
+    def _fix_deprecated_property(self):
+        for prop in self.DEPRECATED_PROPERTY_LIST:
+            translator_inst = utils.DeprecatedTermTranslator(prop, quiet=self.quiet)
+            translator_inst.fix()
 
     def _check_fence_sbd_parameters(self) -> CheckResult:
         if not self.disk_based:

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -538,12 +538,6 @@ class SBDCheckItem(IntEnum):
 
 class SBDConfigChecker(SBDTimeout):
 
-    DEPRECATED_PROPERTY_LIST = [
-        "stonith-watchdog-timeout",
-        "stonith-timeout",
-        "stonith-enabled"
-    ]
-
     def __init__(self, quiet=False, fix=False):
         super().__init__()
         self.quiet = quiet
@@ -1145,16 +1139,26 @@ class SBDConfigChecker(SBDTimeout):
                 shell.get_stdout_or_raise_error(cmd)
         time.sleep(2)
 
+    @staticmethod
+    def get_sbd_related_deprecated_properties() -> list[str]:
+        return [
+            p
+            for p in utils.get_all_configured_deprecated_properties()
+            if p.startswith("fence-") or p.startswith("stonith-") or p in [
+                "concurrent-fencing",
+            ]
+        ]
+
     def _check_deprecated_property(self) -> CheckResult:
         check_res_list = []
-        for prop in self.DEPRECATED_PROPERTY_LIST:
+        for prop in SBDConfigChecker.get_sbd_related_deprecated_properties():
             translator_inst = utils.DeprecatedTermTranslator(prop, quiet=self.quiet)
             check_res = CheckResult.SUCCESS if translator_inst.check() else CheckResult.WARNING
             check_res_list.append(check_res)
         return SBDConfigChecker._return_helper(check_res_list)
 
     def _fix_deprecated_property(self):
-        for prop in self.DEPRECATED_PROPERTY_LIST:
+        for prop in SBDConfigChecker.get_sbd_related_deprecated_properties():
             translator_inst = utils.DeprecatedTermTranslator(prop, quiet=self.quiet)
             translator_inst.fix()
 

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -686,9 +686,9 @@ class SBDConfigChecker(SBDTimeout):
 
 
     def _get_current_terms(self):
-        self.current_watchdog_timeout_term = utils.DeprecatedTermTranslator.get_working_term("stonith-watchdog-timeout")
-        self.current_timeout_term = utils.DeprecatedTermTranslator.get_working_term("stonith-timeout")
-        self.current_enabled_term = utils.DeprecatedTermTranslator.get_working_term("stonith-enabled")
+        self.current_watchdog_timeout_term = utils.DeprecatedTermTranslator.get_working_term("fencing-watchdog-timeout")
+        self.current_timeout_term = utils.DeprecatedTermTranslator.get_working_term("fencing-timeout")
+        self.current_enabled_term = utils.DeprecatedTermTranslator.get_working_term("fencing-enabled")
 
     def check_and_fix(self) -> CheckResult:
         if not ServiceManager().service_is_active(constants.SBD_SERVICE):

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -700,10 +700,13 @@ class SBDConfigChecker(SBDTimeout):
         self.current_enabled_term = utils.DeprecatedTermTranslator.get_working_term("fencing-enabled")
 
     def check_and_fix(self) -> CheckResult:
-        if not ServiceManager().service_is_active(constants.SBD_SERVICE):
-            if self.fix:
-                raise FixAborted("%s is not active, skip fixing SBD-related configuration issues" % constants.SBD_SERVICE)
-            elif not SBDUtils.diskbased_sbd_configured() and not SBDUtils.diskless_sbd_configured():
+        service_manager = ServiceManager()
+        if self.fix:
+            for service in (constants.SBD_SERVICE, constants.PCMK_SERVICE):
+                if not service_manager.service_is_active(service):
+                    raise FixAborted(f"{service} is not active, skip fixing SBD-related configuration issues")
+        elif not service_manager.service_is_active(constants.SBD_SERVICE):
+            if not SBDUtils.diskbased_sbd_configured() and not SBDUtils.diskless_sbd_configured():
                 raise FixAborted("Neither disk-based nor disk-less SBD is configured, skip checking SBD timeout issues")
 
         all_nodes_reachable = True

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -859,7 +859,7 @@ to get the geo cluster configuration.""",
                     return False
                 except sbd.FixAborted as e:
                     logger.error('%s', e)
-                    logger.error('SBD: Check sbd timeout configuration: FAIL.')
+                    logger.error('SBD: Check SBD-related configurations: FAIL.')
                     return False
                 return sbd.SBDConfigChecker.log_and_return(result, fix)
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -254,7 +254,7 @@ def _prim_params_completer(agent, args):
     elif '=' in completing:
         return []
     command.enable_custom_sort_order()
-    return utils.filter_keys(agent.params(), args)
+    return utils.filter_keys(agent.get_param_list_without_deprecated(), args)
 
 
 def _prim_meta_completer(agent, args):
@@ -632,7 +632,7 @@ class CibConfig(command.UI):
     @command.name("get_property")
     @command.alias("get-property")
     @command.skill_level('administrator')
-    @command.completers_repeating(compl.call(ra.get_properties_list))
+    @command.completers_repeating(compl.call(ra.get_properties_without_deprecated))
     def do_get_property(self, context, *args):
         "usage: get-property [-t|--true [<name>...]"
         utils.load_cib_file_env()
@@ -640,7 +640,7 @@ class CibConfig(command.UI):
         truth = any(a for a in args if a in ('-t', '--true'))
 
         if not properties:
-            utils.multicolumn(ra.get_properties_list())
+            utils.multicolumn(ra.get_properties_without_deprecated())
             return
 
         def print_value(v):
@@ -1174,7 +1174,7 @@ class CibConfig(command.UI):
         "usage: property [$id=<set_id>] <option>=<value>"
         self.__override_lower_level_attrs(*args)
         if not args:
-            utils.multicolumn(ra.get_properties_list())
+            utils.multicolumn(ra.get_properties_without_deprecated())
             return
         return self.__conf_object(context.get_command_name(), *args)
 

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -254,7 +254,7 @@ def _prim_params_completer(agent, args):
     elif '=' in completing:
         return []
     command.enable_custom_sort_order()
-    return utils.filter_keys(agent.get_all_params_dict(), args)
+    return utils.filter_keys(agent.get_active_params(), args)
 
 
 def _prim_meta_completer(agent, args):

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -254,7 +254,7 @@ def _prim_params_completer(agent, args):
     elif '=' in completing:
         return []
     command.enable_custom_sort_order()
-    return utils.filter_keys(agent.get_param_list_without_deprecated(), args)
+    return utils.filter_keys(agent.get_all_params_dict(), args)
 
 
 def _prim_meta_completer(agent, args):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2320,19 +2320,21 @@ def get_pcmk_delay_max(two_node_without_qdevice=False):
         return 0
 
 
-def get_property(name, property_type="crm_config", peer=None, get_default=True):
+def get_property(name, property_type="crm_config", peer=None, get_default=True, direct=False):
     """
     Get cluster properties
 
     "property_type" can be crm_config|rsc_defaults|op_defaults
     "get_default" is used to get the default value from cluster metadata,
     when it is False, the property value will be got from cib
+    When "direct" is True, get exactly the given property without deprecated-term translation
     """
-    translate_inst = DeprecatedTermTranslator(name)
-    if translate_inst.using_new_term and \
-            translate_inst.deprecated_configured and \
-            not translate_inst.new_configured:
-        name = translate_inst.deprecated_term
+    if not direct:
+        translate_inst = DeprecatedTermTranslator(name)
+        if translate_inst.using_new_term and \
+                translate_inst.deprecated_configured and \
+                not translate_inst.new_configured:
+            name = translate_inst.deprecated_term
 
     if property_type == "crm_config" and get_default:
         cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
@@ -2410,20 +2412,22 @@ def leverage_maintenance_mode() -> typing.Generator[bool, None, None]:
         yield False
 
 
-def set_property(property_name, property_value, property_type="crm_config", conditional=False):
+def set_property(property_name, property_value, property_type="crm_config", conditional=False, direct=False):
     """
     Set property for cluster, resource and operator
 
     "property_type" can be crm_config|rsc_defaults|op_defaults
     When "conditional" is True, set the property if given "property_value" is larger then value from cib
+    When "direct" is True, set exactly the given property without deprecated-term translation
     """
-    translate_inst = DeprecatedTermTranslator(property_name)
-    if translate_inst.using_new_term and \
-            translate_inst.deprecated_configured and \
-            not translate_inst.new_configured:
-        property_name = translate_inst.deprecated_term
+    if not direct:
+        translate_inst = DeprecatedTermTranslator(property_name)
+        if translate_inst.using_new_term and \
+                translate_inst.deprecated_configured and \
+                not translate_inst.new_configured:
+            property_name = translate_inst.deprecated_term
 
-    origin_value = get_property(property_name, property_type)
+    origin_value = get_property(property_name, property_type, direct=True)
     if origin_value and str(origin_value) == str(property_value):
         return
     if conditional and crm_msec(origin_value) >= crm_msec(property_value):
@@ -2436,9 +2440,11 @@ def set_property(property_name, property_value, property_type="crm_config", cond
     cmd = "crm configure {} {}={}".format(property_sub_cmd, property_name, property_value)
     sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
-    deprecated_inst = DeprecatedTermTranslator(property_name)
-    if deprecated_inst.both_configured:
-        delete_property(deprecated_inst.deprecated_term)
+    if not direct:
+        deprecated_inst = DeprecatedTermTranslator(property_name)
+        if deprecated_inst.both_configured:
+            delete_property(deprecated_inst.deprecated_term)
+
 
 def get_systemd_timeout_start_in_sec(time_res):
     """
@@ -2880,11 +2886,13 @@ class DeprecatedTermTranslator:
     def __init__(
         self,
         term: str,
-        existing_xml_node: typing.Optional[etree.Element] = None
+        existing_xml_node: typing.Optional[etree.Element] = None,
+        quiet: bool = False
     ):
         self.original_term = term
         self.existing_xml_node = existing_xml_node
         self._resolve_res: TermResolution|None = self._resolve()
+        self.logger = log.QuietLoggerAdapter(logger, quiet=quiet)
 
     @classmethod
     def _get_maps(cls) -> tuple[dict, dict]:
@@ -2934,44 +2942,67 @@ class DeprecatedTermTranslator:
             new_configured=new_configured
         )
 
-    def check(self, internal: bool = True) -> None:
+    def check(self, internal: bool = True) -> bool:
+        passed = True
+        res = self._resolve_res
+        if not res:
+            return passed
+
+        if res.using_deprecated and res.deprecated_configured:
+            passed = False
+            if res.new_configured:
+                self.logger.warning(
+                    "\"%s\" is configured; \"%s\" is deprecated and ignored.",
+                    res.new_term, res.deprecated_term
+                )
+            elif res.new_term:
+                self.logger.warning(
+                    "\"%s\" is deprecated, please consider using \"%s\"",
+                    res.deprecated_term, res.new_term
+                )
+            else:
+                self.logger.warning(
+                    "\"%s\" is deprecated, please consider removing it",
+                    res.deprecated_term
+                )
+
+        if internal:
+            return passed
+
+        if not res.using_deprecated and res.deprecated_configured:
+            if not res.new_configured:
+                passed = False
+                self.logger.warning(
+                    "\"%s\" is not configured but deprecated \"%s\" is; Cluster now is using the deprecated property, instead of the default value of \"%s\".",
+                    res.new_term, res.deprecated_term, res.new_term
+                )
+            return passed
+
+        if res.using_deprecated and res.new_configured:
+            if not res.deprecated_configured:
+                passed = True
+                self.logger.warning(
+                    "\"%s\" is deprecated and not configured but \"%s\" is; Cluster now is using the new property, instead of the default value of \"%s\".",
+                    res.deprecated_term, res.new_term, res.deprecated_term
+                )
+            return passed
+
+        return passed
+
+    def fix(self) -> None:
         res = self._resolve_res
         if not res:
             return
 
         if res.using_deprecated and res.deprecated_configured:
             if res.new_configured:
-                logger.warning(
-                    "\"%s\" is configured; \"%s\" is deprecated and ignored.",
-                    res.new_term, res.deprecated_term
-                )
+                delete_property(res.deprecated_term)
             elif res.new_term:
-                logger.warning(
-                    "\"%s\" is deprecated, please consider using \"%s\"",
-                    res.deprecated_term, res.new_term
-                )
+                value = get_property(res.deprecated_term, get_default=False, direct=True)
+                set_property(res.new_term, value, direct=True)
+                delete_property(res.deprecated_term)
             else:
-                logger.warning(
-                    "\"%s\" is deprecated, please consider removing it",
-                    res.deprecated_term
-                )
-
-        if internal:
-            return
-
-        if not res.using_deprecated and res.deprecated_configured:
-            if not res.new_configured:
-                logger.warning(
-                    "\"%s\" is not configured but deprecated \"%s\" is; Cluster now is using the deprecated property, instead of the default value of \"%s\".",
-                    res.new_term, res.deprecated_term, res.new_term
-                )
-
-        if res.using_deprecated and res.new_configured:
-            if not res.deprecated_configured:
-                logger.warning(
-                    "\"%s\" is deprecated and not configured but \"%s\" is; Cluster now is using the new property, instead of the default value of \"%s\".",
-                    res.deprecated_term, res.new_term, res.deprecated_term
-                )
+                delete_property(res.deprecated_term)
 
     @classmethod
     def get_working_term(cls, term: str) -> str:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2900,7 +2900,7 @@ class DeprecatedTermTranslator:
         new_to_dep = cls._cached_new_to_deprecated
 
         if dep_to_new is None or new_to_dep is None:
-            dep_to_new = ra.get_properties_meta().get_deprecated_params_dict()
+            dep_to_new = ra.get_properties_meta().get_deprecated_mapping()
             new_to_dep = {
                 v: k for k, v in dep_to_new.items()
                 if v is not None

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2946,6 +2946,13 @@ class DeprecatedTermTranslator:
             new_configured=new_configured
         )
 
+    def _deprecated_value_is_default(self, term: str) -> bool:
+        default_value = ra.get_properties_meta().param_default(term)
+        if default_value is None:
+            return False
+        configured_value = _get_raw_property(term, get_default=False)
+        return str(configured_value) == str(default_value)
+
     def check(self, internal: bool = True) -> bool:
         passed = True
         res = self._resolve_res
@@ -2970,6 +2977,8 @@ class DeprecatedTermTranslator:
                     "\"%s\" is deprecated, please consider removing it",
                     res.deprecated_term
                 )
+                if self._deprecated_value_is_default(res.deprecated_term):
+                    passed = False
 
         if internal:
             return passed
@@ -3006,6 +3015,9 @@ class DeprecatedTermTranslator:
                 value = _get_raw_property(res.deprecated_term, get_default=False)
                 if value is not None:
                     _set_raw_property(res.new_term, value)
+                    delete_property(res.deprecated_term)
+            else:
+                if self._deprecated_value_is_default(res.deprecated_term):
                     delete_property(res.deprecated_term)
 
     @classmethod

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2320,22 +2320,7 @@ def get_pcmk_delay_max(two_node_without_qdevice=False):
         return 0
 
 
-def get_property(name, property_type="crm_config", peer=None, get_default=True, direct=False):
-    """
-    Get cluster properties
-
-    "property_type" can be crm_config|rsc_defaults|op_defaults
-    "get_default" is used to get the default value from cluster metadata,
-    when it is False, the property value will be got from cib
-    When "direct" is True, get exactly the given property without deprecated-term translation
-    """
-    if not direct:
-        translate_inst = DeprecatedTermTranslator(name)
-        if translate_inst.using_new_term and \
-                translate_inst.deprecated_configured and \
-                not translate_inst.new_configured:
-            name = translate_inst.deprecated_term
-
+def _get_raw_property(name, property_type="crm_config", peer=None, get_default=True):
     if property_type == "crm_config" and get_default:
         cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
         cmd = "CIB_file={} sudo --preserve-env=CIB_file crm configure get_property {}".format(cib_path, name)
@@ -2345,8 +2330,26 @@ def get_property(name, property_type="crm_config", peer=None, get_default=True, 
     return stdout if rc == 0 else None
 
 
+def get_property(name, property_type="crm_config", peer=None, get_default=True):
+    """
+    Get cluster properties
+
+    "property_type" can be crm_config|rsc_defaults|op_defaults
+    "get_default" is used to get the default value from cluster metadata,
+    when it is False, the property value will be got from cib
+    """
+    translate_inst = DeprecatedTermTranslator(name)
+    if translate_inst.using_new_term and \
+            translate_inst.deprecated_configured and \
+            not translate_inst.new_configured:
+        name = translate_inst.deprecated_term
+
+    return _get_raw_property(name, property_type, peer, get_default)
+
+
 def property_configured(name, property_type="crm_config", peer=None):
-    cmd = f"crm_attribute -t {property_type} -n {name} -Gq"
+    cib_path = os.getenv('CIB_file', constants.CIB_RAW_FILE)
+    cmd = f"CIB_file={cib_path} crm_attribute -t {property_type} -n {name} -Gq"
     rc, _, _ = sh.cluster_shell().get_rc_stdout_stderr_without_input(peer, cmd)
     return rc == 0
 
@@ -2412,22 +2415,8 @@ def leverage_maintenance_mode() -> typing.Generator[bool, None, None]:
         yield False
 
 
-def set_property(property_name, property_value, property_type="crm_config", conditional=False, direct=False):
-    """
-    Set property for cluster, resource and operator
-
-    "property_type" can be crm_config|rsc_defaults|op_defaults
-    When "conditional" is True, set the property if given "property_value" is larger then value from cib
-    When "direct" is True, set exactly the given property without deprecated-term translation
-    """
-    if not direct:
-        translate_inst = DeprecatedTermTranslator(property_name)
-        if translate_inst.using_new_term and \
-                translate_inst.deprecated_configured and \
-                not translate_inst.new_configured:
-            property_name = translate_inst.deprecated_term
-
-    origin_value = get_property(property_name, property_type, direct=True)
+def _set_raw_property(property_name, property_value, property_type="crm_config", conditional=False):
+    origin_value = _get_raw_property(property_name, property_type, get_default=False)
     if origin_value and str(origin_value) == str(property_value):
         return
     if conditional and crm_msec(origin_value) >= crm_msec(property_value):
@@ -2440,10 +2429,25 @@ def set_property(property_name, property_value, property_type="crm_config", cond
     cmd = "crm configure {} {}={}".format(property_sub_cmd, property_name, property_value)
     sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
-    if not direct:
-        deprecated_inst = DeprecatedTermTranslator(property_name)
-        if deprecated_inst.both_configured:
-            delete_property(deprecated_inst.deprecated_term)
+
+def set_property(property_name, property_value, property_type="crm_config", conditional=False):
+    """
+    Set property for cluster, resource and operator
+
+    "property_type" can be crm_config|rsc_defaults|op_defaults
+    When "conditional" is True, set the property if given "property_value" is larger then value from cib
+    """
+    translate_inst = DeprecatedTermTranslator(property_name)
+    if translate_inst.using_new_term and \
+            translate_inst.deprecated_configured and \
+            not translate_inst.new_configured:
+        property_name = translate_inst.deprecated_term
+
+    _set_raw_property(property_name, property_value, property_type, conditional)
+
+    deprecated_inst = DeprecatedTermTranslator(property_name)
+    if deprecated_inst.both_configured:
+        delete_property(deprecated_inst.deprecated_term)
 
 
 def get_systemd_timeout_start_in_sec(time_res):
@@ -2961,6 +2965,7 @@ class DeprecatedTermTranslator:
                     res.deprecated_term, res.new_term
                 )
             else:
+                passed = True
                 self.logger.warning(
                     "\"%s\" is deprecated, please consider removing it",
                     res.deprecated_term
@@ -2998,11 +3003,10 @@ class DeprecatedTermTranslator:
             if res.new_configured:
                 delete_property(res.deprecated_term)
             elif res.new_term:
-                value = get_property(res.deprecated_term, get_default=False, direct=True)
-                set_property(res.new_term, value, direct=True)
-                delete_property(res.deprecated_term)
-            else:
-                delete_property(res.deprecated_term)
+                value = _get_raw_property(res.deprecated_term, get_default=False)
+                if value is not None:
+                    _set_raw_property(res.new_term, value)
+                    delete_property(res.deprecated_term)
 
     @classmethod
     def get_working_term(cls, term: str) -> str:
@@ -3054,4 +3058,10 @@ class DeprecatedTermTranslator:
         return not self._resolve_res.using_deprecated
 
 
+def get_all_configured_deprecated_properties() -> list[str]:
+    return [
+        p
+        for p in ra.get_properties_meta().get_deprecated_params()
+        if property_configured(p)
+    ]
 # vim:ts=4:sw=4:et:

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -1100,7 +1100,7 @@ health hawk2|sbd|sles16 [--local] [--fix]
   is needed by hawk2.
     ** `--fix`: attempts to automatically resolve any detected issues, eg.
        hacluster passwordless
-* `sbd`: check or fix SBD timeout-related configurations.
+* `sbd`: check or fix SBD-related configurations.
     ** `--fix`: attempts to automatically resolve any detected issues.
 * `sles16`: check whether the cluster is good to migrate to SLES 16.
     ** `--local`: run checks in local mode

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -115,6 +115,11 @@ Feature: configure sbd delay start correctly
 
     When    Try "crm configure property fencing-watchdog-timeout=1" on "hanode1"
     Then    Except "It's required to set fencing-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
+    # Expect successfully set stonith-watchdog-timeout=5 since already set fencing-watchdog-timeout
+    When    Run "crm configur proerty stonith-watchdog-timeout=5" on "hanode1"
+    Then    Cluster property "fencing-watchdog-timeout" is "30"
+    When    Try "crm -F configure filter "sed 's/fencing-watchdog-timeout=30/#fencing-watchdog-timeout=30/g'"" on "hanode1"
+    Then    Expected "It's required to set stonith-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
     Then    Cluster property "fencing-watchdog-timeout" is "30"
 
   @clean
@@ -397,11 +402,11 @@ Feature: configure sbd delay start correctly
     When    Run "crm cluster init sbd -S -y" on "hanode1"
     Then    Service "sbd" is "started" on "hanode1"
     And     Service "sbd" is "started" on "hanode2"
-    # Delete stonith-watchdog-timeout
-    When    Delete property "stonith-watchdog-timeout" from cluster
+    # Delete fencing-watchdog-timeout
+    When    Delete property "fencing-watchdog-timeout" from cluster
     When    Try "crm sbd configure show" on "hanode1"
-    Then    Expected "It's required that stonith-watchdog-timeout is set to 30, now is not set" in stderr
+    Then    Expected "It's required that fencing-watchdog-timeout is set to 30, now is not set" in stderr
     When    Try "crm cluster health sbd" on "hanode1"
-    Then    Expected "It's required that stonith-watchdog-timeout is set to 30, now is not set" in stderr
+    Then    Expected "It's required that fencing-watchdog-timeout is set to 30, now is not set" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
     Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout

--- a/test/features/bootstrap_sbd_delay.feature
+++ b/test/features/bootstrap_sbd_delay.feature
@@ -116,7 +116,7 @@ Feature: configure sbd delay start correctly
     When    Try "crm configure property fencing-watchdog-timeout=1" on "hanode1"
     Then    Except "It's required to set fencing-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
     # Expect successfully set stonith-watchdog-timeout=5 since already set fencing-watchdog-timeout
-    When    Run "crm configur proerty stonith-watchdog-timeout=5" on "hanode1"
+    When    Run "crm configure property stonith-watchdog-timeout=5" on "hanode1"
     Then    Cluster property "fencing-watchdog-timeout" is "30"
     When    Try "crm -F configure filter "sed 's/fencing-watchdog-timeout=30/#fencing-watchdog-timeout=30/g'"" on "hanode1"
     Then    Expected "It's required to set stonith-watchdog-timeout to at least 2*SBD_WATCHDOG_TIMEOUT: 30" in stderr
@@ -343,15 +343,15 @@ Feature: configure sbd delay start correctly
     Then    Expected "/etc/sysconfig/sbd is not consistent across cluster nodes" in stderr
     When    Run "sed -i 's/SBD_DELAY_START=.*/SBD_DELAY_START=71/' /etc/sysconfig/sbd" on "hanode2"
     When    Run "crm cluster health sbd" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
     # check sbd disk metadata
     When    Run "sbd -1 15 -4 16 -d /dev/sda1 create" on "hanode1"
-    When    Try "crm sbd configur show disk_metadata" on "hanode1"
+    When    Try "crm sbd configure show disk_metadata" on "hanode1"
     Then    Expected "ERROR: It's required that SBD msgwait(now 16) >= 30" in stderr
     When    Try "crm cluster health sbd" on "hanode1"
     Then    Expected "ERROR: It's required that SBD msgwait(now 16) >= 30" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
     # check SBD_DELAY_START
     When    Run "sed -i 's/SBD_DELAY_START=.*/SBD_DELAY_START=40/' /etc/sysconfig/sbd" on "hanode1"
     When    Run "sed -i 's/SBD_DELAY_START=.*/SBD_DELAY_START=40/' /etc/sysconfig/sbd" on "hanode2"
@@ -360,7 +360,7 @@ Feature: configure sbd delay start correctly
     When    Try "crm cluster health sbd" on "hanode1"
     Then    Expected "It's required that SBD_DELAY_START is set to 71, now is 40" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
     # check fencing-timeout
     When    Run "crm configure property fencing-timeout=50" on "hanode1"
     When    Try "crm sbd configure show" on "hanode1"
@@ -368,7 +368,7 @@ Feature: configure sbd delay start correctly
     When    Try "crm cluster health sbd" on "hanode1"
     Then    Expected "It's required that fencing-timeout is set to 71, now is 50" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
     # check crashdump and pcmk_delay_max
     When    Run "crm resource param fencing-sbd set crashdump 1" on "hanode1"
     When    Run "crm resource param fencing-sbd delete pcmk_delay_max" on "hanode1"
@@ -379,7 +379,7 @@ Feature: configure sbd delay start correctly
       It's required that pcmk_delay_max parameter is set to 30s in resource fencing-sbd for 2-node cluster without qdevice, now is not set
       """
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
     # Adjust token timeout in corosync.conf
     When    Run "sed -i 's/token: .*/token: 10000/' /etc/corosync/corosync.conf" on "hanode1"
     When    Run "sed -i 's/token: .*/token: 10000/' /etc/corosync/corosync.conf" on "hanode2"
@@ -389,7 +389,7 @@ Feature: configure sbd delay start correctly
     When    Try "crm cluster health sbd" on "hanode1"
     Then    Expected "It's required that SBD_DELAY_START is set to 82, now is 71" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout
 
   @clean
   Scenario: Check and fix sbd-related timeout values for diskless sbd
@@ -409,4 +409,4 @@ Feature: configure sbd delay start correctly
     When    Try "crm cluster health sbd" on "hanode1"
     Then    Expected "It's required that fencing-watchdog-timeout is set to 30, now is not set" in stderr
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected "SBD: Check sbd timeout configuration: OK" in stdout
+    Then    Expected "SBD: Check SBD-related configurations: OK." in stdout

--- a/test/features/deprecated_term.feature
+++ b/test/features/deprecated_term.feature
@@ -39,7 +39,6 @@ Feature: Deprecated terms check and translate
     # set deprecated property which don't have replacement
     When    Run "crm configure property enable-startup-probes=true" on "hanode1"
     Then    Expected ""enable-startup-probes" is deprecated, please consider removing it" in stderr
-    When    Delete property "enable-startup-probes" from cluster
 
   Scenario: Deprecated property during `crm cluster health sbd --fix`
     Then    Cluster property "stonith-timeout" is "80"
@@ -52,22 +51,20 @@ Feature: Deprecated terms check and translate
       It's recommended that stonith-timeout is set to 71, now is 80
       "stonith-timeout" is deprecated, please consider using "fencing-timeout"
       """
-    # --fix still keep stonith-timeout name after fixed
+    # --fix migrates stonith-timeout to fencing-timeout after fixing its value
     When    Run "crm cluster health sbd --fix" on "hanode1"
-    Then    Expected multiple lines in stderr
-      """
-      "stonith-timeout" in crm_config is set to 71, it was 80
-      "stonith-timeout" is deprecated, please consider using "fencing-timeout"
-      """
-    Then    Cluster property "stonith-timeout" is "71"
-    And     Cluster property "fencing-timeout" is not configured
+    Then    Expected ""stonith-timeout" in crm_config is set to 71, it was 80" in stderr
+    Then    Cluster property "stonith-timeout" is not configured
+    And     Cluster property "fencing-timeout" is "71"
+    And     Cluster property "enable-startup-probes" is "true"
 
     When    Run "crm configure show" on "hanode1"
-    Then    Expected ""stonith-timeout" is deprecated, please consider using "fencing-timeout" in stderr
+    Then    Expected ""enable-startup-probes" is deprecated, please consider removing it" in stderr
+    When    Delete property "enable-startup-probes" from cluster
 
   Scenario: SBD purge
-    When    Run "crm configure property fencing-timeout=80" on "hanode1"
-    Then    Cluster property "fencing-timeout" is "80"
+    When    Run "crm configure property stonith-timeout=80" on "hanode1"
+    Then    Cluster property "stonith-timeout" is "80"
     When    Run "crm sbd purge" on "hanode1"
     Then    Expected multiple lines in output
       """

--- a/test/features/sbd_ui.feature
+++ b/test/features/sbd_ui.feature
@@ -111,11 +111,11 @@ Feature: crm sbd ui test cases
     When    Run "crm sbd configure crashdump-watchdog-timeout=60" on "hanode1"
     Then    Run "crm sbd configure show sysconfig |grep SBD_TIMEOUT_ACTION=flush,crashdump" OK
     Then    Run "crm sbd configure show sysconfig |grep "SBD_OPTS=\"-C 60 -Z\""" OK
-    Then    Run "crm sbd configure show property |grep stonith-watchdog-timeout=75" OK
+    Then    Run "crm sbd configure show property |grep fencing-watchdog-timeout=75" OK
     When    Run "crm sbd configure crashdump-watchdog-timeout=60" on "hanode1"
     Then    Expected "No change in SBD configuration" in stdout
     When    Run "crm sbd configure crashdump-watchdog-timeout=10" on "hanode1"
-    Then    Run "crm sbd configure show property |grep stonith-watchdog-timeout=30" OK
+    Then    Run "crm sbd configure show property |grep fencing-watchdog-timeout=30" OK
     # Purge crashdump
     When    Run "crm sbd purge crashdump" on "hanode1"
     When    Try "crm sbd configure show sysconfig |grep SBD_TIMEOUT_ACTION=flush,crashdump"

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1499,7 +1499,7 @@ done
     def test_adjust_fencing_timeout(self, mock_get_timeout, mock_set):
         mock_get_timeout.return_value = 30
         bootstrap.adjust_fencing_timeout()
-        mock_set.assert_called_once_with("stonith-timeout", 30, conditional=True)
+        mock_set.assert_called_once_with("fencing-timeout", 30, conditional=True)
 
     @mock.patch('crmsh.utils.set_property')
     def test_adjust_priority_in_rsc_defaults_2node(self, mock_set):

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -77,17 +77,18 @@ class TestFenceInfo(TestCase):
         self.assertEqual(res, True)
         mock_get_property.assert_called_once_with("fencing-enabled")
 
-    @mock.patch('crmsh.utils.DeprecatedTermTranslator.get_working_term')
     @mock.patch('crmsh.crash_test.utils.msg_error')
     @mock.patch('crmsh.ra.get_property_options')
+    @mock.patch('crmsh.crash_test.utils.crmshutils.DeprecatedTermTranslator.get_working_term')
     @mock.patch('crmsh.crash_test.utils.crmshutils.get_property')
-    def test_fence_action_none(self, mock_get_property, mock_get_property_options, mock_error, mock_get_working_term):
+    def test_fence_action_none(self, mock_get_property, mock_get_working_term, mock_get_property_options, mock_error):
         mock_get_property_options.return_value = ["off", "reboot"]
-        mock_get_property.return_value = None
         mock_get_working_term.return_value = "fencing-action"
+        mock_get_property.return_value = None
         res = self.fence_info_inst.fence_action
         self.assertEqual(res, None)
         mock_get_property.assert_called_once_with("fencing-action")
+        mock_get_working_term.assert_called_once_with("fencing-action")
         mock_error.assert_called_once_with('Cluster property "fencing-action" should be off|reboot')
 
     @mock.patch('crmsh.ra.get_property_options')

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -734,7 +734,7 @@ Membership information
 
         mock_get_sbd_value.assert_called_once_with("SBD_WATCHDOG_TIMEOUT")
         mock_update_config.assert_called_once_with({"SBD_WATCHDOG_TIMEOUT": str(sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)})
-        mock_set.assert_called_once_with("stonith-watchdog-timeout", 2*sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)
+        mock_set.assert_called_once_with("fencing-watchdog-timeout", 2*sbd.SBDTimeout.SBD_WATCHDOG_TIMEOUT_DEFAULT_WITH_QDEVICE)
 
     @mock.patch('crmsh.sh.cluster_shell')
     @mock.patch('crmsh.utils.cluster_run_cmd')

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -303,6 +303,41 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.assertTrue(self.instance_check.log_and_return(sbd.CheckResult.WARNING, fix_flag=True))
         mock_logger_info.assert_called_once_with("SBD: Check sbd timeout configuration: OK.")
 
+    @patch('crmsh.sbd.utils.DeprecatedTermTranslator')
+    def test_check_deprecated_property_warning(self, mock_translator):
+        translator_insts = [Mock(), Mock(), Mock()]
+        translator_insts[0].check.return_value = True
+        translator_insts[1].check.return_value = False
+        translator_insts[2].check.return_value = True
+        mock_translator.side_effect = translator_insts
+
+        res = self.instance_check._check_deprecated_property()
+
+        self.assertEqual(res, sbd.CheckResult.WARNING)
+        self.assertEqual(mock_translator.call_args_list, [
+            call('stonith-watchdog-timeout', quiet=False),
+            call('stonith-timeout', quiet=False),
+            call('stonith-enabled', quiet=False),
+        ])
+        for translator_inst in translator_insts:
+            translator_inst.check.assert_called_once_with()
+
+    @patch('crmsh.sbd.utils.DeprecatedTermTranslator')
+    def test_fix_deprecated_property(self, mock_translator):
+        translator_insts = [Mock(), Mock(), Mock()]
+        mock_translator.side_effect = translator_insts
+
+        self.instance_fix._fix_deprecated_property()
+
+        self.assertEqual(mock_translator.call_args_list, [
+            call('stonith-watchdog-timeout', quiet=False),
+            call('stonith-timeout', quiet=False),
+            call('stonith-enabled', quiet=False),
+        ])
+        for translator_inst in translator_insts:
+            translator_inst.fix.assert_called_once_with()
+
+
     @patch('crmsh.sbd.ServiceManager')
     def test_check_and_fix_sbd_not_active(self, mock_service_manager):
         self.instance_check.fix = True
@@ -402,6 +437,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         mock_service_manager_inst = Mock()
         mock_service_manager.return_value = mock_service_manager_inst
         mock_service_manager_inst.service_is_active = Mock(return_value=True)
+        mock_check_deprecated_property.return_value = sbd.CheckResult.SUCCESS
         self.instance_fix._check_config_consistency = Mock(return_value=True)
         self.instance_fix._load_configurations_from_runtime = Mock()
 

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -289,19 +289,19 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('logging.Logger.info')
     def test_log_and_return_success(self, mock_logger_info):
         self.assertTrue(self.instance_check.log_and_return(sbd.CheckResult.SUCCESS))
-        mock_logger_info.assert_called_once_with("SBD: Check sbd timeout configuration: OK.")
+        mock_logger_info.assert_called_once_with("SBD: Check SBD-related configurations: OK.")
 
     @patch('logging.Logger.info')
     @patch('logging.Logger.error')
     def test_log_and_return_error(self, mock_logger_error, mock_logger_info):
         self.assertFalse(self.instance_check.log_and_return(sbd.CheckResult.ERROR))
         mock_logger_info.assert_called_once_with("Please run \"crm cluster health sbd --fix\" to fix the above error on the running cluster")
-        mock_logger_error.assert_called_once_with("SBD: Check sbd timeout configuration: FAIL.")
+        mock_logger_error.assert_called_once_with("SBD: Check SBD-related configurations: FAIL.")
 
     @patch('logging.Logger.info')
     def test_log_and_return_warning(self, mock_logger_info):
         self.assertTrue(self.instance_check.log_and_return(sbd.CheckResult.WARNING, fix_flag=True))
-        mock_logger_info.assert_called_once_with("SBD: Check sbd timeout configuration: OK.")
+        mock_logger_info.assert_called_once_with("SBD: Check SBD-related configurations: OK.")
 
     @patch('crmsh.sbd.utils.get_all_configured_deprecated_properties')
     @patch('crmsh.sbd.utils.DeprecatedTermTranslator')
@@ -473,7 +473,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         res = self.instance_fix.check_and_fix()
         self.assertEqual(res, sbd.CheckResult.SUCCESS)
 
-        mock_service_manager_inst.service_is_active.assert_called_once_with(constants.SBD_SERVICE)
+        mock_service_manager_inst.service_is_active.assert_has_calls([call(constants.SBD_SERVICE), call(constants.PCMK_SERVICE)])
         self.instance_fix._check_config_consistency.assert_called_once()
         self.instance_fix._load_configurations_from_runtime.assert_called_once()
         self.instance_fix._check_sbd_disk_metadata.assert_called_once()

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -303,8 +303,15 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.assertTrue(self.instance_check.log_and_return(sbd.CheckResult.WARNING, fix_flag=True))
         mock_logger_info.assert_called_once_with("SBD: Check sbd timeout configuration: OK.")
 
+    @patch('crmsh.sbd.utils.get_all_configured_deprecated_properties')
     @patch('crmsh.sbd.utils.DeprecatedTermTranslator')
-    def test_check_deprecated_property_warning(self, mock_translator):
+    def test_check_deprecated_property_warning(self, mock_translator, mock_get_deprecated):
+        deprecated_props = [
+            'stonith-watchdog-timeout',
+            'stonith-timeout',
+            'stonith-enabled',
+        ]
+        mock_get_deprecated.return_value = deprecated_props
         translator_insts = [Mock(), Mock(), Mock()]
         translator_insts[0].check.return_value = True
         translator_insts[1].check.return_value = False
@@ -314,6 +321,7 @@ class TestSBDConfigChecker(unittest.TestCase):
         res = self.instance_check._check_deprecated_property()
 
         self.assertEqual(res, sbd.CheckResult.WARNING)
+        mock_get_deprecated.assert_called_once_with()
         self.assertEqual(mock_translator.call_args_list, [
             call('stonith-watchdog-timeout', quiet=False),
             call('stonith-timeout', quiet=False),
@@ -322,13 +330,21 @@ class TestSBDConfigChecker(unittest.TestCase):
         for translator_inst in translator_insts:
             translator_inst.check.assert_called_once_with()
 
+    @patch('crmsh.sbd.utils.get_all_configured_deprecated_properties')
     @patch('crmsh.sbd.utils.DeprecatedTermTranslator')
-    def test_fix_deprecated_property(self, mock_translator):
+    def test_fix_deprecated_property(self, mock_translator, mock_get_deprecated):
+        deprecated_props = [
+            'stonith-watchdog-timeout',
+            'stonith-timeout',
+            'stonith-enabled',
+        ]
+        mock_get_deprecated.return_value = deprecated_props
         translator_insts = [Mock(), Mock(), Mock()]
         mock_translator.side_effect = translator_insts
 
         self.instance_fix._fix_deprecated_property()
 
+        mock_get_deprecated.assert_called_once_with()
         self.assertEqual(mock_translator.call_args_list, [
             call('stonith-watchdog-timeout', quiet=False),
             call('stonith-timeout', quiet=False),
@@ -336,7 +352,6 @@ class TestSBDConfigChecker(unittest.TestCase):
         ])
         for translator_inst in translator_insts:
             translator_inst.fix.assert_called_once_with()
-
 
     @patch('crmsh.sbd.ServiceManager')
     def test_check_and_fix_sbd_not_active(self, mock_service_manager):

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -724,15 +724,65 @@ def test_deprecated_term_fix_deletes_old_when_both_configured(mock_resolve, mock
 @mock.patch('crmsh.utils.delete_property')
 @mock.patch('crmsh.utils._set_raw_property')
 @mock.patch('crmsh.utils._get_raw_property')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
-def test_deprecated_term_fix_keeps_old_without_replacement(mock_resolve, mock_get, mock_set, mock_delete):
+def test_deprecated_term_fix_deletes_default_without_replacement(mock_resolve, mock_get_meta, mock_get, mock_set, mock_delete):
     mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
+    mock_get_meta.return_value.param_default.return_value = 'true'
+    mock_get.return_value = 'true'
 
     utils.DeprecatedTermTranslator('stonith-timeout').fix()
 
+    mock_get_meta.return_value.param_default.assert_called_once_with('stonith-timeout')
+    mock_get.assert_called_once_with('stonith-timeout', get_default=False)
+    mock_set.assert_not_called()
+    mock_delete.assert_called_once_with('stonith-timeout')
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_keeps_non_default_without_replacement(mock_resolve, mock_get_meta, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
+    mock_get_meta.return_value.param_default.return_value = 'true'
+    mock_get.return_value = 'false'
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get_meta.return_value.param_default.assert_called_once_with('stonith-timeout')
+    mock_get.assert_called_once_with('stonith-timeout', get_default=False)
+    mock_set.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_keeps_without_replacement_and_default(mock_resolve, mock_get_meta, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
+    mock_get_meta.return_value.param_default.return_value = None
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get_meta.return_value.param_default.assert_called_once_with('stonith-timeout')
     mock_get.assert_not_called()
     mock_set.assert_not_called()
     mock_delete.assert_not_called()
+
+
+@mock.patch('crmsh.utils._get_raw_property')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_check_fails_default_without_replacement(mock_resolve, mock_get_meta, mock_get):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
+    mock_get_meta.return_value.param_default.return_value = 'true'
+    mock_get.return_value = 'true'
+
+    assert utils.DeprecatedTermTranslator('stonith-timeout', quiet=True).check() is False
 
 
 @mock.patch('crmsh.utils.delete_property')

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -619,10 +619,10 @@ def test_set_property(mock_get, mock_run, mock_warn, mock_translator, mock_delet
 def test_set_property_the_same(mock_get, mock_translator):
     mock_inst = mock.Mock()
     mock_translator.return_value = mock_inst
-    mock_translator.using_new_term = False
+    mock_inst.using_new_term = False
     mock_get.return_value = "value1"
     utils.set_property("no-quorum-policy", "value1")
-    mock_get.assert_called_once_with("no-quorum-policy", "crm_config")
+    mock_get.assert_called_once_with("no-quorum-policy", "crm_config", direct=True)
 
 
 @mock.patch('crmsh.utils.DeprecatedTermTranslator')
@@ -631,12 +631,123 @@ def test_set_property_the_same(mock_get, mock_translator):
 def test_set_property_conditional(mock_get, mock_msec, mock_translator):
     mock_inst = mock.Mock()
     mock_translator.return_value = mock_inst
-    mock_translator.using_new_term = False
+    mock_inst.using_new_term = False
     mock_get.return_value = "10s"
     mock_msec.side_effect = ["1000", "1000"]
     utils.set_property("timeout", "10", conditional=True)
-    mock_get.assert_called_once_with("timeout", "crm_config")
+    mock_get.assert_called_once_with("timeout", "crm_config", direct=True)
     mock_msec.assert_has_calls([mock.call("10s"), mock.call("10")])
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.utils.get_property')
+def test_set_property_cleans_deprecated_alias(mock_get, mock_run, mock_translator, mock_delete):
+    mock_inst = mock.Mock()
+    mock_inst.using_new_term = False
+    mock_inst.both_configured = True
+    mock_inst.deprecated_term = 'stonith-timeout'
+    mock_translator.return_value = mock_inst
+    mock_get.return_value = None
+
+    utils.set_property('fencing-timeout', '120')
+
+    mock_run.assert_called_once_with('crm configure property fencing-timeout=120')
+    mock_delete.assert_called_once_with('stonith-timeout')
+
+
+@mock.patch('crmsh.utils.DeprecatedTermTranslator')
+@mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
+@mock.patch('crmsh.utils.get_property')
+def test_set_property_direct_skips_deprecated_translation(mock_get, mock_run, mock_translator):
+    mock_get.return_value = None
+
+    utils.set_property('fencing-timeout', '120', direct=True)
+
+    mock_translator.assert_not_called()
+    mock_get.assert_called_once_with('fencing-timeout', 'crm_config', direct=True)
+    mock_run.assert_called_once_with('crm configure property fencing-timeout=120')
+
+
+def _deprecated_resolution(deprecated_configured, new_configured, new_term='fencing-timeout'):
+    return utils.TermResolution(
+        deprecated_term='stonith-timeout',
+        new_term=new_term,
+        using_deprecated=True,
+        deprecated_configured=deprecated_configured,
+        new_configured=new_configured,
+    )
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils.set_property')
+@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_moves_value_to_new_term(mock_resolve, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False)
+    mock_get.return_value = '120'
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get.assert_called_once_with('stonith-timeout', get_default=False, direct=True)
+    mock_set.assert_called_once_with('fencing-timeout', '120', direct=True)
+    mock_delete.assert_called_once_with('stonith-timeout')
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils.set_property')
+@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_deletes_old_when_both_configured(mock_resolve, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=True)
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get.assert_not_called()
+    mock_set.assert_not_called()
+    mock_delete.assert_called_once_with('stonith-timeout')
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils.set_property')
+@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_deletes_old_without_replacement(mock_resolve, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get.assert_not_called()
+    mock_set.assert_not_called()
+    mock_delete.assert_called_once_with('stonith-timeout')
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils.set_property')
+@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_ignores_unresolved_term(mock_resolve, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = None
+
+    utils.DeprecatedTermTranslator('unknown').fix()
+
+    mock_get.assert_not_called()
+    mock_set.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_check_returns_bool_for_no_warning(mock_resolve):
+    mock_resolve.return_value = utils.TermResolution(
+        deprecated_term='stonith-timeout',
+        new_term='fencing-timeout',
+        using_deprecated=False,
+        deprecated_configured=False,
+        new_configured=False,
+    )
+
+    assert utils.DeprecatedTermTranslator('fencing-timeout').check(internal=False) is True
 
 
 @mock.patch('crmsh.corosync.is_qdevice_configured')

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -47,7 +47,6 @@ def test_get_nodeid_from_name(mock_parser):
     mock_parser_inst.get_node_id_from_name.assert_called_once_with("node1")
 
 
-
 @mock.patch("crmsh.sh.ShellUtils.get_stdout")
 def test_get_nodeinfo_from_cmaptool_return_none(mock_get_stdout):
     mock_get_stdout.return_value = (1, None)
@@ -603,7 +602,7 @@ def test_get_property(mock_run, mock_env, mock_translator):
 @mock.patch('crmsh.utils.DeprecatedTermTranslator')
 @mock.patch('logging.Logger.warning')
 @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._get_raw_property')
 def test_set_property(mock_get, mock_run, mock_warn, mock_translator, mock_delete):
     mock_inst = mock.Mock()
     mock_translator.return_value = mock_inst
@@ -615,19 +614,19 @@ def test_set_property(mock_get, mock_run, mock_warn, mock_translator, mock_delet
 
 
 @mock.patch('crmsh.utils.DeprecatedTermTranslator')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._get_raw_property')
 def test_set_property_the_same(mock_get, mock_translator):
     mock_inst = mock.Mock()
     mock_translator.return_value = mock_inst
     mock_inst.using_new_term = False
     mock_get.return_value = "value1"
     utils.set_property("no-quorum-policy", "value1")
-    mock_get.assert_called_once_with("no-quorum-policy", "crm_config", direct=True)
+    mock_get.assert_called_once_with("no-quorum-policy", "crm_config", get_default=False)
 
 
 @mock.patch('crmsh.utils.DeprecatedTermTranslator')
 @mock.patch('crmsh.utils.crm_msec')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._get_raw_property')
 def test_set_property_conditional(mock_get, mock_msec, mock_translator):
     mock_inst = mock.Mock()
     mock_translator.return_value = mock_inst
@@ -635,14 +634,14 @@ def test_set_property_conditional(mock_get, mock_msec, mock_translator):
     mock_get.return_value = "10s"
     mock_msec.side_effect = ["1000", "1000"]
     utils.set_property("timeout", "10", conditional=True)
-    mock_get.assert_called_once_with("timeout", "crm_config", direct=True)
+    mock_get.assert_called_once_with("timeout", "crm_config", get_default=False)
     mock_msec.assert_has_calls([mock.call("10s"), mock.call("10")])
 
 
 @mock.patch('crmsh.utils.delete_property')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator')
 @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._get_raw_property')
 def test_set_property_cleans_deprecated_alias(mock_get, mock_run, mock_translator, mock_delete):
     mock_inst = mock.Mock()
     mock_inst.using_new_term = False
@@ -657,16 +656,14 @@ def test_set_property_cleans_deprecated_alias(mock_get, mock_run, mock_translato
     mock_delete.assert_called_once_with('stonith-timeout')
 
 
-@mock.patch('crmsh.utils.DeprecatedTermTranslator')
 @mock.patch('crmsh.sh.ClusterShell.get_stdout_or_raise_error')
-@mock.patch('crmsh.utils.get_property')
-def test_set_property_direct_skips_deprecated_translation(mock_get, mock_run, mock_translator):
+@mock.patch('crmsh.utils._get_raw_property')
+def test_set_raw_property_skips_deprecated_translation(mock_get, mock_run):
     mock_get.return_value = None
 
-    utils.set_property('fencing-timeout', '120', direct=True)
+    utils._set_raw_property('fencing-timeout', '120')
 
-    mock_translator.assert_not_called()
-    mock_get.assert_called_once_with('fencing-timeout', 'crm_config', direct=True)
+    mock_get.assert_called_once_with('fencing-timeout', 'crm_config', get_default=False)
     mock_run.assert_called_once_with('crm configure property fencing-timeout=120')
 
 
@@ -681,8 +678,8 @@ def _deprecated_resolution(deprecated_configured, new_configured, new_term='fenc
 
 
 @mock.patch('crmsh.utils.delete_property')
-@mock.patch('crmsh.utils.set_property')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
 def test_deprecated_term_fix_moves_value_to_new_term(mock_resolve, mock_get, mock_set, mock_delete):
     mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False)
@@ -690,14 +687,29 @@ def test_deprecated_term_fix_moves_value_to_new_term(mock_resolve, mock_get, moc
 
     utils.DeprecatedTermTranslator('stonith-timeout').fix()
 
-    mock_get.assert_called_once_with('stonith-timeout', get_default=False, direct=True)
-    mock_set.assert_called_once_with('fencing-timeout', '120', direct=True)
+    mock_get.assert_called_once_with('stonith-timeout', get_default=False)
+    mock_set.assert_called_once_with('fencing-timeout', '120')
     mock_delete.assert_called_once_with('stonith-timeout')
 
 
 @mock.patch('crmsh.utils.delete_property')
-@mock.patch('crmsh.utils.set_property')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
+@mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
+def test_deprecated_term_fix_skips_missing_value(mock_resolve, mock_get, mock_set, mock_delete):
+    mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False)
+    mock_get.return_value = None
+
+    utils.DeprecatedTermTranslator('stonith-timeout').fix()
+
+    mock_get.assert_called_once_with('stonith-timeout', get_default=False)
+    mock_set.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+@mock.patch('crmsh.utils.delete_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
 def test_deprecated_term_fix_deletes_old_when_both_configured(mock_resolve, mock_get, mock_set, mock_delete):
     mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=True)
@@ -710,22 +722,22 @@ def test_deprecated_term_fix_deletes_old_when_both_configured(mock_resolve, mock
 
 
 @mock.patch('crmsh.utils.delete_property')
-@mock.patch('crmsh.utils.set_property')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
-def test_deprecated_term_fix_deletes_old_without_replacement(mock_resolve, mock_get, mock_set, mock_delete):
+def test_deprecated_term_fix_keeps_old_without_replacement(mock_resolve, mock_get, mock_set, mock_delete):
     mock_resolve.return_value = _deprecated_resolution(deprecated_configured=True, new_configured=False, new_term=None)
 
     utils.DeprecatedTermTranslator('stonith-timeout').fix()
 
     mock_get.assert_not_called()
     mock_set.assert_not_called()
-    mock_delete.assert_called_once_with('stonith-timeout')
+    mock_delete.assert_not_called()
 
 
 @mock.patch('crmsh.utils.delete_property')
-@mock.patch('crmsh.utils.set_property')
-@mock.patch('crmsh.utils.get_property')
+@mock.patch('crmsh.utils._set_raw_property')
+@mock.patch('crmsh.utils._get_raw_property')
 @mock.patch('crmsh.utils.DeprecatedTermTranslator._resolve')
 def test_deprecated_term_fix_ignores_unresolved_term(mock_resolve, mock_get, mock_set, mock_delete):
     mock_resolve.return_value = None
@@ -748,6 +760,42 @@ def test_deprecated_term_check_returns_bool_for_no_warning(mock_resolve):
     )
 
     assert utils.DeprecatedTermTranslator('fencing-timeout').check(internal=False) is True
+
+
+@mock.patch('crmsh.utils.property_configured')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
+def test_get_all_configured_deprecated_properties(mock_get_meta, mock_property_configured):
+    mock_meta = mock.Mock()
+    mock_get_meta.return_value = mock_meta
+    mock_meta.get_deprecated_params.return_value = {
+        'stonith-watchdog-timeout': {},
+        'stonith-timeout': {},
+        'stonith-enabled': {},
+    }
+    mock_property_configured.side_effect = [True, False, True]
+
+    assert utils.get_all_configured_deprecated_properties() == [
+        'stonith-watchdog-timeout',
+        'stonith-enabled',
+    ]
+    mock_meta.get_deprecated_params.assert_called_once_with()
+    mock_property_configured.assert_has_calls([
+        mock.call('stonith-watchdog-timeout'),
+        mock.call('stonith-timeout'),
+        mock.call('stonith-enabled'),
+    ])
+
+
+@mock.patch('crmsh.utils.property_configured')
+@mock.patch('crmsh.utils.ra.get_properties_meta')
+def test_get_all_configured_deprecated_properties_empty(mock_get_meta, mock_property_configured):
+    mock_meta = mock.Mock()
+    mock_get_meta.return_value = mock_meta
+    mock_meta.get_deprecated_params.return_value = {}
+
+    assert utils.get_all_configured_deprecated_properties() == []
+    mock_meta.get_deprecated_params.assert_called_once_with()
+    mock_property_configured.assert_not_called()
 
 
 @mock.patch('crmsh.corosync.is_qdevice_configured')


### PR DESCRIPTION
## Description

This PR updates crmsh to use Pacemaker replacement cluster-property names by default and adds deprecated-property handling to the SBD health check/fix flow.

It reverts bootstrap-side use of deprecated `stonith-*` names, discovers configured deprecated cluster properties from Pacemaker metadata, warns when deprecated properties are still present, and migrates or removes them during `crm cluster health sbd --fix`.

## Changes

- Use `fencing-*` properties in bootstrap, SBD, qdevice, crash-test, UI, feature tests, and unit tests instead of deprecated `stonith-*` names.
- Hide deprecated RA parameters from configure completion and property listings while keeping metadata available for translation.
- Add an SBD deprecated-property check/fix item to `SBDConfigChecker`.
- Discover configured deprecated properties dynamically from Pacemaker metadata.
- Split RA helpers into predictable active, deprecated, and deprecated-mapping helpers.
- Add raw property helpers for migration I/O without recursive translation.
- Add translator checks that return success/warning state and use quiet-aware warning output.
- For deprecated terms without replacements, delete configured defaults and keep values that are non-default or have no metadata default.
- Add unit coverage for deprecated-property discovery, SBD check/fix behavior, raw migration paths, no-replacement handling, default-value cleanup, and missing-value handling.

## Fix policy for deprecated properties

`utils.DeprecatedTermTranslator.fix()` applies this policy when the deprecated term is configured and the running cluster uses deprecated properties:

- If the replacement term is also configured, delete the deprecated term because Pacemaker ignores it.
- If a replacement term exists, copy the deprecated value to the replacement term with raw property I/O, then delete the deprecated term.
- If no replacement term exists and the configured value equals the Pacemaker metadata default, delete the deprecated term.
- If no replacement term exists and the property has no metadata default, keep the deprecated term.
- If no replacement term exists and the configured value differs from the metadata default, keep the deprecated term.

## Notes

- `get_property()` and `set_property()` remain the translated public wrappers.
- `_get_raw_property()` and `_set_raw_property()` are used where the exact property name must be addressed during migration.
