### PR TITLE
Dev: migration: Add --force-breaks-pacemaker switch to bypass health check blockers (bsc#1250586)

### DIFF
--- a/crmsh/migration.py
+++ b/crmsh/migration.py
@@ -159,8 +159,15 @@ class CheckResultInteractiveHandler(CheckResultHandler):
 def migrate(args: typing.Sequence[str]):
     parser = argparse.ArgumentParser(args[0])
     parser.add_argument('--local', action='store_true')
+    parser.add_argument('--force-breaks-pacemaker', action='store_true')
     parsed_args = parser.parse_args(args[1:])
     try:
+        if parsed_args.force_breaks_pacemaker:
+            logger.info('Starting forced migration...')
+            migrate_corosync_conf(local=parsed_args.local)
+            logger.info('Finished forced migration.')
+            return 0
+
         match _check_impl(local=parsed_args.local, json='', summary=False):
             case CheckReturnCode.ALREADY_MIGRATED:
                 logger.info("This cluster works on SLES 16. No migration is needed.")

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -866,7 +866,7 @@ to get the geo cluster configuration.""",
             case 'sles16':
                 try:
                     if parsed_args.fix:
-                        migration.migrate(['sles16'] + remaining_args)
+                        return 0 == migration.migrate(['sles16'] + remaining_args)
                     else:
                         return 0 == migration.check(['sles16'] + remaining_args)
                 except migration.MigrationFailure as e:

--- a/test/features/migration.feature
+++ b/test/features/migration.feature
@@ -159,6 +159,20 @@ Feature: migration
     Then    Expected return code is "0"
     And     Run "grep -F 'ring0_addr: @hanode2.ip.0' /etc/corosync/corosync.conf" OK
 
+  Scenario: Run pre-migration checks with unsupported agents and bypass them with --force-breaks-pacemaker
+    Given   Run "crm cluster start --all" OK on "hanode1"
+    And     Run "crm --force configure primitive testVip IPaddr ip=192.0.2.100" OK on "hanode1"
+    And     Run "crm --force configure primitive testService service:testService" OK on "hanode1"
+    And     Run "crm cluster stop --all" OK on "hanode1"
+    When    Try "crm cluster health sles16 --fix" on "hanode1"
+    Then    Expected return code is "1"
+    When    Try "crm cluster health sles16 --fix --force-breaks-pacemaker" on "hanode1"
+    Then    Expected return code is "0"
+    And     Run "crm cluster start --all" OK on "hanode1"
+    And     Run "crm configure delete testVip" OK on "hanode1"
+    And     Run "crm configure delete testService" OK on "hanode1"
+    And     Run "crm cluster stop --all" OK on "hanode1"
+
   Scenario: Run pre-migration checks when some of the nodes are offline.
     When    Run "systemctl stop sshd" on "hanode2"
     And     Try "crm cluster health sles16" on "hanode1"

--- a/test/unittests/test_migration.py
+++ b/test/unittests/test_migration.py
@@ -114,3 +114,30 @@ class TestCheckRemovedResourceAgents(unittest.TestCase):
                 'Please run "crm configure upgrade force" to upgrade to the latest version.',
             ]
         )
+
+
+class TestMigrate(unittest.TestCase):
+    @mock.patch('crmsh.migration.migrate_corosync_conf')
+    @mock.patch('crmsh.migration._check_impl')
+    def test_migrate_force_breaks_pacemaker(self, mock_check_impl, mock_migrate_corosync_conf):
+        res = migration.migrate(['sles16', '--force-breaks-pacemaker'])
+        self.assertEqual(res, 0)
+        mock_check_impl.assert_not_called()
+        mock_migrate_corosync_conf.assert_called_once_with(local=False)
+
+    @mock.patch('crmsh.migration.migrate_corosync_conf')
+    @mock.patch('crmsh.migration._check_impl')
+    def test_migrate_force_breaks_pacemaker_local(self, mock_check_impl, mock_migrate_corosync_conf):
+        res = migration.migrate(['sles16', '--force-breaks-pacemaker', '--local'])
+        self.assertEqual(res, 0)
+        mock_check_impl.assert_not_called()
+        mock_migrate_corosync_conf.assert_called_once_with(local=True)
+
+    @mock.patch('crmsh.migration.migrate_corosync_conf')
+    @mock.patch('crmsh.migration._check_impl')
+    def test_migrate_no_force_success(self, mock_check_impl, mock_migrate_corosync_conf):
+        mock_check_impl.return_value = migration.CheckReturnCode.PASS_NEED_AUTO_FIX
+        res = migration.migrate(['sles16'])
+        self.assertEqual(res, 0)
+        mock_check_impl.assert_called_once_with(local=False, json='', summary=False)
+        mock_migrate_corosync_conf.assert_called_once_with(local=False)


### PR DESCRIPTION
Allows users to force the corosync configuration migration even if CIB
prerequisite checks return critical blockers (such as unsupported resource or
fence agents). This enables starting the cluster in an unsupported state on
the new OS so that users can carry out manual actions to fix the unsupported
agents afterwards.

- Adds --force-breaks-pacemaker option to the migration parser.
- Skips _check_impl() and runs migrate_corosync_conf() directly if the switch is set.
- Adds new unit tests to test_migration.py verifying the bypass logic.
- Adds a functional test scenario to migration.feature to test the bypass behavior under blocker conditions.
