### PR TITLE
Dev: qdevice: Move utils.get_qdevice_sync_timeout into QDevice class

### DIFF
--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -663,3 +663,14 @@ class QDevice(object):
         logger_utils.log_only_to_file(desc)
         if cmd:
             logger_utils.log_only_to_file(f"Run: {cmd}")
+
+    @staticmethod
+    def get_qdevice_sync_timeout() -> int:
+        """
+        Get qdevice sync_timeout
+        """
+        out = corosync.query_qdevice_status()
+        res = re.search(r"Sync HB interval:\s+(\d+)ms", out)
+        if not res:
+            raise ValueError("Cannot find qdevice sync timeout")
+        return int(int(res.group(1))/1000)

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -14,6 +14,7 @@ from . import corosync
 from . import xmlutil
 from . import watchdog
 from . import cibquery
+from . import qdevice
 from .service_manager import ServiceManager
 from .sh import ShellUtils
 
@@ -303,7 +304,7 @@ class SBDTimeout(object):
         '''
         # add sbd after qdevice started
         if corosync.is_qdevice_configured() and ServiceManager().service_is_active("corosync-qdevice.service"):
-            qdevice_sync_timeout = utils.get_qdevice_sync_timeout()
+            qdevice_sync_timeout = qdevice.QDevice.get_qdevice_sync_timeout()
             if self.sbd_watchdog_timeout <= qdevice_sync_timeout:
                 watchdog_timeout_with_qdevice = qdevice_sync_timeout + self.QDEVICE_SYNC_TIMEOUT_MARGIN
                 self.logger.warning(

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2253,17 +2253,6 @@ def append_res_to_group(group_id, res_id):
     sh.cluster_shell().get_stdout_or_raise_error(cmd)
 
 
-def get_qdevice_sync_timeout():
-    """
-    Get qdevice sync_timeout
-    """
-    out = sh.cluster_shell().get_stdout_or_raise_error("crm corosync status qdevice")
-    res = re.search(r"Sync HB interval:\s+(\d+)ms", out)
-    if not res:
-        raise ValueError("Cannot find qdevice sync timeout")
-    return int(int(res.group(1))/1000)
-
-
 def detect_virt():
     """
     Detect if running in virt environment


### PR DESCRIPTION
Move utils.get_qdevice_sync_timeout into qdevice.QDevice as a staticmethod to better organize qdevice-related helpers and reduce utils.py scope.

- Replace utils.get_qdevice_sync_timeout with QDevice.get_qdevice_sync_timeout
- Reuse corosync.query_qdevice_status in new implementation