### PR TITLE
Dev: migration: Add check and online auto-fix for deprecated cluster properties

### DIFF
--- a/crmsh/cibquery.py
+++ b/crmsh/cibquery.py
@@ -72,3 +72,12 @@ def get_node_name_by_id(cib: lxml.etree.Element, node_id: int) -> typing.Optiona
     xpath = f"/cib/configuration/nodes/node[@id='{node_id}']/@uname"
     result = cib.xpath(xpath)
     return result[0] if result else None
+
+
+def get_crm_config_properties(cib: lxml.etree.Element) -> dict[str, str]:
+    """Return a dict of configured properties (name -> value) under crm_config"""
+    return {
+        e.get('name'): e.get('value', '')
+        for e in cib.xpath('.//crm_config//cluster_property_set/nvpair')
+        if e.get('name') is not None
+    }

--- a/crmsh/migration.py
+++ b/crmsh/migration.py
@@ -24,6 +24,7 @@ from crmsh import corosync
 from crmsh import corosync_config_format
 from crmsh import iproute2
 from crmsh import parallax
+from crmsh import service_manager
 from crmsh import sh
 from crmsh import utils
 from crmsh import xmlutil
@@ -171,6 +172,8 @@ def migrate(args: typing.Sequence[str]):
             case CheckReturnCode.PASS_NEED_AUTO_FIX:
                 logger.info('Starting migration...')
                 migrate_corosync_conf(local=parsed_args.local)
+                if not parsed_args.local:
+                    migrate_deprecated_cib_properties()
                 logger.info('Finished migration.')
                 return 0
             case _:
@@ -299,6 +302,7 @@ def check_global(handler: CheckResultHandler):
     cib = xmlutil.text2elem(sh.LocalShell().get_stdout_or_raise_error(None, 'crm configure show xml'))
     check_cib_schema_version(handler, cib)
     check_unsupported_resource_agents(handler, cib)
+    check_deprecated_cib_properties(handler, cib)
 
 
 def check_dependency_version(handler: CheckResultHandler):
@@ -726,3 +730,38 @@ def _get_latest_cib_schema_version() -> tuple[int, int]:
         re.match(r'^pacemaker-(\d+)\.(\d+)\.rng$', filename)
         for filename in glob.iglob('pacemaker-*.rng', root_dir='/usr/share/pacemaker')
     ) if x is not None)
+
+
+def check_deprecated_cib_properties(handler: CheckResultHandler, cib: lxml.etree.Element):
+    deprecated_found = [
+        p for p in utils.get_all_configured_deprecated_properties(existing_xml_node=cib)
+        if not utils.DeprecatedTermTranslator(p, existing_xml_node=cib, quiet=True).check()
+    ]
+
+    if deprecated_found:
+        handler.handle_problem(
+            True, False, handler.LEVEL_WARN,
+            'Deprecated CIB properties found',
+            [f'The following properties are deprecated: {", ".join(deprecated_found)}. Please run "crm cluster health sles16 --fix" when cluster is running to migrate them.']
+        )
+
+
+def migrate_deprecated_cib_properties():
+    if service_manager.ServiceManager().service_is_active('pacemaker'):
+        logger.info("Pacemaker is running, starting online migration for CIB properties.")
+        try:
+            cib = xmlutil.text2elem(sh.LocalShell().get_stdout_or_raise_error(None, 'crm configure show xml'))
+            migrated = False
+            for prop in utils.get_all_configured_deprecated_properties(existing_xml_node=cib):
+                if not utils.DeprecatedTermTranslator(prop, existing_xml_node=cib, quiet=True).check():
+                    logger.info("Migrating deprecated CIB property: %s", prop)
+                    utils.DeprecatedTermTranslator(prop, existing_xml_node=cib, quiet=True).fix()
+                    migrated = True
+            if migrated:
+                logger.info("Finished online migration for CIB properties.")
+            else:
+                logger.info("No deprecated CIB properties found.")
+        except Exception as e:
+            logger.error("Failed to migrate CIB properties: %s", e)
+    else:
+        logger.info("Pacemaker is not running. Online migration for CIB properties is skipped.")

--- a/crmsh/migration.py
+++ b/crmsh/migration.py
@@ -118,7 +118,7 @@ class CheckResultInteractiveHandler(CheckResultHandler):
         self.write_in_color(sys.stdout, constants.GREEN, '[INFO] ')
         print(fmt % args)
 
-    def handle_problem(self, need_auto_fix: bool, is_blocker: bool, level:int, title: str, details: typing.Iterable[str]):
+    def handle_problem(self, need_auto_fix: bool, is_blocker: bool, level:int, title: str, detail: typing.Iterable[str]):
         self.has_problems = True
         self.block_migration = self.block_migration or is_blocker
         self.need_auto_fix = self.need_auto_fix or need_auto_fix
@@ -128,7 +128,7 @@ class CheckResultInteractiveHandler(CheckResultHandler):
             case self.LEVEL_WARN:
                 self.write_in_color(sys.stdout, constants.YELLOW, '[WARN] ')
         print(title)
-        for line in details:
+        for line in detail:
             sys.stdout.write('       ')
             print(line)
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -3059,7 +3059,13 @@ class DeprecatedTermTranslator:
         return not self._resolve_res.using_deprecated
 
 
-def get_all_configured_deprecated_properties() -> list[str]:
+def get_all_configured_deprecated_properties(existing_xml_node: typing.Optional[etree.Element] = None) -> list[str]:
+    if existing_xml_node is not None:
+        return [
+            p
+            for p in ra.get_properties_meta().get_deprecated_params()
+            if existing_xml_node.find(f".//*[@name='{p}']") is not None
+        ]
     return [
         p
         for p in ra.get_properties_meta().get_deprecated_params()

--- a/test/features/migration.feature
+++ b/test/features/migration.feature
@@ -159,6 +159,29 @@ Feature: migration
     Then    Expected return code is "0"
     And     Run "grep -F 'ring0_addr: @hanode2.ip.0' /etc/corosync/corosync.conf" OK
 
+  Scenario: Run pre-migration checks and fixes against deprecated CIB properties
+    When    Run "crm cluster start" on "hanode1"
+    And     Run "crm cluster start" on "hanode2"
+    Then    Cluster service is "started" on "hanode1"
+    And     Cluster service is "started" on "hanode2"
+    When    Run "crm_attribute -t crm_config -n stonith-timeout -v 120s" on "hanode1"
+    And     Try "crm cluster health sles16" on "hanode1"
+    Then    Expected return code is "1"
+    And     Expect stdout contains snippets ["[PASS] This cluster is good to migrate to SLES 16.", "[WARN] Deprecated CIB properties found", "stonith-timeout"].
+    When    Try "crm cluster health sles16 --fix" on "hanode1"
+    Then    Expected return code is "0"
+    And     Cluster property "fencing-timeout" is "120"
+    And     Cluster property "stonith-timeout" is not configured
+    When    Run "crm_attribute -t crm_config -n cluster-ipc-limit -v 800" on "hanode1"
+    And     Try "crm cluster health sles16" on "hanode1"
+    Then    Expected return code is "0"
+    When    Try "crm cluster health sles16 --fix" on "hanode1"
+    Then    Expected return code is "0"
+    And     Expected "Migrating deprecated CIB property: cluster-ipc-limit" not in stdout
+    And     Cluster property "cluster-ipc-limit" is "800"
+    When    Run "crm cluster stop" on "hanode1"
+    And     Run "crm cluster stop" on "hanode2"
+
   Scenario: Run pre-migration checks when some of the nodes are offline.
     When    Run "systemctl stop sshd" on "hanode2"
     And     Try "crm cluster health sles16" on "hanode1"

--- a/test/unittests/test_cibquery.py
+++ b/test/unittests/test_cibquery.py
@@ -112,3 +112,16 @@ class TestCibQuery(unittest.TestCase):
     def test_get_node_name_by_id(self):
         self.assertEqual(cibquery.get_node_name_by_id(self.cib, 1), "ha-1-1")
         self.assertIsNone(cibquery.get_node_name_by_id(self.cib, 2))
+
+    def test_get_crm_config_properties(self):
+        self.assertDictEqual(
+            {
+                'have-watchdog': 'false',
+                'dc-version': '2.1.5+20221208.a3f44794f-150500.4.9-2.1.5+20221208.a3f44794f',
+                'cluster-infrastructure': 'corosync',
+                'cluster-name': 'hacluster',
+                'fencing-enabled': 'true',
+                'fencing-timeout': '71',
+            },
+            cibquery.get_crm_config_properties(self.cib),
+        )

--- a/test/unittests/test_migration.py
+++ b/test/unittests/test_migration.py
@@ -114,3 +114,105 @@ class TestCheckRemovedResourceAgents(unittest.TestCase):
                 'Please run "crm configure upgrade force" to upgrade to the latest version.',
             ]
         )
+
+
+class TestDeprecatedCibProperties(unittest.TestCase):
+    @mock.patch('crmsh.utils.get_all_configured_deprecated_properties')
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator._get_maps')
+    def test_check_deprecated_cib_properties_found(self, mock_get_maps, mock_get_dep_properties):
+        mock_get_dep_properties.return_value = ['stonith-timeout']
+        mock_get_maps.return_value = ({'stonith-timeout': 'fencing-timeout'}, {})
+        cib = lxml.etree.fromstring('''
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair name="stonith-timeout" value="120s"/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+        ''')
+        handler = mock.Mock(migration.CheckResultHandler)
+        migration.check_deprecated_cib_properties(handler, cib)
+        handler.handle_problem.assert_called_with(
+            True, False, handler.LEVEL_WARN,
+            'Deprecated CIB properties found',
+            ['The following properties are deprecated: stonith-timeout. Please run "crm cluster health sles16 --fix" when cluster is running to migrate them.']
+        )
+
+    @mock.patch('crmsh.utils.get_all_configured_deprecated_properties')
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator._get_maps')
+    def test_check_deprecated_cib_properties_not_found(self, mock_get_maps, mock_get_dep_properties):
+        mock_get_dep_properties.return_value = []
+        mock_get_maps.return_value = ({'stonith-timeout': 'fencing-timeout'}, {})
+        cib = lxml.etree.fromstring('''
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair name="fencing-timeout" value="120s"/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+        ''')
+        handler = mock.Mock(migration.CheckResultHandler)
+        migration.check_deprecated_cib_properties(handler, cib)
+        handler.handle_problem.assert_not_called()
+
+    @mock.patch('crmsh.utils.get_all_configured_deprecated_properties')
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator._get_maps')
+    @mock.patch('crmsh.utils.ra.get_properties_meta')
+    def test_check_deprecated_cib_properties_without_replacement_not_found(self, mock_get_properties_meta, mock_get_maps, mock_get_dep_properties):
+        mock_get_dep_properties.return_value = ['stonith-timeout']
+        mock_get_maps.return_value = ({'stonith-timeout': None}, {})
+        mock_get_properties_meta.return_value.param_default.return_value = 'true'
+        cib = lxml.etree.fromstring('''
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair name="stonith-timeout" value="false"/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+        ''')
+        handler = mock.Mock(migration.CheckResultHandler)
+        migration.check_deprecated_cib_properties(handler, cib)
+        handler.handle_problem.assert_not_called()
+
+    @mock.patch('crmsh.utils.get_all_configured_deprecated_properties')
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator')
+    @mock.patch('crmsh.sh.LocalShell.get_stdout_or_raise_error')
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    def test_migrate_deprecated_cib_properties_active(self, mock_service_is_active, mock_get_stdout, mock_translator, mock_get_dep_properties):
+        mock_service_is_active.return_value = True
+        mock_get_dep_properties.return_value = ['stonith-timeout']
+        mock_get_stdout.return_value = '''
+            <cib>
+              <configuration>
+                <crm_config>
+                  <cluster_property_set id="cib-bootstrap-options">
+                    <nvpair name="stonith-timeout" value="120s"/>
+                  </cluster_property_set>
+                </crm_config>
+              </configuration>
+            </cib>
+        '''
+        mock_trans_inst = mock.Mock()
+        mock_trans_inst.check.return_value = False
+        mock_translator.return_value = mock_trans_inst
+
+        migration.migrate_deprecated_cib_properties()
+
+        mock_translator.assert_called_with('stonith-timeout', existing_xml_node=mock.ANY, quiet=True)
+        mock_trans_inst.fix.assert_called_once()
+
+    @mock.patch('crmsh.service_manager.ServiceManager.service_is_active')
+    @mock.patch('crmsh.utils.DeprecatedTermTranslator')
+    def test_migrate_deprecated_cib_properties_inactive(self, mock_translator, mock_service_is_active):
+        mock_service_is_active.return_value = False
+        migration.migrate_deprecated_cib_properties()
+        mock_translator.assert_not_called()


### PR DESCRIPTION
Implement the updated SLES 16 pre-migration health check use case for deprecated clustser properties, and add corresponding functional tests.

- Scans cluster properties and warns users of deprecated ones during diagnostic phase.
- Live-translates deprecated properties when the cluster service is running during --fix.
- Covered with unit and BDD functional tests.