### PR TITLE
refactor(xmlutil): use crm_mon XML for resource location, fix trace input validation

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -536,7 +536,7 @@ def wait_for_resource(message, resource, timeout_ms=WAIT_TIMEOUT_MS_DEFAULT, fat
     with logger_utils.status_long(message) as progress_bar:
         start_time = int(time.clock_gettime(time.CLOCK_MONOTONIC) * 1000)
         while True:
-            if xmlutil.CrmMonXmlParser().is_resource_started(resource):
+            if xmlutil.CrmMonXMLParser().is_resource_started(resource):
                 break
             status_progress(progress_bar)
             if 0 < timeout_ms <= (int(time.clock_gettime(time.CLOCK_MONOTONIC) * 1000) - start_time):
@@ -576,7 +576,7 @@ def is_online():
     Check whether local node is online
     Besides that, in join process, check whether init node is online
     """
-    if not xmlutil.CrmMonXmlParser().is_node_online(utils.this_node()):
+    if not xmlutil.CrmMonXMLParser().is_node_online(utils.this_node()):
         return False
 
     # if peer_node is None, this is in the init process
@@ -587,7 +587,7 @@ def is_online():
     # The communication IP maybe mis-configured
     user, cluster_node = _parse_user_at_host(_context.cluster_node, None)
     cluster_node = get_node_canonical_hostname(cluster_node)
-    if not xmlutil.CrmMonXmlParser().is_node_online(cluster_node):
+    if not xmlutil.CrmMonXMLParser().is_node_online(cluster_node):
         shutil.copy(_context.get_corosync_conf_orig(), corosync.conf())
         sync_path(corosync.conf(), cluster_node)
         sh.cluster_shell().get_stdout_or_raise_error("corosync-cfgtool -R", cluster_node)
@@ -1409,7 +1409,7 @@ def init_cluster():
 
     init_cluster_local()
 
-    node_list = xmlutil.CrmMonXmlParser().get_node_list(online=True, node_type="member")
+    node_list = xmlutil.CrmMonXMLParser().get_node_list(online=True, node_type="member")
     nnodes = len(node_list)
     if nnodes < 1:
         utils.fatal("No nodes found in cluster")
@@ -1759,7 +1759,7 @@ def join_ssh_merge(cluster_node, remote_user):
         stderr=subprocess.DEVNULL,
     )
 
-    node_list = xmlutil.CrmMonXmlParser(cluster_node).get_node_list(online=True, node_type="member")
+    node_list = xmlutil.CrmMonXMLParser(cluster_node).get_node_list(online=True, node_type="member")
     hosts = node_list + [utils.this_node()]
     known_hosts_new: set[str] = set()
     cat_cmd = "[ -e ~/.ssh/known_hosts ] && cat ~/.ssh/known_hosts || true"
@@ -2061,7 +2061,7 @@ def rm_configuration_files(remote=None):
 def remove_pacemaker_remote_node_from_cluster(node):
     logger.info("Removing pacemaker remote node %s from cluster", node)
     shell = sh.cluster_shell()
-    remote_node_res_id = xmlutil.CrmMonXmlParser().get_res_id_of_remote_node(node)
+    remote_node_res_id = xmlutil.CrmMonXMLParser().get_res_id_of_remote_node(node)
     if not remote_node_res_id:
         logger.error("Cannot find the resource ID of the pacemaker remote node %s", node)
         return
@@ -2076,7 +2076,7 @@ def remove_node_from_cluster(node, dead_node=False):
     """
     Remove node from running cluster and the corosync / pacemaker configuration.
     """
-    if xmlutil.CrmMonXmlParser().is_node_remote(node):
+    if xmlutil.CrmMonXMLParser().is_node_remote(node):
         remove_pacemaker_remote_node_from_cluster(node)
         return
 
@@ -2422,7 +2422,7 @@ def bootstrap_remove(context):
             utils.fatal("Removing self requires --force")
         remove_self(force_flag)
     else:
-        configured_nodes = xmlutil.CrmMonXmlParser().get_node_list()
+        configured_nodes = xmlutil.CrmMonXMLParser().get_node_list()
         if cluster_node in configured_nodes:
             remove_node_from_cluster(cluster_node)
         else:
@@ -2775,7 +2775,7 @@ def sync_path(path, peer_node=None):
     """
     node_list = []
     if peer_node:
-        node_list = xmlutil.CrmMonXmlParser(peer_node).get_node_list(online=True, node_type="member")
+        node_list = xmlutil.CrmMonXMLParser(peer_node).get_node_list(online=True, node_type="member")
     utils.cluster_copy_path(path, nodes=node_list)
 
 

--- a/crmsh/cluster_fs.py
+++ b/crmsh/cluster_fs.py
@@ -394,7 +394,7 @@ e.g. crm cluster init {self.type.lower()} -o <device>
             return
         cluster_fs_type, device = target_dict["cluster_fs_type"], target_dict["device"]
         with logger_utils.status_long(f"Verify {cluster_fs_type.upper()} environment on {device}"):
-            use_cluster_lvm2 = xmlutil.CrmMonXmlParser(peer).is_resource_configured(constants.LVMLOCKD_RA)
+            use_cluster_lvm2 = xmlutil.CrmMonXMLParser(peer).is_resource_configured(constants.LVMLOCKD_RA)
             self._verify_packages(cluster_fs_type.upper(), use_cluster_lvm2)
             if storage_utils.is_dev_a_plain_raw_disk_or_partition(device, peer):
                 storage_utils.compare_uuid_with_peer_dev([device], peer)

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -69,8 +69,8 @@ def primitives(args):
     return [x.get("id") for x in nodes if xmlutil.is_primitive(x)]
 
 
-nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), None)
-online_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), False)
-standby_nodes = call(lambda x: xmlutil.CrmMonXmlParser().get_node_list(standby=x), True)
+nodes = call(lambda x: xmlutil.CrmMonXMLParser().get_node_list(standby=x), None)
+online_nodes = call(lambda x: xmlutil.CrmMonXMLParser().get_node_list(standby=x), False)
+standby_nodes = call(lambda x: xmlutil.CrmMonXMLParser().get_node_list(standby=x), True)
 
 shadows = call(lambda: xmlutil.listshadows())

--- a/crmsh/crash_test/task.py
+++ b/crmsh/crash_test/task.py
@@ -133,7 +133,7 @@ TYPE Yes TO CONTINUE, OTHER INPUTS WILL CANCEL THIS CASE [Yes/No](No): """
         """
         # Try to find out which node fire the fence action
         while not self.thread_stop_event.is_set():
-            fence_event_dict = xmlutil.CrmMonXmlParser().get_last_fence_event_info()
+            fence_event_dict = xmlutil.CrmMonXMLParser().get_last_fence_event_info()
             if fence_event_dict:
                 target_node = fence_event_dict.get('target')
                 origin_node = fence_event_dict.get('origin')

--- a/crmsh/crash_test/utils.py
+++ b/crmsh/crash_test/utils.py
@@ -140,7 +140,7 @@ def online_nodes():
     """
     Get online node list
     """
-    return xmlutil.CrmMonXmlParser().get_node_list(online=True, node_type='member')
+    return xmlutil.CrmMonXMLParser().get_node_list(online=True, node_type='member')
 
 
 def peer_node_list():

--- a/crmsh/lock.py
+++ b/crmsh/lock.py
@@ -155,7 +155,7 @@ class RemoteLock(Lock):
 
             if self.for_join:
                 # Might lose claiming lock again, start to wait again
-                online_list = xmlutil.CrmMonXmlParser(self.remote_node).get_node_list(online=True, node_type="member")
+                online_list = xmlutil.CrmMonXMLParser(self.remote_node).get_node_list(online=True, node_type="member")
                 if pre_online_list and pre_online_list != online_list:
                     timeout = current_time + self.lock_timeout
                 pre_online_list = online_list

--- a/crmsh/qdevice.py
+++ b/crmsh/qdevice.py
@@ -53,7 +53,7 @@ def evaluate_qdevice_quorum_effect(mode):
     if utils.calculate_quorate_status(expected_votes, actual_votes) and not diskless_sbd:
         # safe to use reload
         return QdevicePolicy.QDEVICE_RELOAD
-    elif xmlutil.CrmMonXmlParser().is_non_stonith_resource_running() and not utils.is_cluster_in_maintenance_mode():
+    elif xmlutil.CrmMonXMLParser().is_non_stonith_resource_running() and not utils.is_cluster_in_maintenance_mode():
         # will lose quorum, with non-stonith resource running
         # no reload, no restart cluster service
         # just leave a warning

--- a/crmsh/sbd.py
+++ b/crmsh/sbd.py
@@ -1097,7 +1097,7 @@ class SBDConfigChecker(SBDTimeout):
         if not self.disk_based:
             return CheckResult.SUCCESS
 
-        xml_inst = xmlutil.CrmMonXmlParser()
+        xml_inst = xmlutil.CrmMonXMLParser()
         if xml_inst.not_connected():
             cib = xmlutil.text2elem(sh.cluster_shell().get_stdout_or_raise_error("crm configure show xml"))
             ra = cibquery.ResourceAgent("stonith", "", "fence_sbd")
@@ -1126,7 +1126,7 @@ class SBDConfigChecker(SBDTimeout):
         return CheckResult.SUCCESS
 
     def _fix_fence_sbd(self):
-        xml_inst = xmlutil.CrmMonXmlParser()
+        xml_inst = xmlutil.CrmMonXMLParser()
         shell = sh.cluster_shell()
         if not xml_inst.is_resource_configured(SBDManager.SBD_RA):
             logger.info("Configuring fence agent %s", SBDManager.SBD_RA)
@@ -1583,9 +1583,9 @@ class SBDManager:
 
 
 def cleanup_existing_sbd_resource():
-    if xmlutil.CrmMonXmlParser().is_resource_configured(SBDManager.SBD_RA):
-        sbd_id_list = xmlutil.CrmMonXmlParser().get_resource_id_list_via_type(SBDManager.SBD_RA)
-        if xmlutil.CrmMonXmlParser().is_resource_started(SBDManager.SBD_RA):
+    if xmlutil.CrmMonXMLParser().is_resource_configured(SBDManager.SBD_RA):
+        sbd_id_list = xmlutil.CrmMonXMLParser().get_resource_id_list_via_type(SBDManager.SBD_RA)
+        if xmlutil.CrmMonXMLParser().is_resource_started(SBDManager.SBD_RA):
             for sbd_id in sbd_id_list:
                 logger.info("Stop sbd resource '%s'(%s)", sbd_id, SBDManager.SBD_RA)
                 utils.ext_cmd("crm resource stop {}".format(sbd_id))

--- a/crmsh/storage_utils.py
+++ b/crmsh/storage_utils.py
@@ -173,14 +173,14 @@ def is_dlm_running(peer=None, on_node=None):
     """
     Check if dlm ra controld is running
     """
-    return xmlutil.CrmMonXmlParser(peer).is_resource_started(constants.DLM_CONTROLD_RA, node=on_node)
+    return xmlutil.CrmMonXMLParser(peer).is_resource_started(constants.DLM_CONTROLD_RA, node=on_node)
 
 
 def is_dlm_configured(peer=None):
     """
     Check if dlm configured
     """
-    return xmlutil.CrmMonXmlParser(peer).is_resource_configured(constants.DLM_CONTROLD_RA)
+    return xmlutil.CrmMonXMLParser(peer).is_resource_configured(constants.DLM_CONTROLD_RA)
 
 
 def check_no_quorum_policy_with_dlm():

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -639,7 +639,7 @@ Finally run `crm cluster init qdevice` on any node in the cluster to re-deploy t
         logger.info("Setting cluster-name property to %s in CIB", new_name)
         utils.set_property("cluster-name", new_name)
 
-        if xmlutil.CrmMonXmlParser().is_non_stonith_resource_running():
+        if xmlutil.CrmMonXMLParser().is_non_stonith_resource_running():
             context.info("To apply the change, restart the cluster service at convenient time")
         else:
             bootstrap.restart_cluster()

--- a/crmsh/ui_maintenance.py
+++ b/crmsh/ui_maintenance.py
@@ -60,7 +60,7 @@ class Maintenance(command.UI):
         return v and all(x == 'true' for x in v)
 
     def _runs_on_this_node(self, resource):
-        nodes = utils.running_on(resource)
+        nodes = xmlutil.CrmMonXMLParser().get_resource_running_nodes(resource)
         return set(nodes) == set([utils.this_node()])
 
     @command.skill_level('administrator')

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -83,7 +83,7 @@ def update_xml_node(cluster_node_name, attr, value):
     node_obj = cib_factory.find_node(cluster_node_name)
     if node_obj is None:
         # Append node section for remote node
-        if xmlutil.CrmMonXmlParser().is_node_remote(cluster_node_name):
+        if xmlutil.CrmMonXMLParser().is_node_remote(cluster_node_name):
             xml_item = etree.Element("node", id=cluster_node_name, uname=cluster_node_name, type="remote")
             cib_factory.create_from_node(xml_item)
             node_obj = cib_factory.find_node(cluster_node_name)
@@ -273,7 +273,7 @@ class NodeMgmt(command.UI):
         def do_print(uname):
             xml = find(uname, cfg_nodes)
             if xml is not None:
-                is_offline = not xmlutil.CrmMonXmlParser().is_node_online(uname)
+                is_offline = not xmlutil.CrmMonXMLParser().is_node_online(uname)
                 print_node(*unpack_node_xmldata(xml, is_offline))
 
         if node is not None:
@@ -335,7 +335,7 @@ class NodeMgmt(command.UI):
 
         xml_item_list = cib.xpath(xml_path)
         uname_list_in_xml = [xml_item.get("uname") for xml_item in xml_item_list]
-        crm_mon_parser_inst = xmlutil.CrmMonXmlParser()
+        crm_mon_parser_inst = xmlutil.CrmMonXMLParser()
         create_remote_node = False
         for node in node_list:
             if node not in uname_list_in_xml:

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -744,7 +744,10 @@ class RscMgmt(command.UI):
             return False
 
         rsc_type = rsc.node.get("type")
-        logger.info("Trace for %s%s is written to %s", rsc_id, ":"+op if op else "", f"{trace_dir}/{rsc_type}")
+        running_nodes = xmlutil.CrmMonXMLParser().get_resource_running_nodes(rsc_id)
+        node_str = " on node %s" % (", ".join(running_nodes)) if running_nodes else ""
+        logger.info("Trace for %s%s is written to %s/%s%s",
+                    rsc_id, ":" + op if op else "", trace_dir, rsc_type, node_str)
         if op and op != "monitor":
             logger.info("Trace set, restart %s to trace the %s operation", rsc_id, op)
         else:
@@ -801,5 +804,7 @@ class RscMgmt(command.UI):
             self._untrace_op_interval(context, rsc_id, rsc, op, interval)
         if not cibconfig.cib_factory_instance().commit():
             return False
-        logger.info("Stop tracing %s%s", rsc_id, " for operation "+op if op else "")
+        running_nodes = xmlutil.CrmMonXMLParser().get_resource_running_nodes(rsc_id)
+        node_str = " on node %s" % (", ".join(running_nodes)) if running_nodes else ""
+        logger.info("Stop tracing %s%s%s", rsc_id, ":" + op if op else "", node_str)
         return True

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -720,7 +720,7 @@ class RscMgmt(command.UI):
                 if trace_dir is not None:
                     context.fatal_error(usage)
                 trace_dir = arg
-            elif arg.isnumeric():
+            elif utils.crm_msec(arg) != -1:
                 if interval is not None:
                     context.fatal_error(usage)
                 interval = arg
@@ -733,6 +733,8 @@ class RscMgmt(command.UI):
         if op == "probe":
             op = "monitor"
             interval = interval or "0"
+        if op is not None and op not in constants.op_cli_names:
+            context.fatal_error("Unknown operation: %s" % (op))
         if op is None:
             self._trace_resource(context, rsc_id, rsc, trace_dir)
         elif interval is None:
@@ -748,10 +750,6 @@ class RscMgmt(command.UI):
         node_str = " on node %s" % (", ".join(running_nodes)) if running_nodes else ""
         logger.info("Trace for %s%s is written to %s/%s%s",
                     rsc_id, ":" + op if op else "", trace_dir, rsc_type, node_str)
-        if op and op != "monitor":
-            logger.info("Trace set, restart %s to trace the %s operation", rsc_id, op)
-        else:
-            logger.info("Trace set, restart %s to trace non-monitor operations", rsc_id)
         return True
 
     def _remove_trace(self, rsc, op_node):

--- a/crmsh/ui_sbd.py
+++ b/crmsh/ui_sbd.py
@@ -702,7 +702,7 @@ class SBD(command.UI):
 
     def _print_sbd_agent_status(self):
         for node in self.cluster_nodes:
-            crm_mon_xml_parser = xmlutil.CrmMonXmlParser(node)
+            crm_mon_xml_parser = xmlutil.CrmMonXMLParser(node)
             if crm_mon_xml_parser.is_resource_configured(sbd.SBDManager.SBD_RA):
                 print("# Status of fence_sbd:")
                 sbd_id_list = crm_mon_xml_parser.get_resource_id_list_via_type(sbd.SBDManager.SBD_RA)

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -2055,7 +2055,7 @@ def valid_nodeid(nodeid):
 
 
 def get_nodeid_from_name(name):
-    crm_mon_xml_parser = xmlutil.CrmMonXmlParser()
+    crm_mon_xml_parser = xmlutil.CrmMonXMLParser()
     if crm_mon_xml_parser.is_node_remote(name):
         return name
     return crm_mon_xml_parser.get_node_id_from_name(name)
@@ -2129,7 +2129,7 @@ def check_all_nodes_reachable(
     peer_node: str = None,
     check_passwd: bool = True
 ) -> ReachabilitySummary:
-    crm_mon_inst = xmlutil.CrmMonXmlParser(peer_node)
+    crm_mon_inst = xmlutil.CrmMonXMLParser(peer_node)
     if crm_mon_inst.not_connected():
         try:
             nodes_to_check = list_cluster_nodes_except_me()
@@ -2273,7 +2273,7 @@ def cluster_with_quorum(peer=None):
     """
     Check if current cluster has quorum
     """
-    return xmlutil.CrmMonXmlParser(peer).with_quorum()
+    return xmlutil.CrmMonXMLParser(peer).with_quorum()
 
 
 def is_2node_cluster_without_qdevice():
@@ -2799,7 +2799,7 @@ def validate_and_get_reachable_nodes(
 
     pcmk_remote_list = []
     if include_remote:
-        pcmk_remote_list = xmlutil.CrmMonXmlParser().get_node_list(online=True, node_type="remote")
+        pcmk_remote_list = xmlutil.CrmMonXMLParser().get_node_list(online=True, node_type="remote")
 
     local_node = this_node()
 
@@ -2822,7 +2822,7 @@ def validate_and_get_reachable_nodes(
         return member_list
 
     shell = sh.cluster_shell()
-    crm_mon_inst = xmlutil.CrmMonXmlParser()
+    crm_mon_inst = xmlutil.CrmMonXMLParser()
     for node in member_list[:]:
         if node == local_node or crm_mon_inst.is_node_online(node):
             continue
@@ -2844,7 +2844,7 @@ def able_to_restart_cluster(in_maintenance_mode: bool = False) -> bool:
     """
     if not ServiceManager().service_is_active(constants.PCMK_SERVICE):
         return True
-    crm_mon_parser = xmlutil.CrmMonXmlParser()
+    crm_mon_parser = xmlutil.CrmMonXMLParser()
     if not crm_mon_parser.is_non_stonith_resource_running():
         return True
     elif in_maintenance_mode:

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1703,22 +1703,6 @@ def service_info(name):
     return None
 
 
-def running_on(resource):
-    "returns list of node names where the given resource is running"
-    rsc_locate = "crm_resource --resource '%s' --locate"
-    rc, out, err = ShellUtils().get_stdout_stderr(rsc_locate % (resource))
-    if rc != 0:
-        return []
-    nodes = []
-    head = "resource %s is running on: " % (resource)
-    for line in out.split('\n'):
-        if line.strip().startswith(head):
-            w = line[len(head):].split()
-            if w:
-                nodes.append(w[0])
-    logger.debug("%s running on: %s", resource, nodes)
-    return nodes
-
 
 # This RE matches nvpair values that can
 # be left unquoted

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1633,6 +1633,13 @@ class CrmMonXMLParser(object):
             xpath += f"/node[@name='{node}']"
         return bool(self.xml_elem.xpath(xpath))
 
+    def get_resource_running_nodes(self, resource_id) -> list[str]:
+        """
+        Get nodes where the resource is currently running.
+        """
+        xpath = f'//resource[@id="{resource_id}" and @active="true"]/node'
+        return [elem.get('name') for elem in self.xml_elem.xpath(xpath)]
+
     def get_resource_top_parent_id_set_via_type(self, ra_type):
         """
         Given configured ra type, get the topmost parent ra id set

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -397,7 +397,7 @@ def is_our_node(s):
 
     Includes remote nodes as well
     '''
-    for n in CrmMonXmlParser().get_node_list():
+    for n in CrmMonXMLParser().get_node_list():
         if n.lower() == s.lower():
             return True
     return False
@@ -1502,7 +1502,7 @@ def attributes(typename, rules, values, xmlid=None, score=None):
     return e
 
 
-class CrmMonXmlParser(object):
+class CrmMonXMLParser(object):
     """
     Class to parse xml output of crm_mon
     """

--- a/test/features/steps/step_implementation.py
+++ b/test/features/steps/step_implementation.py
@@ -266,22 +266,22 @@ def step_impl(context):
 
 @then('Node "{node}" is standby')
 def step_impl(context, node):
-    assert xmlutil.CrmMonXmlParser().is_node_standby(node) is True
+    assert xmlutil.CrmMonXMLParser().is_node_standby(node) is True
 
 
 @then('Node "{node}" is online')
 def step_impl(context, node):
-    assert xmlutil.CrmMonXmlParser().is_node_standby(node) is False
+    assert xmlutil.CrmMonXMLParser().is_node_standby(node) is False
 
 
 @then('Node "{node}" is maintenance')
 def step_impl(context, node):
-    assert xmlutil.CrmMonXmlParser().is_node_maintenance(node) is True
+    assert xmlutil.CrmMonXMLParser().is_node_maintenance(node) is True
 
 
 @then('Node "{node}" is ready')
 def step_impl(context, node):
-    assert xmlutil.CrmMonXmlParser().is_node_maintenance(node) is False
+    assert xmlutil.CrmMonXMLParser().is_node_maintenance(node) is False
 
 
 @then('IP "{addr}" is used by corosync on "{node}"')

--- a/test/testcases/resource.exp
+++ b/test/testcases/resource.exp
@@ -398,7 +398,6 @@ Deleted 'p0' option: id=p0-meta_attributes-m0 name=m0
 
 .TRY resource trace p0 probe
 INFO: Trace for p0:monitor is written to /var/lib/heartbeat/trace_ra/Dummy
-INFO: Trace set, restart p0 to trace non-monitor operations
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -430,7 +429,6 @@ INFO: Trace set, restart p0 to trace non-monitor operations
 
 .TRY resource trace p0 start
 INFO: Trace for p0:start is written to /var/lib/heartbeat/trace_ra/Dummy
-INFO: Trace set, restart p0 to trace the start operation
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -467,7 +465,6 @@ INFO: Trace set, restart p0 to trace the start operation
 
 .TRY resource trace p0 stop
 INFO: Trace for p0:stop is written to /var/lib/heartbeat/trace_ra/Dummy
-INFO: Trace set, restart p0 to trace the stop operation
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -508,7 +505,7 @@ INFO: Trace set, restart p0 to trace the stop operation
 </cib>
 
 .TRY resource untrace p0 probe
-INFO: Stop tracing p0 for operation monitor
+INFO: Stop tracing p0:monitor
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -543,7 +540,7 @@ INFO: Stop tracing p0 for operation monitor
 </cib>
 
 .TRY resource untrace p0 start
-INFO: Stop tracing p0 for operation start
+INFO: Stop tracing p0:start
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0
@@ -573,7 +570,7 @@ INFO: Stop tracing p0 for operation start
 </cib>
 
 .TRY resource untrace p0 stop
-INFO: Stop tracing p0 for operation stop
+INFO: Stop tracing p0:stop
 .INP: configure
 .INP: _regtest on
 .INP: show xml p0

--- a/test/unittests/test_bootstrap.py
+++ b/test/unittests/test_bootstrap.py
@@ -1059,7 +1059,7 @@ done
 
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser.is_node_online')
     def test_is_online_local_offline(self, mock_is_online, mock_get_hostname, mock_this_node):
         bootstrap._context = mock.Mock(cluster_node='node2')
         mock_this_node.return_value = "node1"
@@ -1073,7 +1073,7 @@ done
 
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser.is_node_online')
     def test_is_online_on_init_node(self, mock_is_online, mock_get_hostname, mock_this_node):
         bootstrap._context = mock.Mock(cluster_node=None)
         mock_this_node.return_value = "node1"
@@ -1093,7 +1093,7 @@ done
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_is_online_peer_offline(self, mock_parser, mock_get_hostname, mock_this_node,
             mock_copy, mock_corosync_conf, mock_sync, mock_stop_service, mock_error, mock_cluster_shell):
         bootstrap._context = mock.Mock(cluster_node='node1')
@@ -1126,7 +1126,7 @@ done
     @mock.patch('shutil.copy')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser.is_node_online')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser.is_node_online')
     def test_is_online_both_online(self, mock_is_online, mock_get_hostname, mock_this_node,
             mock_copy, mock_corosync_conf, mock_csync2, mock_stop_service, mock_error):
         bootstrap._context = mock.Mock(cluster_node='node2')
@@ -1551,7 +1551,7 @@ done
         mock_adj_fence.assert_called_once_with(True)
 
     @mock.patch('crmsh.utils.cluster_copy_path')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_sync_path_peer(self, mock_parser, mock_cluster_copy):
         mock_parser_inst = mock.Mock()
         mock_parser.return_value = mock_parser_inst
@@ -1915,7 +1915,7 @@ class TestValidation(unittest.TestCase):
         mock_check_all_nodes.assert_called_once_with("removing a node from the cluster")
 
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -1952,7 +1952,7 @@ class TestValidation(unittest.TestCase):
 
     @mock.patch('crmsh.utils.check_all_nodes_reachable')
     @mock.patch('crmsh.bootstrap.remove_node_from_cluster')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     @mock.patch('crmsh.utils.this_node')
     @mock.patch('crmsh.bootstrap.confirm')
     @mock.patch('crmsh.bootstrap.get_node_canonical_hostname')
@@ -2076,7 +2076,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
     @mock.patch('crmsh.network_utils.get_cluster_node_ips')
     @mock.patch('crmsh.utils.get_nodeid_from_name')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_remove_node_from_cluster_rm_node_failed(self, mock_crm_mon_parser, mock_get_nodeid, mock_get_ips, mock_stop, mock_status, mock_invoke, mock_error, mock_rm_conf_files, mock_call_delnode):
         mock_crm_mon_parser_inst = mock.Mock()
         mock_crm_mon_parser.return_value = mock_crm_mon_parser_inst
@@ -2116,7 +2116,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
     @mock.patch('crmsh.network_utils.get_cluster_node_ips')
     @mock.patch('crmsh.utils.get_nodeid_from_name')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_remove_node_from_cluster_hostname(self, mock_crm_mon_parser, mock_get_nodeid, mock_get_ips, mock_stop, mock_status,
             mock_invoke, mock_error, mock_get_values, mock_del_by_name, mock_del_by_id, mock_csync2,
             mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_firewall, mock_cluster_shell, mock_host_user_config):
@@ -2172,7 +2172,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
     @mock.patch('crmsh.network_utils.get_cluster_node_ips')
     @mock.patch('crmsh.utils.get_nodeid_from_name')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_remove_node_from_cluster_by_nodeid(self, mock_crm_mon_parser, mock_get_nodeid, mock_get_ips, mock_stop, mock_status,
             mock_invoke, mock_error, mock_get_values, mock_del_by_name, mock_del_by_id, mock_csync2,
             mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_firewall, mock_cluster_shell, mock_host_user_config):
@@ -2222,7 +2222,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
     @mock.patch('crmsh.utils.get_nodeid_from_name')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_remove_node_from_cluster_fallback_success(self, mock_crm_mon_parser, mock_get_nodeid, mock_stop, mock_status,
             mock_invoke, mock_error, mock_get_values, mock_del_by_name, mock_del_by_id, mock_csync2,
             mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_firewall, mock_cluster_shell, mock_host_user_config,
@@ -2271,7 +2271,7 @@ class TestValidation(unittest.TestCase):
     @mock.patch('logging.Logger.info')
     @mock.patch('crmsh.bootstrap.stop_and_disable_services')
     @mock.patch('crmsh.utils.get_nodeid_from_name')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_remove_node_from_cluster_del_node_failed(self, mock_crm_mon_parser, mock_get_nodeid, mock_stop, mock_status,
             mock_invoke, mock_error, mock_get_values, mock_del_by_name, mock_del_by_id, mock_csync2,
             mock_adjust_priority, mock_adjust_fence_delay, mock_rm_conf_files, mock_is_active, mock_cal_delnode, mock_firewall, mock_cluster_shell, mock_host_user_config,

--- a/test/unittests/test_cluster_fs.py
+++ b/test/unittests/test_cluster_fs.py
@@ -298,7 +298,7 @@ class TestClusterFSManager(unittest.TestCase):
 
     @mock.patch("crmsh.cluster_fs.storage_utils.compare_uuid_with_peer_dev")
     @mock.patch("crmsh.cluster_fs.storage_utils.is_dev_a_plain_raw_disk_or_partition")
-    @mock.patch("crmsh.xmlutil.CrmMonXmlParser")
+    @mock.patch("crmsh.xmlutil.CrmMonXMLParser")
     @mock.patch("crmsh.log.LoggerUtils.status_long")
     def test_join(self, mock_status_long, mock_crmmonxmlparser, mock_is_dev_a_plain_raw_disk_or_partition, mock_compare_uuid_with_peer_dev):
         mock_crmmonxmlparser_inst = mock.Mock()

--- a/test/unittests/test_crashtest_task.py
+++ b/test/unittests/test_crashtest_task.py
@@ -732,7 +732,7 @@ class TestTask(TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('crmsh.crash_test.task.Task.info')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_fence_action_monitor(self, mock_parser, mock_info, mock_sleep):
         self.task_inst.thread_stop_event = mock.Mock()
         self.task_inst.thread_stop_event.is_set.side_effect = [False, False]

--- a/test/unittests/test_crashtest_utils.py
+++ b/test/unittests/test_crashtest_utils.py
@@ -319,7 +319,7 @@ class TestUtils(TestCase):
             mock.call(b'/usr/sbin/sbd\x00')
             ])
 
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     def test_online_nodes(self, mock_crmmon_parser):
         mock_inst = mock.Mock()
         mock_crmmon_parser.return_value = mock_inst

--- a/test/unittests/test_lock.py
+++ b/test/unittests/test_lock.py
@@ -178,7 +178,7 @@ class TestRemoteLock(unittest.TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('logging.Logger.warning')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     @mock.patch('crmsh.lock.Lock._create_lock_dir')
     @mock.patch('crmsh.lock.RemoteLock.lock_timeout', new_callable=mock.PropertyMock)
     @mock.patch('time.time')
@@ -203,7 +203,7 @@ class TestRemoteLock(unittest.TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('logging.Logger.warning')
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
     @mock.patch('crmsh.lock.Lock._create_lock_dir')
     @mock.patch('crmsh.lock.RemoteLock.lock_timeout', new_callable=mock.PropertyMock)
     @mock.patch('time.time')

--- a/test/unittests/test_network_utils.py
+++ b/test/unittests/test_network_utils.py
@@ -302,7 +302,7 @@ class TestInterfacesInfo(unittest.TestCase):
 
 
 @mock.patch('crmsh.network_utils.ssh_port_reachable_check')
-@mock.patch("crmsh.utils.xmlutil.CrmMonXmlParser")
+@mock.patch("crmsh.utils.xmlutil.CrmMonXMLParser")
 def test_check_all_nodes_reachable_dead_nodes(mock_xml, mock_reachable):
     mock_xml_inst = mock.Mock()
     mock_xml.return_value = mock_xml_inst
@@ -318,7 +318,7 @@ def test_check_all_nodes_reachable_dead_nodes(mock_xml, mock_reachable):
 @mock.patch('crmsh.network_utils.check_ssh_passwd_need')
 @mock.patch("crmsh.utils.crmsh.user_of_host.UserOfHost.instance")
 @mock.patch('crmsh.network_utils.ssh_port_reachable_check')
-@mock.patch("crmsh.utils.xmlutil.CrmMonXmlParser")
+@mock.patch("crmsh.utils.xmlutil.CrmMonXMLParser")
 def test_check_all_nodes_reachable(mock_xml, mock_reachable, mock_user_of_host, mock_check_passwd):
     mock_xml_inst = mock.Mock()
     mock_xml.return_value = mock_xml_inst

--- a/test/unittests/test_qdevice.py
+++ b/test/unittests/test_qdevice.py
@@ -24,7 +24,7 @@ def test_evaluate_qdevice_quorum_effect_reload(mock_get_dict, mock_quorate):
 
 
 @mock.patch('crmsh.utils.is_cluster_in_maintenance_mode')
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 @mock.patch('crmsh.utils.calculate_quorate_status')
 @mock.patch('crmsh.utils.get_quorum_votes_dict')
 def test_evaluate_qdevice_quorum_effect_later(mock_get_dict, mock_quorate, mock_parser, mock_maintenance):
@@ -38,7 +38,7 @@ def test_evaluate_qdevice_quorum_effect_later(mock_get_dict, mock_quorate, mock_
     mock_quorate.assert_called_once_with(2, 1)
 
 
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 @mock.patch('crmsh.utils.calculate_quorate_status')
 @mock.patch('crmsh.utils.get_quorum_votes_dict')
 def test_evaluate_qdevice_quorum_effect(mock_get_dict, mock_quorate, mock_parser):

--- a/test/unittests/test_ratrace.py
+++ b/test/unittests/test_ratrace.py
@@ -106,6 +106,34 @@ class TestRATrace(unittest.TestCase):
         self.assertEqual(obj.node.xpath('.//*[@name="trace_ra"]'), [])
 
     @mock.patch('logging.Logger.error')
+    @mock.patch.object(RscMgmt, '_get_trace_rsc')
+    def test_ratrace_unknown_op(self, mock_get_rsc, mock_error):
+        """Check that do_trace rejects an unknown operation name."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy"/>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+        mock_get_rsc.return_value = obj
+
+        with self.assertRaises(ValueError) as err:
+            RscMgmt().do_trace(self.context, obj.obj_id, 'xxx')
+        self.assertEqual(str(err.exception), "Unknown operation: xxx")
+
+    @mock.patch('logging.Logger.error')
+    @mock.patch.object(RscMgmt, '_get_trace_rsc')
+    def test_ratrace_interval_with_unit(self, mock_get_rsc, mock_error):
+        """Check that do_trace accepts an interval expressed with a time unit."""
+        xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">
+            <operations>
+              <op id="r1-monitor-10s" interval="10s" name="monitor"/>
+            </operations>
+          </primitive>'''
+        obj = self.factory.create_from_node(etree.fromstring(xml))
+        mock_get_rsc.return_value = obj
+
+        RscMgmt().do_trace(self.context, obj.obj_id, 'monitor', '10s')
+        self.assertEqual(obj.node.xpath('operations/op/@id'), ['r1-monitor-10s'])
+        self.assertEqual(obj.node.xpath('operations/op[@id="r1-monitor-10s"]/instance_attributes/nvpair[@name="trace_ra"]/@value'), ['1'])
+
+    @mock.patch('logging.Logger.error')
     def test_ratrace_op_interval(self, mock_error):
         """Check setting RA tracing for an operation+interval."""
         xml = '''<primitive class="ocf" id="r1" provider="pacemaker" type="Dummy">

--- a/test/unittests/test_sbd.py
+++ b/test/unittests/test_sbd.py
@@ -811,12 +811,12 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.instance_fix._fix_sbd_service_is_enabled()
         mock_logger_info.assert_called_once_with("Enabling %s on node %s", constants.SBD_SERVICE, 'node2')
 
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_check_fence_sbd_not_configured(self, mock_CrmMonXmlParser):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_check_fence_sbd_not_configured(self, mock_CrmMonXMLParser):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = False
         mock_parser_instance.is_resource_configured.return_value = False
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.ERROR)
@@ -826,12 +826,12 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.cibquery.ResourceAgent')
     @patch('crmsh.xmlutil.text2elem')
     @patch('crmsh.sh.cluster_shell')
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_check_fence_sbd_not_configured_cluster_offline(self, mock_CrmMonXmlParser, mock_cluster_shell, mock_text2elem, mock_ResourceAgent, mock_get_primitives_with_ra):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_check_fence_sbd_not_configured_cluster_offline(self, mock_CrmMonXMLParser, mock_cluster_shell, mock_text2elem, mock_ResourceAgent, mock_get_primitives_with_ra):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = True
         mock_cluster_shell_inst = Mock()
         mock_cluster_shell.return_value = mock_cluster_shell_inst
@@ -847,11 +847,11 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.cibquery.ResourceAgent')
     @patch('crmsh.xmlutil.text2elem')
     @patch('crmsh.sh.cluster_shell')
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_check_fence_sbd_success_cluster_offline(self, mock_CrmMonXmlParser, mock_cluster_shell, mock_text2elem, mock_ResourceAgent, mock_get_primitives_with_ra):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_check_fence_sbd_success_cluster_offline(self, mock_CrmMonXMLParser, mock_cluster_shell, mock_text2elem, mock_ResourceAgent, mock_get_primitives_with_ra):
         self.instance_check.disk_based = True
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = True
         mock_cluster_shell_inst = Mock()
         mock_cluster_shell.return_value = mock_cluster_shell_inst
@@ -863,24 +863,24 @@ class TestSBDConfigChecker(unittest.TestCase):
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.SUCCESS)
 
     @patch('crmsh.utils.is_cluster_in_maintenance_mode')
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_check_fence_sbd_not_started(self, mock_CrmMonXmlParser, mock_is_cluster_in_maintenance_mode):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_check_fence_sbd_not_started(self, mock_CrmMonXMLParser, mock_is_cluster_in_maintenance_mode):
         self.instance_check.disk_based = True
         self.instance_check.quiet = False
         mock_is_cluster_in_maintenance_mode.return_value = False
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = False
         mock_parser_instance.is_resource_configured.return_value = True
         mock_parser_instance.is_resource_started.return_value = False
         self.assertEqual(self.instance_check._check_fence_sbd(), sbd.CheckResult.ERROR)
         self.mock_quiet_logger_error.assert_called_once_with("Fence agent %s is not started", sbd.SBDManager.SBD_RA)
 
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_check_fence_sbd_success(self, mock_CrmMonXmlParser):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_check_fence_sbd_success(self, mock_CrmMonXMLParser):
         self.instance_check.disk_based = True
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.not_connected.return_value = False
         mock_parser_instance.is_resource_configured.return_value = True
         mock_parser_instance.is_resource_started.return_value = True
@@ -890,10 +890,10 @@ class TestSBDConfigChecker(unittest.TestCase):
     @patch('crmsh.utils.is_2node_cluster_without_qdevice')
     @patch('logging.Logger.info')
     @patch('crmsh.sh.cluster_shell')
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_fix_fence_sbd_not_configured(self, mock_CrmMonXmlParser, mock_cluster_shell, mock_logger_info, mock_is_2node_cluster_without_qdevice, mock_adjust_pcmk_delay_max):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_fix_fence_sbd_not_configured(self, mock_CrmMonXMLParser, mock_cluster_shell, mock_logger_info, mock_is_2node_cluster_without_qdevice, mock_adjust_pcmk_delay_max):
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.is_resource_configured.return_value = False
         mock_cluster_shell_inst = Mock()
         mock_cluster_shell.return_value = mock_cluster_shell_inst
@@ -904,10 +904,10 @@ class TestSBDConfigChecker(unittest.TestCase):
 
     @patch('logging.Logger.info')
     @patch('crmsh.sh.cluster_shell')
-    @patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_fix_fence_sbd_not_started(self, mock_CrmMonXmlParser, mock_cluster_shell, mock_logger_info):
+    @patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_fix_fence_sbd_not_started(self, mock_CrmMonXMLParser, mock_cluster_shell, mock_logger_info):
         mock_parser_instance = Mock()
-        mock_CrmMonXmlParser.return_value = mock_parser_instance
+        mock_CrmMonXMLParser.return_value = mock_parser_instance
         mock_parser_instance.is_resource_configured.return_value = True
         mock_parser_instance.is_resource_started.return_value = False
         mock_parser_instance.get_resource_id_list_via_type.return_value = ['fence_sbd_0']
@@ -1302,11 +1302,11 @@ class TestOutterFunctions(unittest.TestCase):
     """
     @patch('crmsh.utils.ext_cmd')
     @patch('logging.Logger.info')
-    @patch('crmsh.sbd.xmlutil.CrmMonXmlParser')
-    def test_cleanup_existing_sbd_resource(self, mock_CrmMonXmlParser, mock_logger_info, mock_ext_cmd):
-        mock_CrmMonXmlParser.return_value.is_resource_configured.return_value = True
-        mock_CrmMonXmlParser.return_value.get_resource_id_list_via_type.return_value = ['sbd_resource']
-        mock_CrmMonXmlParser.return_value.is_resource_started.return_value = True
+    @patch('crmsh.sbd.xmlutil.CrmMonXMLParser')
+    def test_cleanup_existing_sbd_resource(self, mock_CrmMonXMLParser, mock_logger_info, mock_ext_cmd):
+        mock_CrmMonXMLParser.return_value.is_resource_configured.return_value = True
+        mock_CrmMonXMLParser.return_value.get_resource_id_list_via_type.return_value = ['sbd_resource']
+        mock_CrmMonXMLParser.return_value.is_resource_started.return_value = True
         sbd.cleanup_existing_sbd_resource()
         mock_logger_info.assert_has_calls([
             call("Stop sbd resource '%s'(%s)", 'sbd_resource', sbd.SBDManager.SBD_RA),

--- a/test/unittests/test_storage_utils.py
+++ b/test/unittests/test_storage_utils.py
@@ -241,7 +241,7 @@ def test_set_dlm_option(mock_get_dict, mock_run):
     mock_run_inst.get_stdout_or_raise_error.assert_called_once_with('dlm_tool set_config "key2=test"', None)
 
 
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 def test_is_dlm_configured(mock_crmmon):
     mock_crmmon_inst = mock.Mock()
     mock_crmmon.return_value = mock_crmmon_inst
@@ -250,7 +250,7 @@ def test_is_dlm_configured(mock_crmmon):
     mock_crmmon_inst.is_resource_configured.assert_called_once_with(constants.DLM_CONTROLD_RA)
 
 
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 def test_is_dlm_running(mock_crmmon):
     mock_crmmon_inst = mock.Mock()
     mock_crmmon.return_value = mock_crmmon_inst
@@ -259,7 +259,7 @@ def test_is_dlm_running(mock_crmmon):
     mock_crmmon_inst.is_resource_started.assert_called_once_with(constants.DLM_CONTROLD_RA, node=None)
 
 
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 def test_is_dlm_running_on_node(mock_crmmon):
     mock_crmmon_inst = mock.Mock()
     mock_crmmon.return_value = mock_crmmon_inst

--- a/test/unittests/test_ui_sbd.py
+++ b/test/unittests/test_ui_sbd.py
@@ -624,10 +624,10 @@ class TestSBD(unittest.TestCase):
         self.sbd_instance_diskbased._service_is_active.assert_called_once_with(constants.SBD_SERVICE)
         mock_check_all_nodes_reachable.assert_called_once_with("purging SBD")
 
-    @mock.patch('crmsh.xmlutil.CrmMonXmlParser')
-    def test_print_sbd_agent_status(self, mock_CrmMonXmlParser):
-        mock_CrmMonXmlParser.return_value.is_resource_configured.return_value = True
-        mock_CrmMonXmlParser.return_value.get_resource_id_list_via_type.return_value = ["sbd"]
+    @mock.patch('crmsh.xmlutil.CrmMonXMLParser')
+    def test_print_sbd_agent_status(self, mock_CrmMonXMLParser):
+        mock_CrmMonXMLParser.return_value.is_resource_configured.return_value = True
+        mock_CrmMonXMLParser.return_value.get_resource_id_list_via_type.return_value = ["sbd"]
         self.sbd_instance_diskbased.cluster_shell.get_rc_output_without_input.return_value = (0, "active")
         with mock.patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
             self.sbd_instance_diskbased._print_sbd_agent_status()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -24,7 +24,7 @@ def test_package_is_installed_local(mock_run):
     mock_run.assert_called_once_with("rpm -q --quiet crmsh")
 
 
-@mock.patch("crmsh.utils.xmlutil.CrmMonXmlParser")
+@mock.patch("crmsh.utils.xmlutil.CrmMonXMLParser")
 def test_get_nodeid_from_name_remote(mock_parser):
     mock_parser_inst = mock.Mock()
     mock_parser.return_value = mock_parser_inst
@@ -34,7 +34,7 @@ def test_get_nodeid_from_name_remote(mock_parser):
     mock_parser_inst.is_node_remote.assert_called_once_with("node1")
 
 
-@mock.patch("crmsh.utils.xmlutil.CrmMonXmlParser")
+@mock.patch("crmsh.utils.xmlutil.CrmMonXMLParser")
 def test_get_nodeid_from_name(mock_parser):
     mock_parser_inst = mock.Mock()
     mock_parser.return_value = mock_parser_inst
@@ -523,7 +523,7 @@ def test_detect_virt(mock_run):
     mock_run.assert_called_once_with("systemd-detect-virt")
 
 
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 def test_cluster_with_quorum(mock_crmmon):
     mock_crmmon_inst = mock.Mock()
     mock_crmmon.return_value = mock_crmmon_inst
@@ -1123,7 +1123,7 @@ def test_validate_and_get_reachable_nodes_no_cib(mock_list_nodes, mock_get_addre
 
 
 @mock.patch('logging.Logger.error')
-@mock.patch('crmsh.xmlutil.CrmMonXmlParser')
+@mock.patch('crmsh.xmlutil.CrmMonXMLParser')
 @mock.patch('crmsh.sh.cluster_shell')
 @mock.patch('crmsh.network_utils.get_reachable_node_list')
 @mock.patch('crmsh.utils.this_node')

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -22,6 +22,7 @@ FAKE_XML = '''
     <resource id="ocfs2-clusterfs" resource_agent="ocf:heartbeat:Filesystem" role="Started" active="true" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="1">
       <node name="tbw-2" id="1084783312" cached="true"/>
     </resource>
+    <resource id="d1" resource_agent="ocf:heartbeat:Dummy" role="Stopped" target_role="Stopped" active="false" orphaned="false" blocked="false" managed="true" failed="false" failure_ignored="false" nodes_running_on="0"/>
   </resources>
 </data>
 '''
@@ -72,6 +73,11 @@ class TestCrmMonXMLParser(unittest.TestCase):
         assert self.parser_inst.is_resource_started("test") is False
         assert self.parser_inst.is_resource_started("ocfs2-clusterfs") is True
         assert self.parser_inst.is_resource_started("ocf:pacemaker:controld") is True
+
+    def test_get_resource_running_nodes(self):
+        assert self.parser_inst.get_resource_running_nodes("test") == []
+        assert self.parser_inst.get_resource_running_nodes("d1") == []
+        assert self.parser_inst.get_resource_running_nodes("ocfs2-clusterfs") == ["tbw-2"]
 
     def test_get_resource_id_list_via_type(self):
         assert self.parser_inst.get_resource_id_list_via_type("test") == []

--- a/test/unittests/test_xmlutil.py
+++ b/test/unittests/test_xmlutil.py
@@ -32,9 +32,9 @@ OFFLINE_XML = '''
 </data>
 '''
 
-class TestCrmMonXmlParser(unittest.TestCase):
+class TestCrmMonXMLParser(unittest.TestCase):
     """
-    Unitary tests for crmsh.xmlutil.CrmMonXmlParser
+    Unitary tests for crmsh.xmlutil.CrmMonXMLParser
     """
     @mock.patch('crmsh.sh.cluster_shell')
     def setUp(self, mock_cluster_shell):
@@ -42,9 +42,9 @@ class TestCrmMonXmlParser(unittest.TestCase):
         Test setUp.
         """
         mock_cluster_shell().get_rc_stdout_stderr_without_input.return_value = (0, FAKE_XML, '')
-        self.parser_inst = xmlutil.CrmMonXmlParser()
+        self.parser_inst = xmlutil.CrmMonXMLParser()
         mock_cluster_shell().get_rc_stdout_stderr_without_input.return_value = (0, OFFLINE_XML, '')
-        self.offline_parser_inst = xmlutil.CrmMonXmlParser()
+        self.offline_parser_inst = xmlutil.CrmMonXMLParser()
 
     def test_is_cluster_not_connected(self):
         assert self.offline_parser_inst.not_connected() is True


### PR DESCRIPTION
## Summary

Use `crm_mon` XML (already parsed for cluster status) to locate where a
resource is running, instead of shelling out to `crm_resource --locate`,
and fix two related input-validation bugs in `crm resource trace`.

## Changes

- Rename the `crm_mon` XML parser class to `xmlutil.CrmMonXMLParser` for clarity
- Add `CrmMonXMLParser.get_resource_running_nodes()` to query running nodes from `crm_mon` XML
- Use it in `ui_maintenance._runs_on_this_node` instead of `utils.running_on`
- Include the running node(s) in `resource trace`/`untrace` log messages
- Remove the now-unused `utils.running_on` shell helper
- Reject unknown operation names in `crm resource trace <rsc> <op>` (previously silently accepted)
- Recognize trace intervals with time units (e.g. `10s`, `1m`), which were previously rejected because only plain integers were accepted
- Add unit test coverage for the above (`test_xmlutil.py`, `test_ratrace.py`)

## Testing

Full unit test suite passes: `pytest -q test/unittests`
