### PR TITLE
Dev: report: Collect cluster health output

### DIFF
--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -573,3 +573,18 @@ def collect_corosync_status(context: core.Context) -> None:
             f.write(f"# {cmd}\n")
             f.write(utils.get_cmd_output(cmd))
     logger.debug(f"Dump corosync status info into {utils.real_path(corosync_f)}")
+
+
+def collect_cluster_health(context: core.Context) -> None:
+    cluster_health_f = os.path.join(context.work_dir, constants.CLUSTER_HEALTH_F)
+    cmd_list = [
+        "crm cluster health hawk2",
+        "crm cluster health sbd",
+        "crm cluster health sles16"
+    ]
+    with open(cluster_health_f, "w") as f:
+        for cmd in cmd_list:
+            f.write(f"\n\n{DIVIDER}\n")
+            f.write(f"# {cmd}\n")
+            f.write(utils.get_cmd_output(cmd))
+    logger.debug(f"Dump cluster health info into {utils.real_path(cluster_health_f)}")

--- a/crmsh/report/constants.py
+++ b/crmsh/report/constants.py
@@ -177,6 +177,7 @@ CONFIGURATIONS = [
 COROSYNC_RECORDER_F = "fdata.txt"
 COROSYNC_F = "corosync.conf"
 COROSYNC_STATUS_F = "corosync_status.txt"
+CLUSTER_HEALTH_F = "cluster_health.txt"
 CRM_MON_F = "crm_mon.txt"
 CRM_VERIFY_F = "crm_verify.txt"
 DESCRIPTION_F = "description.txt"

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -588,6 +588,35 @@ id            0x19041a12
         ])
         mock_debug.assert_called_once_with(f"Dump corosync status info into {mock_real_path.return_value}")
 
+    @mock.patch("crmsh.report.utils.real_path")
+    @mock.patch("logging.Logger.debug")
+    @mock.patch("crmsh.report.utils.get_cmd_output")
+    @mock.patch("builtins.open", create=True)
+    def test_collect_cluster_health(self, mock_open_file, mock_get_cmd_output, mock_debug, mock_real_path):
+        mock_ctx_inst = mock.Mock(work_dir="/opt/workdir")
+        cluster_health_f = f"/opt/workdir/{constants.CLUSTER_HEALTH_F}"
+        mock_real_path.return_value = cluster_health_f
+        mock_open_write = mock.mock_open()
+        file_handle = mock_open_write.return_value.__enter__.return_value
+        mock_open_file.return_value = mock_open_write.return_value
+        mock_get_cmd_output.side_effect = ["data1", "data2", "data3"]
+
+        collect.collect_cluster_health(mock_ctx_inst)
+
+        mock_open_file.assert_called_once_with(cluster_health_f, "w")
+        file_handle.write.assert_has_calls([
+            mock.call(f"\n\n{collect.DIVIDER}\n"),
+            mock.call("# crm cluster health hawk2\n"),
+            mock.call("data1"),
+            mock.call(f"\n\n{collect.DIVIDER}\n"),
+            mock.call("# crm cluster health sbd\n"),
+            mock.call("data2"),
+            mock.call(f"\n\n{collect.DIVIDER}\n"),
+            mock.call("# crm cluster health sles16\n"),
+            mock.call("data3")
+        ])
+        mock_debug.assert_called_once_with(f"Dump cluster health info into {cluster_health_f}")
+
     @mock.patch("logging.Logger.error")
     @mock.patch('crmsh.utils.str2file')
     @mock.patch("crmsh.report.utils.real_path")


### PR DESCRIPTION
crm report should include the cluster health checks that are useful for support diagnostics. Add a report collector that records the hawk2, sbd, and sles16 health command output into a dedicated report file.

- Add cluster_health.txt report constant
- Collect crm cluster health hawk2 output
- Collect crm cluster health sbd output
- Collect crm cluster health sles16 output
- Cover cluster health collection with a unit test