### PR TITLE
ci(workflow): optimize test container caching and remove artifact overhead

### DIFF
--- a/.github/actions/setup-functional-tests/action.yml
+++ b/.github/actions/setup-functional-tests/action.yml
@@ -1,13 +1,14 @@
 name: 'Setup Functional Tests'
-description: 'Downloads and loads the functional test container image'
+description: 'Restores and loads the functional test container image'
 runs:
   using: 'composite'
   steps:
-    - name: Download container image artifact
-      uses: actions/download-artifact@v8
+    - name: Restore container image from cache
+      uses: actions/cache@v6
       with:
-        name: haleap-image
-        path: /tmp
+        path: /tmp/haleap.tar
+        key: test-container-${{ hashFiles('test_container/**') }}
+        fail-on-cache-miss: true
     - name: Load container image
       shell: bash
       run: |

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -20,7 +20,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Cache container image
       id: cache-container
-      uses: actions/cache@v5
+      uses: actions/cache@v6
+      # actions/cache will update the cache in the "Post Run" stage
       with:
         path: /tmp/haleap.tar
         key: test-container-${{ hashFiles('test_container/**') }}
@@ -30,12 +31,6 @@ jobs:
         podman image build -t haleap:ci ./test_container
         mkdir -p /tmp
         podman save -o /tmp/haleap.tar haleap:ci
-    - name: Upload container image artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: haleap-image
-        path: /tmp/haleap.tar
-        retention-days: 1
 
   general_check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Currently, the workflow uses `actions/upload-artifact` and `actions/download-artifact` to pass test container image between different jobs. This is redundant as `actions/cache` is also capable to pass artifacts.