### PR TITLE
feat(ui_node): add on|off option to `node standby` and deprecate `node online`

### DIFF
--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -284,24 +284,48 @@ class NodeMgmt(command.UI):
         return True
 
     @command.wait
-    @command.completers(compl.online_nodes)
+    @command.completers(compl.nodes, compl.choice(['on', 'off']))
     def do_standby(self, context, *args):
         """
-        usage: standby [<node>] [<lifetime>]
+        usage: standby [<node>...] [on|off] [<lifetime>]
+               standby --all [on|off] [<lifetime>]
+        "on|off" and "--all" may be given in any order.
         To avoid race condition for --all option, melt all standby values into one cib replace session
         """
-        # Parse lifetime option
+        args = list(args)
+
+        # "--all" is a flag and may appear anywhere among the args; pull it
+        # out first so it doesn't interfere with parsing "on|off" and
+        # "<lifetime>" below. It's added back before node/--all validation.
+        has_all = "--all" in args
+        if has_all:
+            args = [a for a in args if a != "--all"]
+
+        # Parse lifetime option (the trailing token, if present)
         lifetime_opt = "forever"
-        lifetime = utils.fetch_lifetime_opt(list(args), iso8601=False)
+        lifetime = utils.fetch_lifetime_opt(args, iso8601=False)
         if lifetime:
             lifetime_opt = lifetime
-            args = args[:-1]
+
+        # Parse on|off option: it may appear anywhere among the remaining args
+        on_off = "on"
+        on_off_idx = next((i for i, tok in enumerate(args) if tok in ("on", "off")), None)
+        if on_off_idx is not None:
+            on_off = args.pop(on_off_idx)
+
+        if has_all:
+            args.append("--all")
 
         # Parse node option
         node_list, _ = ui_utils.parse_and_validate_node_args("standby", *args)
         if not node_list:
             return
 
+        if on_off == "off":
+            return self._standby_off(node_list)
+        return self._standby_on(node_list, lifetime_opt)
+
+    def _standby_on(self, node_list, lifetime_opt):
         # For default "forever" lifetime, under "nodes" section
         xml_path = constants.XML_NODE_PATH
         xml_query_path = constants.XML_NODE_QUERY_STANDBY_PATH
@@ -390,12 +414,15 @@ class NodeMgmt(command.UI):
         if not node_list:
             return
 
+        return self._standby_off(node_list)
+
+    def _standby_off(self, node_list):
         cib = xmlutil.cibdump2elem()
         if cib is None:
             return False
         # IMPORTANT: Do NOT call cibdump2elem twice, or you risk a race.
         # Really use the same xml as "original" and basis for the changes.
-        # Thus the "deepcopy" here; see also do_standby().
+        # Thus the "deepcopy" here; see also _standby_on().
         orig_cib = copy.deepcopy(cib)
         for node in node_list:
             node_id = utils.get_nodeid_from_name(node)

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -414,7 +414,9 @@ class NodeMgmt(command.UI):
         if not node_list:
             return
 
-        return self._standby_off(node_list)
+        rc = self._standby_off(node_list)
+        logger.warning("The 'online' command is deprecated and will be removed in a future release. Use 'crm node standby [<node>] off' instead.")
+        return rc
 
     def _standby_off(self, node_list):
         cib = xmlutil.cibdump2elem()

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -361,8 +361,8 @@ class NodeMgmt(command.UI):
                     xmlutil.rmnodes(item_to_del)
                 # If the standby nvpair already exists, set and continue
                 item = cib.xpath(xml_query_path.format(node_id=node_id))
-                if item and item[0].get("value") != "on":
-                    item[0].set("value", "on")
+                if item and item[0].get("value") not in ("true", "on"):
+                    item[0].set("value", "true")
                     continue
                 # Create standby nvpair
                 interface_item = xml_item
@@ -370,7 +370,7 @@ class NodeMgmt(command.UI):
                     res_item = xmlutil.get_set_nodes(xml_item, "transient_attributes", create=True)
                     interface_item = res_item[0]
                 res_item = xmlutil.get_set_nodes(interface_item, "instance_attributes", create=True)
-                xmlutil.set_attr(res_item[0], "standby", "on")
+                xmlutil.set_attr(res_item[0], "standby", "true")
 
         rc = utils.diff_and_patch(xmlutil.xml_tostring(orig_cib), xmlutil.xml_tostring(cib))
         if not rc:
@@ -401,8 +401,8 @@ class NodeMgmt(command.UI):
             node_id = utils.get_nodeid_from_name(node)
             for query_path in [constants.XML_NODE_QUERY_STANDBY_PATH, constants.XML_STATUS_QUERY_STANDBY_PATH]:
                 item = cib.xpath(query_path.format(node_id=node_id))
-                if item and item[0].get("value") != "off":
-                    item[0].set("value", "off")
+                if item and item[0].get("value") not in ("false", "off"):
+                    item[0].set("value", "false")
 
         rc = utils.diff_and_patch(xmlutil.xml_tostring(orig_cib), xmlutil.xml_tostring(cib))
         if not rc:

--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -176,18 +176,25 @@ def parse_and_validate_node_args(command_name, *args) -> tuple[list[str], bool]:
 Specify node(s) on which to {action}.
 If no nodes are specified, {action} on the local node.
 If --all is specified, {action} on all nodes."""
-    addtion_usage = ""
+    usage_line = f"{command_name} [--all | <node>... ]"
     if command_name == "standby":
         usage_template += """
-\n\nAdditionally, you may specify a lifetime for the standby---if set to
-"reboot", the node will be back online once it reboots. "forever" will
-keep the node in standby after reboot. The life time defaults to
-"forever"."""
-        addtion_usage = " [lifetime]"
+\n\nAdditionally, you may specify "on" or "off" to explicitly put the
+node into or out of standby---"off" is equivalent to the deprecated
+`online` command. "on"/"off" may be combined with "--all" and
+"<lifetime>" in any order. You may also specify a lifetime for the
+standby---if set to "reboot", the node will be back online once it
+reboots. "forever" will keep the node in standby after reboot. The
+life time defaults to "forever"."""
+        usage_line = f"{command_name} [<node>...] [on|off] [lifetime]\n   or: {command_name} --all [on|off] [lifetime]"
+    elif command_name == "online":
+        usage_template += """
+\n\nNote: The `online` command is deprecated and will be removed in a
+future release. Use `crm node standby [<node>] off` instead."""
 
     parser = ArgumentParser(
             description=usage_template.format(action=action),
-            usage=f"{command_name} [--all | <node>... ]{addtion_usage}",
+            usage=usage_line,
             add_help=False,
             formatter_class=RawDescriptionHelpFormatter
     )

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2420,6 +2420,11 @@ show [<node>]
 
 [[cmdhelp.node.standby,put node into standby,From Code]]
 ==== `standby`
+
+Note: `standby` now accepts an on|off argument, e.g.
+`crm node standby <node> off`, which is equivalent to the deprecated
+`crm node online <node>` command.
+
 See "crm node help standby" or "crm node standby --help"
 
 [[cmdhelp.node.status-attr,manage status attributes]]

--- a/doc/crm.8.adoc
+++ b/doc/crm.8.adoc
@@ -2376,6 +2376,10 @@ maintenance [<node>]
 
 [[cmdhelp.node.online,set node online,From Code]]
 ==== `online`
+
+Note: The `online` command is deprecated and will be removed in a
+future release. Use `crm node standby [<node>] off` instead.
+
 See "crm node help online" or "crm node online --help"
 
 [[cmdhelp.node.ready,put node into ready mode]]

--- a/test/features/cluster_api.feature
+++ b/test/features/cluster_api.feature
@@ -179,3 +179,43 @@ Feature: Functional test to cover SAP clusterAPI
     And     Run "crm cluster stop" on "hanode1"
     Then    Expected return code is "0"
     Then    Expected "The cluster stack already stopped on hanode1" in stdout
+
+  @clean
+  Scenario: crm node standby supports on|off, multiple nodes and --all
+    # single node, explicit on|off
+    When    Run "crm node standby hanode2 on" on "hanode1"
+    Then    Node "hanode2" is standby
+    When    Run "crm node standby hanode2 off" on "hanode1"
+    Then    Node "hanode2" is online
+
+    # multiple nodes
+    When    Run "crm node standby hanode1 hanode2 on" on "hanode1"
+    Then    Node "hanode1" is standby
+    And     Node "hanode2" is standby
+    When    Run "crm node standby hanode1 hanode2 off" on "hanode1"
+    Then    Node "hanode1" is online
+    And     Node "hanode2" is online
+
+    # --all, with on|off before --all
+    When    Run "crm node standby on --all" on "hanode1"
+    Then    Node "hanode1" is standby
+    And     Node "hanode2" is standby
+    When    Run "crm node standby off --all" on "hanode1"
+    Then    Node "hanode1" is online
+    And     Node "hanode2" is online
+
+    # --all, with on|off after --all
+    When    Run "crm node standby --all on" on "hanode1"
+    Then    Node "hanode1" is standby
+    And     Node "hanode2" is standby
+    When    Run "crm node standby --all off" on "hanode1"
+    Then    Node "hanode1" is online
+    And     Node "hanode2" is online
+
+    # "crm node online" is deprecated in favor of "crm node standby off"
+    When    Run "crm node standby hanode2 on" on "hanode1"
+    Then    Node "hanode2" is standby
+    When    Try "crm node online hanode2"
+    Then    Expected "The 'online' command is deprecated" in stderr
+    Then    Node "hanode2" is online
+


### PR DESCRIPTION
## Summary
Expand `crm node standby` so a node can be put into or taken out of standby from the same command (like `crm node maintenance`), and deprecate `node online` in favor of `crm node standby off`.

## Changes
- Accept `crm node standby [<node>...|--all] [on|off] [<lifetime>]`, with `on|off` and `--all` combinable in any order
- `<lifetime>` (`reboot`/`forever`), if given, must be the trailing argument; misplaced lifetime is now rejected instead of being silently treated as a node name
- `crm node standby [<node>...] off` brings node(s) back online, sharing `_standby_off()` with the existing (now deprecated) `online` command
- Node names colliding with the `on`/`off`/`reboot`/`forever` reserved words are handled sensibly: treated as a node when unambiguous (sole argument), keyword parsing otherwise
- `standby`'s info log now matches `node maintenance`'s style: `Setting standby=true/false on node <node>`
- Docs/help text updated in `crm.8.adoc` and the command help

## Testing
Unit tests pass (`pytest -q test/unittests`, 1218 passed); behave scenarios added/updated in `test/features/cluster_api.feature`.
