### PR TITLE
Dev: Avoid hash for content checks

### DIFF
--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -271,17 +271,18 @@ class CibObjectSet(object):
         '''
         rc = False
         try:
-            s = self._pre_edit(s)
-            filehash = hash(s)
-            tmp = utils.str2tmp(s)
+            config_text = self._pre_edit(s)
+            original_config_text = config_text
+            tmp = utils.str2tmp(config_text)
             if not tmp:
                 return False
             while not rc:
                 if utils.edit_file(tmp) != 0:
                     break
-                s = open(tmp).read()
-                if hash(s) != filehash:
-                    ok = self.save(self._post_edit(s))
+                with open(tmp) as tmp_file:
+                    edited_config_text = tmp_file.read()
+                if edited_config_text != original_config_text:
+                    ok = self.save(self._post_edit(edited_config_text))
                     if not ok and options.force:
                         logger.error("Save failed and --force is set, aborting edit to avoid infinite loop")
                     elif not ok and utils.ask("Edit or discard changes (yes to edit, no to discard)?"):
@@ -311,12 +312,12 @@ class CibObjectSet(object):
         Pipe string s through a filter. Parse/save the output.
         If no changes are done, return silently.
         '''
-        rc, outp = utils.filter_string(fltr, s)
+        rc, filtered_config_text = utils.filter_string(fltr, s)
         if rc != 0:
             return False
-        if hash(outp) == hash(s):
+        if filtered_config_text == s:
             return True
-        return self.save(outp)
+        return self.save(filtered_config_text)
 
     def filter(self, fltr):
         with clidisplay.nopretty():

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -205,18 +205,17 @@ def pull_configuration(from_node):
            fname]
     rc = utils.ext_cmd_nosudo(cmd, shell=False)
     if rc == 0:
-        data = open(fname).read()
-        newhash = hash(data)
+        with open(fname) as remote_config_file:
+            remote_config_data = remote_config_file.read()
         if os.path.isfile(local_path):
-            oldata = open(local_path).read()
-            oldhash = hash(oldata)
-            if newhash == oldhash:
+            with open(local_path) as local_config_file:
+                local_config_data = local_config_file.read()
+            if remote_config_data == local_config_data:
                 print("No change.")
                 return
         print("Writing %s:%s..." % (utils.this_node(), local_path))
-        local_file = open(local_path, 'w')
-        local_file.write(data)
-        local_file.close()
+        with open(local_path, 'w') as local_config_file:
+            local_config_file.write(remote_config_data)
     else:
         raise ValueError("Failed to retrieve %s from %s" % (local_path, from_node))
 


### PR DESCRIPTION
Content comparisons used Python hash values, which are unnecessary and can theoretically collide. This change compares the actual strings and uses context managers for the touched file reads and writes.

- Compare edited CIB text directly
- Compare filtered CIB output directly
- Compare pulled corosync config directly
- Use context managers in touched file I/O