### PR TITLE
ci(workflow): fix weekly cache key week number mismatch

### DIFF
--- a/.github/actions/setup-functional-tests/action.yml
+++ b/.github/actions/setup-functional-tests/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Get current week
       id: get-week
       shell: bash
-      run: echo "week=$(date -u +'%G-%V')" >> $GITHUB_OUTPUT
+      run: echo "week=$(date -u +'%Y-%U')" >> $GITHUB_OUTPUT
     - name: Restore container image from cache
       uses: actions/cache@v6
       with:

--- a/.github/workflows/crmsh-ci.yml
+++ b/.github/workflows/crmsh-ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Get current week
       id: get-week
-      run: echo "week=$(date -u +'%G-%V')" >> $GITHUB_OUTPUT
+      run: echo "week=$(date -u +'%Y-%U')" >> $GITHUB_OUTPUT
     - name: Cache container image
       id: cache-container
       uses: actions/cache@v6


### PR DESCRIPTION
- Shift cache week-number generation from ISO 8601 (%G-%V, Monday-based)
  to standard Sunday-based week numbers (%Y-%U).
- This aligns the week increment precisely with the scheduled Sunday
  04:31 UTC workflow trigger.
- Fixes cache misses and unnecessary rebuilds on Monday-Saturday runs
  by ensuring the Sunday-built cache matches the week key used for the
  rest of the week.
