### PR TITLE
Fix: completers: Avoid repeated node completions

### DIFF
--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -41,6 +41,17 @@ def join(*fns):
     return completer
 
 
+def exclude_completed(fn, start_index=1):
+    def completer(args):
+        completions = fn(args)
+        current = args[-1] if args else ""
+        completed = set(args[start_index:-1])
+        if current in completions:
+            return [current]
+        return [item for item in completions if item not in completed]
+    return completer
+
+
 booleans = choice(['yes', 'no', 'true', 'false', 'on', 'off'])
 
 

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -568,7 +568,7 @@ Examples:
         return True
 
     @command.alias("delete")
-    @command.completers_repeating(compl.nodes)
+    @command.completers_repeating(compl.exclude_completed(compl.nodes))
     @command.skill_level('administrator')
     def do_remove(self, context, *args):
         '''

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -602,7 +602,7 @@ class CibConfig(command.UI):
         utils.page_string('\n'.join(diff))
 
     @command.skill_level('administrator')
-    @command.completers_repeating(_id_show_list)
+    @command.completers_repeating(compl.exclude_completed(_id_show_list))
     def do_show(self, context, *args):
         "usage: show [xml] [<id>...]"
         utils.load_cib_file_env()
@@ -632,7 +632,11 @@ class CibConfig(command.UI):
     @command.name("get_property")
     @command.alias("get-property")
     @command.skill_level('administrator')
-    @command.completers_repeating(compl.call(ra.get_properties_without_deprecated))
+    @command.completers_repeating(
+        compl.exclude_completed(
+            compl.call(ra.get_properties_without_deprecated)
+        )
+    )
     def do_get_property(self, context, *args):
         "usage: get-property [-t|--true [<name>...]"
         utils.load_cib_file_env()
@@ -897,7 +901,7 @@ class CibConfig(command.UI):
         return len(to_stop)
 
     @command.skill_level('administrator')
-    @command.completers_repeating(_id_list)
+    @command.completers_repeating(compl.exclude_completed(_id_list))
     @command.alias('rm')
     def do_delete(self, context, *args):
         "usage: delete [-f|--force] <id> [<id>...]"

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -24,21 +24,6 @@ from .service_manager import ServiceManager
 logger = logging.getLogger(__name__)
 
 
-def _push_completer(args):
-    try:
-        n = utils.list_cluster_nodes()
-        n.remove(utils.this_node())
-        if args[-1] in n:
-            # continue complete
-            return [args[-1]]
-        for item in args:
-            if item in n:
-                n.remove(item)
-        return n
-    except:
-        n = []
-
-
 def _diff_nodes(args):
     try:
         if len(args) > 3:
@@ -216,10 +201,10 @@ class Link(command.UI):
             return False
 
 
-    @command.completer(completers.call(lambda: [
+    @command.completers(completers.call(lambda: [
         str(link.linknumber)
         for link in corosync.LinkManager.load_config_file().links()
-        if link and link.linknumber != 0
+        if link
     ]))
     def do_remove(self, context, linknumber: str):
         if not linknumber.isdecimal():
@@ -339,7 +324,11 @@ class Corosync(command.UI):
         return corosync.cfgtool('-R')[0] == 0
 
     @command.skill_level('administrator')
-    @command.completers_repeating(_push_completer)
+    @command.completers_repeating(
+        completers.exclude_completed(
+            completers.call(utils.list_cluster_nodes_except_me)
+        )
+    )
     def do_push(self, context, *nodes):
         '''
         Push corosync configuration to other cluster nodes.
@@ -352,7 +341,7 @@ class Corosync(command.UI):
         return corosync.push_configuration(nodes)
 
     @command.skill_level('administrator')
-    @command.completers(_push_completer)
+    @command.completers(completers.call(utils.list_cluster_nodes_except_me))
     def do_pull(self, context, node):
         '''
         Pull corosync configuration from another node.

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -288,7 +288,7 @@ class NodeMgmt(command.UI):
         return True
 
     @command.wait
-    @command.completers(compl.online_nodes)
+    @command.completers_repeating(compl.exclude_completed(compl.online_nodes))
     def do_standby(self, context, *args):
         """
         usage: standby [<node>] [<lifetime>]
@@ -383,7 +383,7 @@ class NodeMgmt(command.UI):
             logger.info("standby node %s", node)
 
     @command.wait
-    @command.completers(compl.standby_nodes)
+    @command.completers_repeating(compl.exclude_completed(compl.standby_nodes))
     def do_online(self, context, *args):
         """
         usage: online [<node>]

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -437,7 +437,7 @@ class RscMgmt(command.UI):
     @command.alias('migrate')
     @command.skill_level('administrator')
     @command.wait
-    @command.completers_repeating(compl.resources, compl.nodes)
+    @command.completers(compl.resources, compl.nodes)
     def do_move(self, context, rsc, *args):
         """usage: move <rsc> [<node>] [<lifetime>] [force]"""
         return self.move_or_ban(context, rsc, *args)
@@ -445,7 +445,7 @@ class RscMgmt(command.UI):
 
     @command.skill_level('administrator')
     @command.wait
-    @command.completers_repeating(compl.resources, compl.nodes)
+    @command.completers(compl.resources, compl.nodes)
     def do_ban(self, context, rsc, *args):
         """usage: ban <rsc> [<node>] [<lifetime>] [force]"""
         return self.move_or_ban(context, rsc, *args)


### PR DESCRIPTION
Node-based completers could keep suggesting arguments that were already completed. This made commands such as cluster remove offer duplicate node choices, while resource move and ban repeated node completion beyond their single node argument.

- Add shared exclude_completed completer wrapper
- Filter completed nodes for cluster remove
- Use positional node completion for move and ban