### PR TITLE
Fix: ui_sbd: Resolve SBD device aliases on removal

### DIFF
--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -2,6 +2,7 @@ import logging
 import typing
 import re
 import os
+from pathlib import Path
 
 from crmsh import sbd
 from crmsh import watchdog
@@ -489,15 +490,19 @@ class SBD(command.UI):
         '''
         sbd.SBDUtils.verify_sbd_device(self.device_list_from_config, self.cluster_nodes)
 
+        config_device_by_path = {Path(dev).resolve(): dev for dev in self.device_list_from_config}
+        devices_to_remove_from_config = []
         for dev in devices_to_remove:
-            if dev not in self.device_list_from_config:
-                raise self.SyntaxError(f"Device {dev} is not in config")
+            config_dev = config_device_by_path.get(Path(dev).resolve())
+            if config_dev is None:
+                raise ValueError(f"Device {dev} is not configured")
+            devices_to_remove_from_config.append(config_dev)
         # To keep the order of devices during removal
-        left_device_list = [dev for dev in self.device_list_from_config if dev not in devices_to_remove]
+        left_device_list = [dev for dev in self.device_list_from_config if dev not in devices_to_remove_from_config]
         if len(left_device_list) == 0:
-            raise self.SyntaxError("Not allowed to remove all devices")
+            raise ValueError("Not allowed to remove all devices")
 
-        logger.info("Remove devices: %s", ';'.join(devices_to_remove))
+        logger.info("Remove devices: %s", ';'.join(devices_to_remove_from_config))
         update_dict = {"SBD_DEVICE": ";".join(left_device_list)}
         with utils.leverage_maintenance_mode() as enabled:
             if not utils.able_to_restart_cluster(enabled):

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -436,13 +436,13 @@ class TestSBD(unittest.TestCase):
 
     @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     def test_device_remove_dev_not_in_config(self, mock_verify_sbd_device):
-        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+        with self.assertRaises(ValueError) as e:
             self.sbd_instance_diskbased._device_remove(["/dev/sda2"])
-        self.assertEqual(str(e.exception), "Device /dev/sda2 is not in config")
+        self.assertEqual(str(e.exception), "Device /dev/sda2 is not configured")
 
     @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
     def test_device_remove_last_dev(self, mock_verify_sbd_device):
-        with self.assertRaises(ui_sbd.SBD.SyntaxError) as e:
+        with self.assertRaises(ValueError) as e:
             self.sbd_instance_diskbased._device_remove(["/dev/sda1"])
         self.assertEqual(str(e.exception), "Not allowed to remove all devices")
 
@@ -464,6 +464,60 @@ class TestSBD(unittest.TestCase):
         mock_update_sbd_configuration.assert_called_once_with({"SBD_DEVICE": "/dev/sda2"})
         mock_restart_cluster.assert_called_once()
         mock_logger_info.assert_called_once_with("Remove devices: %s", "/dev/sda1")
+
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    @mock.patch('crmsh.utils.able_to_restart_cluster')
+    @mock.patch('crmsh.utils.leverage_maintenance_mode')
+    @mock.patch('crmsh.bootstrap.restart_cluster')
+    @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.ui_sbd.Path.resolve')
+    def test_device_remove_resolved_path_from_dm_to_mapper(self, mock_resolve, mock_logger_info, mock_update_sbd_configuration, mock_restart_cluster, mock_leverage_maintenance_mode, mock_able_to_restart_cluster, mock_verify_sbd_device):
+        enable_value = True
+        cm = mock.Mock()
+        cm.__enter__ = mock.Mock(return_value=enable_value)
+        cm.__exit__ = mock.Mock(return_value=True)
+        mock_leverage_maintenance_mode.return_value = cm
+        mock_able_to_restart_cluster.return_value = True
+        mock_resolve.side_effect = [
+            "/dev/dm-7",
+            "/dev/dm-5",
+            "/dev/dm-7",
+        ]
+        self.sbd_instance_diskbased.device_list_from_config = ["/dev/mapper/shared_iscsi_lun1-part10", "/dev/mapper/shared_iscsi_lun1-part8"]
+
+        self.sbd_instance_diskbased._device_remove(["/dev/dm-7"])
+
+        mock_update_sbd_configuration.assert_called_once_with({"SBD_DEVICE": "/dev/mapper/shared_iscsi_lun1-part8"})
+        mock_restart_cluster.assert_called_once()
+        mock_logger_info.assert_called_once_with("Remove devices: %s", "/dev/mapper/shared_iscsi_lun1-part10")
+
+    @mock.patch('crmsh.sbd.SBDUtils.verify_sbd_device')
+    @mock.patch('crmsh.utils.able_to_restart_cluster')
+    @mock.patch('crmsh.utils.leverage_maintenance_mode')
+    @mock.patch('crmsh.bootstrap.restart_cluster')
+    @mock.patch('crmsh.sbd.SBDManager.update_sbd_configuration')
+    @mock.patch('logging.Logger.info')
+    @mock.patch('crmsh.ui_sbd.Path.resolve')
+    def test_device_remove_resolved_path_from_mapper_to_dm(self, mock_resolve, mock_logger_info, mock_update_sbd_configuration, mock_restart_cluster, mock_leverage_maintenance_mode, mock_able_to_restart_cluster, mock_verify_sbd_device):
+        enable_value = True
+        cm = mock.Mock()
+        cm.__enter__ = mock.Mock(return_value=enable_value)
+        cm.__exit__ = mock.Mock(return_value=True)
+        mock_leverage_maintenance_mode.return_value = cm
+        mock_able_to_restart_cluster.return_value = True
+        mock_resolve.side_effect = [
+            "/dev/dm-7",
+            "/dev/dm-5",
+            "/dev/dm-7",
+        ]
+        self.sbd_instance_diskbased.device_list_from_config = ["/dev/dm-7", "/dev/dm-5"]
+
+        self.sbd_instance_diskbased._device_remove(["/dev/mapper/shared_iscsi_lun1-part10"])
+
+        mock_update_sbd_configuration.assert_called_once_with({"SBD_DEVICE": "/dev/dm-5"})
+        mock_restart_cluster.assert_called_once()
+        mock_logger_info.assert_called_once_with("Remove devices: %s", "/dev/dm-7")
 
     def test_do_device_no_service(self):
         self.sbd_instance_diskbased._load_attributes = mock.Mock()


### PR DESCRIPTION
## Problem
```
# crm sbd device remove /dev/dm-7
INFO: Configured sbd devices: /dev/mapper/shared_iscsi_lun1-part10;/dev/mapper/shared_iscsi_lun1-part8
ERROR: Device /dev/dm-7 is not in config
INFO: Usage: crm sbd device <add|remove> <device>... 
```
Actually,/dev/dm-7 is /dev/mapper/shared_iscsi_lun1-part10
```
# ll /dev/mapper/|grep part10
lrwxrwxrwx 1 root root       7 Aug 12 12:50 shared_iscsi_lun1-part10 -> ../dm-7
```
## Changes
SBD device removal compared the requested device path with configured paths as raw strings. This rejected equivalent dm and mapper paths, so resolve paths before matching and remove the original configured entry.

- Match remove requests by resolved device path
- Preserve configured device names in SBD_DEVICE
- Improve the missing-device error message
- Cover dm and mapper alias removal