### PR TITLE
feat(ui_node): add on|off option to `crm node maintenance` and deprecate `node ready`

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -222,7 +222,6 @@ class NodeMgmt(command.UI):
     name = "node"
 
     node_standby = "crm_attribute -t nodes -N '%s' -n standby -v '%s' %s"
-    node_maint = "crm_attribute -t nodes -N '%s' -n maintenance -v '%s'"
     node_delete = """cibadmin -D -o nodes -X '<node uname="%s"/>'"""
     node_delete_status = """cibadmin -D -o status -X '<node_state uname="%s"/>'"""
     node_cleanup_resources = "crm_resource --cleanup --node '%s'"
@@ -435,7 +434,12 @@ class NodeMgmt(command.UI):
             node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
-        return utils.ext_cmd(self.node_maint % (node, "off")) == 0
+        rc = self._commit_node_attr(context, node, "maintenance", "false")
+        if rc:
+            logger.info("Setting maintenance=false on node %s", node)
+        suggestion = f"crm node maintenance {node} off"
+        logger.warning("The 'ready' command is deprecated and will be removed in a future release. Use '%s' instead.", suggestion)
+        return rc
 
     @command.wait
     @command.completers(compl.nodes)

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -411,14 +411,20 @@ class NodeMgmt(command.UI):
             logger.info("online node %s", node)
 
     @command.wait
-    @command.completers(compl.nodes)
-    def do_maintenance(self, context, node=None):
-        'usage: maintenance [<node>]'
+    @command.completers(compl.nodes, compl.choice(['on', 'off']))
+    def do_maintenance(self, context, node=None, on_off='on'):
+        'usage: maintenance [<node>] [on|off]'
         if not node:
             node = utils.this_node()
         if not utils.is_name_sane(node):
             return False
-        return self._commit_node_attr(context, node, "maintenance", "true")
+        if on_off not in ['on', 'off']:
+            context.fatal_error("Expected <node> [on|off]")
+        _value = "true" if on_off == 'on' else "false"
+        rc = self._commit_node_attr(context, node, "maintenance", _value)
+        if rc:
+            logger.info("Setting maintenance=%s on node %s", _value, node)
+        return rc
 
 
     @command.wait

--- a/test/features/cluster_api.feature
+++ b/test/features/cluster_api.feature
@@ -22,6 +22,29 @@ Feature: Functional test to cover SAP clusterAPI
     When    Run "echo 'export PATH=$PATH:/usr/sbin/' > ~hacluster/.bashrc" on "hanode2"
 
   @clean
+  Scenario: crm node maintenance supports on|off
+    When    Run "crm node maintenance hanode2 on" on "hanode1"
+    Then    Node "hanode2" is maintenance
+    When    Run "crm node maintenance hanode2 off" on "hanode1"
+    Then    Node "hanode2" is ready
+
+    # default value is "on"
+    When    Run "crm node maintenance hanode2" on "hanode1"
+    Then    Node "hanode2" is maintenance
+    When    Run "crm node maintenance hanode2 off" on "hanode1"
+    Then    Node "hanode2" is ready
+
+    When    Try "crm node maintenance hanode2 xxx"
+    Then    Except "ERROR: node.maintenance: Expected <node> [on|off]"
+
+    # "crm node ready" is deprecated in favor of "crm node maintenance <node> off"
+    When    Run "crm node maintenance hanode2 on" on "hanode1"
+    Then    Node "hanode2" is maintenance
+    When    Run "crm node ready hanode2" on "hanode1"
+    Then    Node "hanode2" is ready
+    Then    Expected "The 'ready' command is deprecated and will be removed in a future release" in stderr
+
+  @clean
   Scenario: Test cluster copy
     When    Try "crm cluster copy /tmp/none"
     Then    Expected "/tmp/none does not exist" in stderr
@@ -179,3 +202,4 @@ Feature: Functional test to cover SAP clusterAPI
     And     Run "crm cluster stop" on "hanode1"
     Then    Expected return code is "0"
     Then    Expected "The cluster stack already stopped on hanode1" in stdout
+

--- a/test/testcases/confbasic.exp
+++ b/test/testcases/confbasic.exp
@@ -160,6 +160,7 @@ op_defaults opsdef2: \
 	record-pending=true
 .INP: commit
 .TRY -F node maintenance node1
+INFO: Setting maintenance=true on node node1
 .TRY -F resource maintenance g1 off
 .TRY -F resource maintenance d1
 .TRY -F configure property maintenance-mode=true

--- a/test/testcases/node.exp
+++ b/test/testcases/node.exp
@@ -75,6 +75,7 @@ node1: member(offline)
 .TRY -F node maintenance node1
 INFO: 'maintenance' attribute already exists in p5. Remove it? [YES]
 INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
+INFO: Setting maintenance=true on node node1
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -95,7 +96,8 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
 </cib>
 
 .TRY node ready node1
-.EXT crm_attribute -t nodes -N 'node1' -n maintenance -v 'off'
+INFO: Setting maintenance=false on node node1
+WARNING: The 'ready' command is deprecated and will be removed in a future release. Use 'crm node maintenance node1 off' instead.
 .INP: configure
 .INP: _regtest on
 .INP: show xml node1
@@ -106,7 +108,7 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>
@@ -127,7 +129,7 @@ INFO: 'maintenance' attribute already exists in g0. Remove it? [YES]
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
           <nvpair id="nodes-node1-a1" name="a1" value="1 2 3"/>
         </instance_attributes>
       </node>
@@ -150,7 +152,7 @@ scope=nodes  name=a1 value=1 2 3
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
           <nvpair id="nodes-node1-a1" name="a1" value="1 2 3"/>
         </instance_attributes>
       </node>
@@ -173,7 +175,7 @@ Deleted nodes attribute: id=nodes-node1-a1 name=a1
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>
@@ -193,7 +195,7 @@ Deleted nodes attribute: id=nodes-node1-a1 name=a1
     <nodes>
       <node uname="node1" id="node1">
         <instance_attributes id="nodes-node1">
-          <nvpair id="nodes-node1-maintenance" name="maintenance" value="off"/>
+          <nvpair id="nodes-node1-maintenance" name="maintenance" value="false"/>
         </instance_attributes>
       </node>
     </nodes>


### PR DESCRIPTION
## Summary

Expand `crm node maintenance` so maintenance can be enabled or cleared
from the same command, matching the cluster and resource maintenance
command forms, and support the same local-node-default / multi-node
conventions already used by `crm node standby`.

## Changes

- Accept `crm node maintenance [<node>...] [on|off]` to enable/disable
  maintenance
- Set node maintenance attribute using `true`/`false` instead of only
  enabling it
- Log successful maintenance attribute updates
- Deprecate `crm node ready` in favor of `crm node maintenance <node>
  off`, with a deprecation warning in command output
- `crm node maintenance off` (no node given) now targets the local
  node, instead of misinterpreting `off` as a node name
- `crm node maintenance <node1> <node2> ... [on|off]` now supports
  multiple nodes in a single invocation
- Document the on|off option, multi-node/local-node-default support,
  and the `ready` deprecation in `crm.8.adoc`
- Update regression test expectations (`cluster_api.feature`)

## Testing

Full unit test suite passes: `pytest -q test/unittests`
