### PR TITLE
Fix: cluster_fs: Detect SBD device conflicts early

### DIFF
--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from contextlib import contextmanager
+from pathlib import Path
 from . import utils, sh, storage_utils
 from . import bootstrap
 from . import ra
@@ -36,6 +37,8 @@ class ClusterFSManager(object):
         self.mount_point = context.mount_point
         self.use_stage = context.stage in ("ocfs2", "gfs2")
         self.yes_to_all = context.yes_to_all
+        sbd_devices = getattr(context, "sbd_devices", None)
+        self.sbd_devices = sbd_devices if isinstance(sbd_devices, list) else []
         self.exist_ra_id_list = []
         self.vg_id = None
         self.group_id = None
@@ -121,6 +124,7 @@ class ClusterFSManager(object):
         Verify OCFS2/GFS2 devices
         """
         node_list = utils.list_cluster_nodes() if self.use_stage else [utils.this_node()]
+        self._check_device_with_sbd_device()
         for dev in self.devices:
             failed_nodes = storage_utils.get_non_block_device_nodes(dev, node_list)
             if failed_nodes:
@@ -163,12 +167,14 @@ e.g. crm cluster init {self.type.lower()} -o <device>
         """
         Raise error when OCFS2/GFS2 device is the same with sbd device
         """
-        if ServiceManager().service_is_enabled(constants.SBD_SERVICE):
-            sbd_device_list = sbd.SBDUtils.get_sbd_device_from_config()
-            for dev in self.devices:
-                if dev in sbd_device_list:
-                    msg = f"{dev} cannot be the same with SBD device" + self.error_hints_for_stage
-                    raise Error(msg)
+        sbd_device_list = list(self.sbd_devices)
+        if not sbd_device_list and ServiceManager().service_is_enabled(constants.SBD_SERVICE):
+            sbd_device_list.extend(sbd.SBDUtils.get_sbd_device_from_config())
+
+        resolved_sbd_devices = [Path(dev).resolve() for dev in sbd_device_list]
+        for dev in self.devices:
+            if Path(dev).resolve() in resolved_sbd_devices:
+                raise Error(f"{dev} cannot be the same with SBD device")
 
     def _confirm_to_overwrite_device(self):
         """
@@ -197,7 +203,6 @@ e.g. crm cluster init {self.type.lower()} -o <device>
             msg = f"{self.type} requires fence device configured and running." + self.error_hints_for_stage
             raise Error(msg)
 
-        self._check_device_with_sbd_device()
         self._confirm_to_overwrite_device()
 
     def _gen_ra_scripts(self, ra_type: str, kv: dict) -> tuple[str, str]:

--- a/test/unittests/test_cluster_fs.py
+++ b/test/unittests/test_cluster_fs.py
@@ -91,6 +91,7 @@ class TestClusterFSManager(unittest.TestCase):
     @mock.patch("crmsh.utils.list_cluster_nodes")
     @mock.patch("crmsh.cluster_fs.storage_utils.get_non_block_device_nodes")
     def test_verify_devices_not_block_device(self, mock_get_non_block_device_nodes, mock_list_cluster_nodes):
+        self.ocfs2_instance_one_device._check_device_with_sbd_device = mock.Mock()
         mock_list_cluster_nodes.return_value = ["node1", "node2"]
         mock_get_non_block_device_nodes.return_value = ["node1"]
         with self.assertRaises(cluster_fs.Error) as context:
@@ -100,6 +101,7 @@ class TestClusterFSManager(unittest.TestCase):
     @mock.patch("crmsh.cluster_fs.storage_utils.is_dev_used_for_lvm")
     @mock.patch("crmsh.cluster_fs.storage_utils.get_non_block_device_nodes")
     def test_verify_devices_clvm2_with_lv(self, mock_get_non_block_device_nodes, mock_is_dev_used_for_lvm):
+        self.gfs2_instance_one_device_clvm2._check_device_with_sbd_device = mock.Mock()
         mock_get_non_block_device_nodes.return_value = []
         mock_is_dev_used_for_lvm.return_value = True
         with self.assertRaises(cluster_fs.Error) as context:
@@ -110,6 +112,7 @@ class TestClusterFSManager(unittest.TestCase):
     @mock.patch("crmsh.cluster_fs.storage_utils.is_dev_used_for_lvm")
     @mock.patch("crmsh.cluster_fs.storage_utils.get_non_block_device_nodes")
     def test_verify_devices_already_mounted(self, mock_get_non_block_device_nodes, mock_is_dev_used_for_lvm, mock_has_disk_mounted):
+        self.ocfs2_instance_one_device._check_device_with_sbd_device = mock.Mock()
         mock_get_non_block_device_nodes.return_value = []
         mock_is_dev_used_for_lvm.return_value = False
         mock_has_disk_mounted.return_value = True
@@ -144,16 +147,35 @@ class TestClusterFSManager(unittest.TestCase):
         self.ocfs2_instance_one_device._check_if_already_configured.assert_called_once()
         self.ocfs2_instance_one_device._verify_devices.assert_called_once()
 
+    @mock.patch("pathlib.Path.resolve")
     @mock.patch("crmsh.sbd.SBDUtils.get_sbd_device_from_config")
     @mock.patch("crmsh.cluster_fs.ServiceManager")
-    def test_check_device_with_sbd_device(self, mock_service_manager, mock_get_sbd_device_from_config):
+    def test_check_device_with_sbd_device(self, mock_service_manager, mock_get_sbd_device_from_config, mock_resolve):
         mock_service_manager_inst = mock.Mock()
         mock_service_manager.return_value = mock_service_manager_inst
         mock_service_manager_inst.service_is_enabled.return_value = True
-        mock_get_sbd_device_from_config.return_value = "/dev/sda1"
+        mock_get_sbd_device_from_config.return_value = ["/dev/disk/by-id/sda1"]
+        mock_resolve.return_value = "/dev/sda1"
         with self.assertRaises(cluster_fs.Error) as context:
             self.instance_ocfs2_stage_with_device._check_device_with_sbd_device()
         self.assertEqual(str(context.exception), '/dev/sda1 cannot be the same with SBD device')
+
+    @mock.patch("pathlib.Path.resolve")
+    @mock.patch("crmsh.sbd.SBDUtils.get_sbd_device_from_config")
+    @mock.patch("crmsh.cluster_fs.ServiceManager")
+    def test_check_device_with_bootstrap_sbd_device(self, mock_service_manager, mock_get_sbd_device_from_config, mock_resolve):
+        mock_service_manager_inst = mock.Mock()
+        mock_service_manager.return_value = mock_service_manager_inst
+        mock_service_manager_inst.service_is_enabled.return_value = True
+        mock_resolve.return_value = "/dev/sda1"
+        self.instance_ocfs2_stage_with_device.sbd_devices = ["/dev/disk/by-id/sda1"]
+
+        with self.assertRaises(cluster_fs.Error) as context:
+            self.instance_ocfs2_stage_with_device._check_device_with_sbd_device()
+
+        self.assertEqual(str(context.exception), '/dev/sda1 cannot be the same with SBD device')
+        mock_service_manager_inst.service_is_enabled.assert_not_called()
+        mock_get_sbd_device_from_config.assert_not_called()
 
     @mock.patch("crmsh.bootstrap.confirm")
     @mock.patch("crmsh.cluster_fs.storage_utils.has_dev_partitioned")


### PR DESCRIPTION
Cluster filesystem validation should reject devices that resolve to the same path as an SBD device before initialization proceeds. This change uses bootstrap SBD options first and falls back to configured SBD devices only when needed.

- Resolve device paths before comparing
- Check SBD conflicts during device verification
- Prefer bootstrap SBD devices over config
- Add unit tests for fallback behavior