### PR TITLE
[crmsh-4.6] feat(report): collect OCFS2 volume details

### DIFF
--- a/crmsh/cibquery.py
+++ b/crmsh/cibquery.py
@@ -23,3 +23,12 @@ def has_primitive_filesystem_with_fstype(cib: lxml.etree.Element, fstype: str) -
         '/cib/configuration/resources//primitive[@class="ocf" and @provider="heartbeat" and @type="Filesystem"]'
         f'/instance_attributes/nvpair[@name="fstype" and @value="{fstype}"]'
     ))
+
+
+def get_filesystem_devices(cib: lxml.etree.Element, fstype: str) -> typing.List[str]:
+    """Return device values for Filesystem primitives matching fstype."""
+    return cib.xpath(
+        '/cib/configuration/resources//primitive[@class="ocf" and @provider="heartbeat" and @type="Filesystem"]'
+        f'[instance_attributes/nvpair[@name="fstype" and @value="{fstype}"]]'
+        '/instance_attributes/nvpair[@name="device"]/@value'
+    )

--- a/crmsh/report/collect.py
+++ b/crmsh/report/collect.py
@@ -10,11 +10,14 @@ import stat
 import pwd
 import datetime
 import subprocess
+import shlex
 from subprocess import TimeoutExpired
 from typing import List, Optional
 
+import lxml.etree
+
 import crmsh.user_of_host
-from crmsh import log, sh, corosync
+from crmsh import log, sh, corosync, cibquery
 from crmsh import utils as crmutils
 from crmsh.report import constants, utils, core
 from crmsh.sh import ShellUtils
@@ -139,6 +142,31 @@ def lsof_cluster_fs_device(fs_type: str) -> str:
     return out_string
 
 
+def ocfs2_devices_from_cib() -> List[str]:
+    """Return OCFS2 devices configured in the live CIB."""
+    rc, out, err = ShellUtils().get_stdout_stderr("cibadmin -Q")
+    if rc != 0:
+        logger.warning('Failed to run "cibadmin -Q" for OCFS2 device lookup: %s', err)
+        return []
+
+    try:
+        cib = lxml.etree.fromstring(out.encode())
+    except lxml.etree.XMLSyntaxError as err:
+        logger.warning("Failed to parse CIB for OCFS2 device lookup: %s", err)
+        return []
+
+    return cibquery.get_filesystem_devices(cib, "ocfs2")
+
+
+def cmd_binary_name(cmd: str) -> Optional[str]:
+    """Return the binary name from a command, ignoring leading env assignments."""
+    for part in shlex.split(cmd):
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", part):
+            continue
+        return part
+    return None
+
+
 def cluster_fs_commands_output(fs_type: str) -> str:
     """
     Run OCFS2/GFS2 related commands, return outputs
@@ -146,7 +174,6 @@ def cluster_fs_commands_output(fs_type: str) -> str:
     out_string = ""
 
     cmds = [
-        "dmesg",
         "ps -efL",
         "lsblk -o 'NAME,KNAME,MAJ:MIN,FSTYPE,LABEL,RO,RM,MODEL,SIZE,OWNER,GROUP,MODE,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,ROTA,SCHED,MOUNTPOINT'",
         "findmnt",
@@ -158,9 +185,18 @@ def cluster_fs_commands_output(fs_type: str) -> str:
             "mounted.ocfs2 -f",
             "cat /sys/fs/ocfs2/cluster_stack"
         ])
+        for device in ocfs2_devices_from_cib():
+            cmds.extend([
+                f"o2info --volinfo {device}",
+                f"PAGER=cat debugfs.ocfs2 -n -R 'stats' {device}"
+            ])
+
+    # Append dmesg command at the end since its output might be huge
+    cmds.append("dmesg")
 
     for cmd in cmds:
-        cmd_name = cmd.split()[0]
+        cmd_name = cmd_binary_name(cmd)
+        assert cmd_name
         if not shutil.which(cmd_name):
             continue
         if cmd_name == "cat" and not os.path.exists(cmd.split()[1]):

--- a/test/unittests/test_cibquery.py
+++ b/test/unittests/test_cibquery.py
@@ -108,3 +108,10 @@ class TestCibQuery(unittest.TestCase):
     def test_has_primitive_filesystem_with_fstype(self):
         self.assertTrue(cibquery.has_primitive_filesystem_with_fstype(self.cib, 'ocfs2'))
         self.assertFalse(cibquery.has_primitive_filesystem_with_fstype(self.cib, 'foo'))
+
+    def test_get_filesystem_devices(self):
+        self.assertEqual(
+            ['/dev/disk/by-partlabel/ocfs2-157'],
+            cibquery.get_filesystem_devices(self.cib, 'ocfs2'),
+        )
+        self.assertEqual([], cibquery.get_filesystem_devices(self.cib, 'gfs2'))

--- a/test/unittests/test_report_collect.py
+++ b/test/unittests/test_report_collect.py
@@ -639,11 +639,37 @@ tmpfs on /run/user/0 type tmpfs (rw,nosuid,nodev,relatime,size=169544k,nr_inodes
         ])
 
     @mock.patch('crmsh.report.utils.get_cmd_output')
+    @mock.patch('crmsh.report.collect.ocfs2_devices_from_cib')
     @mock.patch('os.path.exists')
     @mock.patch('shutil.which')
-    def test_cluster_fs_commands_output(self, mock_which, mock_exists, mock_run):
-        mock_which.side_effect = [False for i in range(5)] + [True, True]
+    def test_cluster_fs_commands_output(self, mock_which, mock_exists, mock_devices, mock_run):
+        mock_which.side_effect = [False for i in range(4)] + [True, True, True, True, False]
         mock_exists.return_value = False
+        mock_devices.return_value = ["/dev/sda6"]
         mock_run.return_value = "data"
         res = collect.cluster_fs_commands_output("OCFS2")
-        self.assertEqual(res, "\n\n#===== [ Command ] ==========================#\n# mounted.ocfs2 -f\ndata")
+        self.assertEqual(
+            res,
+            "\n\n#===== [ Command ] ==========================#\n# mounted.ocfs2 -f\ndata"
+            "\n\n#===== [ Command ] ==========================#\n# o2info --volinfo /dev/sda6\ndata"
+            "\n\n#===== [ Command ] ==========================#\n# PAGER=cat debugfs.ocfs2 -n -R 'stats' /dev/sda6\ndata"
+        )
+
+    @mock.patch('crmsh.cibquery.get_filesystem_devices')
+    @mock.patch('lxml.etree.fromstring')
+    @mock.patch('crmsh.report.collect.ShellUtils')
+    def test_ocfs2_devices_from_cib(self, mock_shell, mock_fromstring, mock_get_devices):
+        mock_shell_inst = mock.Mock()
+        mock_shell.return_value = mock_shell_inst
+        mock_shell_inst.get_stdout_stderr.return_value = (0, "<cib/>", None)
+        mock_fromstring.return_value = "cib"
+        mock_get_devices.return_value = ["/dev/sda6"]
+
+        self.assertEqual(["/dev/sda6"], collect.ocfs2_devices_from_cib())
+        mock_shell_inst.get_stdout_stderr.assert_called_once_with("cibadmin -Q")
+        mock_fromstring.assert_called_once_with(b"<cib/>")
+        mock_get_devices.assert_called_once_with("cib", "ocfs2")
+
+    def test_cmd_binary_name(self):
+        self.assertEqual("debugfs.ocfs2", collect.cmd_binary_name("PAGER=cat debugfs.ocfs2 -n"))
+        self.assertEqual("o2info", collect.cmd_binary_name("o2info --volinfo /dev/sda6"))


### PR DESCRIPTION
Collect additional OCFS2 diagnostics in crm report so storage state is available when analyzing cluster filesystem issues.

- Query Filesystem primitives from the live CIB
- Add o2info and debugfs.ocfs2 output for OCFS2 devices
- Keep dmesg collection last to avoid hiding smaller command output
- Cover CIB device lookup and command selection with unit tests

Backport from:
- #2187 