### PR TITLE
Dev: crash_test: Prefer nft for split-brain blocking

### DIFF
--- a/crmsh/crash_test/config.py
+++ b/crmsh/crash_test/config.py
@@ -2,6 +2,18 @@ FENCE_TIMEOUT = 60
 FENCE_NODE = "crm_attribute -t status -N '{}' -n terminate -v true"
 BLOCK_IP = '''iptables -{action} INPUT -s {peer_ip} -j DROP;
               iptables -{action} OUTPUT -d {peer_ip} -j DROP'''
-REMOVE_PORT = "firewall-cmd --zone=public --remove-port={port}/udp"
-ADD_PORT = "firewall-cmd --zone=public --add-port={port}/udp"
+NFT_TABLE = "crmsh_split_brain"
+NFT_RULESET = '''destroy table inet {table}
+table inet {table} {{
+  chain input {{
+    type filter hook input priority -300; policy accept;
+{input_rules}
+  }}
+  chain output {{
+    type filter hook output priority -300; policy accept;
+{output_rules}
+  }}
+}}'''
+NFT_APPLY_RULESET = "nft -f - <<'EOF'\n{ruleset}\nEOF"
+NFT_DELETE_TABLE = "nft destroy table inet {table}"
 SBD_CONF = "/etc/sysconfig/sbd"

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -443,6 +443,8 @@ class TaskSplitBrain(Task):
         self.expected = "One of nodes get fenced"
         self.ports = []
         self.peer_nodelist = []
+        self.use_nft = False
+        self.shell = ShellUtils()
         super(self.__class__, self).__init__(self.description, flush=True)
         self.force = force
 
@@ -475,10 +477,14 @@ Fence timeout:     {}
         """
         self.task_pre_check()
 
-        for cmd in ["iptables"]:
-            rc, _, err = ShellUtils().get_stdout_stderr("which {}".format(cmd))
-            if rc != 0 and err:
-                raise TaskError(err)
+        rc, _, _ = self.shell.get_stdout_stderr("which nft")
+        if rc == 0:
+            self.use_nft = True
+        else:
+            rc, _, _ = self.shell.get_stdout_stderr("which iptables")
+            if rc != 0:
+                raise TaskError("Please provide the nft or iptables command")
+            self.use_nft = False
 
         if len(utils.online_nodes()) < 2:
             raise TaskError("At least two nodes online!")
@@ -488,36 +494,67 @@ Fence timeout:     {}
         """
         Context manager to block and unblock ip/ports
         """
-        self.do_block_iptables()
+        if self.use_nft:
+            self.do_block_nft()
+        else:
+            self.do_block_iptables()
         try:
             yield
         finally:
             self.un_block()
 
+    def do_block_nft(self):
+        """
+        Block corosync communication ip using nftables
+        """
+        self.peer_nodelist = utils.peer_node_list()
+        peer_ips = []
+        for node in self.peer_nodelist:
+            self.info("Trying to temporarily block {} communication ip".format(node))
+            peer_ips.extend(crmshutils.get_iplist_from_name(node))
+
+        input_rules = "\n".join("    ip saddr {} drop".format(ip) for ip in peer_ips)
+        output_rules = "\n".join("    ip daddr {} drop".format(ip) for ip in peer_ips)
+        ruleset = config.NFT_RULESET.format(
+            table=config.NFT_TABLE,
+            input_rules=input_rules,
+            output_rules=output_rules,
+        )
+        self.shell.get_stdout_stderr(config.NFT_APPLY_RULESET.format(ruleset=ruleset))
+
     def do_block_iptables(self):
         """
-        Block corosync communication ip
+        Block corosync communication ip using iptables
         """
         self.peer_nodelist = utils.peer_node_list()
         for node in self.peer_nodelist:
             self.info("Trying to temporarily block {} communication ip".format(node))
             for ip in crmshutils.get_iplist_from_name(node):
-                ShellUtils().get_stdout_stderr(config.BLOCK_IP.format(action='I', peer_ip=ip))
+                self.shell.get_stdout_stderr(config.BLOCK_IP.format(action="I", peer_ip=ip))
 
     def un_block(self):
         """
         Unblock corosync ip/ports
         """
-        self.un_block_iptables()
+        if self.use_nft:
+            self.un_block_nft()
+        else:
+            self.un_block_iptables()
+
+    def un_block_nft(self):
+        """
+        Unblock corosync communication ip using nftables
+        """
+        self.shell.get_stdout_stderr(config.NFT_DELETE_TABLE.format(table=config.NFT_TABLE))
 
     def un_block_iptables(self):
         """
-        Unblock corosync communication ip
+        Unblock corosync communication ip using iptables
         """
         for node in self.peer_nodelist:
             self.info("Trying to recover {} communication ip".format(node))
             for ip in crmshutils.get_iplist_from_name(node):
-                ShellUtils().get_stdout_stderr(config.BLOCK_IP.format(action='D', peer_ip=ip))
+                self.shell.get_stdout_stderr(config.BLOCK_IP.format(action='D', peer_ip=ip))
 
     def run(self):
         """

--- a/test/unittests/test_crashtest_task.py
+++ b/test/unittests/test_crashtest_task.py
@@ -347,11 +347,41 @@ Fence timeout:     60
     @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
     @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
     def test_pre_check_no_cmd(self, mock_pre_check, mock_run):
-        mock_run.return_value = (1, None, "error")
+        mock_run.side_effect = [(1, None, "nft error"), (1, None, "iptables error")]
         with self.assertRaises(task.TaskError) as err:
             self.task_sp_inst.pre_check()
-        self.assertEqual("error", str(err.exception))
-        mock_run.assert_called_once_with("which iptables")
+        self.assertEqual("Please provide the nft or iptables command", str(err.exception))
+        mock_run.assert_has_calls([
+            mock.call("which nft"),
+            mock.call("which iptables"),
+        ])
+        mock_pre_check.assert_called_once_with()
+
+    @mock.patch('crmsh.crash_test.utils.online_nodes')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
+    @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
+    def test_pre_check_prefers_nft(self, mock_pre_check, mock_run, mock_online_nodes):
+        mock_run.return_value = (0, None, None)
+        mock_online_nodes.return_value = ["node1", "node2"]
+        self.task_sp_inst.pre_check()
+        self.assertTrue(self.task_sp_inst.use_nft)
+        mock_run.assert_called_once_with("which nft")
+        mock_online_nodes.assert_called_once_with()
+        mock_pre_check.assert_called_once_with()
+
+    @mock.patch('crmsh.crash_test.utils.online_nodes')
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
+    @mock.patch('crmsh.crash_test.task.Task.task_pre_check')
+    def test_pre_check_fallback_to_iptables(self, mock_pre_check, mock_run, mock_online_nodes):
+        mock_run.side_effect = [(1, None, "nft error"), (0, None, None)]
+        mock_online_nodes.return_value = ["node1", "node2"]
+        self.task_sp_inst.pre_check()
+        self.assertFalse(self.task_sp_inst.use_nft)
+        mock_run.assert_has_calls([
+            mock.call("which nft"),
+            mock.call("which iptables"),
+        ])
+        mock_online_nodes.assert_called_once_with()
         mock_pre_check.assert_called_once_with()
 
     @mock.patch('crmsh.crash_test.utils.online_nodes')
@@ -363,7 +393,8 @@ Fence timeout:     60
         with self.assertRaises(task.TaskError) as err:
             self.task_sp_inst.pre_check()
         self.assertEqual("At least two nodes online!", str(err.exception))
-        mock_run.assert_called_once_with("which iptables")
+        mock_run.assert_called_once_with("which nft")
+        self.assertTrue(self.task_sp_inst.use_nft)
         mock_online_nodes.assert_called_once_with()
 
     @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
@@ -389,6 +420,29 @@ Fence timeout:     60
             mock.call(config.BLOCK_IP.format(action='I', peer_ip="10.10.10.2")),
             mock.call(config.BLOCK_IP.format(action='I', peer_ip="20.20.20.2"))
             ])
+
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
+    @mock.patch('crmsh.crash_test.task.crmshutils.get_iplist_from_name')
+    @mock.patch('crmsh.crash_test.task.Task.info')
+    @mock.patch('crmsh.crash_test.utils.peer_node_list')
+    def test_do_block_nft(self, mock_peer_list, mock_info, mock_get_iplist, mock_run):
+        self.task_sp_inst.use_nft = True
+        mock_peer_list.return_value = ["node1"]
+        mock_get_iplist.return_value = ["10.10.10.1"]
+        self.task_sp_inst.do_block_nft()
+        ruleset = config.NFT_RULESET.format(
+            table=config.NFT_TABLE,
+            input_rules="    ip saddr 10.10.10.1 drop",
+            output_rules="    ip daddr 10.10.10.1 drop",
+        )
+        mock_run.assert_called_once_with(config.NFT_APPLY_RULESET.format(ruleset=ruleset))
+
+    @mock.patch('crmsh.crash_test.task.TaskSplitBrain.do_block_nft')
+    def test_do_block_uses_nft(self, mock_do_block_nft):
+        self.task_sp_inst.use_nft = True
+        with self.task_sp_inst.do_block():
+            pass
+        mock_do_block_nft.assert_called_once_with()
 
     @mock.patch('crmsh.crash_test.task.TaskSplitBrain.un_block_iptables')
     def test_un_block(self, mock_unblock_iptables):
@@ -416,6 +470,17 @@ Fence timeout:     60
             mock.call(config.BLOCK_IP.format(action='D', peer_ip="10.10.10.2")),
             mock.call(config.BLOCK_IP.format(action='D', peer_ip="20.20.20.2"))
             ])
+
+    @mock.patch('crmsh.sh.ShellUtils.get_stdout_stderr')
+    def test_un_block_nft(self, mock_run):
+        self.task_sp_inst.un_block_nft()
+        mock_run.assert_called_once_with(config.NFT_DELETE_TABLE.format(table=config.NFT_TABLE))
+
+    @mock.patch('crmsh.crash_test.task.TaskSplitBrain.un_block_nft')
+    def test_un_block_uses_nft(self, mock_unblock_nft):
+        self.task_sp_inst.use_nft = True
+        self.task_sp_inst.un_block()
+        mock_unblock_nft.assert_called_once_with()
 
     @mock.patch('crmsh.crash_test.task.Task.fence_action_monitor')
     @mock.patch('threading.Thread')


### PR DESCRIPTION
The split-brain crash test should use nft when available because nft can
apply the full blocking ruleset atomically. Keep iptables as a fallback for
systems without nft.
    
- Apply nft blocking rules as one ruleset
- Prefer nft and fall back to iptables
- Destroy the nft table during cleanup
- Cover nft-first pre-check and ruleset generation